### PR TITLE
Fix for skipped turn on load in MP issue

### DIFF
--- a/CvGameCoreDLL_Expansion2/CustomMods.h
+++ b/CvGameCoreDLL_Expansion2/CustomMods.h
@@ -955,6 +955,8 @@
 #define MOD_BUGFIX_NO_HOVERING_REBELS               gCustomMods.isBUGFIX_NO_HOVERING_REBELS()
 // Fixes some bugs/regressions that disable the effect of IsNoMinorCivs of some strategies
 #define MOD_BUGFIX_MINOR_CIV_STRATEGIES				gCustomMods.isBUGFIX_MINOR_CIV_STRATEGIES()
+// Workaround for the first human turn after loading a MP game being skipped sometimes
+#define MOD_BUGFIX_SKIPPED_HUMAN_TURN_ON_MP_LOAD	(true)
 
 #endif // ACHIEVEMENT_HACKS
 

--- a/CvGameCoreDLL_Expansion2/CvGame.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGame.cpp
@@ -9087,6 +9087,10 @@ void CvGame::updateMoves()
 
 	int currentTurn = getGameTurn();
 	bool activatePlayers = playersToProcess.empty() && m_lastTurnAICivsProcessed != currentTurn;
+
+#if defined(MOD_BUGFIX_SKIPPED_HUMAN_TURN_ON_MP_LOAD)
+	bool firstActivationOfPlayersAfterLoad = activatePlayers && m_lastTurnAICivsProcessed == -1;
+#endif
 	// If no AI with an active turn, check humans.
 	if(playersToProcess.empty())
 	{
@@ -9364,6 +9368,22 @@ void CvGame::updateMoves()
 				if(!player.isTurnActive() && player.isHuman() && player.isAlive() && player.isSimultaneousTurns())
 				{
 					player.setTurnActive(true);
+#if defined(MOD_BUGFIX_SKIPPED_HUMAN_TURN_ON_MP_LOAD)
+					if (firstActivationOfPlayersAfterLoad && player.isLocalPlayer())
+					{
+						// DN: There is a strange issue with players missing their turns after loading a game, with the AI getting two turns in a row.
+						// It seems *to me* that Civ is incorrectly thinking telling us that the players have already indicated they have finished their turns
+						// A hacky solution to this is to tell Civ to cancel the player turn complete state.
+						// Otherwise they get their turn ended in the next call to updateMoves after the condition (!player.isEndTurn() && gDLL->HasReceivedTurnComplete(player.GetID()) && player.isHuman())
+						if (gDLL->HasReceivedTurnComplete(player.GetID()))
+						{
+							bool unreadied = gDLL->sendTurnUnready();
+							bool turnComplete = gDLL->HasReceivedTurnComplete(player.GetID());
+							NET_MESSAGE_DEBUG_OSTR_ALWAYS("UpdateMoves() : Attempting to fix skipped first turn issue - HasReceivedTurnComplete(" << player.GetID() << ") returned 1, sendTurnUnready() returned "
+								<< unreadied << " and now HasReceivedTurnComplete(" << player.GetID() << ") returned " << turnComplete);
+						}
+					}
+#endif
 				}
 			}
 		}


### PR DESCRIPTION
After loading an MP game the first turns of human players can often be skipped, meaning the AI gets two turns in a row. I traced the problem down to being a result of the players erroneously being flagged as
having already submitted their ready message for the turn. The fix isn't really a fix as I believe the problem is in the host. Instead I just check for the problem upon the first activation of the local player and
send the unready message if need be. 

In short, HasReceivedTurnComplete was sometimes already returning true after a load so I call sendTurnUnready when it does so their turn doesn't end immediately.

I have played a few games (2 human/6 AI) with the change and have not noticed any negative effects but maybe you can. 

I can probably dig up some save games which exhibit the issue but they will have been using a modded version of the 2/7 release. I didn't figure out why the problem occurs only sometimes.

The issue has been spoken about in:
#2576 


EDIT:
Naturally, I just remembered that I, possibly wrongly, assumed that the problem only occurs when player with dynamic/simultaneous turns. My code will only execute in those modes and changes will still need to be made if sequential turns modes also have the same issue. Should be straight forward though.