### PR TITLE
Prussian Discipline

### DIFF
--- a/Community Balance Patch/Balance Changes/Text/en_US/UnitText.xml
+++ b/Community Balance Patch/Balance Changes/Text/en_US/UnitText.xml
@@ -440,6 +440,9 @@
 		<Row Tag="TXT_KEY_EUPANEL_TRAIT_LOW_POP_BONUS">
 			<Text>Lower Population than Enemy</Text>
 		</Row>
+		<Row Tag="TXT_KEY_EUPANEL_BONUS_PER_ADJACENT_UNIT_COMBAT">
+			<Text>Bonus from Adjacent Units</Text>
+		</Row>
 
 		<Row Tag="TXT_KEY_UNIT_ELEPHANT_RIDER">
 			<Text>War Elephant</Text>

--- a/Community Patch/Core Files/Core Tables/CoreTableAdditions.xml
+++ b/Community Patch/Core Files/Core Tables/CoreTableAdditions.xml
@@ -900,6 +900,15 @@
 		<Column name="YieldType" type="text" reference="Yields(Type)"/>
 		<Column name="Yield" type="integer"/>
 	</Table>
+	<!-- Promotion: Unit gains the specified combat modifier (can specify attack or defense only) per adjacent unit of the specified unit combat type -->
+	<Table name="UnitPromotions_CombatModPerAdjacentUnitCombat">
+		<Column name="PromotionType" type="text" reference="UnitPromotions(Type)"/>
+		<Column name="UnitCombatType" type="text" reference="UnitCombatInfos(Type)"/>
+		<Column name="Modifier" type="integer"/>
+		<Column name="Attack" type="integer"/>
+		<Column name="Defense" type="integer"/> <!-- note the American spelling -->
+	</Table>
+
 
 	
 	<!-- Corporations System -->

--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -15474,6 +15474,50 @@ int CvPlot::GetNumFriendlyUnitsAdjacent(TeamTypes eMyTeam, DomainTypes eDomain, 
 	return iNumFriendliesAdjacent;
 }
 
