### PR TITLE
Fixed issue with Active Diplomacy deal request withdrawal logic

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvDiplomacyRequests.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyRequests.cpp
@@ -269,8 +269,14 @@ void CvDiplomacyRequests::CheckRemainingNotifications()
 					continue;
 				}
 
-				bool bGood = pDeal->AreAllTradeItemsValid();
-				if (!bGood)
+				bool bDealOk = pDeal->AreAllTradeItemsValid();
+				if (bDealOk && !CvPreGame::isHuman(iter->m_eFromPlayer))
+				{
+					int iDealValueToMe, iValueImOffering, iValueTheyreOffering, iAmountOverWeWillRequest, iAmountUnderWeWillOffer;
+					bool bCantMatchOffer;
+					bDealOk = GET_PLAYER(iter->m_eFromPlayer).GetDealAI()->IsDealWithHumanAcceptable(pDeal, m_ePlayer, /*Passed by reference*/ iDealValueToMe, iValueImOffering, iValueTheyreOffering, iAmountOverWeWillRequest, iAmountUnderWeWillOffer, &bCantMatchOffer, false);
+				}
+				if (!bDealOk)
 				{
 					GC.getGame().GetGameDeals().RemoveProposedDeal(iter->m_eFromPlayer, m_ePlayer, NULL, false);
 


### PR DESCRIPTION
Looks like a bool was named incorrectly, leading to some inverted logic.
The bug would cause valid deals being withdrawal by the AI and invalid
deals no withdrawn.

The bug had been addressed by the time I got around to submitting the fix but I am not sure if the fix that was checked in is the best solution since I believe it would result in bad deals being presented to the player.

I have an upcoming pull request that does actually remove this condition but also implements logic to try to adjust the deal so that it is acceptable before presenting.