### PR TITLE
Fixed iteration over Active Diplomacy deal request notifications

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvDiplomacyRequests.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyRequests.cpp
@@ -276,9 +276,7 @@ void CvDiplomacyRequests::CheckRemainingNotifications()
 
 					if (iter->m_iLookupIndex >= 0)
 						GET_PLAYER(m_ePlayer).GetNotifications()->Dismiss(iter->m_iLookupIndex, false);
-
-					iter = m_aRequests.erase(iter);
-
+					
 					CvPlayerAI& kFromPlayer = GET_PLAYER(iter->m_eFromPlayer);
 					Localization::String strMessage;
 					Localization::String strSummary;
@@ -287,6 +285,9 @@ void CvDiplomacyRequests::CheckRemainingNotifications()
 					strMessage = Localization::Lookup("TXT_KEY_DEAL_WITHDRAWN_BY_THEM");
 					strMessage << kFromPlayer.getNickName();
 					GET_PLAYER(m_ePlayer).GetNotifications()->Add(NOTIFICATION_PLAYER_DEAL_RESOLVED, strMessage.toUTF8(), strSummary.toUTF8(), iter->m_eFromPlayer, -1, -1);
+
+					iter = m_aRequests.erase(iter);
+					continue;
 				}
 			}
 			++iter;


### PR DESCRIPTION
A couple of errors in CvDiplomacyRequests::CheckRemainingNotifications()
which could result CTDs, the wrong details used in deal withdrawal
notifications, or deals could be skipped over.

This is due to the
erasing during processing which also assigns back to the iterator before
it has finished using it. The iterator would then be pointing to the
next element, which could even be end(). Also the iterator essentially
being incremented twice but would be processed on the next call to the
function and not be a real problem in reality.