### PR TITLE
fix bypass MP check when overwriting savegame 

### DIFF
--- a/Community Patch/Core Files/CoreLua/SaveMenu.lua
+++ b/Community Patch/Core Files/CoreLua/SaveMenu.lua
@@ -1,0 +1,662 @@
+include( "InstanceManager" );
+include( "IconSupport" );
+include( "SupportFunctions" );
+include( "UniqueBonuses" );
+include( "MapUtilities" );
+
+local g_IsSingle = true;
+local g_IsAuto   = false;
+local g_IsDeletingFile = true;
+
+-- Global Constants
+g_InstanceManager = InstanceManager:new( "LoadButton", "Button", Controls.LoadFileButtonStack );
+s_maxCloudSaves = Steam.GetMaxCloudSaves();
+
+-- Global Variables
+g_SavedGames = {};			-- A list of all saved game entries.
+g_SelectedEntry = nil;		-- The currently selected entry.
+
+----------------------------------------------------------------        
+----------------------------------------------------------------
+function DoSaveToFile()
+	if (PreGame.IsMultiplayerGame() and PreGame.GameStarted()) then
+		UI.CopyLastAutoSave( Controls.NameBox:GetText() );
+	else
+		UI.SaveGame( Controls.NameBox:GetText() );
+	end
+end
+----------------------------------------------------------------        
+----------------------------------------------------------------
+function DoSaveToSteamCloud(i)
+	if (PreGame.IsMultiplayerGame() and PreGame.GameStarted()) then
+		Steam.CopyLastAutoSaveToSteamCloud( i );
+	else
+		Steam.SaveGameToCloud( i );
+	end
+end
+----------------------------------------------------------------        
+----------------------------------------------------------------
+function OnSave()
+	if(g_SelectedEntry == nil) then
+		local newSave = Controls.NameBox:GetText();
+		for i, v in ipairs(g_SavedGames) do
+			if(v.DisplayName ~= nil and Locale.Length(v.DisplayName) > 0) then
+				if(Locale.ToUpper(newSave) == Locale.ToUpper(v.DisplayName)) then
+					g_SelectedEntry = v;		
+				end
+			end
+		end
+	end
+	
+	if(g_SelectedEntry ~= nil) then
+		if(g_SelectedEntry.SaveData == nil and g_SelectedEntry.IsCloudSave) then
+			for i, v in ipairs(g_SavedGames) do
+				if(v == g_SelectedEntry) then
+					DoSaveToSteamCloud( i );
+					break;
+				end
+			end
+		else
+			g_IsDeletingFile = false;
+			Controls.Message:SetText( Locale.ConvertTextKey("TXT_KEY_OVERWRITE_TXT") );
+			Controls.DeleteConfirm:SetHide(false);
+			return;
+		end
+	else
+		DoSaveToFile();
+	end
+	
+	Controls.NameBox:ClearString();
+	SetupFileButtonList();
+	OnBack();
+end
+Controls.SaveButton:RegisterCallback( Mouse.eLClick, OnSave );
+
+
+function GetDefaultSaveName()
+	if (PreGame.GameStarted()) then 
+		local iPlayer = Game.GetActivePlayer();
+		local leaderName = PreGame.GetLeaderName(iPlayer);
+		local civ = PreGame.GetCivilization();
+		local civInfo = GameInfo.Civilizations[civ];
+		local leader = GameInfo.Leaders[GameInfo.Civilization_Leaders( "CivilizationType = '" .. civInfo.Type .. "'" )().LeaderheadType];
+		
+		local leaderDescription = Locale.ConvertTextKey(leader.Description);
+		if leaderName ~= nil and leaderName ~= ""then
+			leaderDescription = leaderName;
+		end
+						
+		return leaderDescription .. "_" .. Game.GetTimeString();
+	else
+		-- Saving before the game starts, this will just save the setup data
+		return Locale.ConvertTextKey("TXT_KEY_DEFAULT_GAME_CONFIGURATION_NAME");
+	end
+		
+end
+
+
+----------------------------------------------------------------        
+----------------------------------------------------------------
+function OnEditBoxChange( _, _, bIsEnter )	
+	local text = Controls.NameBox:GetText();
+	
+	if( g_SelectedEntry ~= nil ) then
+		g_SelectedEntry.Instance.SelectHighlight:SetHide( true );
+		local iPlayer = 0;
+		if (PreGame.GameStarted()) then
+			local iPlayer = Game.GetActivePlayer();
+			SetSaveInfoToCiv(PreGame.GetCivilization(), PreGame.GetGameSpeed(), PreGame.GetEra(), 0, 
+							 PreGame.GetHandicap(), PreGame.GetWorldSize(), PreGame.GetMapScript(), nil, 
+							 PreGame.GetLeaderName(iPlayer),PreGame.GetCivilizationDescription(iPlayer), Players[iPlayer]:GetCurrentEra(), PreGame.GetGameType() );
+		else
+			local iPlayer = Matchmaking.GetLocalID();
+			SetSaveInfoToCiv(PreGame.GetCivilization(), PreGame.GetGameSpeed(), PreGame.GetEra(), 0, 
+							 PreGame.GetHandicap(), PreGame.GetWorldSize(), PreGame.GetMapScript(), nil, 
+							 PreGame.GetLeaderName(iPlayer),PreGame.GetCivilizationDescription(iPlayer), PreGame.GetEra(), PreGame.GetGameType() );
+		end
+						 
+		g_SelectedEntry = nil;
+	end
+	
+	if(not ValidateText(text)) then
+		Controls.SaveButton:SetDisabled(true);
+	else
+		Controls.SaveButton:SetDisabled(false);
+	end	
+	Controls.Delete:SetDisabled(true); 
+	
+	if( bIsEnter ) then
+	    OnSave();
+	end
+end
+Controls.NameBox:RegisterCallback( OnEditBoxChange )
+
+----------------------------------------------------------------        
+----------------------------------------------------------------
+function OnDelete()
+	g_IsDeletingFile = true;
+	Controls.Message:SetText( Locale.ConvertTextKey("TXT_KEY_CONFIRM_TXT") );
+	Controls.DeleteConfirm:SetHide(false);
+	Controls.BGBlock:SetHide(true);
+end
+Controls.Delete:RegisterCallback( Mouse.eLClick, OnDelete );
+
+----------------------------------------------------------------        
+----------------------------------------------------------------
+function OnYes()
+	Controls.DeleteConfirm:SetHide(true);
+	Controls.BGBlock:SetHide(false);
+	if(g_IsDeletingFile) then
+		UI.DeleteSavedGame( g_SelectedEntry.FileName );
+	else
+		if(g_SelectedEntry.IsCloudSave) then
+			for i, v in ipairs(g_SavedGames) do
+				if(v == g_SelectedEntry) then
+					DoSaveToSteamCloud( i );
+					break;
+				end
+			end
+		else
+			DoSaveToFile();
+		end
+		
+		OnBack();
+	end
+	
+	SetupFileButtonList();
+	Controls.NameBox:ClearString();
+	Controls.SaveButton:SetDisabled(true);
+end
+Controls.Yes:RegisterCallback( Mouse.eLClick, OnYes );
+
+----------------------------------------------------------------        
+----------------------------------------------------------------
+function OnNo( )
+	Controls.DeleteConfirm:SetHide(true);
+	Controls.BGBlock:SetHide(false);
+end
+Controls.No:RegisterCallback( Mouse.eLClick, OnNo );
+-------------------------------------------------
+-------------------------------------------------
+function OnBack()
+	-- Test if we are modal or a popup
+	if (UIManager:IsModal( ContextPtr )) then
+		UIManager:PopModal( ContextPtr );
+	else
+		UIManager:DequeuePopup( ContextPtr );
+	end
+    Controls.NameBox:ClearString();
+    SetSelected( nil );
+end
+Controls.BackButton:RegisterCallback( Mouse.eLClick, OnBack );
+-------------------------------------------------
+-------------------------------------------------
+Controls.CloudCheck:RegisterCheckHandler(function(checked)
+
+	if(checked) then
+		Controls.NameBox:ClearString();
+	else
+		Controls.NameBox:SetText(GetDefaultSaveName());
+	end
+	SetSelected( nil );
+	SetupFileButtonList();
+end);
+-------------------------------------------------
+-------------------------------------------------
+function SetSelected( entry )
+    if( g_SelectedEntry ~= nil ) then
+        g_SelectedEntry.Instance.SelectHighlight:SetHide( true );
+    end
+    
+    g_SelectedEntry = entry;
+    
+    if( entry ~= nil) then
+		Controls.NameBox:SetText( entry.DisplayName );
+		entry.Instance.SelectHighlight:SetHide( false );
+		
+		if(entry.SaveData == nil and entry.FileName ~= nil and not entry.IsCloudSave) then
+			entry.SaveData = PreGame.GetFileHeader(entry.FileName);
+		end
+		
+		if(entry.SaveData ~= nil) then
+			local header = entry.SaveData;
+			
+			local date;
+			if(entry.FileName) then
+				date = UI.GetSavedGameModificationTime(entry.FileName);
+			end
+			
+			SetSaveInfoToCiv(header.PlayerCivilization, header.GameSpeed, header.StartEra, header.TurnNumber, header.Difficulty, header.WorldSize, header.MapScript, date, header.LeaderName, header.CivilizationName, header.CurrentEra, header.GameType);
+			Controls.Delete:SetDisabled(false); 
+		
+		elseif(entry.IsCloudSave) then
+			SetSaveInfoToEmptyCloudSave();
+		else
+			SetSaveInfoToNone();
+		end
+		
+		Controls.SaveButton:SetDisabled(false);  
+			
+	else -- No saves are selected
+		if (PreGame.GameStarted()) then
+			local iPlayer = Game.GetActivePlayer();
+			SetSaveInfoToCiv(PreGame.GetCivilization(), PreGame.GetGameSpeed(), PreGame.GetEra(), Game.GetElapsedGameTurns(), 
+							 PreGame.GetHandicap(), PreGame.GetWorldSize(), PreGame.GetMapScript(), nil,
+							 PreGame.GetLeaderName(iPlayer), PreGame.GetCivilizationDescription(iPlayer), Players[iPlayer]:GetCurrentEra(), PreGame.GetGameType() );
+		else
+			local iPlayer = Matchmaking.GetLocalID();
+			SetSaveInfoToCiv(PreGame.GetCivilization(), PreGame.GetGameSpeed(), PreGame.GetEra(), 0, 
+							 PreGame.GetHandicap(), PreGame.GetWorldSize(), PreGame.GetMapScript(), nil,
+							 PreGame.GetLeaderName(iPlayer), PreGame.GetCivilizationDescription(iPlayer), PreGame.GetEra(), PreGame.GetGameType() );
+		end
+		Controls.Delete:SetDisabled(true);
+    end
+end
+
+-------------------------------------------------
+-------------------------------------------------
+function SetSaveInfoToCiv(civType, gameSpeed, era, turn, difficulty, mapSize, mapScript, date, leaderName, civName, curEra, gameType)
+	
+	local currentEra;
+	local startEra;
+		
+	if(curEra ~= "") then
+		currentEra = GameInfo.Eras[curEra];
+	end
+	
+	if(era ~= "") then
+		startEra = GameInfo.Eras[era];
+	end
+	
+	if(currentEra ~= nil) then
+		Controls.EraTurn:LocalizeAndSetText("TXT_KEY_CUR_ERA_TURNS_FORMAT", currentEra.Description, turn);
+	else
+		Controls.EraTurn:LocalizeAndSetText("TXT_KEY_CUR_ERA_TURNS_FORMAT", "TXT_KEY_MISC_UNKNOWN", turn);
+	end
+	
+	if(startEra ~= nil) then
+		Controls.StartEra:LocalizeAndSetText("TXT_KEY_START_ERA", startEra.Description);
+	else
+		Controls.StartEra:LocalizeAndSetText("TXT_KEY_START_ERA", "TXT_KEY_MISC_UNKNOWN");
+	end
+							  
+	-- Set Save file time
+	if(date ~= nil) then
+		Controls.TimeSaved:SetText(date);	
+	else
+		Controls.TimeSaved:SetText("");
+	end
+	
+	if (gameType == GameTypes.GAME_HOTSEAT_MULTIPLAYER) then
+		Controls.GameType:SetText( Locale.ConvertTextKey("TXT_KEY_MULTIPLAYER_HOTSEAT_GAME") );
+	else
+		if (gameType == GameTypes.GAME_NETWORK_MULTIPLAYER) then
+			Controls.GameType:SetText(  Locale.ConvertTextKey("TXT_KEY_MULTIPLAYER_STRING") );
+		else
+			if (gameType == GameTypes.GAME_SINGLE_PLAYER) then
+				Controls.GameType:SetText(  Locale.ConvertTextKey("TXT_KEY_SINGLE_PLAYER") );
+			else
+				Controls.GameType:SetText( "" );
+			end
+		end
+	end
+	
+	
+	-- ? leader icon
+	IconHookup( 22, 128, "LEADER_ATLAS", Controls.Portrait );
+	local civDesc = Locale.ConvertTextKey("TXT_KEY_MISC_UNKNOWN");
+	local leaderDescription = Locale.ConvertTextKey("TXT_KEY_MISC_UNKNOWN");
+	
+	-- Sets civ icon and tool tip
+	local civ = GameInfo.Civilizations[civType];
+	if (civ ~= nil) then
+		civDesc = Locale.ConvertTextKey(civ.Description);
+		local leader = GameInfo.Leaders[GameInfo.Civilization_Leaders( "CivilizationType = '" .. civ.Type .. "'" )().LeaderheadType];
+		if (leader ~= nil) then		
+			leaderDescription = Locale.ConvertTextKey(leader.Description);
+			IconHookup( leader.PortraitIndex, 128, leader.IconAtlas, Controls.Portrait );
+		end
+		local textureOffset, textureAtlas = IconLookup( civ.PortraitIndex, 64, civ.IconAtlas );
+		if textureOffset ~= nil then       
+			Controls.CivIcon:SetTexture( textureAtlas );
+			Controls.CivIcon:SetTextureOffset( textureOffset );
+			Controls.CivIcon:SetToolTipString( Locale.ConvertTextKey( civ.ShortDescription) );
+		end
+		Controls.LargeMapImage:UnloadTexture();
+		local mapTexture = civ.MapImage;
+		Controls.LargeMapImage:SetTexture(mapTexture);		
+	end
+		
+	if(leaderName ~= nil and leaderName ~= "")then
+		leaderDescription = leaderName;
+	end
+	
+	if(civName ~= nil and civName ~= "")then
+		civDesc = civName;
+	end
+	Controls.Title:LocalizeAndSetText("TXT_KEY_RANDOM_LEADER_CIV", leaderDescription, civDesc );
+	
+	local mapInfo = MapUtilities.GetBasicInfo(mapScript);
+	IconHookup( mapInfo.IconIndex, 64, mapInfo.IconAtlas, Controls.MapType );
+	Controls.MapType:SetToolTipString(Locale.Lookup(mapInfo.Name));
+	
+	-- Sets map size icon and tool tip
+	info = GameInfo.Worlds[ mapSize ];
+	if(info ~= nil) then
+		IconHookup( info.PortraitIndex, 64, info.IconAtlas, Controls.MapSize );
+		Controls.MapSize:SetToolTipString( Locale.ConvertTextKey( info.Description) );
+	else
+		if(questionOffset ~= nil) then
+			Controls.MapSize:SetTexture( questionTextureSheet );
+			Controls.MapSize:SetTextureOffset( questionOffset );
+			Controls.MapSize:SetToolTipString( unknownString );
+		end
+	end
+	
+	-- Sets handicap icon and tool tip
+	info = GameInfo.HandicapInfos[ difficulty ];
+	if(info ~= nil) then
+		IconHookup( info.PortraitIndex, 64, info.IconAtlas, Controls.Handicap );
+		Controls.Handicap:SetToolTipString( Locale.ConvertTextKey( info.Description ) );
+	else
+		if(questionOffset ~= nil) then
+			Controls.Handicap:SetTexture( questionTextureSheet );
+			Controls.Handicap:SetTextureOffset( questionOffset );
+			Controls.Handicap:SetToolTipString( unknownString );
+		end
+	end
+	
+	-- Sets game pace icon and tool tip
+	info = GameInfo.GameSpeeds[ gameSpeed ];
+	if(info ~= nil) then
+		IconHookup( info.PortraitIndex, 64, info.IconAtlas, Controls.SpeedIcon );
+		Controls.SpeedIcon:SetToolTipString( Locale.ConvertTextKey( info.Description ) );
+	else
+		if(questionOffset ~= nil) then
+			Controls.SpeedIcon:SetTexture( questionTextureSheet );
+			Controls.SpeedIcon:SetTextureOffset( questionOffset );
+			Controls.SpeedIcon:SetToolTipString( unknownString );
+		end
+	end
+end
+
+function SetSaveInfoToNone()
+	-- Disable ability to enter game if none are selected
+	Controls.SaveButton:SetDisabled(true);
+	Controls.Delete:SetDisabled(true);
+	
+	-- Empty all text fields
+	Controls.Title:SetText( "" );
+	Controls.EraTurn:SetText( "" );
+	Controls.TimeSaved:SetText( "" );
+	Controls.StartEra:SetText( "" );
+	Controls.GameType:SetText( "" );
+
+	-- ? leader icon
+	IconHookup( 22, 128, "LEADER_ATLAS", Controls.Portrait );
+	
+	-- Set all icons across bottom of left panel to ?
+	if questionOffset ~= nil then      
+		-- Civ Icon 
+		Controls.CivIcon:SetTexture( questionTextureSheet );
+		Controls.CivIcon:SetTextureOffset( questionOffset );
+		Controls.CivIcon:SetToolTipString( unknownString );
+
+		-- Map Type Icon 
+		Controls.MapType:SetTexture( questionTextureSheet );
+		Controls.MapType:SetTextureOffset( questionOffset );
+		Controls.MapType:SetToolTipString( unknownString );
+		-- Map Size Icon 
+		Controls.MapSize:SetTexture( questionTextureSheet );
+		Controls.MapSize:SetTextureOffset( questionOffset );
+		Controls.MapSize:SetToolTipString( unknownString );
+		-- Handicap Icon 
+		Controls.Handicap:SetTexture( questionTextureSheet );
+		Controls.Handicap:SetTextureOffset( questionOffset );
+		Controls.Handicap:SetToolTipString( unknownString );
+		-- Game Speed Icon 
+		Controls.SpeedIcon:SetTexture( questionTextureSheet );
+		Controls.SpeedIcon:SetTextureOffset( questionOffset );
+		Controls.SpeedIcon:SetToolTipString( unknownString );
+	end
+    
+	-- Set Selected Civ Map
+	Controls.LargeMapImage:UnloadTexture();
+	local mapTexture="MapRandom512.dds";
+	Controls.LargeMapImage:SetTexture(mapTexture);
+end
+
+function SetSaveInfoToEmptyCloudSave()
+	
+	-- Empty all text fields
+	Controls.Title:LocalizeAndSetText("TXT_KEY_STEAM_EMPTY_SAVE");
+	Controls.EraTurn:SetText("");
+	Controls.TimeSaved:SetText("");
+	Controls.StartEra:SetText( "" );
+	Controls.GameType:SetText("");
+
+	-- ? leader icon
+	IconHookup( 22, 128, "LEADER_ATLAS", Controls.Portrait );
+	
+	-- Set all icons across bottom of left panel to ?
+	if questionOffset ~= nil then      
+		-- Civ Icon 
+		Controls.CivIcon:SetTexture( questionTextureSheet );
+		Controls.CivIcon:SetTextureOffset( questionOffset );
+		Controls.CivIcon:SetToolTipString( unknownString );
+
+		-- Map Type Icon 
+		Controls.MapType:SetTexture( questionTextureSheet );
+		Controls.MapType:SetTextureOffset( questionOffset );
+		Controls.MapType:SetToolTipString( unknownString );
+		-- Map Size Icon 
+		Controls.MapSize:SetTexture( questionTextureSheet );
+		Controls.MapSize:SetTextureOffset( questionOffset );
+		Controls.MapSize:SetToolTipString( unknownString );
+		-- Handicap Icon 
+		Controls.Handicap:SetTexture( questionTextureSheet );
+		Controls.Handicap:SetTextureOffset( questionOffset );
+		Controls.Handicap:SetToolTipString( unknownString );
+		-- Game Speed Icon 
+		Controls.SpeedIcon:SetTexture( questionTextureSheet );
+		Controls.SpeedIcon:SetTextureOffset( questionOffset );
+		Controls.SpeedIcon:SetToolTipString( unknownString );
+	end
+    
+	-- Set Selected Civ Map
+	Controls.LargeMapImage:UnloadTexture();
+	local mapTexture="MapRandom512.dds";
+	Controls.LargeMapImage:SetTexture(mapTexture);
+end
+----------------------------------------------------------------        
+----------------------------------------------------------------
+function ChopFileName(file)
+	_, _, chop = string.find(file,"\\.+\\(.+)%."); 
+	return chop;
+end
+
+----------------------------------------------------------------        
+----------------------------------------------------------------
+function ValidateText(text)
+	local isAllWhiteSpace = true;
+	for i = 1, #text, 1 do
+		if (string.byte(text, i) ~= 32) then
+			isAllWhiteSpace = false;
+			break;
+		end
+	end
+	
+	if (isAllWhiteSpace) then
+		return false;
+	end
+
+	-- don't allow % character
+	for i = 1, #text, 1 do
+		if string.byte(text, i) == 37 then
+			return false;
+		end
+	end
+
+	local invalidCharArray = { '\"', '<', '>', '|', '\b', '\0', '\t', '\n', '/', '\\', '*', '?', ':' };
+
+	for i, ch in ipairs(invalidCharArray) do
+		if (string.find(text, ch) ~= nil) then
+			return false;
+		end
+	end
+
+	-- don't allow control characters
+	for i = 1, #text, 1 do
+		if (string.byte(text, i) < 32) then
+			return false;
+		end
+	end
+
+	return true;
+end
+
+----------------------------------------------------------------        
+----------------------------------------------------------------
+function SetupFileButtonList()
+	SetSelected( nil );
+    g_InstanceManager:ResetInstances();
+    
+    SetSaveInfoToNone();
+    
+    local bUsingSteamCloud = Controls.CloudCheck:IsChecked();
+    
+    if(bUsingSteamCloud) then
+		local cloudSaveData = Steam.GetCloudSaves();
+		
+		local sortTable = {};
+		
+		for i = 1, s_maxCloudSaves, 1 do
+			
+			local instance = g_InstanceManager:GetInstance();
+			local data = cloudSaveData[i];
+			
+			g_SavedGames[i] = {
+				Instance = instance,
+				SaveData = data,
+				IsCloudSave = true,
+			}
+			
+			local title = Locale.ConvertTextKey("TXT_KEY_STEAM_EMPTY_SAVE");
+			if(data ~= nil) then
+			
+				local civName = Locale.ConvertTextKey("TXT_KEY_MISC_UNKNOWN");
+				local leaderDescription = Locale.ConvertTextKey("TXT_KEY_MISC_UNKNOWN");
+				
+				local civ = GameInfo.Civilizations[ data.PlayerCivilization ];
+				if(civ ~= nil) then
+					local leader = GameInfo.Leaders[GameInfo.Civilization_Leaders( "CivilizationType = '" .. civ.Type .. "'" )().LeaderheadType];
+					leaderDescription = Locale.Lookup(leader.Description);
+					civName = Locale.Lookup(civ.Description);
+				end
+
+				if(not Locale.IsNilOrWhitespace(data.CivilizationName)) then
+					civName = data.CivilizationName;
+				end
+				
+				if(not Locale.IsNilOrWhitespace(data.LeaderName)) then
+					leaderDescription = data.LeaderName;
+				end
+				
+				title = Locale.Lookup("TXT_KEY_RANDOM_LEADER_CIV", leaderDescription, civName );
+			end
+			
+			instance.ButtonText:LocalizeAndSetText("TXT_KEY_STEAMCLOUD_SAVE", i, title);
+			instance.Button:RegisterCallback( Mouse.eLClick, function() SetSelected(g_SavedGames[i]); end);
+		end
+    else
+        -- build a table of all save file names that we found
+        local savedGames = {};
+        local gameType = GameTypes.GAME_SINGLE_PLAYER;
+        if (PreGame.IsMultiplayerGame()) then
+			gameType = GameTypes.GAME_NETWORK_MULTIPLAYER;
+        elseif (PreGame.IsHotSeatGame()) then
+			gameType = GameTypes.GAME_HOTSEAT_MULTIPLAYER;
+        end
+		UI.SaveFileList( savedGames, gameType, false, true);
+	   
+		for i, v in ipairs(savedGames) do
+    		local instance = g_InstanceManager:GetInstance();
+    		
+    		-- chop the part that we are going to display out of the bigger string
+			local displayName = Path.GetFileNameWithoutExtension(v);
+						
+			g_SavedGames[i] = {
+				Instance = instance,
+				FileName = v,
+				DisplayName = displayName,
+			}
+	    	
+			TruncateString(instance.ButtonText, instance.Button:GetSizeX(), displayName); 
+			
+			instance.Button:SetVoid1( i );
+			instance.Button:RegisterCallback( Mouse.eLClick, function() SetSelected(g_SavedGames[i]); end);
+		end
+    end
+    
+	Controls.Delete:SetHide(bUsingSteamCloud);
+	Controls.NameBoxFrame:SetHide(bUsingSteamCloud);
+	
+	Controls.LoadFileButtonStack:CalculateSize();
+    Controls.LoadFileButtonStack:ReprocessAnchoring();
+    Controls.ScrollPanel:CalculateInternalSize();
+end
+
+
+----------------------------------------------------------------        
+---------------------------------------------------------------- 
+function OnSaveMap()
+    UIManager:QueuePopup( Controls.SaveMapMenu, PopupPriority.SaveMapMenu );
+end
+Controls.SaveMapButton:RegisterCallback( Mouse.eLClick, OnSaveMap );
+
+
+----------------------------------------------------------------        
+-- Key Down Processing
+----------------------------------------------------------------        
+function InputHandler( uiMsg, wParam, lParam )
+    if uiMsg == KeyEvents.KeyDown then
+        if wParam == Keys.VK_ESCAPE then
+			if(Controls.DeleteConfirm:IsHidden())then
+				OnBack();
+			else
+				Controls.DeleteConfirm:SetHide(true);
+            	Controls.BGBlock:SetHide(false);
+			end
+        end
+    end
+    return true;
+end
+ContextPtr:SetInputHandler( InputHandler );
+
+----------------------------------------------------------------        
+----------------------------------------------------------------
+function ShowHideHandler( isHide )
+    if( not isHide ) then
+
+    	if (PreGame.GameStarted()) then    	
+	    	-- If the lock mods option is on then disable the save map button    	
+    		if( PreGame.IsMultiplayerGame() or
+    			Modding.AnyActivatedModsContainPropertyValue( "DisableSaveMapOption", "1" ) or
+        		PreGame.GetGameOption( GameOptionTypes.GAMEOPTION_LOCK_MODS ) ~= 0 or
+        		UIManager:IsModal( ContextPtr ) ) then
+        		Controls.SaveMapButton:SetHide( true );
+    		else
+        		Controls.SaveMapButton:SetHide( false );
+    		end
+			else
+				-- Saving before the game starts, this will just save the setup data
+      	Controls.SaveMapButton:SetHide( true );
+    	end
+			
+			Controls.NameBox:SetText(GetDefaultSaveName());
+      Controls.NameBox:TakeFocus();
+			SetupFileButtonList();
+			OnEditBoxChange();
+	end
+end
+ContextPtr:SetShowHideHandler( ShowHideHandler );

