### PR TITLE
Update LeagueOverview.lua

### DIFF
--- a/Community Balance Patch/LUA/LeagueOverview.lua
+++ b/Community Balance Patch/LUA/LeagueOverview.lua
@@ -1210,6 +1210,28 @@ function VoteYesNoController.new(voteController, entry)
 		voteController:UpdateVoteState();
 	end);
 	
+	instance.VoteUpButton:RegisterCallback(Mouse.eMClick, function()
+		local votes = entry.Votes;
+		if(votes >= 0) then
+			if voteController.VotesAvailable >= 10 then
+				entry.Votes = entry.Votes + 10;
+				voteController.VotesAvailable = voteController.VotesAvailable - 10;
+			else 
+				entry.Votes = entry.Votes + voteController.VotesAvailable;
+				voteController.VotesAvailable = voteController.VotesAvailable - voteController.VotesAvailable;
+			end
+		elseif(votes <= -10) then
+			voteController.VotesAvailable = voteController.VotesAvailable + 10;
+			entry.Votes = entry.Votes + 10;
+		elseif(votes < 0) then
+			voteController.VotesAvailable = voteController.VotesAvailable - entry.Votes;
+			entry.Votes = entry.Votes - entry.Votes;
+		end	
+		
+		entryController:UpdateVoteInstance();
+		voteController:UpdateVoteState();
+	end);
+	
 	instance.VoteDownButton:RegisterCallback(Mouse.eLClick, function()
 		local votes = entry.Votes;
 		if(votes > 0) then
@@ -1218,6 +1240,29 @@ function VoteYesNoController.new(voteController, entry)
 			voteController.VotesAvailable = voteController.VotesAvailable - 1;
 		end	
 		entry.Votes = votes - 1;	
+		
+		entryController:UpdateVoteInstance();
+		voteController:UpdateVoteState();
+	end);
+	
+	instance.VoteDownButton:RegisterCallback(Mouse.eMClick, function()
+		local votes = entry.Votes;
+		if(votes >= 10) then
+			entry.Votes = entry.Votes - 10;
+			voteController.VotesAvailable = voteController.VotesAvailable + 10;
+		elseif(votes > 0) then
+			voteController.VotesAvailable = voteController.VotesAvailable + entry.Votes;
+			entry.Votes = entry.Votes - entry.Votes;
+		elseif(votes <= 0) then
+			if voteController.VotesAvailable >= 10 then
+				entry.Votes = entry.Votes - 10;
+				voteController.VotesAvailable = voteController.VotesAvailable - 10;
+			else 
+				entry.Votes = entry.Votes - voteController.VotesAvailable;
+				voteController.VotesAvailable = voteController.VotesAvailable - voteController.VotesAvailable;
+			end
+		end	
+			
 		
 		entryController:UpdateVoteInstance();
 		voteController:UpdateVoteState();

--- a/EUI Compatibility Files/EUI Compatibility Files/LUA/LeagueOverview.lua
+++ b/EUI Compatibility Files/EUI Compatibility Files/LUA/LeagueOverview.lua
@@ -1194,7 +1194,29 @@ function VoteYesNoController.new(voteController, entry)
 		entryController:UpdateVoteInstance();
 		voteController:UpdateVoteState();
 	end);
