### PR TITLE
refresh TR cache on war state change

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvPlayerManager.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayerManager.cpp
@@ -35,5 +35,15 @@ void CvPlayerManager::Refresh(bool bWarDeclaration)
 		//only after loading, force danger update (only known enemy units are serialized)
 		if(!bWarDeclaration && kPlayer.m_pDangerPlots)
 			kPlayer.UpdateDangerPlots(true);
+
+		if (bWarDeclaration)
+		{
+			// Despite comments to the contrary, I think the cached trade path info might depend on war state. I may have read the code wrong.
+			GC.getGame().GetGameTrade()->InvalidateTradePathCache(iPlayerCivLoop);
+			// I am not 100% confident that the cache is asked to be updated often enough and may be invalid when read.
+			// However, during testing I was only calling update and therefore nothing much was probably happening, so all of this could just be a waste of time...or not.
+			// Invalidating in theoretically the right thing to do BUT since I did my testing with this here I want to leave it for the time being.
+			GC.getGame().GetGameTrade()->UpdateTradePathCache(iPlayerCivLoop);
+		}
 	}
 }


### PR DESCRIPTION
Despite what the code comments say, I believe some trade routes calcs depend on the war state and they should be updated when it changes.

This done in a very heavy handed fashion because I don't trust the cache
to actually be updated even though it is invalid when accessed.

The location in which I am doing this is far from ideal as the cache will be refreshed multiple times unnecessarily. Ideally I would just invalidate the cache but, as stated above, I think the caching is somewhat deficient.

I would like to address the issue by making the cache access more fool-proof but that will take some more time and testing.