### PR TITLE
Added column AoEDamageOnMove to UnitPromotions

### DIFF
--- a/Community Patch/Core Files/Core Tables/CoreTableEntries.sql
+++ b/Community Patch/Core Files/Core Tables/CoreTableEntries.sql
@@ -758,6 +758,7 @@ ALTER TABLE UnitPromotions ADD 'SplashDamage' INTEGER DEFAULT 0;
 
 ALTER TABLE UnitPromotions ADD 'AOEDamageOnKill' INTEGER DEFAULT 0;
 ALTER TABLE UnitPromotions ADD 'AoEWhileFortified' INTEGER DEFAULT 0;
+ALTER TABLE UnitPromotions ADD 'AoEDamageOnMove' INTEGER DEFAULT 0; -- JJ: Do AoE damage when the unit moves
 
 ALTER TABLE UnitPromotions ADD 'WorkRateMod' INTEGER DEFAULT 0;
 

--- a/CvGameCoreDLL_Expansion2/CvPromotionClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPromotionClasses.cpp
@@ -171,6 +171,7 @@ CvPromotionEntry::CvPromotionEntry():
 	m_iCombatBonusFromNearbyUnitClass(NO_UNITCLASS),
 	m_iWonderProductionModifier(0),
 	m_iAOEDamageOnKill(0),
+	m_iAoEDamageOnMove(0),
 	m_iSplashDamage(0),
 	m_iMinRange(0),
 	m_iMaxRange(0),
@@ -397,6 +398,7 @@ bool CvPromotionEntry::CacheResults(Database::Results& kResults, CvDatabaseUtili
 	m_iNearbyUnitClassBonus = kResults.GetInt("NearbyUnitClassBonus");
 	m_iWonderProductionModifier = kResults.GetInt("WonderProductionModifier");
 	m_iAOEDamageOnKill = kResults.GetInt("AOEDamageOnKill");
+	m_iAoEDamageOnMove = kResults.GetInt("AoEDamageOnMove");
 	m_iSplashDamage = kResults.GetInt("SplashDamage");
 	m_iMinRange = kResults.GetInt("MinimumRangeRequired");
 	m_iMaxRange = kResults.GetInt("MaximumRangeRequired");
@@ -1902,6 +1904,10 @@ int CvPromotionEntry::GetWonderProductionModifier() const
 int CvPromotionEntry::GetAOEDamageOnKill() const
 {
 	return m_iAOEDamageOnKill;
+}
+int CvPromotionEntry::GetAoEDamageOnMove() const
+{
+	return m_iAoEDamageOnMove;
 }
 int CvPromotionEntry::GetSplashDamage() const
 {

--- a/CvGameCoreDLL_Expansion2/CvPromotionClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvPromotionClasses.h
@@ -173,6 +173,7 @@ public:
 	bool IsStrongerDamaged() const;
 	bool IsMountainsDoubleMove() const;
 	int GetAOEDamageOnKill() const;
+	int GetAoEDamageOnMove() const;
 	int GetSplashDamage() const;
 	int GetMinRange() const;
 	int GetMaxRange() const;
@@ -479,6 +480,7 @@ protected:
 	UnitClassTypes m_iCombatBonusFromNearbyUnitClass;
 	int m_iWonderProductionModifier;
 	int m_iAOEDamageOnKill;
+	int m_iAoEDamageOnMove;
 	int m_iSplashDamage;
 	int m_iMinRange;
 	int m_iMaxRange;

--- a/CvGameCoreDLL_Expansion2/CvUnit.h
+++ b/CvGameCoreDLL_Expansion2/CvUnit.h
@@ -953,8 +953,12 @@ public:
 	void changeFortifyTurns(int iChange);
 	bool IsFortifiedThisTurn() const;
 	void SetFortifiedThisTurn(bool bValue);
-
+	
+#if defined(MOD_BALANCE_CORE)
+	void DoAoEDamage(int iValue, char chText[256]);
+#else
 	void DoAoEDamage(int iValue);
+#endif
 
 	int getBlitzCount() const;
 	bool isBlitz() const;
@@ -990,6 +994,9 @@ public:
 
 	int getAOEDamageOnKill() const;
 	void changeAOEDamageOnKill(int iChange);
+	
+	int getAoEDamageOnMove() const;
+	void changeAoEDamageOnMove(int iChange);
 
 	int getSplashDamage() const;
 	void changeSplashDamage(int iChange);
@@ -1824,6 +1831,7 @@ protected:
 #if defined(MOD_BALANCE_CORE)
 	FAutoVariable<int, CvUnit> m_iMountainsDoubleMoveCount;
 	FAutoVariable<int, CvUnit> m_iAOEDamageOnKill;
+	FAutoVariable<int, CvUnit> m_iAoEDamageOnMove;
 	FAutoVariable<int, CvUnit> m_iSplashDamage;
 	FAutoVariable<int, CvUnit> m_iMultiAttackBonus;
 	FAutoVariable<int, CvUnit> m_iLandAirDefenseValue;


### PR DESCRIPTION
- Does AoE damage to adjacent units equal to the integer defined in AoEDamageOnMove when a unit moves (including melee units after killing another unit).
- Changed function CvUnit::DoAoEDamage so that the string tag to be displayed is an argument. Changed code relating to AoEWhileFortified to account for this.

I do not see any functions in the whole DLL which takes char 256 as an argument. Is there a particular reason for this?