### PR TITLE
Fixed blank names in AD deal withdrawn notes

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvDiplomacyRequests.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyRequests.cpp
@@ -291,7 +291,7 @@ void CvDiplomacyRequests::CheckRemainingNotifications()
 
 					strSummary = Localization::Lookup("TXT_KEY_DEAL_WITHDRAWN");
 					strMessage = Localization::Lookup("TXT_KEY_DEAL_WITHDRAWN_BY_THEM");
-					strMessage << kFromPlayer.getNickName();
+					strMessage << kFromPlayer.getName();
 					GET_PLAYER(m_ePlayer).GetNotifications()->Add(NOTIFICATION_PLAYER_DEAL_RESOLVED, strMessage.toUTF8(), strSummary.toUTF8(), iter->m_eFromPlayer, -1, -1);
 				}
 			}


### PR DESCRIPTION
Now using getName() since nicknames are not populated for AI players, it
seems. getName() is used with much success all over the codebase.

There are still many instances of getNickName being used elsewhere. They obviously must work sometimes but it is definitely not always the case. I am of the opinion that getName is the better choice since it looks to be coded to handle all situations. Your thoughts?