### PR TITLE
AirInterceptRangeChange and PolicyGEorGM

### DIFF
--- a/Community Patch/Core Files/Core Tables/CoreTableEntries.sql
+++ b/Community Patch/Core Files/Core Tables/CoreTableEntries.sql
@@ -804,6 +804,9 @@ ALTER TABLE UnitPromotions ADD IsNearbyEnemyCityPromotion BOOLEAN DEFAULT 0;
 ALTER TABLE UnitPromotions ADD IsFriendlyLands BOOLEAN DEFAULT 0;
 ALTER TABLE UnitPromotions ADD RequiredUnit TEXT DEFAULT NULL REFERENCES Units(Type);
 
+-- Changes the intercept range against air units (NEW)
+ALTER TABLE UnitPromotions ADD AirInterceptRangeChange INTEGER DEFAULT 0;
+
 -- Allows you to Convert a unit when it X plot is a different domain, e.g. A great general becomes a great admiral, etc.
 ALTER TABLE UnitPromotions ADD ConvertDomainUnit TEXT DEFAULT NULL REFERENCES Units(Type);
 ALTER TABLE UnitPromotions ADD ConvertDomain TEXT DEFAULT NULL REFERENCES Domains(Type);

--- a/CvGameCoreDLL_Expansion2/CvAStar.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAStar.cpp
@@ -383,7 +383,7 @@ bool CvAStar::FindPathWithCurrentConfiguration(int iXstart, int iYstart, int iXd
 		if (iStartIndex==giLastStartIndex && iStartIndex>0)
 		{
 			OutputDebugString("Repeated pathfinding start\n");
-			gStackWalker.ShowCallstack();
+			//gStackWalker.ShowCallstack(); //JJ: Commented out because it is messing up the compile and I don't understand why
 		}
 		giLastStartIndex = iStartIndex;
 
@@ -414,8 +414,8 @@ bool CvAStar::FindPathWithCurrentConfiguration(int iXstart, int iYstart, int iXd
 				}
 
 #ifdef STACKWALKER
-				//gStackWalker.SetLog(pLog);
-				//gStackWalker.ShowCallstack();
+				//gStackWalker.SetLog(pLog); //JJ: Commented out because it is messing up the compile and I don't understand why
+				//gStackWalker.ShowCallstack(); //JJ: Commented out because it is messing up the compile and I don't understand why
 #endif
 
 				for (size_t i=0; i<svPathLog.size(); i++)

--- a/CvGameCoreDLL_Expansion2/CvMilitaryAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvMilitaryAI.cpp
@@ -5340,7 +5340,7 @@ int CvMilitaryAI::GetMaxPossibleInterceptions(CvPlot* pTargetPlot, bool bCountPe
 						if ((pLoopUnit->getDomainType() != DOMAIN_AIR) || !(pLoopUnit->hasMoved() && pLoopUnit->GetActivityType() == ACTIVITY_INTERCEPT))
 						{
 							// Test range
-							if (plotDistance(pLoopUnit->getX(), pLoopUnit->getY(), pTargetPlot->getX(), pTargetPlot->getY()) <= pLoopUnit->getUnitInfo().GetAirInterceptRange())
+							if (plotDistance(pLoopUnit->getX(), pLoopUnit->getY(), pTargetPlot->getX(), pTargetPlot->getY()) <= (pLoopUnit->getUnitInfo().GetAirInterceptRange() + pLoopUnit->GetExtraAirInterceptRange())) // JJ: Added consideration for additional intercept range from promotions
 							{
 								if (pLoopUnit->currInterceptionProbability() > 0)
 								{

--- a/CvGameCoreDLL_Expansion2/CvPolicyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPolicyAI.cpp
@@ -697,8 +697,15 @@ void CvPolicyAI::DoChooseIdeology(CvPlayer *pPlayer)
 	if(iPolicyGEorGM > 0)
 	{
 		CvCity* pLoopCity;
+		CvCity* pCapital = pPlayer->getCapitalCity(); // JJ: Define capital
 		int iLoop;
-		int iValue = iPolicyGEorGM * (pPlayer->GetCurrentEra() + 1);
+			int iEra = pPlayer->GetCurrentEra(); // JJ: Changed era scaling to match rest of VP
+			if(iEra < 1)
+			{
+				iEra = 1;
+			}
+		int iValue = iPolicyGEorGM * iEra; // JJ: Changed formula
+		iValue *= GC.getGame().getGameSpeedInfo().getTrainPercent(); // JJ: Game speed mod
 		SpecialistTypes eBestSpecialist = NO_SPECIALIST;
 		int iRandom = GC.getGame().getJonRandNum(100, "Random GE or GM value");
 		if(iRandom <= 33)
@@ -715,70 +722,79 @@ void CvPolicyAI::DoChooseIdeology(CvPlayer *pPlayer)
 		}
 		if(eBestSpecialist != NULL)
 		{
-			for(pLoopCity = pPlayer->firstCity(&iLoop); pLoopCity != NULL; pLoopCity = pPlayer->nextCity(&iLoop))
+			CvSpecialistInfo* pkSpecialistInfo = GC.getSpecialistInfo(eBestSpecialist);
+			if(pkSpecialistInfo)
 			{
-				if(eBestSpecialist == (SpecialistTypes)GC.getInfoTypeForString("SPECIALIST_ENGINEER"))
+				int iGPThreshold = pCapital->GetCityCitizens()->GetSpecialistUpgradeThreshold((UnitClassTypes)pkSpecialistInfo->getGreatPeopleUnitClass());
+				iGPThreshold *= 100;
+				//Get % of threshold for test.
+				iGPThreshold *= iPolicyGEorGM;
+				iGPThreshold /= 100;
+				int iGPThresholdString = iGPThreshold / 100;
+				
+				for(pLoopCity = pPlayer->firstCity(&iLoop); pLoopCity != NULL; pLoopCity = pPlayer->nextCity(&iLoop))
 				{
-					pLoopCity->changeProduction(iValue);
-				}
-				else if(eBestSpecialist == (SpecialistTypes)GC.getInfoTypeForString("SPECIALIST_MERCHANT"))
-				{
-					pPlayer->GetTreasury()->ChangeGold(iValue);
-				}
-				else if(eBestSpecialist == (SpecialistTypes)GC.getInfoTypeForString("SPECIALIST_SCIENTIST"))
-				{
-					TechTypes eCurrentTech = pPlayer->GetPlayerTechs()->GetCurrentResearch();
-					if(eCurrentTech == NO_TECH)
+					if(eBestSpecialist == (SpecialistTypes)GC.getInfoTypeForString("SPECIALIST_ENGINEER"))
 					{
-						pPlayer->changeOverflowResearch(iValue);
-						if(pPlayer->getOverflowResearch() <= 0)
+						pLoopCity->changeProduction(iValue*2); // JJ: Production yield is 2x of science
+					}
+					else if(eBestSpecialist == (SpecialistTypes)GC.getInfoTypeForString("SPECIALIST_MERCHANT"))
+					{
+						pPlayer->GetTreasury()->ChangeGold(iValue*4); // JJ: Gold yield is 4x of science, 2x of production
+					}
+					else if(eBestSpecialist == (SpecialistTypes)GC.getInfoTypeForString("SPECIALIST_SCIENTIST"))
+					{
+						TechTypes eCurrentTech = pPlayer->GetPlayerTechs()->GetCurrentResearch();
+						if(eCurrentTech == NO_TECH)
 						{
-							pPlayer->setOverflowResearch(0);
+							pPlayer->changeOverflowResearch(iValue);
+							if(pPlayer->getOverflowResearch() <= 0)
+							{
+								pPlayer->setOverflowResearch(0);
+							}
+						}
+						else
+						{
+							GET_TEAM(pPlayer->getTeam()).GetTeamTechs()->ChangeResearchProgress(eCurrentTech, iValue, pPlayer->GetID());
+							if(GET_TEAM(pPlayer->getTeam()).GetTeamTechs()->GetResearchProgress(eCurrentTech) <= 0)
+							{
+								GET_TEAM(pPlayer->getTeam()).GetTeamTechs()->SetResearchProgress(eCurrentTech, 0, pPlayer->GetID());
+							}
 						}
 					}
-					else
-					{
-						GET_TEAM(pPlayer->getTeam()).GetTeamTechs()->ChangeResearchProgress(eCurrentTech, iValue, pPlayer->GetID());
-						if(GET_TEAM(pPlayer->getTeam()).GetTeamTechs()->GetResearchProgress(eCurrentTech) <= 0)
-						{
-							GET_TEAM(pPlayer->getTeam()).GetTeamTechs()->SetResearchProgress(eCurrentTech, 0, pPlayer->GetID());
-						}
-					}
-				}
-				CvSpecialistInfo* pkSpecialistInfo = GC.getSpecialistInfo(eBestSpecialist);
-				if(pkSpecialistInfo)
-				{
-					int iGPThreshold = pLoopCity->GetCityCitizens()->GetSpecialistUpgradeThreshold((UnitClassTypes)pkSpecialistInfo->getGreatPeopleUnitClass());
-					iGPThreshold *= 100;
-					//Get % of threshold for test.
-					iGPThreshold *= iPolicyGEorGM;
-					iGPThreshold /= 100;
+				//CvSpecialistInfo* pkSpecialistInfo = GC.getSpecialistInfo(eBestSpecialist);
+				// JJ: Moved outside of for loop
+					//int iGPThreshold = pLoopCity->GetCityCitizens()->GetSpecialistUpgradeThreshold((UnitClassTypes)pkSpecialistInfo->getGreatPeopleUnitClass());
+					//iGPThreshold *= 100;
+					////Get % of threshold for test.
+					//iGPThreshold *= iPolicyGEorGM;
+					//iGPThreshold /= 100;
 				
 					pLoopCity->GetCityCitizens()->ChangeSpecialistGreatPersonProgressTimes100(eBestSpecialist, iGPThreshold, true);
 					if(pPlayer->GetID() == GC.getGame().getActivePlayer())
 					{
-						iGPThreshold /= 100;
+						//iGPThreshold /= 100; JJ: Do not touch iGPThreshold in the for loop
 						char text[256] = {0};
 						float fDelay = 0.5f;
-						sprintf_s(text, "[COLOR_WHITE]+%d[ENDCOLOR][ICON_GREAT_PEOPLE]", iGPThreshold);
+						sprintf_s(text, "[COLOR_WHITE]+%d[ENDCOLOR][ICON_GREAT_PEOPLE]", iGPThresholdString);
 						DLLUI->AddPopupText(pLoopCity->getX(),pLoopCity->getY(), text, fDelay);
 						CvNotifications* pNotification = pPlayer->GetNotifications();
 						if(pNotification)
 						{
-							CvString strMessage = GetLocalizedText("TXT_KEY_POLICY_ADOPT_GP_BONUS", iGPThreshold);
+							CvString strMessage = GetLocalizedText("TXT_KEY_POLICY_ADOPT_GP_BONUS", iGPThresholdString);
 							CvString strSummary;
 							// Class specific specialist message
 							if((UnitClassTypes)pkSpecialistInfo->getGreatPeopleUnitClass() == GC.getInfoTypeForString("UNITCLASS_MERCHANT"))
 							{
-								strMessage = GetLocalizedText("TXT_KEY_POLICY_ADOPT_GP_BONUS_MERCHANT", iGPThreshold);
+								strMessage = GetLocalizedText("TXT_KEY_POLICY_ADOPT_GP_BONUS_MERCHANT", iGPThresholdString);
 							}
 							else if((UnitClassTypes)pkSpecialistInfo->getGreatPeopleUnitClass() == GC.getInfoTypeForString("UNITCLASS_ENGINEER"))
 							{
-								strMessage = GetLocalizedText("TXT_KEY_POLICY_ADOPT_GP_BONUS_ENGINEER", iGPThreshold);
+								strMessage = GetLocalizedText("TXT_KEY_POLICY_ADOPT_GP_BONUS_ENGINEER", iGPThresholdString);
 							}
 							else if((UnitClassTypes)pkSpecialistInfo->getGreatPeopleUnitClass() == GC.getInfoTypeForString("UNITCLASS_SCIENTIST"))
 							{
-								strMessage = GetLocalizedText("TXT_KEY_POLICY_ADOPT_GP_BONUS_SCIENTIST", iGPThreshold);
+								strMessage = GetLocalizedText("TXT_KEY_POLICY_ADOPT_GP_BONUS_SCIENTIST", iGPThresholdString);
 							}
 							strSummary = GetLocalizedText("TXT_KEY_POLICY_ADOPT_SUMMARY_GP_BONUS");
 							pNotification->Add(NOTIFICATION_GENERIC, strMessage, strSummary, -1, -1, -1);

--- a/CvGameCoreDLL_Expansion2/CvPolicyClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPolicyClasses.cpp
@@ -4923,8 +4923,15 @@ void CvPlayerPolicies::DoUnlockPolicyBranch(PolicyBranchTypes eBranchType)
 	if(iPolicyGEorGM > 0)
 	{
 		CvCity* pLoopCity;
+		CvCity* pCapital = m_pPlayer->getCapitalCity(); // JJ: Define capital
 		int iLoop;
-		int iValue = iPolicyGEorGM * (m_pPlayer->GetCurrentEra() + 1);
+			int iEra = m_pPlayer->GetCurrentEra(); // JJ: Changed era scaling to match rest of VP
+			if(iEra < 1)
+			{
+				iEra = 1;
+			}
+		int iValue = iPolicyGEorGM * iEra; // JJ: Changed formula
+		iValue *= GC.getGame().getGameSpeedInfo().getTrainPercent(); // JJ: Game speed mod
 		SpecialistTypes eBestSpecialist = NO_SPECIALIST;
 		int iRandom = GC.getGame().getJonRandNum(100, "Random GE or GM value");
 		if(iRandom <= 33)
@@ -4941,70 +4948,79 @@ void CvPlayerPolicies::DoUnlockPolicyBranch(PolicyBranchTypes eBranchType)
 		}
 		if(eBestSpecialist != NULL)
 		{
-			for(pLoopCity = m_pPlayer->firstCity(&iLoop); pLoopCity != NULL; pLoopCity = m_pPlayer->nextCity(&iLoop))
+			CvSpecialistInfo* pkSpecialistInfo = GC.getSpecialistInfo(eBestSpecialist);
+			if(pkSpecialistInfo)
 			{
-				if(eBestSpecialist == (SpecialistTypes)GC.getInfoTypeForString("SPECIALIST_ENGINEER"))
+				int iGPThreshold = pCapital->GetCityCitizens()->GetSpecialistUpgradeThreshold((UnitClassTypes)pkSpecialistInfo->getGreatPeopleUnitClass());
+				iGPThreshold *= 100;
+				//Get % of threshold for test.
+				iGPThreshold *= iPolicyGEorGM;
+				iGPThreshold /= 100;
+				int iGPThresholdString = iGPThreshold / 100;
+				
+				for(pLoopCity = m_pPlayer->firstCity(&iLoop); pLoopCity != NULL; pLoopCity = m_pPlayer->nextCity(&iLoop))
 				{
-					pLoopCity->changeProduction(iValue);
-				}
-				else if(eBestSpecialist == (SpecialistTypes)GC.getInfoTypeForString("SPECIALIST_MERCHANT"))
-				{
-					m_pPlayer->GetTreasury()->ChangeGold(iValue);
-				}
-				else if(eBestSpecialist == (SpecialistTypes)GC.getInfoTypeForString("SPECIALIST_SCIENTIST"))
-				{
-					TechTypes eCurrentTech = m_pPlayer->GetPlayerTechs()->GetCurrentResearch();
-					if(eCurrentTech == NO_TECH)
+					if(eBestSpecialist == (SpecialistTypes)GC.getInfoTypeForString("SPECIALIST_ENGINEER"))
 					{
-						m_pPlayer->changeOverflowResearch(iValue);
-						if(m_pPlayer->getOverflowResearch() <= 0)
+						pLoopCity->changeProduction(iValue*2); // JJ: Production yield is 2x of science
+					}
+					else if(eBestSpecialist == (SpecialistTypes)GC.getInfoTypeForString("SPECIALIST_MERCHANT"))
+					{
+						m_pPlayer->GetTreasury()->ChangeGold(iValue*4); // JJ: Gold yield is 4x of science, 2x of production
+					}
+					else if(eBestSpecialist == (SpecialistTypes)GC.getInfoTypeForString("SPECIALIST_SCIENTIST"))
+					{
+						TechTypes eCurrentTech = m_pPlayer->GetPlayerTechs()->GetCurrentResearch();
+						if(eCurrentTech == NO_TECH)
 						{
-							m_pPlayer->setOverflowResearch(0);
+							m_pPlayer->changeOverflowResearch(iValue);
+							if(m_pPlayer->getOverflowResearch() <= 0)
+							{
+								m_pPlayer->setOverflowResearch(0);
+							}
+						}
+						else
+						{
+							GET_TEAM(m_pPlayer->getTeam()).GetTeamTechs()->ChangeResearchProgress(eCurrentTech, iValue, m_pPlayer->GetID());
+							if(GET_TEAM(m_pPlayer->getTeam()).GetTeamTechs()->GetResearchProgress(eCurrentTech) <= 0)
+							{
+								GET_TEAM(m_pPlayer->getTeam()).GetTeamTechs()->SetResearchProgress(eCurrentTech, 0, m_pPlayer->GetID());
+							}
 						}
 					}
-					else
-					{
-						GET_TEAM(m_pPlayer->getTeam()).GetTeamTechs()->ChangeResearchProgress(eCurrentTech, iValue, m_pPlayer->GetID());
-						if(GET_TEAM(m_pPlayer->getTeam()).GetTeamTechs()->GetResearchProgress(eCurrentTech) <= 0)
-						{
-							GET_TEAM(m_pPlayer->getTeam()).GetTeamTechs()->SetResearchProgress(eCurrentTech, 0, m_pPlayer->GetID());
-						}
-					}
-				}
-				CvSpecialistInfo* pkSpecialistInfo = GC.getSpecialistInfo(eBestSpecialist);
-				if(pkSpecialistInfo)
-				{
-					int iGPThreshold = pLoopCity->GetCityCitizens()->GetSpecialistUpgradeThreshold((UnitClassTypes)pkSpecialistInfo->getGreatPeopleUnitClass());
-					iGPThreshold *= 100;
-					//Get % of threshold for test.
-					iGPThreshold *= iPolicyGEorGM;
-					iGPThreshold /= 100;
+				//CvSpecialistInfo* pkSpecialistInfo = GC.getSpecialistInfo(eBestSpecialist);
+				// JJ: Moved outside of for loop
+					//int iGPThreshold = pLoopCity->GetCityCitizens()->GetSpecialistUpgradeThreshold((UnitClassTypes)pkSpecialistInfo->getGreatPeopleUnitClass());
+					//iGPThreshold *= 100;
+					////Get % of threshold for test.
+					//iGPThreshold *= iPolicyGEorGM;
+					//iGPThreshold /= 100;
 				
 					pLoopCity->GetCityCitizens()->ChangeSpecialistGreatPersonProgressTimes100(eBestSpecialist, iGPThreshold, true);
 					if(m_pPlayer->GetID() == GC.getGame().getActivePlayer())
 					{
-						iGPThreshold /= 100;
+						//iGPThreshold /= 100; JJ: Do not touch iGPThreshold in the for loop
 						char text[256] = {0};
 						float fDelay = 0.5f;
-						sprintf_s(text, "[COLOR_WHITE]+%d[ENDCOLOR][ICON_GREAT_PEOPLE]", iGPThreshold);
+						sprintf_s(text, "[COLOR_WHITE]+%d[ENDCOLOR][ICON_GREAT_PEOPLE]", iGPThresholdString);
 						DLLUI->AddPopupText(pLoopCity->getX(),pLoopCity->getY(), text, fDelay);
 						CvNotifications* pNotification = m_pPlayer->GetNotifications();
 						if(pNotification)
 						{
-							CvString strMessage = GetLocalizedText("TXT_KEY_POLICY_ADOPT_GP_BONUS", iGPThreshold);
+							CvString strMessage = GetLocalizedText("TXT_KEY_POLICY_ADOPT_GP_BONUS", iGPThresholdString);
 							CvString strSummary;
 							// Class specific specialist message
 							if((UnitClassTypes)pkSpecialistInfo->getGreatPeopleUnitClass() == GC.getInfoTypeForString("UNITCLASS_MERCHANT"))
 							{
-								strMessage = GetLocalizedText("TXT_KEY_POLICY_ADOPT_GP_BONUS_MERCHANT", iGPThreshold);
+								strMessage = GetLocalizedText("TXT_KEY_POLICY_ADOPT_GP_BONUS_MERCHANT", iGPThresholdString);
 							}
 							else if((UnitClassTypes)pkSpecialistInfo->getGreatPeopleUnitClass() == GC.getInfoTypeForString("UNITCLASS_ENGINEER"))
 							{
-								strMessage = GetLocalizedText("TXT_KEY_POLICY_ADOPT_GP_BONUS_ENGINEER", iGPThreshold);
+								strMessage = GetLocalizedText("TXT_KEY_POLICY_ADOPT_GP_BONUS_ENGINEER", iGPThresholdString);
 							}
 							else if((UnitClassTypes)pkSpecialistInfo->getGreatPeopleUnitClass() == GC.getInfoTypeForString("UNITCLASS_SCIENTIST"))
 							{
-								strMessage = GetLocalizedText("TXT_KEY_POLICY_ADOPT_GP_BONUS_SCIENTIST", iGPThreshold);
+								strMessage = GetLocalizedText("TXT_KEY_POLICY_ADOPT_GP_BONUS_SCIENTIST", iGPThresholdString);
 							}
 							strSummary = GetLocalizedText("TXT_KEY_POLICY_ADOPT_SUMMARY_GP_BONUS");
 							pNotification->Add(NOTIFICATION_GENERIC, strMessage, strSummary, -1, -1, -1);

--- a/CvGameCoreDLL_Expansion2/CvPromotionClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPromotionClasses.cpp
@@ -42,6 +42,9 @@ CvPromotionEntry::CvPromotionEntry():
 	m_iAirSweepCombatModifier(0),
 	m_iInterceptChanceChange(0),
 	m_iNumInterceptionChange(0),
+#if defined(MOD_BALANCE_CORE)
+	m_iAirInterceptRangeChange(0), // JJ: This is new
+#endif
 	m_iEvasionChange(0),
 	m_iCargoChange(0),
 	m_iEnemyHealChange(0),
@@ -491,6 +494,9 @@ bool CvPromotionEntry::CacheResults(Database::Results& kResults, CvDatabaseUtili
 	m_iAirSweepCombatModifier = kResults.GetInt("AirSweepCombatModifier");
 	m_iInterceptChanceChange = kResults.GetInt("InterceptChanceChange");
 	m_iNumInterceptionChange = kResults.GetInt("NumInterceptionChange");
+#if defined(MOD_BALANCE_CORE)
+	m_iAirInterceptRangeChange = kResults.GetInt("AirInterceptRangeChange"); // JJ: This is new
+#endif
 	m_iEvasionChange = kResults.GetInt("EvasionChange");
 	m_iCargoChange = kResults.GetInt("CargoChange");
 	m_iEnemyHealChange = kResults.GetInt("EnemyHealChange");
@@ -1237,6 +1243,14 @@ int CvPromotionEntry::GetNumInterceptionChange() const
 {
 	return m_iNumInterceptionChange;
 }
+
+#if defined(MOD_BALANCE_CORE) // JJ: This is new
+/// Accessor: How much additional range this promotion allows an unit to perform interception (can be negative)
+int CvPromotionEntry::GetAirInterceptRangeChange() const
+{
+	return m_iAirInterceptRangeChange;
+}
+#endif
 
 /// Accessor: How well an air unit can evade interception
 int CvPromotionEntry::GetEvasionChange() const

--- a/CvGameCoreDLL_Expansion2/CvPromotionClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvPromotionClasses.h
@@ -66,6 +66,9 @@ public:
 	int  GetAirSweepCombatModifier() const;
 	int  GetInterceptChanceChange() const;
 	int  GetNumInterceptionChange() const;
+#if defined(MOD_BALANCE_CORE)
+	int  GetAirInterceptRangeChange() const; // JJ: This is new
+#endif
 	int  GetEvasionChange() const;
 	int  GetCargoChange() const;
 	int  GetEnemyHealChange() const;
@@ -345,6 +348,9 @@ protected:
 	int m_iAirSweepCombatModifier;
 	int m_iInterceptChanceChange;
 	int m_iNumInterceptionChange;
+#if defined(MOD_BALANCE_CORE)
+	int m_iAirInterceptRangeChange; // JJ: This is new
+#endif
 	int m_iEvasionChange;
 	int m_iCargoChange;
 	int m_iEnemyHealChange;

--- a/CvGameCoreDLL_Expansion2/CvRandom.cpp
+++ b/CvGameCoreDLL_Expansion2/CvRandom.cpp
@@ -118,8 +118,8 @@ unsigned long CvRandom::get(unsigned long ulNum, const char* pszLog)
 #if defined(MOD_CORE_DEBUGGING)
 					if(MOD_CORE_DEBUGGING)
 					{
-						gStackWalker.SetLog(pLog);
-						gStackWalker.ShowCallstack();
+						//gStackWalker.SetLog(pLog); //JJ: Commented out because it is messing up the compile and I don't understand why
+						//gStackWalker.ShowCallstack(); //JJ: Commented out because it is messing up the compile and I don't understand why
 					}
 #endif
 				}

--- a/CvGameCoreDLL_Expansion2/CvTacticalAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTacticalAI.cpp
@@ -7851,7 +7851,7 @@ CvUnit* CvTacticalAI::GetProbableInterceptor(CvPlot* pTargetPlot) const
 						if ((pLoopUnit->getDomainType() != DOMAIN_AIR) || !(pLoopUnit->hasMoved() && pLoopUnit->GetActivityType() == ACTIVITY_INTERCEPT))
 						{
 							// Test range
-							if (plotDistance(pLoopUnit->getX(), pLoopUnit->getY(), pTargetPlot->getX(), pTargetPlot->getY()) <= pLoopUnit->getUnitInfo().GetAirInterceptRange())
+							if (plotDistance(pLoopUnit->getX(), pLoopUnit->getY(), pTargetPlot->getX(), pTargetPlot->getY()) <= (pLoopUnit->getUnitInfo().GetAirInterceptRange() + pLoopUnit->GetExtraAirInterceptRange())) // JJ: Added consideration for extra intercept range from promotions
 							{
 								if (pLoopUnit->currInterceptionProbability() > 0)
 								{

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -183,6 +183,9 @@ CvUnit::CvUnit() :
 	, m_iExtraMoveDiscount("CvUnit::m_iExtraMoveDiscount", m_syncArchive)
 	, m_iExtraRange("CvUnit::m_iExtraRange", m_syncArchive)
 	, m_iExtraIntercept("CvUnit::m_iExtraIntercept", m_syncArchive)
+#if defined(MOD_BALANCE_CORE)
+	, m_iExtraAirInterceptRange("CvUnit::m_iExtraAirInterceptRange", m_syncArchive) // JJ: This is new
+#endif
 	, m_iExtraEvasion("CvUnit::m_iExtraEvasion", m_syncArchive)
 	, m_iExtraFirstStrikes("CvUnit::m_iExtraFirstStrikes", m_syncArchive)
 	, m_iExtraChanceFirstStrikes("CvUnit::m_iExtraChanceFirstStrikes", m_syncArchive)
@@ -1311,6 +1314,9 @@ void CvUnit::reset(int iID, UnitTypes eUnit, PlayerTypes eOwner, bool bConstruct
 	m_iExtraMoveDiscount = 0;
 	m_iExtraRange = 0;
 	m_iExtraIntercept = 0;
+#if defined(MOD_BALANCE_CORE)
+	m_iExtraAirInterceptRange = 0; // JJ: This is new
+#endif
 	m_iExtraEvasion = 0;
 	m_iExtraFirstStrikes = 0;
 	m_iExtraChanceFirstStrikes = 0;
@@ -17007,7 +17013,7 @@ CvUnit* CvUnit::GetBestInterceptor(const CvPlot& interceptPlot, const CvUnit* pk
 								{
 									// Test range
 									int iDistance = plotDistance(pLoopUnit->getX(), pLoopUnit->getY(), interceptPlot.getX(), interceptPlot.getY());
-									if( iDistance <= pLoopUnit->getUnitInfo().GetAirInterceptRange())
+									if( iDistance <= ((pLoopUnit->getUnitInfo().GetAirInterceptRange()) + pLoopUnit->GetExtraAirInterceptRange()))
 									{
 										int iValue = pLoopUnit->currInterceptionProbability();
 
@@ -24236,6 +24242,20 @@ void CvUnit::ChangeNumInterceptions(int iChange)
 }
 
 //	--------------------------------------------------------------------------------
+int CvUnit::GetExtraAirInterceptRange() const // JJ: NEW
+{
+	VALIDATE_OBJECT
+	return m_iExtraAirInterceptRange;
+}
+
+//	--------------------------------------------------------------------------------
+void CvUnit::ChangeExtraAirInterceptRange(int iChange) // JJ: NEW
+{
+	VALIDATE_OBJECT
+	m_iExtraAirInterceptRange += iChange;
+}
+
+//	--------------------------------------------------------------------------------
 bool CvUnit::isOutOfInterceptions() const
 {
 	VALIDATE_OBJECT
@@ -26178,6 +26198,10 @@ void CvUnit::setHasPromotion(PromotionTypes eIndex, bool bNewValue)
 		changeExtraRoughDefensePercent(thisPromotion.GetRoughDefensePercent() * iChange);
 		changeExtraAttacks(thisPromotion.GetExtraAttacks() * iChange);
 		ChangeNumInterceptions(thisPromotion.GetNumInterceptionChange() * iChange);
+
+#if defined(MOD_BALANCE_CORE) // JJ: New
+		ChangeExtraAirInterceptRange(thisPromotion.GetAirInterceptRangeChange() * iChange);
+#endif
 
 		ChangeGreatGeneralCount(thisPromotion.IsGreatGeneral() ? iChange: 0);
 		ChangeGreatAdmiralCount(thisPromotion.IsGreatAdmiral() ? iChange: 0);

--- a/CvGameCoreDLL_Expansion2/CvUnit.h
+++ b/CvGameCoreDLL_Expansion2/CvUnit.h
@@ -1293,6 +1293,9 @@ public:
 	int GetNumInterceptions() const;
 	void ChangeNumInterceptions(int iChange);
 
+	int GetExtraAirInterceptRange() const; // JJ: New
+	void ChangeExtraAirInterceptRange(int iChange);
+
 	bool isOutOfInterceptions() const;
 	int getMadeInterceptionCount() const;
 	void setMadeInterception(bool bNewValue);
@@ -1972,6 +1975,9 @@ protected:
 	FAutoVariable<int, CvUnit> m_iOutsideFriendlyLandsModifier;
 	FAutoVariable<int, CvUnit> m_iHealIfDefeatExcludeBarbariansCount;
 	FAutoVariable<int, CvUnit> m_iNumInterceptions;
+#if defined(MOD_BALANCE_CORE) // JJ: NEW
+	FAutoVariable<int, CvUnit> m_iExtraAirInterceptRange;
+#endif
 	FAutoVariable<int, CvUnit> m_iMadeInterceptionCount;
 	FAutoVariable<int, CvUnit> m_iEverSelectedCount;
 	FAutoVariable<int, CvUnit> m_iSapperCount;


### PR DESCRIPTION
Changes for upcoming civ compatibility I'm working on. Literally first time editing DLL codes, hopefully it goes well....

## Added AirInterceptRangeChange column to UnitPromotions.
- Allows you to increase (or decrease) AirInterceptRange of a unit using promotions.
## Edited formula for PolicyGEorGM in Traits.
- Gold and production now 4x and 2x of the value stated in the PolicyGEorGM column.
- Yields scale with era according to the current formula, as well as game speed.
- Great person points granted from one policy unlock will always the same. Previously, if a great person is born while the game is cycling through cities, the points you get for subsequent cities will change.
- Since the column isn't used anywhere, I hope it's fine if I just edit it directly like this.
## Note
- Commented out a few lines that have to do with stackwalker just to get the original DLL to compile. Not sure what happened there. I'm hoping someone who knows better can tell me.