### PR TITLE
Trait for modifying starting free experience

### DIFF
--- a/Community Patch/Core Files/Core Tables/CoreTableAdditions.xml
+++ b/Community Patch/Core Files/Core Tables/CoreTableAdditions.xml
@@ -738,6 +738,13 @@
 		<Column name="UnitClassType" type="text" reference="UnitClasses(Type)"/>
 		<Column name="Number" type="integer"/>
 	</Table>
+
+	<!-- TRAIT: Increases the free experience you get (eg from buildings or policies) for a certain domain, modifier is an integer, eg 50 for +50% -->
+	<Table name="Trait_DomainFreeExperienceModifier">
+		<Column name="TraitType" type="text" reference="Traits(Type)"/>
+		<Column name="DomainType" type="text" reference="Domains(Type)"/>
+		<Column name="Modifier" type="integer"/>
+	</Table>
 	
 	<!-- RESOURCES: Allows Resources to grant bonuses if you control a monopoly of the resource. Must have DEALS functions enabled to use. -->
 	<Table name="Resource_YieldChangeFromMonopoly">

--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -9698,6 +9698,10 @@ int CvCity::getProductionExperience(UnitTypes eUnit)
 	iExperience = getFreeExperience();
 	iExperience += kOwner.getFreeExperience();
 
+#if defined(MOD_BALANCE_CORE)
+	int iExperienceModifier = 0;
+#endif
+
 	if(eUnit != NO_UNIT)
 	{
 		CvUnitEntry* pkUnitInfo = GC.getUnitInfo(eUnit);
@@ -9715,8 +9719,21 @@ int CvCity::getProductionExperience(UnitTypes eUnit)
 #endif
 
 			iExperience += getSpecialistFreeExperience();
+
+#if defined(MOD_BALANCE_CORE)
+			// JJ: Get modifier from trait
+			iExperienceModifier += kOwner.GetPlayerTraits()->GetDomainFreeExperienceModifier((DomainTypes)(pkUnitInfo->GetDomainType()));				
+#endif
 		}
 	}
+
+#if defined(MOD_BALANCE_CORE)
+	if(iExperienceModifier != 0) // JJ: Apply modifier if it is non-zero
+	{
+		iExperience *= (100 + iExperienceModifier);
+		iExperience /= 100;
+	}
+#endif
 
 	return std::max(0, iExperience);
 }

--- a/CvGameCoreDLL_Expansion2/CvTraitClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTraitClasses.cpp
@@ -257,6 +257,7 @@ CvTraitEntry::CvTraitEntry() :
 	m_bCombatBoostNearNaturalWonder(false),
 	m_piNumPledgesDomainProdMod(NULL),
 	m_piFreeUnitClassesDOW(NULL),
+	m_piDomainFreeExperienceModifier(NULL),
 	m_ppiYieldFromTileEarnTerrainType(NULL),
 #endif
 #if defined(MOD_API_UNIFIED_YIELDS)
@@ -1454,6 +1455,12 @@ int CvTraitEntry::GetNumPledgeDomainProductionModifier(DomainTypes eDomain) cons
 	CvAssertMsg((int)eDomain > -1, "Index out of bounds");
 	return m_piNumPledgesDomainProdMod ? m_piNumPledgesDomainProdMod[(int)eDomain] : 0;
 }
