### PR TITLE
fix event overview panel lock UI next turn issue

### DIFF
--- a/Community Patch/Core Files/CoreLua/CityEventsInfo.lua
+++ b/Community Patch/Core Files/CoreLua/CityEventsInfo.lua
@@ -9,42 +9,22 @@ local g_ItemManagers = {
 	InstanceManager:new( "ItemInstance", "Button", Controls.CityEventsStack ),
 }
 
-local bHidden = true;
-
-local screenSizeX, screenSizeY = UIManager:GetScreenSizeVal()
-local spWidth, spHeight = Controls.ItemScrollPanel:GetSizeVal();
-
--- Original UI designed at 1050px 
-local heightOffset = screenSizeY - 1020;
-
-spHeight = spHeight + heightOffset;
--- Controls.ItemScrollPanel:SetSizeVal(spWidth, spHeight); 
--- Controls.ItemScrollPanel:CalculateInternalSize();
--- Controls.ItemScrollPanel:ReprocessAnchoring();
-
-local bpWidth, bpHeight = Controls.BottomPanel:GetSizeVal();
---bpHeight = bpHeight * heightRatio;
---print(heightOffset);
---print(bpHeight);
-bpHeight = bpHeight + heightOffset 
---print(bpHeight);
-
 -------------------------------------------------
 -- On Popup
 -------------------------------------------------
 function RefreshData()
-	
+
 	local iActivePlayer = Game.GetActivePlayer();
-	local pPlayer = Players[iActivePlayer];	
-	
+	local pPlayer = Players[iActivePlayer];
+
 	g_Model = {};
 
 	local map = Map;
 
-	local iTotal = 0;	
+	local iTotal = 0;
 	local activeCityRecentEventChoices = pPlayer:GetActiveCityEventChoices();
 	for i,v in ipairs(activeCityRecentEventChoices) do
