### PR TITLE
Fixed a crash issue for a convert unit when it moves from Land to Sea…

### DIFF
--- a/Community Patch/Core Files/Core Tables/CoreTableEntries.sql
+++ b/Community Patch/Core Files/Core Tables/CoreTableEntries.sql
@@ -1029,6 +1029,9 @@ ALTER TABLE Units ADD ConvertOnDamage BOOLEAN DEFAULT 0;
 -- Unit will convert to another UnitType if "ConvertOnDamage" and "DamageThreshold" are defined.
 ALTER TABLE Units ADD ConvertUnit TEXT DEFAULT NULL REFERENCES Units(Type);
 
+-- Special Units that have a different Special rating can be modified here to load on to ships (e.g. Great People).
+ALTER TABLE Units ADD SpecialUnitCargoLoad TEXT DEFAULT NULL REFERENCES SpecialUnits(Type);
+
 -- Unit will convert to another UnitType. Must define a "ConvertOnDamage" and the "ConvertUnit" Type
 ALTER TABLE Units ADD DamageThreshold INTEGER DEFAULT 0;
 

--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -24938,7 +24938,8 @@ void CvCity::updateStrengthValue()
 			CvPlot* pTarget = plot();
 			for(int iUnitLoop = 0; iUnitLoop < pTarget->getNumUnits(); iUnitLoop++)
 			{
-				if(pTarget->getUnitByIndex(iUnitLoop)->IsGreatGeneral() || pTarget->getUnitByIndex(iUnitLoop)->IsGreatAdmiral())
+				//iamblichos - updated to allow units(or combat generals/admirals) that have the general promotion to boost city strength 
+				if(pTarget->getUnitByIndex(iUnitLoop)->IsGreatGeneral() || pTarget->getUnitByIndex(iUnitLoop)->IsGreatAdmiral() || pTarget->getUnitByIndex(iUnitLoop)->GetGreatGeneralCount() > 0 || pTarget->getUnitByIndex(iUnitLoop)->GetGreatAdmiralCount() > 0)
 				{
 					iStrengthFromUnits *= 2;
 					break;

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -1984,7 +1984,7 @@ void CvUnit::convert(CvUnit* pUnit, bool bIsUpgrade)
 //	Parameters:
 //		bDelay			- If true, the unit will be partially cleaned up, but its final removal will happen at the end of the frame.
 //		ePlayer			- Optional player ID who is doing the killing.
-void CvUnit::kill(bool bDelay, PlayerTypes ePlayer /*= NO_PLAYER*/, bool bConvert)
+void CvUnit::kill(bool bDelay, PlayerTypes ePlayer /*= NO_PLAYER*/, bool bSupply)
 {
 	//nothing to do
 	if (bDelay && isDelayedDeath())
@@ -2273,35 +2273,33 @@ void CvUnit::kill(bool bDelay, PlayerTypes ePlayer /*= NO_PLAYER*/, bool bConver
 				}
 			}
 		}
+		if (bSupply && getUnitInfo().GetSupplyCapBoost() != 0)
+		{
+			if (GET_PLAYER(getOwner()).getCapitalCity() != NULL)
+			{
+				GET_PLAYER(getOwner()).getCapitalCity()->changeCitySupplyFlat(getUnitInfo().GetSupplyCapBoost());
+				if (GET_PLAYER(getOwner()).GetID() == GC.getGame().getActivePlayer())
+				{
+					char text[256] = { 0 };
+					float fDelay = 0.5f;
+					sprintf_s(text, "[COLOR_WHITE]+%d[ENDCOLOR][ICON_WAR]", getUnitInfo().GetSupplyCapBoost());
+					DLLUI->AddPopupText(getX(), getY(), text, fDelay);
+					CvNotifications* pNotification = GET_PLAYER(getOwner()).GetNotifications();
+					if (pNotification)
+					{
+						CvString strMessage;
+						CvString strSummary;
+						strMessage = GetLocalizedText("TXT_KEY_UNIT_EXPENDED_SUPPLY", getNameKey(), getUnitInfo().GetSupplyCapBoost());
+						strSummary = GetLocalizedText("TXT_KEY_UNIT_EXPENDED_SUPPLY_S");
+						pNotification->Add(NOTIFICATION_GENERIC, strMessage, strSummary, getX(), getY(), getOwner());
+					}
+				}
+			}
+		}
 #endif
 		startDelayedDeath();
 		return;
 	}
