### PR TITLE
Fix erroneous counter-offer notifications with Active Diplomacy

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvDllGameDeals.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDllGameDeals.cpp
@@ -121,7 +121,7 @@ PlayerTypes CvDllGameDeals::HasMadeProposal(PlayerTypes eFromPlayer)
 bool CvDllGameDeals::ProposedDealExists(PlayerTypes eFromPlayer, PlayerTypes eToPlayer)
 {
 #if defined(MOD_ACTIVE_DIPLOMACY)
-	if(GC.getGame().isReallyNetworkMultiPlayer() && MOD_ACTIVE_DIPLOMACY)
+	if((!GET_PLAYER(eFromPlayer).isHuman() || !GET_PLAYER(eToPlayer).isHuman()) && GC.getGame().isReallyNetworkMultiPlayer() && MOD_ACTIVE_DIPLOMACY)
 	{
 		return m_pGameDeals->GetProposedMPDeal(eFromPlayer, eToPlayer, 0) != NULL;
 	}
@@ -136,7 +136,7 @@ ICvDeal1* CvDllGameDeals::GetProposedDeal(PlayerTypes eFromPlayer, PlayerTypes e
 {
 #if defined(MOD_ACTIVE_DIPLOMACY)
 	CvDeal* pDeal;
-	if(GC.getGame().isReallyNetworkMultiPlayer() && MOD_ACTIVE_DIPLOMACY)
+	if((!GET_PLAYER(eFromPlayer).isHuman() || !GET_PLAYER(eToPlayer).isHuman()) && GC.getGame().isReallyNetworkMultiPlayer() && MOD_ACTIVE_DIPLOMACY)
 	{
 		pDeal = m_pGameDeals->GetProposedMPDeal(eFromPlayer, eToPlayer, 0);
 	}


### PR DESCRIPTION
Prevents getting a counter offer notification instead of a deal proposed
notification to self when making a human-human deal with Active
Diplomacy active.