-		
+
 		print("found an event choice")
 		local eventChoice = {
 			EventChoice = v.EventChoice,
@@ -71,11 +51,11 @@ function RefreshData()
 
 		szChoiceDescString = Locale.Lookup(pEventChoiceInfo.Description);
 		szChoiceHelpString = Locale.ConvertTextKey(pTargetCity:GetScaledEventChoiceValue(pEventChoiceInfo.ID));
-		
+
 		eventChoice.EventParentName = szParentDescString;
 		eventChoice.EventChoiceName = szChoiceDescString;
 		eventChoice.EventChoiceDescription = szChoiceHelpString;
-			
+
 		iTotal = iTotal + 1;
 		table.insert(g_Model, eventChoice);
 	end
@@ -104,18 +84,18 @@ function SortData()
 	table.sort(g_Model, g_SortOptions[g_CurrentSortOption][2]);
 end
 
-function Initialize()	
+function Initialize()
 	local sortByPulldown = Controls.SortByPullDown;
 	sortByPulldown:ClearEntries();
 	for i, v in ipairs(g_SortOptions) do
 		local controlTable = {};
 		sortByPulldown:BuildEntry( "InstanceOne", controlTable );
 		controlTable.Button:LocalizeAndSetText(v[1]);
-		
+
 		controlTable.Button:RegisterCallback(Mouse.eLClick, function()
 			sortByPulldown:GetButton():LocalizeAndSetText(v[1]);
 			g_CurrentSortOption = i;
-			
+
 			SortData();
 			DisplayData();
 		end);
@@ -125,15 +105,15 @@ function Initialize()
 end
 
 function DisplayData()
-	
+
 	for _, itemManager in ipairs(g_ItemManagers) do
 		itemManager:ResetInstances();
 	end
-		
+
 	for _, eventChoice in ipairs(g_Model) do
-		
+
 		local itemInstance = g_ItemManagers[1]:GetInstance();
-		
+
 		itemInstance.CityEventChoiceLocation:SetText("[COLOR_MAGENTA]" .. eventChoice.CityName .. "[ENDCOLOR]");
 
 		itemInstance.CityParentEventTitle:SetText("[COLOR_CYAN]" .. eventChoice.EventParentName .. "[ENDCOLOR]");
@@ -148,16 +128,16 @@ function DisplayData()
 		local buttonWidth, buttonHeight = itemInstance.Button:GetSizeVal();
 		local descWidth, descHeight = itemInstance.CityEventInfoStack:GetSizeVal();
 
-		local newHeight = math.max(100, descHeight + 0);	
-		
+		local newHeight = math.max(100, descHeight + 0);
+
 		itemInstance.Button:SetSizeVal(buttonWidth, newHeight);
 		itemInstance.Box:SetSizeVal(buttonWidth, newHeight);
 		itemInstance.BounceAnim:SetSizeVal(buttonWidth, newHeight + 5);
 		itemInstance.BounceGrid:SetSizeVal(buttonWidth, newHeight + 5);
 
-		itemInstance.GoToCity:RegisterCallback(Mouse.eLClick, function() 
+		itemInstance.GoToCity:RegisterCallback(Mouse.eLClick, function()
 			local plot = Map.GetPlot(eventChoice.CityX, eventChoice.CityY);
-			UI.LookAt(plot, 0);  
+			UI.LookAt(plot, 0);
 		end);
 	end
 
@@ -171,23 +151,11 @@ end
 -------------------------------------------------------------------------------
 -------------------------------------------------------------------------------
 function ShowHideHandler( bIsHide, bInitState )
-
-	bHidden = bIsHide;
-    if( not bInitState ) then
-        if( not bIsHide ) then
-        	UI.incTurnTimerSemaphore();
-        	Events.SerialEventGameMessagePopupShown(g_PopupInfo);
-        	
-        	Initialize();
-        	RefreshData();
-        	SortData();
-        	DisplayData();             	
-        else			
-			if(g_PopupInfo ~= nil) then
-				Events.SerialEventGameMessagePopupProcessed.CallImmediate(g_PopupInfo.Type, 0);
-			end
-            UI.decTurnTimerSemaphore();
-        end
+    if ( not bInitState and not bIsHide ) then
+      	Initialize();
+      	RefreshData();
+      	SortData();
+      	DisplayData();
     end
 end
 ContextPtr:SetShowHideHandler( ShowHideHandler );

--- a/Community Patch/Core Files/CoreLua/CityRecentEventsInfo.lua
+++ b/Community Patch/Core Files/CoreLua/CityRecentEventsInfo.lua
@@ -9,42 +9,22 @@ local g_ItemManagers = {
 	InstanceManager:new( "ItemInstance", "Button", Controls.CityRecentEventsStack ),
 }
 
-local bHidden = true;
-
-local screenSizeX, screenSizeY = UIManager:GetScreenSizeVal()
-local spWidth, spHeight = Controls.ItemScrollPanel:GetSizeVal();
-
--- Original UI designed at 1050px 
-local heightOffset = screenSizeY - 1020;
-
-spHeight = spHeight + heightOffset;
--- Controls.ItemScrollPanel:SetSizeVal(spWidth, spHeight); 
--- Controls.ItemScrollPanel:CalculateInternalSize();
--- Controls.ItemScrollPanel:ReprocessAnchoring();
-
-local bpWidth, bpHeight = Controls.BottomPanel:GetSizeVal();
---bpHeight = bpHeight * heightRatio;
---print(heightOffset);
---print(bpHeight);
-bpHeight = bpHeight + heightOffset 
---print(bpHeight);
-
 -------------------------------------------------
 -- On Popup
 -------------------------------------------------
 function RefreshData()
-	
+
 	local iActivePlayer = Game.GetActivePlayer();
-	local pPlayer = Players[iActivePlayer];	
-	
+	local pPlayer = Players[iActivePlayer];
+
 	g_Model = {};
 
 	local map = Map;
 
-	local iTotal = 0;	
+	local iTotal = 0;
 	local activeCityRecentEventChoices = pPlayer:GetRecentCityEventChoices();
 	for i,v in ipairs(activeCityRecentEventChoices) do
-		
+
 		print("found an event choice")
 		local eventChoice = {
 			EventChoice = v.EventChoice,
@@ -82,7 +62,7 @@ function RefreshData()
 		end
 
 		eventChoice.EventChoiceDescription = szChoiceHelpString;
-			
+
 		iTotal = iTotal + 1;
 		table.insert(g_Model, eventChoice);
 	end
@@ -116,18 +96,18 @@ function SortData()
 	table.sort(g_Model, g_SortOptions[g_CurrentSortOption][2]);
 end
 
-function Initialize()	
+function Initialize()
 	local sortByPulldown = Controls.SortByPullDown;
 	sortByPulldown:ClearEntries();
 	for i, v in ipairs(g_SortOptions) do
 		local controlTable = {};
 		sortByPulldown:BuildEntry( "InstanceOne", controlTable );
 		controlTable.Button:LocalizeAndSetText(v[1]);
-		
+
 		controlTable.Button:RegisterCallback(Mouse.eLClick, function()
 			sortByPulldown:GetButton():LocalizeAndSetText(v[1]);
 			g_CurrentSortOption = i;
-			
+
 			SortData();
 			DisplayData();
 		end);
@@ -137,15 +117,15 @@ function Initialize()
 end
 
 function DisplayData()
-	
+
 	for _, itemManager in ipairs(g_ItemManagers) do
 		itemManager:ResetInstances();
 	end
-		
+
 	for _, eventChoice in ipairs(g_Model) do
-		
+
 		local itemInstance = g_ItemManagers[1]:GetInstance();
-		
+
 		itemInstance.CityRecentEventChoiceLocation:SetText("[COLOR_MAGENTA]" .. eventChoice.CityName .. "[ENDCOLOR]");
 
 		if(eventChoice.EventParentName ~= "") then
@@ -165,16 +145,16 @@ function DisplayData()
 		local buttonWidth, buttonHeight = itemInstance.Button:GetSizeVal();
 		local descWidth, descHeight = itemInstance.CityRecentEventInfoStack:GetSizeVal();
 
-		local newHeight = math.max(100, descHeight + 0);	
-		
+		local newHeight = math.max(100, descHeight + 0);
+
 		itemInstance.Button:SetSizeVal(buttonWidth, newHeight);
 		itemInstance.Box:SetSizeVal(buttonWidth, newHeight);
 		itemInstance.BounceAnim:SetSizeVal(buttonWidth, newHeight + 5);
 		itemInstance.BounceGrid:SetSizeVal(buttonWidth, newHeight + 5);
 
-		itemInstance.GoToCity:RegisterCallback(Mouse.eLClick, function() 
+		itemInstance.GoToCity:RegisterCallback(Mouse.eLClick, function()
 			local plot = Map.GetPlot(eventChoice.CityX, eventChoice.CityY);
-			UI.LookAt(plot, 0);  
+			UI.LookAt(plot, 0);
 		end);
 	end
 
@@ -188,23 +168,11 @@ end
 -------------------------------------------------------------------------------
 -------------------------------------------------------------------------------
 function ShowHideHandler( bIsHide, bInitState )
-
-	bHidden = bIsHide;
-    if( not bInitState ) then
-        if( not bIsHide ) then
-        	UI.incTurnTimerSemaphore();
-        	Events.SerialEventGameMessagePopupShown(g_PopupInfo);
-        	
-        	Initialize();
-        	RefreshData();
-        	SortData();
-        	DisplayData();             	
-        else			
-			if(g_PopupInfo ~= nil) then
-				Events.SerialEventGameMessagePopupProcessed.CallImmediate(g_PopupInfo.Type, 0);
-			end
-            UI.decTurnTimerSemaphore();
-        end
+    if ( not bInitState and not bIsHide ) then
+      	Initialize();
+      	RefreshData();
+      	SortData();
+      	DisplayData();
     end
 end
 ContextPtr:SetShowHideHandler( ShowHideHandler );

--- a/Community Patch/Core Files/CoreLua/PlayerEventsInfo.lua
+++ b/Community Patch/Core Files/CoreLua/PlayerEventsInfo.lua
@@ -9,40 +9,20 @@ local g_ItemManagers = {
 	InstanceManager:new( "ItemInstance", "Button", Controls.PlayerEventsStack ),
 }
 
-local bHidden = true;
-
-local screenSizeX, screenSizeY = UIManager:GetScreenSizeVal()
-local spWidth, spHeight = Controls.ItemScrollPanel:GetSizeVal();
-
--- Original UI designed at 1050px 
-local heightOffset = screenSizeY - 1020;
-
-spHeight = spHeight + heightOffset;
--- Controls.ItemScrollPanel:SetSizeVal(spWidth, spHeight); 
--- Controls.ItemScrollPanel:CalculateInternalSize();
--- Controls.ItemScrollPanel:ReprocessAnchoring();
-
-local bpWidth, bpHeight = Controls.BottomPanel:GetSizeVal();
---bpHeight = bpHeight * heightRatio;
---print(heightOffset);
---print(bpHeight);
-bpHeight = bpHeight + heightOffset 
---print(bpHeight);
-
 -------------------------------------------------
 -- On Popup
 -------------------------------------------------
 function RefreshData()
-	
+
 	local iActivePlayer = Game.GetActivePlayer();
-	local pPlayer = Players[iActivePlayer];	
-	
+	local pPlayer = Players[iActivePlayer];
+
 	g_Model = {};
 
-	local iTotal = 0;	
+	local iTotal = 0;
 	local activeEventChoices = pPlayer:GetActivePlayerEventChoices();
 	for i,v in ipairs(activeEventChoices) do
-		
+
 		print("found an event choice")
 		local eventChoice = {
 			EventChoice = v.EventChoice,
@@ -60,11 +40,11 @@ function RefreshData()
 		szParentDescString = Locale.Lookup(pParentEventInfo.Description);
 		szChoiceDescString = Locale.Lookup(pEventChoiceInfo.Description);
 		szChoiceHelpString = Locale.ConvertTextKey(pPlayer:GetScaledEventChoiceValue(pEventChoiceInfo.ID));
-		
+
 		eventChoice.EventParentName = szParentDescString;
 		eventChoice.EventChoiceName = szChoiceDescString;
 		eventChoice.EventChoiceDescription = szChoiceHelpString;
-		
+
 		iTotal = iTotal + 1;
 		table.insert(g_Model, eventChoice);
 	end
@@ -93,18 +73,18 @@ function SortData()
 	table.sort(g_Model, g_SortOptions[g_CurrentSortOption][2]);
 end
 
-function Initialize()	
+function Initialize()
 	local sortByPulldown = Controls.SortByPullDown;
 	sortByPulldown:ClearEntries();
 	for i, v in ipairs(g_SortOptions) do
 		local controlTable = {};
 		sortByPulldown:BuildEntry( "InstanceOne", controlTable );
 		controlTable.Button:LocalizeAndSetText(v[1]);
-		
+
 		controlTable.Button:RegisterCallback(Mouse.eLClick, function()
 			sortByPulldown:GetButton():LocalizeAndSetText(v[1]);
 			g_CurrentSortOption = i;
-			
+
 			SortData();
 			DisplayData();
 		end);
@@ -114,15 +94,15 @@ function Initialize()
 end
 
 function DisplayData()
-	
+
 	for _, itemManager in ipairs(g_ItemManagers) do
 		itemManager:ResetInstances();
 	end
-		
+
 	for _, eventChoice in ipairs(g_Model) do
-		
+
 		local itemInstance = g_ItemManagers[1]:GetInstance();
-		
+
 		itemInstance.PlayerParentEventTitle:SetText("[COLOR_CYAN]" .. eventChoice.EventParentName .. "[ENDCOLOR]");
 		itemInstance.PlayerEventChoiceTitle:SetText(Locale.ConvertTextKey("TXT_KEY_EVENT_CHOICE_UI") .. " " .. eventChoice.EventChoiceName);
 		itemInstance.PlayerEventChoiceHelpText:SetText(Locale.ConvertTextKey("TXT_KEY_EVENT_CHOICE_RESULT_UI") .. " " .. eventChoice.EventChoiceDescription);
@@ -134,8 +114,8 @@ function DisplayData()
 
 		local buttonWidth, buttonHeight = itemInstance.Button:GetSizeVal();
 		local descWidth, descHeight = itemInstance.PlayerEventInfoStack:GetSizeVal();
-		local newHeight = math.max(100, descHeight + 0);	
-		
+		local newHeight = math.max(100, descHeight + 0);
+
 		itemInstance.Button:SetSizeVal(buttonWidth, newHeight);
 		itemInstance.Box:SetSizeVal(buttonWidth, newHeight);
 		itemInstance.BounceAnim:SetSizeVal(buttonWidth, newHeight + 5);
@@ -153,23 +133,11 @@ end
 -------------------------------------------------------------------------------
 -------------------------------------------------------------------------------
 function ShowHideHandler( bIsHide, bInitState )
-
-	bHidden = bIsHide;
-    if( not bInitState ) then
-        if( not bIsHide ) then
-        	UI.incTurnTimerSemaphore();
-        	Events.SerialEventGameMessagePopupShown(g_PopupInfo);
-        	
-        	Initialize();
-        	RefreshData();
-        	SortData();
-        	DisplayData();             	
-        else			
-			if(g_PopupInfo ~= nil) then
-				Events.SerialEventGameMessagePopupProcessed.CallImmediate(g_PopupInfo.Type, 0);
-			end
-            UI.decTurnTimerSemaphore();
-        end
+    if ( not bInitState and not bIsHide ) then
+      	Initialize();
+      	RefreshData();
+      	SortData();
+      	DisplayData();
     end
 end
 ContextPtr:SetShowHideHandler( ShowHideHandler );

--- a/Community Patch/Core Files/CoreLua/RecentEventsInfo.lua
+++ b/Community Patch/Core Files/CoreLua/RecentEventsInfo.lua
@@ -9,42 +9,22 @@ local g_ItemManagers = {
 	InstanceManager:new( "ItemInstance", "Button", Controls.RecentEventsStack ),
 }
 
-local bHidden = true;
-
-local screenSizeX, screenSizeY = UIManager:GetScreenSizeVal()
-local spWidth, spHeight = Controls.ItemScrollPanel:GetSizeVal();
-
--- Original UI designed at 1050px 
-local heightOffset = screenSizeY - 1020;
-
-spHeight = spHeight + heightOffset;
--- Controls.ItemScrollPanel:SetSizeVal(spWidth, spHeight); 
--- Controls.ItemScrollPanel:CalculateInternalSize();
--- Controls.ItemScrollPanel:ReprocessAnchoring();
-
-local bpWidth, bpHeight = Controls.BottomPanel:GetSizeVal();
---bpHeight = bpHeight * heightRatio;
---print(heightOffset);
---print(bpHeight);
-bpHeight = bpHeight + heightOffset 
---print(bpHeight);
-
 -------------------------------------------------
 -- On Popup
 -------------------------------------------------
 function RefreshData()
-	
+
 	local iActivePlayer = Game.GetActivePlayer();
-	local pPlayer = Players[iActivePlayer];	
-	
+	local pPlayer = Players[iActivePlayer];
+
 	g_Model = {};
 
 	local map = Map;
 
-	local iTotal = 0;	
+	local iTotal = 0;
 	local activeRecentEventChoices = pPlayer:GetRecentPlayerEventChoices();
 	for i,v in ipairs(activeRecentEventChoices) do
-		
+
 		print("found an event choice")
 		local eventChoice = {
 			EventChoice = v.EventChoice,
@@ -60,7 +40,7 @@ function RefreshData()
 
 		szChoiceDescString = Locale.Lookup(pEventChoiceInfo.Description);
 		szChoiceHelpString = Locale.ConvertTextKey(pPlayer:GetScaledEventChoiceValue(pEventChoiceInfo.ID));
-		
+
 		if(eventChoice.ParentEvent ~= -1) then
 			local pParentEventInfo = GameInfo.Events[eventChoice.ParentEvent];
 			szParentDescString = Locale.Lookup(pParentEventInfo.Description);
@@ -72,7 +52,7 @@ function RefreshData()
 		end
 
 		eventChoice.EventChoiceDescription = szChoiceHelpString;
-			
+
 		iTotal = iTotal + 1;
 		table.insert(g_Model, eventChoice);
 	end
@@ -101,18 +81,18 @@ function SortData()
 	table.sort(g_Model, g_SortOptions[g_CurrentSortOption][2]);
 end
 
-function Initialize()	
+function Initialize()
 	local sortByPulldown = Controls.SortByPullDown;
 	sortByPulldown:ClearEntries();
 	for i, v in ipairs(g_SortOptions) do
 		local controlTable = {};
 		sortByPulldown:BuildEntry( "InstanceOne", controlTable );
 		controlTable.Button:LocalizeAndSetText(v[1]);
-		
+
 		controlTable.Button:RegisterCallback(Mouse.eLClick, function()
 			sortByPulldown:GetButton():LocalizeAndSetText(v[1]);
 			g_CurrentSortOption = i;
-			
+
 			SortData();
 			DisplayData();
 		end);
@@ -122,15 +102,15 @@ function Initialize()
 end
 
 function DisplayData()
-	
+
 	for _, itemManager in ipairs(g_ItemManagers) do
 		itemManager:ResetInstances();
 	end
-		
+
 	for _, eventChoice in ipairs(g_Model) do
-		
+
 		local itemInstance = g_ItemManagers[1]:GetInstance();
-		
+
 		if(eventChoice.EventParentName ~= "") then
 			itemInstance.RecentParentEventTitle:SetText("[COLOR_CYAN]" .. eventChoice.EventParentName .. "[ENDCOLOR]");
 			itemInstance.RecentEventChoiceTitle:SetText(eventChoice.EventChoiceName);
@@ -147,8 +127,8 @@ function DisplayData()
 		local buttonWidth, buttonHeight = itemInstance.Button:GetSizeVal();
 		local descWidth, descHeight = itemInstance.RecentEventInfoStack:GetSizeVal();
 
-		local newHeight = math.max(100, descHeight + 0);	
-		
+		local newHeight = math.max(100, descHeight + 0);
+
 		itemInstance.Button:SetSizeVal(buttonWidth, newHeight);
 		itemInstance.Box:SetSizeVal(buttonWidth, newHeight);
 		itemInstance.BounceAnim:SetSizeVal(buttonWidth, newHeight + 5);
@@ -165,23 +145,11 @@ end
 -------------------------------------------------------------------------------
 -------------------------------------------------------------------------------
 function ShowHideHandler( bIsHide, bInitState )
-
-	bHidden = bIsHide;
-    if( not bInitState ) then
-        if( not bIsHide ) then
-        	UI.incTurnTimerSemaphore();
-        	Events.SerialEventGameMessagePopupShown(g_PopupInfo);
-        	
-        	Initialize();
-        	RefreshData();
-        	SortData();
-        	DisplayData();             	
-        else			
-			if(g_PopupInfo ~= nil) then
-				Events.SerialEventGameMessagePopupProcessed.CallImmediate(g_PopupInfo.Type, 0);
-			end
-            UI.decTurnTimerSemaphore();
-        end
+    if ( not bInitState and not bIsHide ) then
+      	Initialize();
+      	RefreshData();
+      	SortData();
+      	DisplayData();
     end
 end
 ContextPtr:SetShowHideHandler( ShowHideHandler );


### PR DESCRIPTION
Hi, I am new to Civ5 mod, 
When I play, I found occupationally if i open/close event overview panel and switch sub panel inside (with EUI), the next turn button can be locked, (no effect when click, but still clickable) , i can reproduce this issue very easily by repeating those operations.

after taking look into the lua file, I think I may found the cause, in those 4 sub panel lua files, 
PlayerEventsInfo.lua, RecentEventsInfo.lua, CityEventsInfo.lua,  CityRecentEventsInfo.lua
they all have ShowHideHandler, and do UI.incTurnTimerSemaphore(); on show and UI.decTurnTimerSemaphore(); on hide

and in EventOverview.lua, it saves m_CurrentPanel as state and call setHide() method for all panels, on close it looks like not calling subpanel SetHide(), and i am not sure how setHide() works internally, whether repeat clicking same sub panel link can result in execute showHideHandler multiple times which can result in unpaired incTurnTimerSemaphore/decTurnTimerSemaphore 

anyway i don't think it's necessary to use incTurnTimerSemaphore on sub panel, since the pair in EventOverview panel will do the job. 

so I removed those code, also cleaned dead code within those 4 files, then it fixed my issue.

please review the change, and let me know if I missed anything.

Thanks,
 