-#if defined(MOD_BALANCE_CORE)
-	if (!bConvert && ePlayer == NO_PLAYER && getUnitInfo().GetSupplyCapBoost() != 0)
-	{
-		if (GET_PLAYER(getOwner()).getCapitalCity() != NULL)
-		{
-			GET_PLAYER(getOwner()).getCapitalCity()->changeCitySupplyFlat(getUnitInfo().GetSupplyCapBoost());
-			if (GET_PLAYER(getOwner()).GetID() == GC.getGame().getActivePlayer())
-			{
-				char text[256] = { 0 };
-				float fDelay = 0.5f;
-				sprintf_s(text, "[COLOR_WHITE]+%d[ENDCOLOR][ICON_WAR]", getUnitInfo().GetSupplyCapBoost());
-				DLLUI->AddPopupText(getX(), getY(), text, fDelay);
-				CvNotifications* pNotification = GET_PLAYER(getOwner()).GetNotifications();
-				if (pNotification)
-				{
-					CvString strMessage;
-					CvString strSummary;
-					strMessage = GetLocalizedText("TXT_KEY_UNIT_EXPENDED_SUPPLY", getNameKey(), getUnitInfo().GetSupplyCapBoost());
-					strSummary = GetLocalizedText("TXT_KEY_UNIT_EXPENDED_SUPPLY_S");
-					pNotification->Add(NOTIFICATION_GENERIC, strMessage, strSummary, getX(), getY(), getOwner());
-				}
-			}
-		}
-	}
-#endif
 
 #if defined(MOD_GLOBAL_NO_LOST_GREATWORKS)
 	if(MOD_GLOBAL_NO_LOST_GREATWORKS && !bDelay)
@@ -6145,32 +6143,36 @@ bool CvUnit::canLoad(const CvPlot& targetPlot) const
 				}
 
 #if defined(MOD_EVENTS_REBASE)