--- a/Community Patch/Core Files/CoreLua/SaveMenu.lua
+++ b/Community Patch/Core Files/CoreLua/SaveMenu.lua
@@ -7,6 +7,7 @@ include( "MapUtilities" );
 local g_IsSingle = true;
 local g_IsAuto   = false;
 local g_IsDeletingFile = true;
+local g_ShowForceCheck = false;
 
 -- Global Constants
 g_InstanceManager = InstanceManager:new( "LoadButton", "Button", Controls.LoadFileButtonStack );
@@ -19,7 +20,7 @@ g_SelectedEntry = nil;		-- The currently selected entry.
 ----------------------------------------------------------------        
 ----------------------------------------------------------------
 function DoSaveToFile()
-	if (PreGame.IsMultiplayerGame() and PreGame.GameStarted()) then
+	if (PreGame.IsMultiplayerGame() and PreGame.GameStarted() and not Controls.ForceFreshMPSave:IsChecked()) then
 		UI.CopyLastAutoSave( Controls.NameBox:GetText() );
 	else
 		UI.SaveGame( Controls.NameBox:GetText() );
@@ -28,7 +29,7 @@ end
 ----------------------------------------------------------------        
 ----------------------------------------------------------------
 function DoSaveToSteamCloud(i)
-	if (PreGame.IsMultiplayerGame() and PreGame.GameStarted()) then
+	if (PreGame.IsMultiplayerGame() and PreGame.GameStarted() and not Controls.ForceFreshMPSave:IsChecked()) then
 		Steam.CopyLastAutoSaveToSteamCloud( i );
 	else
 		Steam.SaveGameToCloud( i );
