### PR TITLE
fix typo in trade log name

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvDealClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDealClasses.cpp
@@ -5294,7 +5294,7 @@ void CvGameDeals::LogDealFailed(CvDeal* pDeal, bool bNoRenew, bool bNotAccepted,
 		}
 		else
 		{
-			strLogName = "DiplomacyAI_TradeAgremeents_Log.csv";
+			strLogName = "DiplomacyAI_TradeAgreements_Log.csv";
 		}
 
 		FILogFile* pLog;


### PR DESCRIPTION
DiplomacyAI_TradeAgreements_Log.csv wrong in one instance.