### PR TITLE
Policy_InternationalRouteYieldModifiers, no tooltips

### DIFF
--- a/Community Patch/Community Patch.civ5proj
+++ b/Community Patch/Community Patch.civ5proj
@@ -87,6 +87,11 @@
       <Action>
         <Set>OnModActivated</Set>
         <Type>UpdateDatabase</Type>
+        <FileName>Core Files/Core Tables/CoreTableAdditions1HH.xml</FileName>
+      </Action>
+      <Action>
+        <Set>OnModActivated</Set>
+        <Type>UpdateDatabase</Type>
         <FileName>Core Files/Core Tables/CoreTableEntries.sql</FileName>
       </Action>
       <Action>
@@ -924,6 +929,10 @@
       <ImportIntoVFS>False</ImportIntoVFS>
     </Content>
     <Content Include="Core Files\Core Tables\CoreTableAdditions.xml">
+      <SubType>Lua</SubType>
+      <ImportIntoVFS>False</ImportIntoVFS>
+    </Content>
+    <Content Include="Core Files\Core Tables\CoreTableAdditions1HH.xml">
       <SubType>Lua</SubType>
       <ImportIntoVFS>False</ImportIntoVFS>
     </Content>

--- a/Community Patch/Core Files/Core Tables/CoreTableAdditions1HH.xml
+++ b/Community Patch/Core Files/Core Tables/CoreTableAdditions1HH.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Created by ModBuddy on 10/14/2016 2:40:55 PM -->
+<GameData>
+	<!-- POLICY: Allows you to define a modifier (+X%) to any type of yield of international trade routes (other than FOOD and PRODUCTION)
+	Interops with UNIFIED_YIELD changes to allow faith, culture, etc. -->
+	<Table name="Policy_InternationalRouteYieldModifiers">
+		<Column name="PolicyType" type="text" reference="Policies(Type)"></Column>
+		<Column name="YieldType" type="text" reference="Yields(Type)"></Column>
+		<Column name="Yield" type="integer" default="0"></Column>
+	</Table>
+</GameData>

--- a/CvGameCoreDLL_Expansion2/CvPolicyClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPolicyClasses.cpp
@@ -313,6 +313,9 @@ CvPolicyEntry::CvPolicyEntry(void):
 	m_piYieldFromMinorDemand(NULL),
 	m_piYieldFromWLTKD(NULL),
 #endif
+#if defined(HH_MOD_API_TRADEROUTE_MODIFIERS)
+	m_piInternationalRouteYieldModifiers(NULL),
+#endif
 	m_ppiBuildingClassYieldModifiers(NULL),
 	m_ppiBuildingClassYieldChanges(NULL),
 	m_piFlavorValue(NULL),
@@ -385,6 +388,9 @@ CvPolicyEntry::~CvPolicyEntry(void)
 	SAFE_DELETE_ARRAY(m_piYieldFromMinorDemand);
 	SAFE_DELETE_ARRAY(m_piYieldFromWLTKD);
 #endif
+#if defined(HH_MOD_API_TRADEROUTE_MODIFIERS)
+	SAFE_DELETE_ARRAY(m_piInternationalRouteYieldModifiers);
+#endif 
 	CvDatabaseUtility::SafeDelete2DArray(m_ppiBuildingClassYieldModifiers);
 	CvDatabaseUtility::SafeDelete2DArray(m_ppiBuildingClassYieldChanges);
 }