@@ -636,10 +637,13 @@ ContextPtr:SetInputHandler( InputHandler );
 ----------------------------------------------------------------        
 ----------------------------------------------------------------
 function ShowHideHandler( isHide )
+		
     if( not isHide ) then
-
+		-- don't want to encourage potentially corrupting operations!
+		Controls.ForceFreshMPSave:SetCheck(false);
     	if (PreGame.GameStarted()) then    	
-	    	-- If the lock mods option is on then disable the save map button    	
+    		Controls.ForceFreshMPSave:SetHide(not g_ShowForceCheck or not PreGame.IsMultiplayerGame());
+	    	-- If the lock mods option is on then disable the save map button    		    		    	
     		if( PreGame.IsMultiplayerGame() or
     			Modding.AnyActivatedModsContainPropertyValue( "DisableSaveMapOption", "1" ) or
         		PreGame.GetGameOption( GameOptionTypes.GAMEOPTION_LOCK_MODS ) ~= 0 or

--- a/Community Patch/Core Files/CoreLua/SaveMenu.xml
+++ b/Community Patch/Core Files/CoreLua/SaveMenu.xml
@@ -47,6 +47,10 @@
         <GridButton Anchor="R,B" ID="SaveButton"     Offset="38,54"     Size="260,45"    Style="BaseButton" String="TXT_KEY_MENU_SAVE" />
 
         <CheckBox Offset="20,44" Anchor="R,T"  String="TXT_KEY_STEAMCLOUD" TextAnchor="L,C"  IsChecked="0" ID="CloudCheck" />
+        
+        <!-- Couldn't figure out how to add text keys to an existing modpack, so for now...  -->
+        <CheckBox Offset="20,109" Anchor="R,B"  String="TXT_KEY_FORCE_MP_SAVE" TextAnchor="L,C"  IsChecked="0" ID="ForceFreshMPSave" ToolTip="TXT_KEY_FORCE_MP_SAVE_TOOLTIP"/>
+        
 
       <!-- Side treatments -->
 			<Box Style="MenuLeftSideTreatment"/>

--- a/Community Patch/Core Files/CoreLua/SaveMenu.xml
+++ b/Community Patch/Core Files/CoreLua/SaveMenu.xml
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Context ColorSet="Beige_Black" Font="TwCenMT22" FontStyle="Shadow">
+
+
+  <Instance Name="LoadButton" >
+    <Container Size="460,32" ID="InstanceRoot" >
+
+      <GridButton Anchor="C,B"  ID="Button" Offset="0,0" Size="460,32" Style="ZoomButton"  >
+        <ShowOnMouseOver>
+          <AlphaAnim Anchor="L,T" Size="460,32" Pause="0" Cycle="Bounce" Speed="1" AlphaStart="2" AlphaEnd="1">
+            <Grid   Size="460,32" Offset="0,-2" Padding="0,0" Style="Grid9FrameTurnsHL" />
+          </AlphaAnim>
+
+        </ShowOnMouseOver>
+
+        <!-- Selected State -->
+        <Grid Anchor="C,C" Offset="0,0" Size="460,32"  Style="Grid9FrameTurns" ID="SelectHighlight" Hidden="1" />
+        <Label ID="ButtonText" Anchor="C,C"  Offset="0,0"  String="TXT_KEY_DELETE_BUTTON" Font="TwCenMT20" ColorSet="Beige_Black_Alpha" FontStyle="Shadow"  />
+
+      </GridButton>
+    </Container>
+  </Instance>
+
+
+  <Box Size="Full,Full" Color="Black,200" ConsumeMouse="1" HideBox="0" ID="BGBlock" />
+
+    <Grid Size="960,658" Anchor="C,C" Offset="0,36" Padding="0,0" Style="Grid9DetailFive140" ConsumeMouse="1">
+
+        <Box Anchor="C,B" AnchorSide="I.I" Offset="0,54"   Size="910,56" Color="255,255,255,0" >
+
+            <!-- Delete Button  -->
+            <GridButton Anchor="C,B"  Style="SmallButton" Size="150,32"  Offset="0,0" StateOffsetIncrement="0,0"  ID="Delete">
+                    <Label Anchor="C,C"  Offset="0,0"  String="TXT_KEY_DELETE_BUTTON" Font="TwCenMT18" ColorSet="Beige_Black_Alpha" FontStyle="Shadow"  />
+            </GridButton>
+            <GridButton Anchor="L,B"  Style="SmallButton" Offset="200,0"  Size="150,32"  StateOffsetIncrement="0,0" ID="SaveMapButton"  >
+                <Label Anchor="C,C"  Offset="0,0" String="TXT_KEY_MENU_SAVE_MAP_LOWER"  Font="TwCenMT18" ColorSet="Beige_Black_Alpha" FontStyle="Shadow" />
+            </GridButton>
+
+            <!-- Back Button  -->
+            <GridButton Anchor="L,B"  Style="SmallButton" Size="150,32"  Offset="14,0" StateOffsetIncrement="0,0" ID="BackButton"  >
+                <Label Anchor="C,C"  Offset="0,0"  String="TXT_KEY_BACK_BUTTON" Font="TwCenMT18" ColorSet="Beige_Black_Alpha" FontStyle="Shadow" />
+            </GridButton>
+
+        </Box>
+
+        <!-- Save Game  -->
+        <GridButton Anchor="R,B" ID="SaveButton"     Offset="38,54"     Size="260,45"    Style="BaseButton" String="TXT_KEY_MENU_SAVE" />
+
+        <CheckBox Offset="20,44" Anchor="R,T"  String="TXT_KEY_STEAMCLOUD" TextAnchor="L,C"  IsChecked="0" ID="CloudCheck" />
+
+      <!-- Side treatments -->
+			<Box Style="MenuLeftSideTreatment"/>
+			<Box Style="MenuRightSideTreatment"/>
+
+			<Box Style="MenuTopTreatment"/>
+			<Box Style="MenuBottomTreatment"/>
+
+
+			<!-- Screen Title  -->
+      <Label Style="MenuTitleCaption" String="TXT_KEY_MENU_SAVE_BUTTON" />
+
+
+      <!-- File List -->
+        <Box Anchor="R,T" Offset="48,102" Size="490,404" Color="255,255,255,0" >
+
+          <ScrollPanel Offset="0,0" Anchor="L,T" Size="495,400" ID="ScrollPanel" Vertical="1" AutoScrollBar="1" >
+
+            <Stack Anchor="C,T" Offset="0,0"  StackGrowth="Bottom" ID="LoadFileButtonStack">
+            </Stack>
+              <!-- Scroll Controls -->
+              <ScrollBar Style="VertSlider" Length="364" Offset="0.18" Anchor="R,T" AnchorSide="O,I" />
+              <UpButton  Offset="0.0"  Style="ScrollBarUp"  Anchor="R,T" AnchorSide="O,I" />
+              <DownButton Offset="0.0" Style="ScrollBarDown"  Anchor="R,B" AnchorSide="O,I" />
+
+          </ScrollPanel>
+
+            <Grid Anchor="L,T" Offset="0,-2" Size="490,404" Padding="0,0" Style="Grid9Frame" Hidden="0" />
+
+        </Box>
+
+
+        <!-- file details treatment -->
+        <Box Anchor="L,T" Offset="48,100" Size="354,404" Color="255,255,255,0" >
+            <Image Anchor="C,C" Offset="0,0" Color="White.36" Size="360,410" Texture="MapAmerica512.dds" ID="LargeMapImage"/>
+            <Grid Anchor="C,C" Offset="0,0" Size="354,404" Padding="0,0" Style="Grid9Frame" Hidden="0" />
+
+            <Image Anchor="L,T" Offset="0.0" Size="128,128"   Texture="Assets/UI/Art/Icons/LeaderPortraits1024Frame.dds"  >
+                    <Image Anchor="C,C" Offset="0,0" Size="128,128"   Texture="Assets/UI/Art/Icons/LeaderPortraits1024.dds" ID="Portrait" />
+            </Image>
+
+            <Stack Anchor="L,T" Offset="6,122"  Padding="8" StackGrowth="Bottom" >
+                
+                <Box Anchor="C,T" Anchorside="I.O" Offset="0,0" Size="330,24" Color="255,255,200,255" ID="NameBoxFrame" >
+                    <Box Anchor="C,C"  Offset="0,0" Size="328,22" Color="0,0,0,255" >
+                        <EditBox CallOnChar="1" Size="324,22" Anchor="C,C" Font="TwCenMT20"  ID="NameBox" MaxLength="32" />
+                    </Box>
+                </Box>
+              <Image Anchor="L.C"  Offset="0,0" Texture="bar340x2.dds" Size="340.1"  Hidden="0"/>
+
+
+                    <Label Anchor="L,C" WrapWidth="350" Offset="6,0" Font="TwCenMT18" ColorSet="Beige_Black_Alpha" FontStyle="Shadow" String="Washington - America" TruncateWidth="305" ID="Title"/>
+                    <Label Anchor="L,C" Offset="6,0" Font="TwCenMT18" ColorSet="Beige_Black_Alpha" FontStyle="Shadow" String="October 24, 1972 10:32 A.M." ID="TimeSaved"/>
+                    <Label Anchor="L,C" Offset="6,0" Font="TwCenMT18" ColorSet="Beige_Black_Alpha" FontStyle="Shadow" String="Ancient Era: (64 Turns)" ID="EraTurn"/>
+                    <Label Anchor="L,C" Offset="6,0" Font="TwCenMT18" ColorSet="Beige_Black_Alpha" FontStyle="Shadow" String="Ancient Era: (64 Turns)" ID="StartEra"/>
+										<Label Anchor="L,C" Offset="6,0" Font="TwCenMT18" ColorSet="Beige_Black_Alpha" FontStyle="Shadow" ID="GameType"/>
+
+						</Stack>
+
+          <Image Anchor="C,B"  Offset="0,84" Texture="bar340x2.dds" Size="340.1"  Hidden="0"/>
+
+
+          <Stack Anchor="C,B" Offset="0,12"  Padding="0" StackGrowth="Right" >
+
+                <Image Anchor="L,C"  Size="64,64"  Offset="0,0" Texture="Assets/UI/Art/Icons/IconFrame64.dds"   ToolTip="TXT_KEY_MULTIPLAYER_STAGING_ROOM_HEADER_CIVILIZATION" >
+                        <Image Size="64,64" Anchor="C,C"  Texture="Assets/UI/Art/Icons/Units/CivSymbolsColor512.dds" Hidden="0" ID="CivIcon" />
+                    <Label Anchor="L,C" Offset="64,0" Font="TwCenMT22" ColorSet="Beige_Black_Alpha" FontStyle="Shadow" String="" />
+                </Image>
+
+                <Image Anchor="L,C"  Size="64,64"  Offset="0,0" Texture="Assets/UI/Art/Icons/IconFrame64.dds"   ToolTip="TXT_KEY_AD_SETUP_MAP_TYPE" >
+                        <Image Anchor="C,C"  Size="64,64" Texture="Assets/UI/Art/Icons/MapTypeIcons256.dds" ID="MapType" />
+                    <Label Anchor="L,C" Offset="64,0" Font="TwCenMT22" ColorSet="Beige_Black_Alpha" FontStyle="Shadow" String="" />
+                </Image>
+
+                <Image Anchor="L,C"  Size="64,64"  Offset="0,0" Texture="Assets/UI/Art/Icons/IconFrame64.dds" ToolTip="TXT_KEY_AD_SETUP_MAP_SIZE"  >
+                        <Image Anchor="C,C"  Size="64,64" Texture="Assets/UI/Art/Icons/MapSizeIcons256.dds" ID="MapSize" />
+                    <Label Anchor="L,C" Offset="64,0" Font="TwCenMT22" ColorSet="Beige_Black_Alpha" FontStyle="Shadow" String=""  />
+                </Image>
+
+                <Image Anchor="L,C"  Size="64,64"  Offset="0,0" Texture="Assets/UI/Art/Icons/IconFrame64.dds" ToolTip="TXT_KEY_AD_SETUP_HANDICAP"  >
+                        <Image Anchor="C,C"  Size="64,64" Texture="Assets/UI/Art/Icons/DifficultyLevelIcons256.dds" ID="Handicap"/>
+                    <Label Anchor="L,C" Offset="64,0" Font="TwCenMT22" ColorSet="Beige_Black_Alpha" FontStyle="Shadow" String=""  />
+                </Image>
+
+                <Image Anchor="L,C"  Size="64,64"  Offset="0,0" Texture="Assets/UI/Art/Icons/IconFrame64.dds" ToolTip="TXT_KEY_GAME_SPEED"   >
+                        <Image Anchor="C,C"  Size="64,64" Texture="Assets/UI/Art/Icons/GameSpeedIcons256.dds" ID="SpeedIcon"/>
+                    <Label Anchor="L,C" Offset="64,0" Font="TwCenMT22" ColorSet="Beige_Black_Alpha" FontStyle="Shadow" String=""   />
+                </Image>
+            </Stack>
+
+        </Box>
+
+    </Grid>
+
+  <Box Color="Black.200" Size="Full.Full" ID="DeleteConfirm" Hidden="1" ConsumeMouseOver="1" >
+    <Grid Size="500,360" Anchor="C,C" Offset="0,0" Padding="0,20" Style="Grid9DetailFive140"  Hidden="0" >
+
+      <!-- Side treatments -->
+			<Box Style="PopupLeftSideTreatment"/>
+			<Box Style="PopupRightSideTreatment"/>
+			<Box Style="PopupNotificationTopTreatment"/>
+
+			<Label ID="Message" Anchor="C,T"  Offset="0,74"  WrapWidth="440" String="TXT_KEY_CONFIRM_TXT" Font="TwCenMT22" ColorSet="Beige_Black_Alpha" FontStyle="Shadow"  />
+      <Stack Anchor="C,B" Offset="0,80" Padding="24" StackGrowth="Bottom" ID="ButtonStack">
+        <!-- Yes Button  -->
+        <GridButton Style="BaseButton"  ID="Yes" Size="400,42" Anchor="C,T" Offset="0,0"  Hidden="0">
+          <Label Anchor="C,C" Offset="0,0" String="TXT_KEY_YES_BUTTON" ColorSet="Beige_Black" Font="TwCenMT24" FontStyle="Shadow" />
+        </GridButton>
+        <!-- No Button  -->
+        <GridButton  Style="BaseButton" ID="No" Size="400,42" Anchor="C,T" Offset="0,0"  Hidden="0">
+          <Label Anchor="C,C" Offset="0,0" String="TXT_KEY_NO_BUTTON" ColorSet="Beige_Black" Font="TwCenMT24" FontStyle="Shadow" />
+        </GridButton>
+      </Stack>
+    </Grid>
+  </Box>
+
+
+    <LuaContext FileName="Assets/UI/InGame/Menus/SaveMapMenu" ID="SaveMapMenu" Hidden="True" />
+
+</Context>

--- a/Community Patch/Core Files/Text/CoreText_en_US.xml
+++ b/Community Patch/Core Files/Text/CoreText_en_US.xml
@@ -7165,6 +7165,14 @@
 		<Row Tag="TXT_KEY_REPLAY_VIEWER_GRAPHBY_TOURISM">
 			<Text>Tourism [ICON_TOURISM] Per Turn</Text>
 		</Row>
+
+		<!-- Hopefully removed if option is not needed or better solution in place -->
+		<Row Tag="TXT_KEY_FORCE_MP_SAVE">
+			<Text>Force Mid-Turn New Save (Not recommended - may corrupt save game!)</Text>
+		</Row>
+		<Row Tag="TXT_KEY_FORCE_MP_SAVE_TOOLTIP">
+			<Text>DANGER! Emulate vanilla where a save of the current turn state could be made mid-turn by exploiting a bug in the overwrite file check. Normally a save is/was just a renamed copy of the most recent autosave. With this option enabled mid-turn state can be saved BUT Firaxis explicitly tried to prevent this, presumably because it can cause issues. This option is in NO WAY recommended and to use at own risk.</Text>
+		</Row>
 	</Language_en_US>
 	<PostDefines>
 		<Row Name="PROMOTION_DEEPWATER_EMBARKATION">


### PR DESCRIPTION
 Fixed bug where overwritten saves save differently

There is deliberate Firaxis code which means manual multiplayer savegames are only ever copies of the most recent autosave. Overwriting save games was going through a code path that avoided the checks that enforced this. This has been fixed and overwritten behavior is consistent with the normal behavior.

This bug is the reason why people have been able to avoid the "double ai turn" problem. However, it is quite possible that this was having other unwanted effects on the game when loaded again. I have not witnessed any problems but I suspect they are possible and Firaxis certainly thought so themselves, hence the checks! I believe Firaxis originally only had autosaves in MP and this is was their quick fix. They could have easily not put in the checks so there is almost certainly some perceived issues with creating fresh saves mid-turn.

Unfortunately, some people may be bothered by not having this gleature, so...

Added code to emulate old-overwrite save bug that allow saving of mid-turn state. Looks nasty. Is nasty.

Hopefully this can be removed. Only provided in case the bug was being relied upon for reasons in addition to working around the "double ai turn" issue.

I am not sure about your philosophy in regards to these kinds of matters.
I am also not sure if I have the files in the correct location.

I have a upcoming pull request that aims to give people more control over their saving their games.