-				if (MOD_EVENTS_REBASE) {
-					if (GAMEEVENTINVOKE_TESTANY(GAMEEVENT_CanLoadAt, getOwner(), GetID(), targetPlot.getX(), targetPlot.getY()) == GAMEEVENTRETURN_TRUE) {
+				if (MOD_EVENTS_REBASE)
+				{
+					if (GAMEEVENTINVOKE_TESTANY(GAMEEVENT_CanLoadAt, getOwner(), GetID(), targetPlot.getX(), targetPlot.getY()) == GAMEEVENTRETURN_TRUE)
+					{
 						return true;
 					}
-				} else {
-#endif
-				ICvEngineScriptSystem1* pkScriptSystem = gDLL->GetScriptSystem();
-				if (pkScriptSystem)
+				}
+				else
 				{
-					CvLuaArgsHandle args;
-					args->Push(getOwner());
-					args->Push(GetID());
-					args->Push(targetPlot.getX());
-					args->Push(targetPlot.getY());
-
-					// Attempt to execute the game events.
-					// Will return false if there are no registered listeners.
-					bool bResult = false;
-					if (LuaSupport::CallTestAny(pkScriptSystem, "CanLoadAt", args.get(), bResult))
+#endif
+					ICvEngineScriptSystem1* pkScriptSystem = gDLL->GetScriptSystem();
+					if (pkScriptSystem)
 					{
-						// Check the result.
-						if (bResult == true) {
-							return true;
+						CvLuaArgsHandle args;
+						args->Push(getOwner());
+						args->Push(GetID());
+						args->Push(targetPlot.getX());
+						args->Push(targetPlot.getY());
+
+						// Attempt to execute the game events.
+						// Will return false if there are no registered listeners.
+						bool bResult = false;
+						if (LuaSupport::CallTestAny(pkScriptSystem, "CanLoadAt", args.get(), bResult))
+						{
+							// Check the result.
+							if (bResult == true) {
+								return true;
+							}
 						}
 					}
-				}
 #if defined(MOD_EVENTS_REBASE)
 				}
 #endif
@@ -7386,7 +7388,7 @@ bool CvUnit::canHeal(const CvPlot* pPlot, bool bTestVisible, bool bCheckMovement
 	if(!bTestVisible)
 	{
 		// Embarked Units can't heal
-		if(pPlot->needsEmbarkation(this))
+		if(pPlot->needsEmbarkation(this) && !isCargo())
 		{
 			return false;
 		}
@@ -18707,7 +18709,14 @@ void CvUnit::setyieldmodifier(YieldTypes eYield, int iValue)
 	CvAssertMsg(eYield < NUM_YIELD_TYPES, "eYield is expected to be within maximum bounds (invalid Index)");
 	m_yieldModifier[eYield] = (m_yieldModifier[eYield] + iValue);
 }
-
+//	--------------------------------------------------------------------------------
+#if defined(MOD_CARGO_SHIPS)
+SpecialUnitTypes CvUnit::specialUnitCargoLoad() const
+{
+	VALIDATE_OBJECT
+		return((SpecialUnitTypes)(m_pUnitInfo->GetSpecialUnitCargoLoad()));
+}
+#endif
 
 //	--------------------------------------------------------------------------------
 SpecialUnitTypes CvUnit::specialCargo() const
@@ -18756,6 +18765,38 @@ bool CvUnit::isFull() const
 int CvUnit::cargoSpaceAvailable(SpecialUnitTypes eSpecialCargo, DomainTypes eDomainCargo) const
 {
 	VALIDATE_OBJECT
+#if defined(MOD_CARGO_SHIPS)
+	if(MOD_CARGO_SHIPS)
+	{
+		if(specialCargo() != NO_SPECIALUNIT && specialUnitCargoLoad() == NO_SPECIALUNIT)
+		{
+			if(specialCargo() != eSpecialCargo)
+			{
+				return 0;
+			}
+		}
+		if(specialCargo() != NO_SPECIALUNIT && specialUnitCargoLoad() != NO_SPECIALUNIT)
+		{
+			if(eSpecialCargo != specialCargo())
+			{
+				if(eSpecialCargo != specialUnitCargoLoad())
+				{
+					return 0;
+				}
+			}
+		}
+	}
+	else
+	{
+		if(specialCargo() != NO_SPECIALUNIT)
+		{
+			if(specialCargo() != eSpecialCargo)
+			{
+				return 0;
+			}
+		}
+	}
+#else
 	if(specialCargo() != NO_SPECIALUNIT)
 	{
 		if(specialCargo() != eSpecialCargo)
@@ -18763,7 +18804,7 @@ int CvUnit::cargoSpaceAvailable(SpecialUnitTypes eSpecialCargo, DomainTypes eDom
 			return 0;
 		}
 	}
-
+#endif
 	if(domainCargo() != NO_DOMAIN)
 	{
 		if(domainCargo() != eDomainCargo)
@@ -18771,47 +18812,8 @@ int CvUnit::cargoSpaceAvailable(SpecialUnitTypes eSpecialCargo, DomainTypes eDom
 			return 0;
 		}
 	}
-#if defined(MOD_CARGO_SHIPS)
-	if(MOD_CARGO_SHIPS)
-	{
-		IDInfo* pUnitNode;
-		CvUnit* pLoopUnit;
-		CvPlot* pPlot;
-		if(domainCargo() == DOMAIN_LAND)
-		{
-			pPlot = plot();
-			pUnitNode = pPlot->headUnitNode();
-			while (pUnitNode != NULL)
-			{
-				pLoopUnit = ::getUnit(*pUnitNode);
-				pUnitNode = pPlot->nextUnitNode(pUnitNode);
-				if(pLoopUnit != NULL)
-				{
-					CvPlot* pAdjacentPlot;
-					int iI;
-					for(iI = 0; iI < NUM_DIRECTION_TYPES; ++iI)
-					{
-						pAdjacentPlot = plotDirection(getX(), getY(), ((DirectionTypes)iI));
-						if(pAdjacentPlot != NULL)
-						{
-							if(pLoopUnit->isCargo() && pLoopUnit->IsCanAttackWithMove() && pLoopUnit->canMoveInto(*pAdjacentPlot, MOVEFLAG_ATTACK))
-							{
-								return std::max(0, (cargoSpace() - getCargo() + 1));
-							}
-						}
-					}
-				}
-			}
-			return std::max(0, (cargoSpace() - getCargo()));
-		}
-		else
- 			return std::max(0, (cargoSpace() - getCargo()));
-	}
-	else
-		return std::max(0, (cargoSpace() - getCargo()));
-#else
+
 	return std::max(0, (cargoSpace() - getCargo()));
-#endif
 }
 
 
@@ -19388,39 +19390,6 @@ if (!bDoEvade)
 			}
 		}
 		DoNearbyUnitPromotion(this, pNewPlot);
-		if(isConvertUnit())
-		{
-			CvUnit* pConvertUnit = NULL;
-			for (int iI = 0; iI < GC.getNumPromotionInfos(); iI++)
-			{
-				const PromotionTypes eLoopPromotion = static_cast<PromotionTypes>(iI);
-				CvPromotionEntry* pkPromotionInfo = GC.getPromotionInfo(eLoopPromotion);
-				if(pkPromotionInfo)
-				{
-					if(pkPromotionInfo->GetConvertDomainUnit() != NO_UNIT)
-					{
-						if((pNewPlot->getDomain() == pkPromotionInfo->GetConvertDomain()) && (this->isHasPromotion(eLoopPromotion)) && (pkPromotionInfo->getRequiredUnit() == this->getUnitType()))
-						{
-							UnitAITypes eAIType = NO_UNITAI;
-							const CvUnitEntry* pkUnitType = GC.getUnitInfo(pkPromotionInfo->GetConvertDomainUnit());
-							if(pkUnitType != NULL)
-							{
-								eAIType = (UnitAITypes)pkUnitType->GetDefaultUnitAIType();
-								CvUnit* pNewUnit = GET_PLAYER(getOwner()).initUnit(pkPromotionInfo->GetConvertDomainUnit(), this->getX(), this->getY(), eAIType, NO_DIRECTION, false, false, 0, 0, NO_CONTRACT, false);
-								pConvertUnit = pNewUnit;
-							}
-						}
-					}
-				}
-			}
-			if(pConvertUnit != NULL)
-			{
-				this->setEmbarked(false);
-				pConvertUnit->convert(this, true);
-				pConvertUnit->setupGraphical();
-				pConvertUnit->finishMoves();
-			}
-		}
 #endif
 		// Moving into a City (friend or foe)
 		if(pNewCity != NULL)
@@ -20056,6 +20025,37 @@ if (!bDoEvade)
 					Localization::String strSummary = Localization::Lookup("TXT_KEY_NOTIFICATION_ENEMY_SUMMARY");
 					pNotifications->Add(NOTIFICATION_ENEMY_IN_TERRITORY, strMessage.toUTF8(), strSummary.toUTF8(), iX, iY, getUnitType(), getOwner());
 				}
