### PR TITLE
TacticalMap updating and desyncs

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -11121,6 +11121,8 @@ void CvPlayer::doTurnPostDiplomacy()
 
 			UpdatePlots();
 			UpdateDangerPlots(false);
+			GetTacticalAI()->GetTacticalAnalysisMap()->Refresh(true); // Just do it now instead of maybe doing it at an unspecified point?
+			GetTacticalAI()->GetTacticalAnalysisMap()->Invalidate(); // Invalidating so that it will be updated even if already (possible erroneously) updated in UpdatdCityThreatCriteria with stale data.
 			UpdateMilitaryStats();
 			UpdateAreaEffectUnits();
 			UpdateAreaEffectPlots();

--- a/CvGameCoreDLL_Expansion2/CvPlayerAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayerAI.cpp
@@ -284,6 +284,7 @@ void CvPlayerAI::AI_unitUpdate()
 
 	//do this only after updating the danger plots (happens in CvPlayer::doTurnPostDiplomacy)
 	//despite the name, the tactical map is used by homeland AI as well.
+	//DN: If the above comment is still true then it sounds like there is an issue since CvPlayer::UpdateCityThreatCriteria is called just before doPostTurnDiplomacy and it refreshes the tacmamp
 	GetTacticalAI()->GetTacticalAnalysisMap()->Refresh();
 
 	//so that workers know where to build roads

--- a/CvGameCoreDLL_Expansion2/CvPlayerManager.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayerManager.cpp
@@ -13,7 +13,7 @@
 #include "CvDangerPlots.h"
 //	-----------------------------------------------------------------------------------------------
 //	Loop through all the players and update cached values
-void CvPlayerManager::Refresh(bool bWarDeclaration)
+void CvPlayerManager::Refresh(bool bWarStateChanged)
 {
 	//include the barbarians!
 	for(int iPlayerCivLoop = 0; iPlayerCivLoop < MAX_PLAYERS; iPlayerCivLoop++)
@@ -33,7 +33,13 @@ void CvPlayerManager::Refresh(bool bWarDeclaration)
 		kPlayer.UpdateCurrentAndFutureWars();
 
 		//only after loading, force danger update (only known enemy units are serialized)
-		if(!bWarDeclaration && kPlayer.m_pDangerPlots)
+		if(!bWarStateChanged && kPlayer.m_pDangerPlots)
 			kPlayer.UpdateDangerPlots(true);
+
+		if (bWarStateChanged)
+			kPlayer.GetTacticalAI()->GetTacticalAnalysisMap()->Refresh(true);
+
+		if (bWarStateChanged)
+			GC.getGame().GetGameTrade()->UpdateTradePathCache(iPlayerCivLoop);
 	}
 }

--- a/CvGameCoreDLL_Expansion2/CvTacticalAnalysisMap.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTacticalAnalysisMap.cpp
@@ -394,10 +394,15 @@ bool CvTacticalAnalysisMap::IsUpToDate()
 	return (m_iTurnBuilt == GC.getGame().getGameTurn() && m_vCells.size()==GC.getMap().numPlots());
 }
 