@@ -1019,6 +1025,9 @@ bool CvPolicyEntry::CacheResults(Database::Results& kResults, CvDatabaseUtility&
 	kUtility.SetYields(m_piYieldChangeWorldWonder, "Policy_YieldChangeWorldWonder", "PolicyType", szPolicyType);
 	kUtility.SetYields(m_piYieldFromMinorDemand, "Policy_YieldFromMinorDemand", "PolicyType", szPolicyType);
 	kUtility.SetYields(m_piYieldFromWLTKD, "Policy_WLTKDYieldMod", "PolicyType", szPolicyType);
+#endif
+#if defined(HH_MOD_API_TRADEROUTE_MODIFIERS)
+	kUtility.SetYields(m_piInternationalRouteYieldModifiers, "Policy_InternationalRouteYieldModifiers", "PolicyType", szPolicyType);
 #endif
 
 	//ImprovementCultureChanges
@@ -2276,6 +2285,23 @@ int* CvPolicyEntry::GetYieldModifierArray() const
 {
 	return m_piYieldModifier;
 }
+#if defined(HH_MOD_API_TRADEROUTE_MODIFIERS)
+/// Change to traderoute yield modifier by type
+int CvPolicyEntry::GetInternationalRouteYieldModifier(int i) const
+{
+	CvAssertMsg(i < NUM_YIELD_TYPES, "Index out of bounds");
+	CvAssertMsg(i > -1, "Index out of bounds");
+	return m_piInternationalRouteYieldModifiers ? m_piInternationalRouteYieldModifiers[i] : -1;
+}
+
+/// Mimic of m_piYieldModifier array getter
+/* not needed
+int* CvPolicyEntry::GetInternationalRouteYieldModifiersArray() const
+{
+	return m_piInternationalRouteYieldModifiers;
+}
+*/
+#endif
 
 /// Change to yield in every City by type
 int CvPolicyEntry::GetCityYieldChange(int i) const
@@ -3970,6 +3996,20 @@ int CvPlayerPolicies::GetYieldModifier(YieldTypes eYieldType)
 
 	return rtnValue;
 }
+#if defined(HH_MOD_API_TRADEROUTE_MODIFIERS)
+int CvPlayerPolicies::GetInternationalRouteYieldModifier(YieldTypes eYield)
+{
+	int totalModifiersFromPolicies = 0;
+	for (int i = 0; i < m_pPolicies->GetNumPolicies(); i++)
+	{
+		if(m_pabHasPolicy[i] && !IsPolicyBlocked((PolicyTypes)i))
+		{
+			totalModifiersFromPolicies += m_pPolicies->GetPolicyEntry(i)->GetInternationalRouteYieldModifier(eYield);
+		}
+	}
+	return totalModifiersFromPolicies;
+}
+#endif
 
 /// Get yield modifier from policies for a specific building class
 int CvPlayerPolicies::GetBuildingClassYieldModifier(BuildingClassTypes eBuildingClass, YieldTypes eYieldType)

--- a/CvGameCoreDLL_Expansion2/CvPolicyClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvPolicyClasses.h
@@ -336,6 +336,10 @@ public:
 	int GetYieldFromWLTKD(int i) const;
 	int* GetYieldFromWLTKDArray() const;
 #endif
+#if defined(HH_MOD_API_TRADEROUTE_MODIFIERS)
+	int GetInternationalRouteYieldModifier(int i) const;
+	/* int* GetInternationalRouteYieldModifiersArray */
+#endif
 	int GetBuildingClassYieldModifiers(int i, int j) const;
 	int GetBuildingClassYieldChanges(int i, int j) const;
 	int GetFlavorValue(int i) const;
@@ -673,6 +677,9 @@ private:
 	int* m_piYieldFromMinorDemand;
 	int* m_piYieldFromWLTKD;
 #endif
+#if defined(HH_MOD_API_TRADEROUTE_MODIFIERS)
+	int* m_piInternationalRouteYieldModifiers;
+#endif
 	int** m_ppiBuildingClassYieldModifiers;
 	int** m_ppiBuildingClassYieldChanges;
 	int* m_piFlavorValue;
@@ -884,6 +891,9 @@ public:
 	int GetYieldModifier(YieldTypes eYieldType);
 	int GetBuildingClassYieldModifier(BuildingClassTypes eBuildingClass, YieldTypes eYieldType);
 	int GetBuildingClassYieldChange(BuildingClassTypes eBuildingClass, YieldTypes eYieldType);