+int CvTraitEntry::GetDomainFreeExperienceModifier(DomainTypes eDomain) const
+{
+	CvAssertMsg((int)eDomain < NUM_DOMAIN_TYPES, "Index out of bounds");
+	CvAssertMsg((int)eDomain > -1, "Index out of bounds");
+	return m_piDomainFreeExperienceModifier ? m_piDomainFreeExperienceModifier[(int)eDomain] : 0;
+}
 int CvTraitEntry::GetFreeUnitClassesDOW(UnitClassTypes eUnitClass) const
 {
 	CvAssertMsg((int)eUnitClass < GC.getNumUnitClassInfos(), "Index out of bounds");
@@ -2244,6 +2251,7 @@ bool CvTraitEntry::CacheResults(Database::Results& kResults, CvDatabaseUtility& 
 	kUtility.SetYields(m_paiGAPToYield, "Trait_GAPToYield", "TraitType", szTraitType);
 	kUtility.SetYields(m_paiMountainRangeYield, "Trait_MountainRangeYield", "TraitType", szTraitType);
 	kUtility.PopulateArrayByValue(m_piNumPledgesDomainProdMod, "Domains", "Trait_NumPledgeDomainProdMod", "DomainType", "TraitType", szTraitType, "Modifier");
+	kUtility.PopulateArrayByValue(m_piDomainFreeExperienceModifier, "Domains", "Trait_DomainFreeExperienceModifier", "DomainType", "TraitType", szTraitType, "Modifier", 0, NUM_DOMAIN_TYPES);
 	kUtility.PopulateArrayByValue(m_piFreeUnitClassesDOW, "UnitClasses", "Trait_FreeUnitClassesDOW", "UnitClassType", "TraitType", szTraitType, "Number");
 #endif
 	const int iNumTerrains = GC.getNumTerrainInfos();
@@ -3804,6 +3812,7 @@ void CvPlayerTraits::InitPlayerTraits()
 			for (int iDomain = 0; iDomain < NUM_DOMAIN_TYPES; iDomain++)
 			{
 				m_aiNumPledgesDomainProdMod[iDomain] = trait->GetNumPledgeDomainProductionModifier((DomainTypes)iDomain);
+				m_aiDomainFreeExperienceModifier[iDomain] = trait->GetDomainFreeExperienceModifier((DomainTypes)iDomain);
 			}
 #endif
 
@@ -3884,6 +3893,9 @@ void CvPlayerTraits::Uninit()
 	m_aiFreeUnitClassesDOW.clear();
 #endif
 	m_ppaaiSpecialistYieldChange.clear();
+#if defined(MOD_BALANCE_CORE)
+	m_aiDomainFreeExperienceModifier.clear();
+#endif
 #if defined(MOD_API_UNIFIED_YIELDS)
 	m_ppiGreatPersonExpendedYield.clear();
 	m_ppiGreatPersonBornYield.clear();
@@ -4300,13 +4312,16 @@ void CvPlayerTraits::Reset()
 
 	m_aiNumPledgesDomainProdMod.clear();
 	m_aiFreeUnitClassesDOW.clear();
+	m_aiDomainFreeExperienceModifier.clear();
 
 	m_aiNumPledgesDomainProdMod.resize(NUM_DOMAIN_TYPES);
+	m_aiDomainFreeExperienceModifier.resize(NUM_DOMAIN_TYPES);
 	m_aiFreeUnitClassesDOW.resize(GC.getNumUnitClassInfos());
 
 	for (int iI = 0; iI < NUM_DOMAIN_TYPES; iI++)
 	{
 		m_aiNumPledgesDomainProdMod[iI] = 0;
+		m_aiDomainFreeExperienceModifier[iI] = 0;
 	}
 
 	m_paiMovesChangeUnitClass.clear();
@@ -6225,6 +6240,7 @@ void CvPlayerTraits::Read(FDataStream& kStream)
 	kStream >> m_aiGoldenAgeFromGreatPersonBirth;
 	kStream >> m_aiNumPledgesDomainProdMod;
 	kStream >> m_aiFreeUnitClassesDOW;
+	kStream >> m_aiDomainFreeExperienceModifier;
 	kStream >> m_ppiYieldFromTileEarnTerrainType;
 
 	kStream >> iNumEntries;
@@ -6633,6 +6649,7 @@ void CvPlayerTraits::Write(FDataStream& kStream)
 	kStream << m_aiGoldenAgeFromGreatPersonBirth;
 	kStream << m_aiNumPledgesDomainProdMod;
 	kStream << m_aiFreeUnitClassesDOW;
+	kStream << m_aiDomainFreeExperienceModifier;
 	kStream << m_ppiYieldFromTileEarnTerrainType;
 
 	kStream << 	m_paiMovesChangeUnitClass.size();

--- a/CvGameCoreDLL_Expansion2/CvTraitClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvTraitClasses.h
@@ -291,6 +291,7 @@ public:
 	int GetGAPToYield(int i) const;
 	int GetMountainRangeYield(int i) const;
 	int GetNumPledgeDomainProductionModifier(DomainTypes eDomain) const;
+	int GetDomainFreeExperienceModifier(DomainTypes eDomain) const;
 	int GetFreeUnitClassesDOW(UnitClassTypes eUnitClass) const;
 	int GetYieldFromTileEarnTerrainType(TerrainTypes eIndex1, YieldTypes eIndex2) const;
 #endif
@@ -637,6 +638,7 @@ protected:
 	bool m_bPopulationBoostReligion;
 	bool m_bCombatBoostNearNaturalWonder;
 	int* m_piNumPledgesDomainProdMod;
+	int* m_piDomainFreeExperienceModifier;
 	int* m_piFreeUnitClassesDOW;
 #endif
 #if defined(MOD_API_UNIFIED_YIELDS)
@@ -1510,6 +1512,10 @@ public:
 	{
 		return ((uint)eDomain < m_aiNumPledgesDomainProdMod.size()) ? m_aiNumPledgesDomainProdMod[(int)eDomain] : 0;
 	};
+	int GetDomainFreeExperienceModifier(DomainTypes eDomain) const
+	{
+		return ((uint)eDomain < m_aiDomainFreeExperienceModifier.size()) ? m_aiDomainFreeExperienceModifier[(int)eDomain] : 0;
+	};
 	int GetFreeUnitClassesDOW(UnitClassTypes eUnitClass) const
 	{
 		return ((uint)eUnitClass < m_aiFreeUnitClassesDOW.size()) ? m_aiFreeUnitClassesDOW[(int)eUnitClass] : 0;
@@ -2059,6 +2065,9 @@ private:
 	std::vector< Firaxis::Array<int, NUM_YIELD_TYPES > > m_ppiTradeRouteYieldChange;
 #endif
 	std::vector< Firaxis::Array<int, NUM_YIELD_TYPES > > m_ppaaiSpecialistYieldChange;
+#if defined(MOD_BALANCE_CORE)
+	std::vector<int> m_aiDomainFreeExperienceModifier;
+#endif
 #if defined(MOD_API_UNIFIED_YIELDS)
 	std::vector<int> m_aiGreatPersonCostReduction;
 	std::vector< Firaxis::Array<int, NUM_YIELD_TYPES > > m_ppiGreatPersonExpendedYield;


### PR DESCRIPTION
- Added table Trait_DomainFreeExperienceModifier.
- Increases the free experience you get (eg from buildings or policies) for a certain domain.
- Fixed missing CoreTableAdditions.xml.