### PR TITLE
bypass Acitve Diplomacy FinalizeDeal code for human-human deals

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvDllGameDeals.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDllGameDeals.cpp
@@ -90,7 +90,8 @@ void CvDllGameDeals::AddProposedDeal(ICvDeal1* pDeal)
 bool CvDllGameDeals::FinalizeDeal(PlayerTypes eFromPlayer, PlayerTypes eToPlayer, bool bAccepted)
 {
 #if defined(MOD_ACTIVE_DIPLOMACY)
-	if(GC.getGame().isReallyNetworkMultiPlayer() && MOD_ACTIVE_DIPLOMACY)
+	// was getting errors in the diplomacy log for human-human deals, bypassing seems ok.
+	if((!GET_PLAYER(eFromPlayer).isHuman() || !GET_PLAYER(eToPlayer).isHuman()) && GC.getGame().isReallyNetworkMultiPlayer() && MOD_ACTIVE_DIPLOMACY)	
 	{
 		return m_pGameDeals->FinalizeMPDealLatest(eFromPlayer, eToPlayer, bAccepted, true);
 	}


### PR DESCRIPTION
At least after my other changes (possibly before also) there were errors in the failed AI diplomacy logs about human to human deals. Just skipping the Active Diplomacy code again for human-human deals seems to fix the issue and not cause any more either.

Didn't investigate much do due the history of similar problems.