+#if defined(MOD_BALANCE_CORE)
+int CvPlot::GetNumSpecificFriendlyUnitCombatsAdjacent(TeamTypes eMyTeam, UnitCombatTypes eUnitCombat, const CvUnit* pUnitToExclude) const
+{
+	int iNumber = 0;
+
+	CvPlot** aPlotsToCheck = GC.getMap().getNeighborsUnchecked(this);
+	for(int iCount=0; iCount<NUM_DIRECTION_TYPES; iCount++)
+	{
+		CvPlot* pLoopPlot = aPlotsToCheck[iCount];
+		if(pLoopPlot != NULL)
+		{
+			IDInfo* pUnitNode = pLoopPlot->headUnitNode();
+
+			// Loop through all units on this plot
+			while(pUnitNode != NULL)
+			{
+				CvUnit* pLoopUnit = ::getUnit(*pUnitNode);
+				pUnitNode = pLoopPlot->nextUnitNode(pUnitNode);
+
+				// No NULL, and no unit we want to exclude
+				if(pLoopUnit && pLoopUnit != pUnitToExclude)
+				{
+					// Must be a combat Unit
+					if(pLoopUnit->IsCombatUnit() && !pLoopUnit->isEmbarked())
+					{
+						// Same team?
+						if(pLoopUnit->getTeam() == eMyTeam)
+						{
+							// Must be same unit combat type
+							if (pLoopUnit->getUnitCombatType() == eUnitCombat)
+							{
+								iNumber++;
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return iNumber;
+}
+#endif
+
 bool CvPlot::IsFriendlyUnitAdjacent(TeamTypes eMyTeam, bool bCombatUnit) const
 {
 	CvPlot** aPlotsToCheck = GC.getMap().getNeighborsUnchecked(this);

--- a/CvGameCoreDLL_Expansion2/CvPlot.h
+++ b/CvGameCoreDLL_Expansion2/CvPlot.h
@@ -935,6 +935,10 @@ public:
 	bool hasSharedAdjacentArea(CvPlot* pOtherPlot) const;
 #endif
 
+#if defined(MOD_BALANCE_CORE)
+	int GetNumSpecificFriendlyUnitCombatsAdjacent(TeamTypes eMyTeam, UnitCombatTypes eUnitCombat, const CvUnit* pUnitToExclude = NULL) const;
+#endif
+
 	bool canPlaceCombatUnit(PlayerTypes ePlayer) const;
 
 protected:

--- a/CvGameCoreDLL_Expansion2/CvPromotionClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvPromotionClasses.h
@@ -299,6 +299,12 @@ public:
 	int GetUnitClassAttackModifier(int i) const;
 	int GetUnitClassDefenseModifier(int i) const;
 
+#if defined(MOD_BALANCE_CORE)
+	int GetCombatModPerAdjacentUnitCombatModifierPercent(int i) const;
+	int GetCombatModPerAdjacentUnitCombatAttackModifier(int i) const;
+	int GetCombatModPerAdjacentUnitCombatDefenseModifier(int i) const;
+#endif
+
 	bool GetTerrainDoubleMove(int i) const;
 	bool GetFeatureDoubleMove(int i) const;
 #if defined(MOD_PROMOTIONS_HALF_MOVE)
@@ -576,6 +582,12 @@ protected:
 
 	int* m_piUnitClassAttackModifier;
 	int* m_piUnitClassDefenseModifier;
+
+#if defined(MOD_BALANCE_CORE)
+	int* m_piCombatModPerAdjacentUnitCombatModifierPercent;
+	int* m_piCombatModPerAdjacentUnitCombatAttackModifier;
+	int* m_piCombatModPerAdjacentUnitCombatDefenseModifier;
+#endif
 
 	int* m_piTerrainPassableTech;
 	int* m_piFeaturePassableTech;

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -346,10 +346,15 @@ CvUnit::CvUnit() :
 	, m_extraTerrainDefensePercent("CvUnit::m_extraTerrainDefensePercent", m_syncArchive/*, true*/)
 	, m_extraFeatureAttackPercent("CvUnit::m_extraFeatureAttackPercent", m_syncArchive/*, true*/)
 	, m_extraFeatureDefensePercent("CvUnit::m_extraFeatureDefensePercent", m_syncArchive/*, true*/)
-	, m_extraUnitClassAttackMod("CvUnit::m_extraFeatureDefensePercent", m_syncArchive/*, true*/)
-	, m_extraUnitClassDefenseMod("CvUnit::m_extraFeatureDefensePercent", m_syncArchive/*, true*/)
+	, m_extraUnitClassAttackMod("CvUnit::m_extraUnitClassAttackMod", m_syncArchive/*, true*/)
+	, m_extraUnitClassDefenseMod("CvUnit::m_extraUnitClassDefenseMod", m_syncArchive/*, true*/)
 	, m_extraUnitCombatModifier("CvUnit::m_extraUnitCombatModifier", m_syncArchive/*, true*/)
 	, m_unitClassModifier("CvUnit::m_unitClassModifier", m_syncArchive/*, true*/)
+#if defined(MOD_BALANCE_CORE)
+	, m_iCombatModPerAdjacentUnitCombatModifier("CvUnit::m_iCombatModPerAdjacentUnitCombatModifier", m_syncArchive/*, true*/)
+	, m_iCombatModPerAdjacentUnitCombatAttackMod("CvUnit::m_iCombatModPerAdjacentUnitCombatAttackMod", m_syncArchive/*, true*/)
+	, m_iCombatModPerAdjacentUnitCombatDefenseMod("CvUnit::m_iCombatModPerAdjacentUnitCombatDefenseMod", m_syncArchive/*, true*/)
+#endif
 	, m_iMissionTimer("CvUnit::m_iMissionTimer", m_syncArchive)
 	, m_iMissionAIX("CvUnit::m_iMissionAIX", m_syncArchive)
 	, m_iMissionAIY("CvUnit::m_iMissionAIY", m_syncArchive)
@@ -1662,9 +1667,22 @@ void CvUnit::reset(int iID, UnitTypes eUnit, PlayerTypes eOwner, bool bConstruct
 		CvAssertMsg((0 < GC.getNumUnitCombatClassInfos()), "GC.getNumUnitCombatClassInfos() is not greater than zero but an array is being allocated in CvUnit::reset");
 		m_extraUnitCombatModifier.clear();
 		m_extraUnitCombatModifier.resize(GC.getNumUnitCombatClassInfos());
+#if defined(MOD_BALANCE_CORE)
+		m_iCombatModPerAdjacentUnitCombatModifier.clear();
+		m_iCombatModPerAdjacentUnitCombatModifier.resize(GC.getNumUnitCombatClassInfos());
+		m_iCombatModPerAdjacentUnitCombatAttackMod.clear();
+		m_iCombatModPerAdjacentUnitCombatAttackMod.resize(GC.getNumUnitCombatClassInfos());
+		m_iCombatModPerAdjacentUnitCombatDefenseMod.clear();
+		m_iCombatModPerAdjacentUnitCombatDefenseMod.resize(GC.getNumUnitCombatClassInfos());
+#endif
 		for(int i = 0; i < GC.getNumUnitCombatClassInfos(); i++)
 		{
 			m_extraUnitCombatModifier.setAt(i,0);
+#if defined(MOD_BALANCE_CORE)
+			m_iCombatModPerAdjacentUnitCombatModifier.setAt(i,0);
+			m_iCombatModPerAdjacentUnitCombatAttackMod.setAt(i,0);
+			m_iCombatModPerAdjacentUnitCombatDefenseMod.setAt(i,0);
+#endif
 		}
 
 		m_unitClassModifier.clear();
@@ -1780,6 +1798,11 @@ void CvUnit::uninitInfos()
 
 	m_extraUnitClassAttackMod.dirtyGet().clear();
 	m_extraUnitClassDefenseMod.dirtyGet().clear();
+#if defined(MOD_BALANCE_CORE)
+	m_iCombatModPerAdjacentUnitCombatModifier.clear();
+	m_iCombatModPerAdjacentUnitCombatAttackMod.clear();
+	m_iCombatModPerAdjacentUnitCombatDefenseMod.clear();
+#endif
 #if defined(MOD_API_UNIFIED_YIELDS)
 	m_yieldFromKills.clear();
 	m_yieldFromBarbarianKills.clear();
@@ -15456,7 +15479,24 @@ int CvUnit::GetGenericMaxStrengthModifier(const CvUnit* pOtherUnit, const CvPlot
 
 	// Adjacent Friendly military Unit?
 	if (pFromPlot->IsFriendlyUnitAdjacent(getTeam(), /*bCombatUnit*/ true))
+	{
 		iModifier += GetAdjacentModifier();
+#if defined(MOD_BALANCE_CORE)
+		for(int iI = 0; iI < GC.getNumUnitCombatClassInfos(); iI++) // Stuff for per adjacent unit combat
+		{
+			const UnitCombatTypes eUnitCombat = static_cast<UnitCombatTypes>(iI);
+			CvBaseInfo* pkUnitCombatInfo = GC.getUnitCombatClassInfo(eUnitCombat);
+			int iModPerAdjacent = getCombatModPerAdjacentUnitCombatModifier(eUnitCombat);
+			if (pkUnitCombatInfo && iModPerAdjacent != 0)
+			{
+				int iNumFriendliesAdjacent = 0;
+				iNumFriendliesAdjacent += pFromPlot->GetNumSpecificFriendlyUnitCombatsAdjacent(getTeam(), eUnitCombat, NULL);
+				iModifier += (iNumFriendliesAdjacent * iModPerAdjacent);
+			}
+		}
+			
+#endif
+	}
 
 	// Our empire fights well in Golden Ages?
 	if(kPlayer.isGoldenAge())
@@ -15812,6 +15852,24 @@ int CvUnit::GetMaxAttackStrength(const CvPlot* pFromPlot, const CvPlot* pToPlot,
 		}
 	}
 #endif
+#if defined(MOD_BALANCE_CORE)
+	// Adjacent Friendly military Unit? (attack mod only)
+	if (pFromPlot->IsFriendlyUnitAdjacent(getTeam(), /*bCombatUnit*/ true))
+	{
+		for(int iI = 0; iI < GC.getNumUnitCombatClassInfos(); iI++) // Stuff for per adjacent unit combat
+		{
+			const UnitCombatTypes eUnitCombat = static_cast<UnitCombatTypes>(iI);
+			CvBaseInfo* pkUnitCombatInfo = GC.getUnitCombatClassInfo(eUnitCombat);
+			int iModPerAdjacent = getCombatModPerAdjacentUnitCombatAttackMod(eUnitCombat);
+			if (pkUnitCombatInfo && iModPerAdjacent != 0)
+			{
+				int iNumFriendliesAdjacent = 0;
+				iNumFriendliesAdjacent += pFromPlot->GetNumSpecificFriendlyUnitCombatsAdjacent(getTeam(), eUnitCombat, NULL);
+				iModifier += (iNumFriendliesAdjacent * iModPerAdjacent);
+			}
+		}
+	}
+#endif
 
 	////////////////////////
 	// KNOWN DESTINATION PLOT
@@ -16020,6 +16078,24 @@ int CvUnit::GetMaxDefenseStrength(const CvPlot* pInPlot, const CvUnit* pAttacker
 			if (pInfo && pInfo->getMonopolyDefenseBonus() > 0)
 			{
 				iModifier += pInfo->getMonopolyDefenseBonus();
+			}
+		}
+	}
+#endif
+#if defined(MOD_BALANCE_CORE)
+	// Adjacent Friendly military Unit? (defense mod only)
+	if (pInPlot->IsFriendlyUnitAdjacent(getTeam(), /*bCombatUnit*/ true))
+	{
+		for(int iI = 0; iI < GC.getNumUnitCombatClassInfos(); iI++) // Stuff for per adjacent unit combat
+		{
+			const UnitCombatTypes eUnitCombat = static_cast<UnitCombatTypes>(iI);
+			CvBaseInfo* pkUnitCombatInfo = GC.getUnitCombatClassInfo(eUnitCombat);
+			int iModPerAdjacent = getCombatModPerAdjacentUnitCombatDefenseMod(eUnitCombat);
+			if (pkUnitCombatInfo && iModPerAdjacent != 0)
+			{
+				int iNumFriendliesAdjacent = 0;
+				iNumFriendliesAdjacent += pInPlot->GetNumSpecificFriendlyUnitCombatsAdjacent(getTeam(), eUnitCombat, NULL);
+				iModifier += (iNumFriendliesAdjacent * iModPerAdjacent);
 			}
 		}
 	}
@@ -25649,6 +25725,63 @@ void CvUnit::changeUnitClassDefenseMod(UnitClassTypes eUnitClass, int iChange)
 }
 #if defined(MOD_BALANCE_CORE)
 //	--------------------------------------------------------------------------------
+int CvUnit::getCombatModPerAdjacentUnitCombatModifier(UnitCombatTypes eIndex) const
+{
+	VALIDATE_OBJECT
+	CvAssertMsg(eIndex >= 0, "eIndex is expected to be non-negative (invalid Index)");
+	CvAssertMsg(eIndex < GC.getNumUnitCombatClassInfos(), "eIndex is expected to be within maximum bounds (invalid Index)");
+	return m_iCombatModPerAdjacentUnitCombatModifier[eIndex];
+}
+
+
+//	--------------------------------------------------------------------------------
+void CvUnit::changeCombatModPerAdjacentUnitCombatModifier(UnitCombatTypes eIndex, int iChange)
+{
+	VALIDATE_OBJECT
+	CvAssertMsg(eIndex >= 0, "eIndex is expected to be non-negative (invalid Index)");
+	CvAssertMsg(eIndex < GC.getNumUnitCombatClassInfos(), "eIndex is expected to be within maximum bounds (invalid Index)");
+	m_iCombatModPerAdjacentUnitCombatModifier.setAt(eIndex, m_iCombatModPerAdjacentUnitCombatModifier[eIndex] + iChange);
+}
+
+//	--------------------------------------------------------------------------------
+int CvUnit::getCombatModPerAdjacentUnitCombatAttackMod(UnitCombatTypes eIndex) const
+{
+	VALIDATE_OBJECT
+	CvAssertMsg(eIndex >= 0, "eIndex is expected to be non-negative (invalid Index)");
+	CvAssertMsg(eIndex < GC.getNumUnitCombatClassInfos(), "eIndex is expected to be within maximum bounds (invalid Index)");
+	return m_iCombatModPerAdjacentUnitCombatAttackMod[eIndex];
+}
+
+
+//	--------------------------------------------------------------------------------
+void CvUnit::changeCombatModPerAdjacentUnitCombatAttackMod(UnitCombatTypes eIndex, int iChange)
+{
+	VALIDATE_OBJECT
+	CvAssertMsg(eIndex >= 0, "eIndex is expected to be non-negative (invalid Index)");
+	CvAssertMsg(eIndex < GC.getNumUnitCombatClassInfos(), "eIndex is expected to be within maximum bounds (invalid Index)");
+	m_iCombatModPerAdjacentUnitCombatAttackMod.setAt(eIndex, m_iCombatModPerAdjacentUnitCombatAttackMod[eIndex] + iChange);
+}
+
+//	--------------------------------------------------------------------------------
+int CvUnit::getCombatModPerAdjacentUnitCombatDefenseMod(UnitCombatTypes eIndex) const
+{
+	VALIDATE_OBJECT
+	CvAssertMsg(eIndex >= 0, "eIndex is expected to be non-negative (invalid Index)");
+	CvAssertMsg(eIndex < GC.getNumUnitCombatClassInfos(), "eIndex is expected to be within maximum bounds (invalid Index)");
+	return m_iCombatModPerAdjacentUnitCombatDefenseMod[eIndex];
+}
+
+
+//	--------------------------------------------------------------------------------
+void CvUnit::changeCombatModPerAdjacentUnitCombatDefenseMod(UnitCombatTypes eIndex, int iChange)
+{
+	VALIDATE_OBJECT
+	CvAssertMsg(eIndex >= 0, "eIndex is expected to be non-negative (invalid Index)");
+	CvAssertMsg(eIndex < GC.getNumUnitCombatClassInfos(), "eIndex is expected to be within maximum bounds (invalid Index)");
+	m_iCombatModPerAdjacentUnitCombatDefenseMod.setAt(eIndex, m_iCombatModPerAdjacentUnitCombatDefenseMod[eIndex] + iChange);
+}
+
+//	--------------------------------------------------------------------------------
 int CvUnit::getYieldFromScouting(YieldTypes eIndex) const
 {
 	VALIDATE_OBJECT
@@ -26387,6 +26520,11 @@ void CvUnit::setHasPromotion(PromotionTypes eIndex, bool bNewValue)
 		for(iI = 0; iI < GC.getNumUnitCombatClassInfos(); iI++)
 		{
 			changeExtraUnitCombatModifier(((UnitCombatTypes)iI), (thisPromotion.GetUnitCombatModifierPercent(iI) * iChange));
+			#if defined(MOD_BALANCE_CORE)
+			changeCombatModPerAdjacentUnitCombatModifier(((UnitCombatTypes)iI), (thisPromotion.GetCombatModPerAdjacentUnitCombatModifierPercent(iI) * iChange));
+			changeCombatModPerAdjacentUnitCombatAttackMod(((UnitCombatTypes)iI), (thisPromotion.GetCombatModPerAdjacentUnitCombatAttackModifier(iI) * iChange));
+			changeCombatModPerAdjacentUnitCombatDefenseMod(((UnitCombatTypes)iI), (thisPromotion.GetCombatModPerAdjacentUnitCombatDefenseModifier(iI) * iChange));
+			#endif
 		}
 
 		for(iI = 0; iI < GC.getNumUnitClassInfos(); iI++)

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -26520,11 +26520,11 @@ void CvUnit::setHasPromotion(PromotionTypes eIndex, bool bNewValue)
 		for(iI = 0; iI < GC.getNumUnitCombatClassInfos(); iI++)
 		{
 			changeExtraUnitCombatModifier(((UnitCombatTypes)iI), (thisPromotion.GetUnitCombatModifierPercent(iI) * iChange));
-			#if defined(MOD_BALANCE_CORE)
+#if defined(MOD_BALANCE_CORE)
 			changeCombatModPerAdjacentUnitCombatModifier(((UnitCombatTypes)iI), (thisPromotion.GetCombatModPerAdjacentUnitCombatModifierPercent(iI) * iChange));
 			changeCombatModPerAdjacentUnitCombatAttackMod(((UnitCombatTypes)iI), (thisPromotion.GetCombatModPerAdjacentUnitCombatAttackModifier(iI) * iChange));
 			changeCombatModPerAdjacentUnitCombatDefenseMod(((UnitCombatTypes)iI), (thisPromotion.GetCombatModPerAdjacentUnitCombatDefenseModifier(iI) * iChange));
-			#endif
+#endif
 		}
 
 		for(iI = 0; iI < GC.getNumUnitClassInfos(); iI++)

--- a/CvGameCoreDLL_Expansion2/CvUnit.h
+++ b/CvGameCoreDLL_Expansion2/CvUnit.h
@@ -826,6 +826,11 @@ public:
 	int unitCombatModifier(UnitCombatTypes eUnitCombat) const;
 	int domainModifier(DomainTypes eDomain) const;
 
+#if defined(MOD_BALANCE_CORE)
+	//int combatModPerAdjacentUnitCombatAttackMod(UnitCombatTypes eIndex) const;
+	int combatModPerAdjacentUnitCombatDefenseMod(UnitCombatTypes eIndex) const;
+#endif
+
 	int GetYieldModifier(YieldTypes eYield) const;
 	void SetYieldModifier(YieldTypes eYield, int iValue);
 
@@ -1430,6 +1435,15 @@ public:
 
 	void ChangeNumTimesAttackedThisTurn(PlayerTypes ePlayer, int iValue);
 	int GetNumTimesAttackedThisTurn(PlayerTypes ePlayer) const;
+
+	int getCombatModPerAdjacentUnitCombatModifier(UnitCombatTypes eIndex) const;
+	void changeCombatModPerAdjacentUnitCombatModifier(UnitCombatTypes eIndex, int iChange);
+
+	int getCombatModPerAdjacentUnitCombatAttackMod(UnitCombatTypes eIndex) const;
+	void changeCombatModPerAdjacentUnitCombatAttackMod(UnitCombatTypes eIndex, int iChange);
+
+	int getCombatModPerAdjacentUnitCombatDefenseMod(UnitCombatTypes eIndex) const;
+	void changeCombatModPerAdjacentUnitCombatDefenseMod(UnitCombatTypes eIndex, int iChange);
 #endif
 
 	int getImpassableCount() const;
@@ -2072,6 +2086,11 @@ protected:
 #endif
 	FAutoVariable<std::vector<int>, CvUnit> m_extraUnitCombatModifier;
 	FAutoVariable<std::vector<int>, CvUnit> m_unitClassModifier;
+#if defined(MOD_BALANCE_CORE)
+	FAutoVariable<std::vector<int>, CvUnit> m_iCombatModPerAdjacentUnitCombatModifier;
+	FAutoVariable<std::vector<int>, CvUnit> m_iCombatModPerAdjacentUnitCombatAttackMod;
+	FAutoVariable<std::vector<int>, CvUnit> m_iCombatModPerAdjacentUnitCombatDefenseMod;
+#endif
 	FAutoVariable<int, CvUnit> m_iMissionTimer;
 	FAutoVariable<int, CvUnit> m_iMissionAIX;
 	FAutoVariable<int, CvUnit> m_iMissionAIY;

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.cpp
@@ -364,6 +364,9 @@ void CvLuaUnit::PushMethods(lua_State* L, int t)
 	Method(UnitClassDefenseModifier);
 	Method(UnitCombatModifier);
 #if defined(MOD_BALANCE_CORE)
+	Method(PerAdjacentUnitCombatModifier);
+	Method(PerAdjacentUnitCombatAttackMod);
+	Method(PerAdjacentUnitCombatDefenseMod);
 	Method(IsMounted);
 	Method(IsStrongerDamaged);
 	Method(GetMultiAttackBonus);
@@ -3688,6 +3691,84 @@ int CvLuaUnit::lUnitCombatModifier(lua_State* L)
 	return 1;
 }
 #if defined(MOD_BALANCE_CORE)
+//------------------------------------------------------------------------------
+//int getCombatModPerAdjacentUnitCombatModifier(int /*UnitCombatTypes*/ eUnitCombat);
+int CvLuaUnit::lPerAdjacentUnitCombatModifier(lua_State* L)
+{
+	CvUnit* pkUnit = GetInstance(L);
+	//const UnitCombatTypes eUnitCombat = (UnitCombatTypes)lua_tointeger(L, 2);
+
+	CvPlot* pFromPlot = pkUnit->plot();
+	
+	int iResult = 0;
+	
+	for(int iI = 0; iI < GC.getNumUnitCombatClassInfos(); iI++)
+	{
+		const UnitCombatTypes eUnitCombat = static_cast<UnitCombatTypes>(iI);
+		CvBaseInfo* pkUnitCombatInfo = GC.getUnitCombatClassInfo(eUnitCombat);
+		int iModPerAdjacent = pkUnit->getCombatModPerAdjacentUnitCombatModifier(eUnitCombat);
+		if (pkUnitCombatInfo && iModPerAdjacent != 0)
+		{
+			int iNumFriendliesAdjacent = pFromPlot->GetNumSpecificFriendlyUnitCombatsAdjacent(pkUnit->getTeam(), eUnitCombat, NULL);
+			iResult += (iNumFriendliesAdjacent * iModPerAdjacent);			
+		}
+	}
+	
+	lua_pushinteger(L, iResult);
+	return 1;
+}
+//------------------------------------------------------------------------------
+//int getCombatModPerAdjacentUnitCombatAttackMod(int /*UnitCombatTypes*/ eUnitCombat);
+int CvLuaUnit::lPerAdjacentUnitCombatAttackMod(lua_State* L)
+{
+	CvUnit* pkUnit = GetInstance(L);
+	//const UnitCombatTypes eUnitCombat = (UnitCombatTypes)lua_tointeger(L, 2);
+
+	CvPlot* pFromPlot = pkUnit->plot();
+	
+	int iResult = 0;
+	
+	for(int iI = 0; iI < GC.getNumUnitCombatClassInfos(); iI++)
+	{
+		const UnitCombatTypes eUnitCombat = static_cast<UnitCombatTypes>(iI);
+		CvBaseInfo* pkUnitCombatInfo = GC.getUnitCombatClassInfo(eUnitCombat);
+		int iModPerAdjacent = pkUnit->getCombatModPerAdjacentUnitCombatAttackMod(eUnitCombat);
+		if (pkUnitCombatInfo && iModPerAdjacent != 0)
+		{
+			int iNumFriendliesAdjacent = pFromPlot->GetNumSpecificFriendlyUnitCombatsAdjacent(pkUnit->getTeam(), eUnitCombat, NULL);
+			iResult += (iNumFriendliesAdjacent * iModPerAdjacent);			
+		}
+	}
+	
+	lua_pushinteger(L, iResult);
+	return 1;
+}
+//------------------------------------------------------------------------------
+//int getCombatModPerAdjacentUnitCombatDefenseMod(int /*UnitCombatTypes*/ eUnitCombat);
+int CvLuaUnit::lPerAdjacentUnitCombatDefenseMod(lua_State* L)
+{
+	CvUnit* pkUnit = GetInstance(L);
+	//const UnitCombatTypes eUnitCombat = (UnitCombatTypes)lua_tointeger(L, 2);
+
+	CvPlot* pFromPlot = pkUnit->plot();
+	
+	int iResult = 0;
+	
+	for(int iI = 0; iI < GC.getNumUnitCombatClassInfos(); iI++)
+	{
+		const UnitCombatTypes eUnitCombat = static_cast<UnitCombatTypes>(iI);
+		CvBaseInfo* pkUnitCombatInfo = GC.getUnitCombatClassInfo(eUnitCombat);
+		int iModPerAdjacent = pkUnit->getCombatModPerAdjacentUnitCombatDefenseMod(eUnitCombat);
+		if (pkUnitCombatInfo && iModPerAdjacent != 0)
+		{
+			int iNumFriendliesAdjacent = pFromPlot->GetNumSpecificFriendlyUnitCombatsAdjacent(pkUnit->getTeam(), eUnitCombat, NULL);
+			iResult += (iNumFriendliesAdjacent * iModPerAdjacent);			
+		}
+	}
+	
+	lua_pushinteger(L, iResult);
+	return 1;
+}
 //------------------------------------------------------------------------------
 //int unitCombatModifier(int /*UnitCombatTypes*/ eUnitCombat);
 int CvLuaUnit::lBarbarianCombatBonus(lua_State* L)

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.h
@@ -375,6 +375,9 @@ protected:
 	static int lUnitClassDefenseModifier(lua_State* L);
 	static int lUnitCombatModifier(lua_State* L);
 #if defined(MOD_BALANCE_CORE)
+	static int lPerAdjacentUnitCombatModifier(lua_State* L);
+	static int lPerAdjacentUnitCombatAttackMod(lua_State* L);
+	static int lPerAdjacentUnitCombatDefenseMod(lua_State* L);
 	static int lBarbarianCombatBonus(lua_State* L);
 	static int lIsMounted(lua_State* L);
 	static int lIsStrongerDamaged(lua_State* L);

--- a/EUI Compatibility Files/EUI Compatibility Files/LUA/EnemyUnitPanel.lua
+++ b/EUI Compatibility Files/EUI Compatibility Files/LUA/EnemyUnitPanel.lua
@@ -1311,6 +1311,17 @@ function UpdateCombatOddsUnitVsUnit(pMyUnit, pTheirUnit)
 				end
 			end
 
+-- CBP
+			-- PerAdjacentUnitCombatModifier
+			iModifier = pMyUnit:PerAdjacentUnitCombatModifier() + pMyUnit:PerAdjacentUnitCombatAttackMod();
+			if (iModifier ~= 0) then
+				controlTable = g_MyCombatDataIM:GetInstance();
+				--local unitClassType = Locale.ConvertTextKey(GameInfo.UnitClasses[pTheirUnit:GetUnitClassType()].Description);
+				controlTable.Text:LocalizeAndSetText( "TXT_KEY_EUPANEL_BONUS_PER_ADJACENT_UNIT_COMBAT" );
+				controlTable.Value:SetText( GetFormattedText(strText, iModifier, true, true) );
+			end
+-- END
+	
 			-- DomainModifier
 			iModifier = pMyUnit:DomainModifier(pTheirUnit:GetDomainType());
 			if (iModifier ~= 0) then
@@ -1806,6 +1817,17 @@ function UpdateCombatOddsUnitVsUnit(pMyUnit, pTheirUnit)
 						--strString.append(GetLocalizedText("TXT_KEY_COMBAT_PLOT_MOD_VS_TYPE", iModifier, GC.getUnitCombatClassInfo(pMyUnit:getUnitCombatType()).GetTextKey()));
 					--end
 				--end
+
+-- CBP
+				-- PerAdjacentUnitCombatModifier
+				iModifier = pTheirUnit:PerAdjacentUnitCombatModifier() + pTheirUnit:PerAdjacentUnitCombatDefenseMod();
+				if (iModifier ~= 0) then
+					controlTable = g_TheirCombatDataIM:GetInstance();
+					--local unitClassType = Locale.ConvertTextKey(GameInfo.UnitClasses[pTheirUnit:GetUnitClassType()].Description);
+					controlTable.Text:LocalizeAndSetText( "TXT_KEY_EUPANEL_BONUS_PER_ADJACENT_UNIT_COMBAT" );
+					controlTable.Value:SetText( GetFormattedText(strText, iModifier, false, true) );
+				end
+-- END
 
 				-- DomainModifier
 				iModifier = pTheirUnit:DomainModifier(pMyUnit:GetDomainType());

--- a/NoEUI Compatibility Files/Mod Template1/LUA/EnemyUnitPanel.lua
+++ b/NoEUI Compatibility Files/Mod Template1/LUA/EnemyUnitPanel.lua
@@ -1311,6 +1311,17 @@ function UpdateCombatOddsUnitVsUnit(pMyUnit, pTheirUnit)
 				end
 			end
 
+-- CBP
+			-- PerAdjacentUnitCombatModifier
+			iModifier = pMyUnit:PerAdjacentUnitCombatModifier() + pMyUnit:PerAdjacentUnitCombatAttackMod();
+			if (iModifier ~= 0) then
+				controlTable = g_MyCombatDataIM:GetInstance();
+				--local unitClassType = Locale.ConvertTextKey(GameInfo.UnitClasses[pTheirUnit:GetUnitClassType()].Description);
+				controlTable.Text:LocalizeAndSetText( "TXT_KEY_EUPANEL_BONUS_PER_ADJACENT_UNIT_COMBAT" );
+				controlTable.Value:SetText( GetFormattedText(strText, iModifier, true, true) );
+			end
+-- END
+
 			-- DomainModifier
 			iModifier = pMyUnit:DomainModifier(pTheirUnit:GetDomainType());
 			if (iModifier ~= 0) then
@@ -1806,6 +1817,17 @@ function UpdateCombatOddsUnitVsUnit(pMyUnit, pTheirUnit)
 						--strString.append(GetLocalizedText("TXT_KEY_COMBAT_PLOT_MOD_VS_TYPE", iModifier, GC.getUnitCombatClassInfo(pMyUnit:getUnitCombatType()).GetTextKey()));
 					--end
 				--end
+
+-- CBP
+				-- PerAdjacentUnitCombatModifier
+				iModifier = pTheirUnit:PerAdjacentUnitCombatModifier() + pTheirUnit:PerAdjacentUnitCombatDefenseMod();
+				if (iModifier ~= 0) then
+					controlTable = g_MyCombatDataIM:GetInstance();
+					--local unitClassType = Locale.ConvertTextKey(GameInfo.UnitClasses[pTheirUnit:GetUnitClassType()].Description);
+					controlTable.Text:LocalizeAndSetText( "TXT_KEY_EUPANEL_BONUS_PER_ADJACENT_UNIT_COMBAT" );
+					controlTable.Value:SetText( GetFormattedText(strText, iModifier, false, true) );
+				end
+-- END
 
 				-- DomainModifier
 				iModifier = pTheirUnit:DomainModifier(pMyUnit:GetDomainType());


### PR DESCRIPTION
- Added table UnitPromotions_CombatModPerAdjacentUnitCombat. The unit with this promotion gets combat bonus based on the number of friendly units nearby of the specified unit combat types.
- Also found a possible bug in line 349 and 350 of CvUnit.cpp.

Haven't thought about this before, but is there a practical limit to the amount of new code / tables you can add to the DLL?