### PR TITLE
refreshing some cached data on make peace

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvPlayerManager.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayerManager.cpp
@@ -13,7 +13,7 @@
 #include "CvDangerPlots.h"
 //	-----------------------------------------------------------------------------------------------
 //	Loop through all the players and update cached values
-void CvPlayerManager::Refresh(bool bWarDeclaration)
+void CvPlayerManager::Refresh(bool bWarStateChanged)
 {
 	//include the barbarians!
 	for(int iPlayerCivLoop = 0; iPlayerCivLoop < MAX_PLAYERS; iPlayerCivLoop++)
@@ -33,7 +33,7 @@ void CvPlayerManager::Refresh(bool bWarDeclaration)
 		kPlayer.UpdateCurrentAndFutureWars();
 
 		//only after loading, force danger update (only known enemy units are serialized)
-		if(!bWarDeclaration && kPlayer.m_pDangerPlots)
+		if(!bWarStateChanged && kPlayer.m_pDangerPlots)
 			kPlayer.UpdateDangerPlots(true);
 	}
 }

--- a/CvGameCoreDLL_Expansion2/CvTeam.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTeam.cpp
@@ -2198,6 +2198,28 @@ void CvTeam::makePeace(TeamTypes eTeam, bool bBumpUnits, bool bSuppressNotificat
 #else
 	DoMakePeace(eTeam, bBumpUnits, bSuppressNotification);
 #endif
+
+	CvPlayerManager::Refresh(true);
+
+	//refresh tactical AI as well!
+	for (int iAttackingPlayer = 0; iAttackingPlayer < MAX_MAJOR_CIVS; iAttackingPlayer++)
+	{
+		PlayerTypes eAttackingPlayer = (PlayerTypes)iAttackingPlayer;
+		CvPlayerAI& kAttackingPlayer = GET_PLAYER(eAttackingPlayer);
+		if (kAttackingPlayer.isAlive() && kAttackingPlayer.getTeam() == GetID())
+		{
+			kAttackingPlayer.GetTacticalAI()->GetTacticalAnalysisMap()->Refresh();
+			for (int iDefendingPlayer = 0; iDefendingPlayer < MAX_MAJOR_CIVS; iDefendingPlayer++)
+			{
+				PlayerTypes eDefendingPlayer = (PlayerTypes)iDefendingPlayer;
+				CvPlayerAI& kDefendingPlayer = GET_PLAYER(eDefendingPlayer);
+				if (kDefendingPlayer.isAlive() && kDefendingPlayer.getTeam() == eTeam)
+				{
+					kDefendingPlayer.GetTacticalAI()->GetTacticalAnalysisMap()->Refresh();
+				}
+			}
+		}
+	}
 }
 
 //	------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This data depends on the warring state but is only updating in the event of war being declared. It seems to me it should be updated on peace too, keeping in mind that the parties could still be at war with other players.

Also renamed arg since it is being called for peace now too.

Code was simply copied from declareWar but am not fussed at the moment. In an upcoming pull request I remove some of this code since I don't think it is particularly as effective as it could be. I plan on cleaning up once proven effective and agreed as the right course of action.