+			}
+		}
+		if(isConvertUnit())
+		{
+			CvUnit* pConvertUnit = NULL;
+			for (int iI = 0; iI < GC.getNumPromotionInfos(); iI++)
+			{
+				const PromotionTypes eLoopPromotion = static_cast<PromotionTypes>(iI);
+				CvPromotionEntry* pkPromotionInfo = GC.getPromotionInfo(eLoopPromotion);
+				if(pkPromotionInfo)
+				{
+					if(pkPromotionInfo->GetConvertDomainUnit() != NO_UNIT)
+					{
+						if((pNewPlot->getDomain() == pkPromotionInfo->GetConvertDomain()) && (this->isHasPromotion(eLoopPromotion)) && (pkPromotionInfo->getRequiredUnit() == this->getUnitType()))
+						{
+							UnitAITypes eAIType = NO_UNITAI;
+							const CvUnitEntry* pkUnitType = GC.getUnitInfo(pkPromotionInfo->GetConvertDomainUnit());
+							if(pkUnitType != NULL)
+							{
+								eAIType = (UnitAITypes)pkUnitType->GetDefaultUnitAIType();
+								CvUnit* pNewUnit = GET_PLAYER(getOwner()).initUnit(pkPromotionInfo->GetConvertDomainUnit(), this->getX(), this->getY(), eAIType, NO_DIRECTION, true, true, 0, 0, NO_CONTRACT, false);
+								pConvertUnit = pNewUnit;
+							}
+						}
+					}
+				}
+			}
+			if(pConvertUnit != NULL)
+			{
+				this->kill(true, NO_PLAYER, false);
+				pConvertUnit->finishMoves();
 			}
 		}
 	}
@@ -25610,7 +25610,14 @@ bool CvUnit::canAcquirePromotion(PromotionTypes ePromotion) const
 	{
 		return false;
 	}
