### PR TITLE
Update CityStateStatusHelper.lua

### DIFF
--- a/EUI Compatibility Files/EUI Compatibility Files/LUA/CityStateStatusHelper.lua
+++ b/EUI Compatibility Files/EUI Compatibility Files/LUA/CityStateStatusHelper.lua
@@ -38,6 +38,8 @@ local civ5_mode = type( MouseOverStrategicViewResource ) == "function"
 
 local newLine = civ5_mode and "[NEWLINE]" or "/n"
 
+local iEmbassy = GameInfoTypes.IMPROVEMENT_EMBASSY
+
 --[[
 local GetCityStateStatusRow = GetCityStateStatusRow
 local GetCityStateStatusType = GetCityStateStatusType
@@ -433,7 +435,11 @@ function GetCityStateStatusToolTip( majorPlayerID, minorPlayerID, isFullInfo )
 		-- Status
 		tip = tip .. " " .. GetCityStateStatusText( majorPlayerID, minorPlayerID )
 		table_insert( tips, tip )
-
+		if minorPlayer:GetImprovementCount(iEmbassy) > 0 then
+			table_insert( tips, L"[COLOR_NEGATIVE_TEXT]Embassy Established.[ENDCOLOR]")
+		else
+			table_insert( tips, L"[COLOR_POSITIVE_TEXT]Establish an Embassy Available![ENDCOLOR]")
+		end
 		-- Influence change
 		if gk_mode then
 			local influenceAnchor = minorPlayer:GetMinorCivFriendshipAnchorWithMajor(majorPlayerID)

--- a/EUI Compatibility Files/EUI Compatibility Files/LUA/CityStateStatusHelper.lua
+++ b/EUI Compatibility Files/EUI Compatibility Files/LUA/CityStateStatusHelper.lua
@@ -436,9 +436,9 @@ function GetCityStateStatusToolTip( majorPlayerID, minorPlayerID, isFullInfo )
 		tip = tip .. " " .. GetCityStateStatusText( majorPlayerID, minorPlayerID )
 		table_insert( tips, tip )
 		if minorPlayer:GetImprovementCount(iEmbassy) > 0 then
-			table_insert( tips, L"[COLOR_NEGATIVE_TEXT]Embassy Established.[ENDCOLOR]")
+			table_insert( tips, L"[COLOR_NEGATIVE_TEXT][ICON_CITY_STATE] Embassy Established.[ENDCOLOR]")
 		else
-			table_insert( tips, L"[COLOR_POSITIVE_TEXT]Establish an Embassy Available![ENDCOLOR]")
+			table_insert( tips, L"[COLOR_POSITIVE_TEXT][ICON_CITY_STATE] Establish an Embassy Available![ENDCOLOR]")
 		end
 		-- Influence change
 		if gk_mode then

--- a/NoEUI Compatibility Files/Mod Template1/LUA/CityStateStatusHelper.lua
+++ b/NoEUI Compatibility Files/Mod Template1/LUA/CityStateStatusHelper.lua
@@ -312,7 +312,12 @@ function GetCityStateStatusToolTip(iMajor, iMinor, bFullInfo)
 										    
 		strStatusTT = strStatusTT .. "[NEWLINE][NEWLINE]" .. Locale.ConvertTextKey("TXT_KEY_NEUTRAL_CSTATE_TT", strShortDescKey);
 	end
-	
+	-- Embassy Check
+	if pMinor:GetImprovementCount(iEmbassy) > 0 then
+		strStatusTT = strStatusTT .. "[NEWLINE][COLOR_NEGATIVE_TEXT][ICON_CITY_STATE] Embassy Established.[ENDCOLOR]";
+	else
+		strStatusTT = strStatusTT .. "[NEWLINE][COLOR_POSITIVE_TEXT][ICON_CITY_STATE] Establish an Embassy Available![ENDCOLOR]";
+	end
 	-- Influence change
 	if (iInfluence ~= iInfluenceAnchor) then
 		strStatusTT = strStatusTT .. "[NEWLINE][NEWLINE]";

--- a/NoEUI Compatibility Files/Mod Template1/LUA/CityStateStatusHelper.lua
+++ b/NoEUI Compatibility Files/Mod Template1/LUA/CityStateStatusHelper.lua
@@ -19,6 +19,8 @@ local kNegBarRange = 81;
 local kBarIconAtlas = "CITY_STATE_INFLUENCE_METER_ICON_ATLAS";
 local kBarIconNeutralIndex = 4;
 
+local iEmbassy = GameInfoTypes.IMPROVEMENT_EMBASSY
+
 -- The order of precedence in which the quest icons and tooltip points are displayed
 ktQuestsDisplayOrder = {
 	-- Global quests are first


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13937047/31870255-c79ffabe-b761-11e7-935a-90670d94349b.png)
![image](https://user-images.githubusercontent.com/13937047/31870250-ba570abe-b761-11e7-9677-0b27df06cf23.png)


This code I tested out for EUI. It basically allows you to view whether or not an Embassy has been established. It won't tell you who owns it because that's too much codework for a simple info that you should just hover to the city-state itself and check it out for yourself.

Ignore the linebreak though. My modmod makes a linebreak to distinguish its CS trait from the rest of the info.

BUT FOR NON-EUI, I DO NOT KNOW HOW THE FORMAT WORK SO THIS IS JUST BASED ON MEMORY. TEST OUT THE NON-EUI UI IF APPROVED

https://github.com/LoneGazebo/Community-Patch-DLL/issues/3406