+#if defined(HH_MOD_API_TRADEROUTE_MODIFIERS)
+	int GetInternationalRouteYieldModifier(YieldTypes eYieldType);
+#endif
 #if defined(MOD_BALANCE_CORE_POLICIES)
 	int GetReligionBuildingClassYieldModifier(BuildingClassTypes eBuildingClass, YieldTypes eYieldType);
 #endif

--- a/CvGameCoreDLL_Expansion2/CvTradeClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTradeClasses.cpp
@@ -3215,6 +3215,29 @@ int CvPlayerTrade::GetTradeConnectionCorporationModifierTimes100(const TradeConn
 	return iModifier;
 }
 #endif
+#if defined(HH_MOD_API_TRADEROUTE_MODIFIERS)
+//	--------------------------------------------------------------------------------
+int CvPlayerTrade::GetTradeConnectionPolicyModifierTimes100(const TradeConnection& kTradeConnection, YieldTypes eYield, bool bAsOriginPlayer)
+{
+	if (bAsOriginPlayer) {
+		CvCity* pOriginCity = CvGameTrade::GetOriginCity(kTradeConnection);
+		if (pOriginCity == NULL)
+		{
+			return 0;
+		}
+		return GET_PLAYER(pOriginCity->getOwner()).GetPlayerPolicies()->GetInternationalRouteYieldModifier(eYield);
+	}
+	else {
+		CvCity* pDestCity = CvGameTrade::GetDestCity(kTradeConnection);
+		if (pDestCity == NULL)
+		{
+			return 0;
+		}
+		return GET_PLAYER(pDestCity->getOwner()).GetPlayerPolicies()->GetInternationalRouteYieldModifier(eYield);
+	}
+	//return 0;
+}
+#endif
 //	--------------------------------------------------------------------------------
 int CvPlayerTrade::GetTradeConnectionValueTimes100 (const TradeConnection& kTradeConnection, YieldTypes eYield, bool bAsOriginPlayer)
 {
@@ -3252,6 +3275,9 @@ int CvPlayerTrade::GetTradeConnectionValueTimes100 (const TradeConnection& kTrad
 					int iCorporationModifier = GetTradeConnectionCorporationModifierTimes100(kTradeConnection, eYield, bAsOriginPlayer);
 					int iOpenBordersModifier = GetTradeConnectionOpenBordersModifierTimes100(kTradeConnection, eYield, bAsOriginPlayer);
 #endif
+#if defined(HH_MOD_API_TRADEROUTE_MODIFIERS)
+					int iPolicyModifier = GetTradeConnectionPolicyModifierTimes100(kTradeConnection, eYield, bAsOriginPlayer);
+#endif
 
 					iValue = iBaseValue;
 					iValue += iOriginPerTurnBonus;
@@ -3272,6 +3298,9 @@ int CvPlayerTrade::GetTradeConnectionValueTimes100 (const TradeConnection& kTrad
 #if defined(MOD_BALANCE_CORE)
 					iModifier += iCorporationModifier;
 					iModifier += iOpenBordersModifier;
+#endif
+#if defined(HH_MOD_API_TRADEROUTE_MODIFIERS)
+					iModifier += iPolicyModifier;
 #endif
 
 					iValue *= iModifier;
@@ -3310,6 +3339,10 @@ int CvPlayerTrade::GetTradeConnectionValueTimes100 (const TradeConnection& kTrad
 					int iCorporationModifier = GetTradeConnectionCorporationModifierTimes100(kTradeConnection, eYield, bAsOriginPlayer);
 					iModifier += iCorporationModifier;
 #endif
+#if defined(HH_MOD_API_TRADEROUTE_MODIFIERS)
+					int iPolicyModifier = GetTradeConnectionPolicyModifierTimes100(kTradeConnection, eYield, bAsOriginPlayer);
+					iModifier += iPolicyModifier;
+#endif
 				
 					iValue *= iModifier;
 					iValue /= 100;
@@ -3317,6 +3350,9 @@ int CvPlayerTrade::GetTradeConnectionValueTimes100 (const TradeConnection& kTrad
 				}
 #endif
 				break;
+#if defined(HH_MOD_API_TRADEROUTE_MODIFIERS)
+/// TODO: Integrate modifier logic into the PRODUCTION and FOOD cases of international trade
+#endif
 #if defined(MOD_BALANCE_CORE)
 			case YIELD_PRODUCTION:
 				{
@@ -3449,6 +3485,9 @@ int CvPlayerTrade::GetTradeConnectionValueTimes100 (const TradeConnection& kTrad
 						int iDomainModifier = GetTradeConnectionDomainValueModifierTimes100(kTradeConnection, eYield);
 						int iDestRiverModifier = GetTradeConnectionRiverValueModifierTimes100(kTradeConnection, eYield, false);
 						int iTraitBonus = GetTradeConnectionOtherTraitValueTimes100(kTradeConnection, eYield, false);
+#if defined(HH_MOD_API_TRADEROUTE_MODIFIERS)
+						int iPolicyModifier = GetTradeConnectionPolicyModifierTimes100(kTradeConnection, eYield, false /*bAsOriginPlayer*/);
+#endif
 
 						iValue = iBaseValue;
 						iValue += iYourBuildingBonus;
@@ -3462,6 +3501,9 @@ int CvPlayerTrade::GetTradeConnectionValueTimes100 (const TradeConnection& kTrad
 
 						iModifier += iDomainModifier;
 						iModifier += iDestRiverModifier;
+#if defined(HH_MOD_API_TRADEROUTE_MODIFIERS)
+						iModifier += iPolicyModifier;
+#endif
 
 						iValue *= iModifier;
 						iValue /= 100;
@@ -3485,6 +3527,10 @@ int CvPlayerTrade::GetTradeConnectionValueTimes100 (const TradeConnection& kTrad
 #endif
 
 						int iModifier = 100;
+#if defined(HH_MOD_API_TRADEROUTE_MODIFIERS)
+						int iPolicyModifier = GetTradeConnectionPolicyModifierTimes100(kTradeConnection, eYield, false /*bAsOriginPlayer*/);
+						iModifier += iPolicyModifier;
+#endif
 
 						iValue = iBaseValue;
 #if defined(MOD_API_UNIFIED_YIELDS)

--- a/CvGameCoreDLL_Expansion2/CvTradeClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvTradeClasses.h
@@ -250,6 +250,10 @@ public:
 	int GetTradeConnectionCorporationModifierTimes100(const TradeConnection& kTradeConnection, YieldTypes eYield, bool bAsOriginPlayer);
 	int GetTradeConnectionOpenBordersModifierTimes100(const TradeConnection& kTradeConnection, YieldTypes eYield, bool bAsOriginPlayer);
 #endif
+#if defined(HH_MOD_API_TRADEROUTE_MODIFIERS)
+	int GetTradeConnectionPolicyModifierTimes100(const TradeConnection& kTradeConnection, YieldTypes eYield, bool bAsOriginPlayer);
+#endif
+
 	int GetTradeConnectionValueTimes100 (const TradeConnection& kTradeConnection, YieldTypes eYield, bool bAsOriginPlayer);
 	void UpdateTradeConnectionValues (void); // updates the all the values for the trade routes that go to and from this player
 

--- a/CvGameCoreDLL_Expansion2/HHMods.h
+++ b/CvGameCoreDLL_Expansion2/HHMods.h
@@ -7,4 +7,9 @@
 #define HH_MOD_NATURAL_WONDER_MODULARITY
 //see: CvPolicyClasses@ CvPolicyEntry; CvPlayer@ CvPlayer
 
+//Modifiers for each yield of international trade routes; secondary table Policy_InternationalRouteYieldModifiers (schema same as Policy_YieldFromBarbarianKills)
+// -- FOOD and PRODUCTION not supported
+#define HH_MOD_API_TRADEROUTE_MODIFIERS
+//see: CvPolicyClasses@ CvPolicyEntry, CvPlayerPolicies; CvTradeClasses@ CvPlayerTrade
+
 #endif


### PR DESCRIPTION
See HHMods.h, which directs you to the preprocessor define HH_MOD_API_TRADEROUTE_MODIFIERS
No tooltips