-
+#if defined(MOD_BALANCE_CORE)
+	CvPlayer& kPlayer = GET_PLAYER(getOwner());
+	PromotionTypes ePromotionRoughTerrain = (PromotionTypes)GC.getInfoTypeForString("PROMOTION_ROUGH_TERRAIN_ENDS_TURN");
+	if(ePromotion == ePromotionRoughTerrain && kPlayer.GetPlayerTraits()->IsConquestOfTheWorld())
+	{
+		return false;
+	}
+#endif
 	//Out-ranged?
 	if (pkPromotionInfo->GetMinRange() != 0 && pkPromotionInfo->GetMinRange() > GetRange())
 		return false;

--- a/CvGameCoreDLL_Expansion2/CvUnit.h
+++ b/CvGameCoreDLL_Expansion2/CvUnit.h
@@ -148,7 +148,7 @@ public:
 	void uninitInfos();  // used to uninit arrays that may be reset due to mod changes
 
 	void convert(CvUnit* pUnit, bool bIsUpgrade);
-	void kill(bool bDelay, PlayerTypes ePlayer = NO_PLAYER, bool bConvert = false);
+	void kill(bool bDelay, PlayerTypes ePlayer = NO_PLAYER, bool bSupply = true);
 
 	void doTurn();
 	bool isActionRecommended(int iAction);
@@ -235,7 +235,9 @@ public:
 
 	bool isCargo() const;
 	void setTransportUnit(CvUnit* pTransportUnit);
-
+#if defined(MOD_CARGO_SHIPS)
+	SpecialUnitTypes specialUnitCargoLoad() const;
+#endif
 	SpecialUnitTypes specialCargo() const;
 	DomainTypes domainCargo() const;
 	int cargoSpace() const;

--- a/CvGameCoreDLL_Expansion2/CvUnitClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnitClasses.cpp
@@ -90,6 +90,7 @@ CvUnitEntry::CvUnitEntry(void) :
 #endif
 #if defined(MOD_CARGO_SHIPS)
 	m_iCargoCombat(0),
+	m_iSpecialUnitCargoLoad(NO_SPECIALUNIT),
 #endif
 	m_iCombatLimit(0),
 	m_iRangedCombat(0),
@@ -397,6 +398,10 @@ bool CvUnitEntry::CacheResults(Database::Results& kResults, CvDatabaseUtility& k
 	{
 		m_iUnitPromotionType = m_iUnitCombatType;
 	}
+#endif
+#if defined(MOD_CARGO_SHIPS)
+	szTextVal = kResults.GetText("SpecialUnitCargoLoad");
+	m_iSpecialUnitCargoLoad = GC.getInfoTypeForString(szTextVal, true);
 #endif
 #if defined(MOD_BALANCE_CORE)
 	szTextVal = kResults.GetText("ResourceType");
@@ -1021,6 +1026,14 @@ int CvUnitEntry::GetSpecialCargo() const
 {
 	return m_iSpecialCargo;
 }
+
+/// Allows this Special unit type to be loaded onto a cargo ship (e.g. Great People)
+#if defined(MOD_CARGO_SHIPS)
+int CvUnitEntry::GetSpecialUnitCargoLoad() const
+{
+	return m_iSpecialUnitCargoLoad;
+}
+#endif
 
 /// Is there a class of units (domain) that this unit carries
 int CvUnitEntry::GetDomainCargo() const

--- a/CvGameCoreDLL_Expansion2/CvUnitClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvUnitClasses.h
@@ -91,6 +91,7 @@ public:
 #endif
 #if defined(MOD_CARGO_SHIPS)
 	int CargoCombat() const;
+	int GetSpecialUnitCargoLoad() const;
 #endif
 	void SetCombat(int iNum);
 	int GetCombatLimit() const;
@@ -315,6 +316,7 @@ private:
 #endif
 #if defined(MOD_CARGO_SHIPS)
 	int m_iCargoCombat;
+	int m_iSpecialUnitCargoLoad;
 #endif
 	int m_iCombatLimit;
 	int m_iRangedCombat;


### PR DESCRIPTION
… or Sea to Land during an AI Operation. Corrected supply to reflect this.

Cargo Ship Mod: can load civilians if defined.
Conquest of the World Trait (Mongolia) Chariot Archers don't receive rough terrain penalty.