### PR TITLE
ProcessPlayerAutoMoves reinit issue

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvGame.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGame.cpp
@@ -8111,6 +8111,8 @@ void CvGame::doTurn()
 	//this turn.  CvGameController::Update() will continue to reset the timer if there is prolonged ai processing.
 	resetTurnTimer(true);
 
+	m_processPlayerAutoMoves = false; // Starts out as false and gets set to true in updateMoves but was never getting set back to false if MP simultaneous turns with no AI.
+
 	// If player unit cycling has been canceled for this turn, set it back to normal for the next
 	GC.GetEngineUserInterface()->setNoSelectionListCycle(false);
 

--- a/CvGameCoreDLL_Expansion2/CvGame.h
+++ b/CvGameCoreDLL_Expansion2/CvGame.h
@@ -892,6 +892,7 @@ protected:
 	FTimer  m_timeSinceGameTurnStart;		//time since game turn started for human players
 	float	m_fCurrentTurnTimerPauseDelta;	//
 	bool    m_sentAutoMoves;
+	bool	m_processPlayerAutoMoves;
 	bool	m_bForceEndingTurn;
 
 #if defined(MOD_BALANCE_CORE_SPIES)


### PR DESCRIPTION
There was a static bool called ProcessPlayerAutoMoves in updateMoves but I made it a member. This due to the static var not being re-inited and maybe causing issues when loading after an exit-to-menu and starting/loading a new game (maybe with different turn types). The member is not serialized, should be OK.

If the static var started off true I think it may have been possible that automoves might processed before they should have been (probably only in  Simultaneous MP with no AI). I don't fully understand the turn process but the code seems to think it important to not start before everyone is ready.

While writing notes for this pull request and trying to document what issues this actually fixes, I noticed what seems like a bigger problem. If in Simultaneous MP with no AI (only), the variable is never reset to false. I might be sleepy but wouldn't this mean automoves are often processed before they are ready to be? I worry I am missing something since it would be a common occurrence. Is anyone familiar with this?

Assuming this is indeed a bug, I slotted in code to set to the member to false at the start of CvGame::doTurn. I don't play simultaneous turns and don't have the time or inclination to test it much though. If it is not a bug for whatever reason, the change will not be catastrophic and I expect will only delay some processing a little.