### PR TITLE
Make Trade Route desync

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvUnitMission.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnitMission.cpp
@@ -1760,8 +1760,11 @@ void CvUnitMission::StartMission(CvUnit* hUnit)
 				CvAssertMsg(pPlot, "pPlot is null! OH NOES, JOEY!");
 				if (pPlot)
 				{
-					// This should fix TR/cargo unit related desyncs (different paths etc). I suspect there is still the potential for desyncs if the user opens the TR popup but something changes before they issue the command. Even just opening the popup could cause problems. I think a net message is in order for a real fix.
-					GC.getGame().GetGameTrade()->InvalidateTradePathCache(hUnit->getOwner()); // although we are only interested in one trade route, we invalidate all since the originating client has updated their whole cache when opening the popup
+					if (GC.getGame().isNetworkMultiPlayer())
+					{
+						// This should fix TR/cargo unit related desyncs (different paths etc). I suspect there is still the potential for desyncs if the user opens the TR popup but something changes before they issue the command. Even just opening the popup could cause problems. I think a net message is in order for a real fix.
+						GC.getGame().GetGameTrade()->InvalidateTradePathCache(hUnit->getOwner()); // although we are only interested in one trade route, we invalidate all since the originating client has updated their whole cache when opening the popup
+					}
 
 					if(hUnit->makeTradeRoute(pPlot->getX(), pPlot->getY(), (TradeConnectionType)pkQueueData->iData2))
 					{

--- a/CvGameCoreDLL_Expansion2/CvUnitMission.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnitMission.cpp
@@ -1760,6 +1760,9 @@ void CvUnitMission::StartMission(CvUnit* hUnit)
 				CvAssertMsg(pPlot, "pPlot is null! OH NOES, JOEY!");
 				if (pPlot)
 				{
+					// This should fix TR/cargo unit related desyncs (different paths etc). I suspect there is still the potential for desyncs if the user opens the TR popup but something changes before they issue the command. Even just opening the popup could cause problems. I think a net message is in order for a real fix.
+					GC.getGame().GetGameTrade()->InvalidateTradePathCache(hUnit->getOwner()); // although we are only interested in one trade route, we invalidate all since the originating client has updated their whole cache when opening the popup
+
 					if(hUnit->makeTradeRoute(pPlot->getX(), pPlot->getY(), (TradeConnectionType)pkQueueData->iData2))
 					{
 						bAction = true;


### PR DESCRIPTION
Largely fixes a variety of trade route related desyncs, such as ones caused by different paths etc. This small change will greatly improve MP experience. I reckon that this bug may have played a big role in the increased complaints about MP after BNW was released.

TR Cache was being updated only on the owner's client. Need to update on all or else route details could be different leading to desyncs. This is now done by invalidating the cache when the establish trade route unit mission is received.

I suspect there is still the potential for desyncs if the user opens the TR popup but something changes before they issue the command. Even just opening the popup could cause problems. I think a net message is in order for a real fix and I will look into it.