-/// Fill the map with data for this AI player's turn
-void CvTacticalAnalysisMap::Refresh()
+void CvTacticalAnalysisMap::Invalidate()
 {
-	if(!IsUpToDate())
+	m_iTurnBuilt = -1;
+}
+
+/// Fill the map with data for this AI player's turn
+void CvTacticalAnalysisMap::Refresh(bool force)
+{
+	if(force || !IsUpToDate())
 	{
 		//can happen in the first turn ...
 		if (m_vCells.size()!=GC.getMap().numPlots())

--- a/CvGameCoreDLL_Expansion2/CvTacticalAnalysisMap.h
+++ b/CvGameCoreDLL_Expansion2/CvTacticalAnalysisMap.h
@@ -570,7 +570,7 @@ public:
 	~CvTacticalAnalysisMap(void);
 
 	void Init(PlayerTypes ePlayer);
-	void Refresh();
+	void Refresh(bool force = false);
 	bool IsUpToDate();
 
 	void EstablishZoneNeighborhood();
@@ -604,6 +604,7 @@ public:
 	void Dump();
 #endif
 
+	void Invalidate();
 protected:
 	bool PopulateCell(int iIndex, CvPlot* pPlot);
 	void AddToDominanceZones(int iIndex, CvTacticalAnalysisCell* pCell);

--- a/CvGameCoreDLL_Expansion2/CvTeam.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTeam.cpp
@@ -1336,24 +1336,25 @@ void CvTeam::declareWar(TeamTypes eTeam, bool bDefensivePact)
 	CvPlayerManager::Refresh(true);
 
 	//refresh tactical AI as well!
-	for (int iAttackingPlayer = 0; iAttackingPlayer < MAX_MAJOR_CIVS; iAttackingPlayer++)
+	// Refreshing all alive players in CvPlayerManager, so no need for this. However, refreshing all might not be required. Have checked in the commented code to show that the refresh needs to be forced.
+	/*for (int iAttackingPlayer = 0; iAttackingPlayer < MAX_MAJOR_CIVS; iAttackingPlayer++)
 	{
 		PlayerTypes eAttackingPlayer = (PlayerTypes)iAttackingPlayer;
 		CvPlayerAI& kAttackingPlayer = GET_PLAYER(eAttackingPlayer);
 		if (kAttackingPlayer.isAlive() && kAttackingPlayer.getTeam() == GetID())
 		{
-			kAttackingPlayer.GetTacticalAI()->GetTacticalAnalysisMap()->Refresh();
+			kAttackingPlayer.GetTacticalAI()->GetTacticalAnalysisMap()->Refresh(true);
 			for (int iDefendingPlayer = 0; iDefendingPlayer < MAX_MAJOR_CIVS; iDefendingPlayer++)
 			{
 				PlayerTypes eDefendingPlayer = (PlayerTypes)iDefendingPlayer;
 				CvPlayerAI& kDefendingPlayer = GET_PLAYER(eDefendingPlayer);
 				if (kDefendingPlayer.isAlive() && kDefendingPlayer.getTeam() == eTeam)
 				{
-					kDefendingPlayer.GetTacticalAI()->GetTacticalAnalysisMap()->Refresh();
+					kDefendingPlayer.GetTacticalAI()->GetTacticalAnalysisMap()->Refresh(true);
 				}
 			}
 		}
-	}
+	}*/
 }
 
 //	-----------------------------------------------------------------------------------------------
@@ -2198,6 +2199,29 @@ void CvTeam::makePeace(TeamTypes eTeam, bool bBumpUnits, bool bSuppressNotificat
 #else
 	DoMakePeace(eTeam, bBumpUnits, bSuppressNotification);
 #endif
+
+	CvPlayerManager::Refresh(true);
+
+	//refresh tactical AI as well!
+	// Refreshing all alive players in CvPlayerManager, so no need for this. However, refreshing all might not be required. Have checked in the commented code to show that the refresh needs to be forced.
+	/*for (int iAttackingPlayer = 0; iAttackingPlayer < MAX_MAJOR_CIVS; iAttackingPlayer++)
+	{
+		PlayerTypes eAttackingPlayer = (PlayerTypes)iAttackingPlayer;
+		CvPlayerAI& kAttackingPlayer = GET_PLAYER(eAttackingPlayer);
+		if (kAttackingPlayer.isAlive() && kAttackingPlayer.getTeam() == GetID())
+		{
+			kAttackingPlayer.GetTacticalAI()->GetTacticalAnalysisMap()->Refresh(true);
+			for (int iDefendingPlayer = 0; iDefendingPlayer < MAX_MAJOR_CIVS; iDefendingPlayer++)
+			{
+				PlayerTypes eDefendingPlayer = (PlayerTypes)iDefendingPlayer;
+				CvPlayerAI& kDefendingPlayer = GET_PLAYER(eDefendingPlayer);
+				if (kDefendingPlayer.isAlive() && kDefendingPlayer.getTeam() == eTeam)
+				{
+					kDefendingPlayer.GetTacticalAI()->GetTacticalAnalysisMap()->Refresh(true);
+				}
+			}
+		}
+	}*/
 }
 
 //	------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Tactical data is desyncing. I believe it is largely to do with the caching mechanism on the TacticalMap.

The TacticalMap is only updated at most once per turn due to existing caching logic. I suspect that the data is desyncing due to the cache being updated at different points on some clients. Unfortunately I haven't figured out the conditions in which the update points are different. Instead I have tried to minimise the potential to desync by forcing updates at specific points. I have also added the ability to invalidate the cache so that the cache is still rebuilt at a later point in the turn (as seems to be desired, otherwise there would not be a need to be lazy about the updates).

This change is very heavy handed but does appear to help prevent desyncs. It can be cleaned up and optimized but right now I just want to prevent desyncs and don't want to worry about something not being updated when it needed to be. With some more investigation I hope to confirm the root cause of the desyncing.

At any rate, it does look like they were being updated too early by CvPlayer::UpdateCityThreadCriteria. A comment in the TacticalMap class says that refreshing should be done after danger plots are updated in CvPlayer::doTurnPostDiplomacy - CvPlayer::UpdateCityThreatCriteria is called just before that.  This sounds like a bug that can be addressed in single player also.

I assume that it is desirable to have the TacticalMap refreshed during ai_unitUpdate, so I also implemented a means of invalidating the cache so that the map is updated then if need be...unless of course something else updates it beforehand.

This is just hanging together and could benefit from further thought but I am not familiar enough at the moment. Is it worth considering forcing an update in ai_unitMoves instead? Maybe just the invalidating is enough. Maybe just re-ordering UpdateCityThreatCriteria would be enough?

In addition to this, I am forcing an update of ALL tactical maps upon war or peace. This most likely overkill  but my testing was done using this and am reluctant to change right now. It could probably be just done for the involved teams in the make war/peace methods (like before or in better spots still, such as DoNowAtWarOrPeace or setAtWar). Existing code was asking the TacticalMap to refresh but this was unlikely to be effectual due to the once-per-turn limit imposed by the caching mechanism.

This change will need to see some refinement before committing to master, even if it is just some wrapping to make it MP only.