-	
+
+	instance.VoteUpButton:RegisterCallback(Mouse.eMClick, function()
+		local votes = entry.Votes;
+		if(votes >= 0) then
+			if voteController.VotesAvailable >= 10 then
+				entry.Votes = entry.Votes + 10;
+				voteController.VotesAvailable = voteController.VotesAvailable - 10;
+			else 
+				entry.Votes = entry.Votes + voteController.VotesAvailable;
+				voteController.VotesAvailable = voteController.VotesAvailable - voteController.VotesAvailable;
+			end
+		elseif(votes <= -10) then
+			voteController.VotesAvailable = voteController.VotesAvailable + 10;
+			entry.Votes = entry.Votes + 10;
+		elseif(votes < 0) then
+			voteController.VotesAvailable = voteController.VotesAvailable - entry.Votes;
+			entry.Votes = entry.Votes - entry.Votes;
+		end	
+		
+		entryController:UpdateVoteInstance();
+		voteController:UpdateVoteState();
+	end);
+
 	instance.VoteUpButton:RegisterCallback(Mouse.eRClick, function()
 		local votes = entry.Votes;
 		local availableVotes = voteController.VotesAvailable;
@@ -1218,6 +1240,29 @@ function VoteYesNoController.new(voteController, entry)
 			voteController.VotesAvailable = voteController.VotesAvailable - 1;
 		end	
 		entry.Votes = votes - 1;	
+		
+		entryController:UpdateVoteInstance();
+		voteController:UpdateVoteState();
+	end);
+	
+	instance.VoteDownButton:RegisterCallback(Mouse.eMClick, function()
+		local votes = entry.Votes;
+		if(votes >= 10) then
+			entry.Votes = entry.Votes - 10;
+			voteController.VotesAvailable = voteController.VotesAvailable + 10;
+		elseif(votes > 0) then
+			voteController.VotesAvailable = voteController.VotesAvailable + entry.Votes;
+			entry.Votes = entry.Votes - entry.Votes;
+		elseif(votes <= 0) then
+			if voteController.VotesAvailable >= 10 then
+				entry.Votes = entry.Votes - 10;
+				voteController.VotesAvailable = voteController.VotesAvailable - 10;
+			else 
+				entry.Votes = entry.Votes - voteController.VotesAvailable;
+				voteController.VotesAvailable = voteController.VotesAvailable - voteController.VotesAvailable;
+			end
+		end	
+			
 		
 		entryController:UpdateVoteInstance();
 		voteController:UpdateVoteState();

--- a/NoEUI Compatibility Files/Mod Template1/LUA/LeagueOverview.lua
+++ b/NoEUI Compatibility Files/Mod Template1/LUA/LeagueOverview.lua
@@ -1195,6 +1195,28 @@ function VoteYesNoController.new(voteController, entry)
 		voteController:UpdateVoteState();
 	end);
 	
+	instance.VoteUpButton:RegisterCallback(Mouse.eMClick, function()
+		local votes = entry.Votes;
+		if(votes >= 0) then
+			if voteController.VotesAvailable >= 10 then
+				entry.Votes = entry.Votes + 10;
+				voteController.VotesAvailable = voteController.VotesAvailable - 10;
+			else 
+				entry.Votes = entry.Votes + voteController.VotesAvailable;
+				voteController.VotesAvailable = voteController.VotesAvailable - voteController.VotesAvailable;
+			end
+		elseif(votes <= -10) then
+			voteController.VotesAvailable = voteController.VotesAvailable + 10;
+			entry.Votes = entry.Votes + 10;
+		elseif(votes < 0) then
+			voteController.VotesAvailable = voteController.VotesAvailable - entry.Votes;
+			entry.Votes = entry.Votes - entry.Votes;
+		end	
+		
+		entryController:UpdateVoteInstance();
+		voteController:UpdateVoteState();
+	end);
+	
 	instance.VoteUpButton:RegisterCallback(Mouse.eRClick, function()
 		local votes = entry.Votes;
 		local availableVotes = voteController.VotesAvailable;
@@ -1218,6 +1240,29 @@ function VoteYesNoController.new(voteController, entry)
 			voteController.VotesAvailable = voteController.VotesAvailable - 1;
 		end	
 		entry.Votes = votes - 1;	
+		
+		entryController:UpdateVoteInstance();
+		voteController:UpdateVoteState();
+	end);
+	
+	instance.VoteDownButton:RegisterCallback(Mouse.eMClick, function()
+		local votes = entry.Votes;
+		if(votes >= 10) then
+			entry.Votes = entry.Votes - 10;
+			voteController.VotesAvailable = voteController.VotesAvailable + 10;
+		elseif(votes > 0) then
+			voteController.VotesAvailable = voteController.VotesAvailable + entry.Votes;
+			entry.Votes = entry.Votes - entry.Votes;
+		elseif(votes <= 0) then
+			if voteController.VotesAvailable >= 10 then
+				entry.Votes = entry.Votes - 10;
+				voteController.VotesAvailable = voteController.VotesAvailable - 10;
+			else 
+				entry.Votes = entry.Votes - voteController.VotesAvailable;
+				voteController.VotesAvailable = voteController.VotesAvailable - voteController.VotesAvailable;
+			end
+		end	
+			
 		
 		entryController:UpdateVoteInstance();
 		voteController:UpdateVoteState();


### PR DESCRIPTION
If a player has 30+ Delegates, it can be annoying to be clicky clicky clicky even with the right-click button. If the player uses the middle button, they will transfer 10 or less delegates toward a yea or a nay instead as a QOL feature.