### PR TITLE
Save Diplo Reqs and Proposed Deals

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvDealClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDealClasses.cpp
@@ -5861,32 +5861,6 @@ FDataStream& operator>>(FDataStream& loadFrom, CvGameDeals& writeTo)
 	loadFrom >> uiVersion;
 	MOD_SERIALIZE_INIT_READ(loadFrom);
 
-#if defined(MOD_ACTIVE_DIPLOMACY)
-	if(GC.getGame().isReallyNetworkMultiPlayer() && MOD_ACTIVE_DIPLOMACY)
-	{
-		// JdH => savegame compatible load
-		loadFrom >> iEntriesToRead;
-		for (int iI = 0; iI < iEntriesToRead; iI++)
-		{
-			loadFrom >> tempItem;
-			if (CvPreGame::isHuman(tempItem.GetFromPlayer()) && CvPreGame::isHuman(tempItem.GetToPlayer()))
-			{
-				// only load human to humand deals until other problems are fixed
-				writeTo.m_ProposedDeals.push_back(tempItem);
-			}
-		}
-	}
-	else
-	{
-		writeTo.m_ProposedDeals.clear();
-		loadFrom >> iEntriesToRead;
-		for(int iI = 0; iI < iEntriesToRead; iI++)
-		{
-			loadFrom >> tempItem;
-			writeTo.m_ProposedDeals.push_back(tempItem);
-		}
-	}
-#else
 	writeTo.m_ProposedDeals.clear();
 	loadFrom >> iEntriesToRead;
 	for(int iI = 0; iI < iEntriesToRead; iI++)
@@ -5894,7 +5868,6 @@ FDataStream& operator>>(FDataStream& loadFrom, CvGameDeals& writeTo)
 		loadFrom >> tempItem;
 		writeTo.m_ProposedDeals.push_back(tempItem);
 	}
-#endif
 	writeTo.m_CurrentDeals.clear();
 	loadFrom >> iEntriesToRead;
 	for(int iI = 0; iI < iEntriesToRead; iI++)
@@ -5922,40 +5895,11 @@ FDataStream& operator<<(FDataStream& saveTo, const CvGameDeals& readFrom)
 	saveTo << uiVersion;
 	MOD_SERIALIZE_INIT_WRITE(saveTo);
 
-#if defined(MOD_ACTIVE_DIPLOMACY)
-	if(GC.getGame().isReallyNetworkMultiPlayer() && MOD_ACTIVE_DIPLOMACY)
-	{
-		// JdH => savegame compatible save
-		DealList saveList;
-		for (it = readFrom.m_ProposedDeals.begin(); it != readFrom.m_ProposedDeals.end(); ++it)
-		{
-			if (CvPreGame::isHuman(it->GetFromPlayer()) && CvPreGame::isHuman(it->GetToPlayer()))
-			{
-				// only save human to human deals until we save notifications & requests too
-				saveList.push_back(*it);
-			}
-		}
-		saveTo << saveList.size();
-		for (it = saveList.begin(); it != saveList.end(); ++it) 
-		{
-			saveTo << *it;
-		}
-	}
-	else
-	{
-		saveTo << readFrom.m_ProposedDeals.size();
-		for(it = readFrom.m_ProposedDeals.begin(); it != readFrom.m_ProposedDeals.end(); ++it)
-		{
-			saveTo << *it;
-		}
-	}
-#else
 	saveTo << readFrom.m_ProposedDeals.size();
 	for(it = readFrom.m_ProposedDeals.begin(); it != readFrom.m_ProposedDeals.end(); ++it)
 	{
 		saveTo << *it;
 	}
-#endif
 	saveTo << readFrom.m_CurrentDeals.size();
 	for(it = readFrom.m_CurrentDeals.begin(); it != readFrom.m_CurrentDeals.end(); ++it)
 	{

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyRequests.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyRequests.cpp
@@ -17,6 +17,7 @@
 #include "CvDealAI.h"
 #endif
 
+#include <sstream>
 // Include this after all other headers.
 #include "LintFree.h"
 
@@ -440,6 +441,14 @@ void CvDiplomacyRequests::DoAIMPDiplomacyWithHumans()
 
 	s_aDiploHumans.clear();
 }
+
+// Because requests aren't removed on all clients after processing I am just gonna clear them at the start/end of turn
+// REally should delete after a net message but concerned about bugs. This should be an improvement at least.
+void CvDiplomacyRequests::ClearAllRequests() {
+	if (!m_aRequests.empty())
+		NET_MESSAGE_DEBUG_OSTR_ALWAYS("CvDiplomacyRequests::ClearAllRequests(): Clearning non-empty m_aRequests of player" << m_ePlayer);
+	m_aRequests.clear();
+}
 /*static*/ std::vector<PlayerTypes> CvDiplomacyRequests::s_aDiploHumans;
 #endif
 //	----------------------------------------------------------------------------
@@ -454,6 +463,10 @@ void CvDiplomacyRequests::SendRequest(PlayerTypes eFromPlayer, PlayerTypes eToPl
 	{
 		if (GC.getGame().isNetworkMultiPlayer() && eToPlayer != GC.getGame().getActivePlayer())
 		{
+			CvPlayer& kPlayer = GET_PLAYER(eToPlayer);
+			CvDiplomacyRequests* pkDiploRequests = kPlayer.GetDiplomacyRequests();
+			if (pkDiploRequests)
+				pkDiploRequests->Add(eFromPlayer, eDiploType, pszMessage, eAnimationType, iExtraGameData);
 			return;
 		}
 		CvPlayer& kPlayer = GET_PLAYER(eToPlayer);
@@ -625,3 +638,4 @@ bool CvDiplomacyRequests::HasActiveDiploRequestWithHuman(PlayerTypes eSourcePlay
 	}
 	return false;
 }
+

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyRequests.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyRequests.cpp
@@ -17,7 +17,6 @@
 #include "CvDealAI.h"
 #endif
 
-#include <sstream>
 // Include this after all other headers.
 #include "LintFree.h"
 
@@ -443,10 +442,8 @@ void CvDiplomacyRequests::DoAIMPDiplomacyWithHumans()
 }
 
 // Because requests aren't removed on all clients after processing I am just gonna clear them at the start/end of turn
-// REally should delete after a net message but concerned about bugs. This should be an improvement at least.
+// Really should delete after a net message but concerned about bugs. This should be an improvement at least.
 void CvDiplomacyRequests::ClearAllRequests() {
-	if (!m_aRequests.empty())
-		NET_MESSAGE_DEBUG_OSTR_ALWAYS("CvDiplomacyRequests::ClearAllRequests(): Clearning non-empty m_aRequests of player" << m_ePlayer);
 	m_aRequests.clear();
 }
 /*static*/ std::vector<PlayerTypes> CvDiplomacyRequests::s_aDiploHumans;

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyRequests.h
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyRequests.h
@@ -44,6 +44,7 @@ public:
 #if defined(MOD_ACTIVE_DIPLOMACY)
 	void ActivateAllFrom(PlayerTypes eFromPlayer);
 	void CheckRemainingNotifications();
+	void ClearAllRequests();
 #endif
 	bool Add(PlayerTypes ePlayerID, DiploUIStateTypes eDiploType, const char* pszMessage, LeaderheadAnimationTypes eAnimationType, int iExtraGameData = -1);
 

--- a/CvGameCoreDLL_Expansion2/CvGame.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGame.cpp
@@ -8116,12 +8116,27 @@ void CvGame::doTurn()
 
 	CvBarbarians::BeginTurn();
 
+#if defined(MOD_ACTIVE_DIPLOMACY)
+	// Dodgy business to cleanup all the completed requests from last turn. Any still here should just be ones that were processed on other clients anyway.
+	if (MOD_ACTIVE_DIPLOMACY)
+	{
+		for (iI = 0; iI < MAX_MAJOR_CIVS; iI++)
+		{
+			CvPlayerAI& kPlayer = GET_PLAYER((PlayerTypes)iI);
+			CvAssertMsg((kPlayer.isLocalPlayer() && !kPlayer.GetDiplomacyRequests()->HasPendingRequests()) || !kPlayer.isLocalPlayer(), "Clearing requests, expected local player to be empty.");
+			kPlayer.GetDiplomacyRequests()->ClearAllRequests();
+		}
+	}
+#endif
+
 	doUpdateCacheOnTurn();
 
 	DoUpdateCachedWorldReligionTechProgress();
 
 	updateScore();
 
+	
+	
 	m_kGameDeals.DoTurn();
 
 	for(iI = 0; iI < MAX_TEAMS; iI++)

--- a/CvGameCoreDLL_Expansion2/CvGame.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGame.cpp
@@ -8135,8 +8135,6 @@ void CvGame::doTurn()
 
 	updateScore();
 
-	
-	
 	m_kGameDeals.DoTurn();
 
 	for(iI = 0; iI < MAX_TEAMS; iI++)

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -44575,7 +44575,7 @@ void CvPlayer::Read(FDataStream& kStream)
 			m_pDiplomacyRequests->Uninit();
 
 		m_pDiplomacyRequests->Init(GetID());
-		//m_pDiplomacyRequests->Read(kStream);
+		m_pDiplomacyRequests->Read(kStream);
 	}
 
 	if(m_bTurnActive)
@@ -44750,7 +44750,10 @@ void CvPlayer::Write(FDataStream& kStream) const
 	kStream << m_strEmbarkedGraphicOverride;
 
 	m_kPlayerAchievements.Write(kStream);
-
+	
+	if (GetID() < MAX_MAJOR_CIVS)
+		m_pDiplomacyRequests->Write(kStream);	
+	
 #if defined(MOD_API_UNIFIED_YIELDS) && defined(MOD_API_PLOT_YIELDS)
 	// MOD_SERIALIZE_READ - v57/v58/v59 broke the save format  couldn't be helped, but don't make a habit of it!!!
 	kStream << m_ppiPlotYieldChange;


### PR DESCRIPTION
ACTIVE_DIPLOMACY specifc code was removed from writing out proposed deals.Comments stated that it was not writing out requests until issues were resolved. I am not sure what the issues were but I may have addressed them. It seems to work OK, albeit still a little odd because I need to clean them out at the start of the turn.

Diplo requests are now being written out also.

I don't think this change has much effect unless you are writing new save games in the middle of the turn, such as "double saving" or using the "mp post autosave" feature I will be submitting shortly. I guess some associated changes (sending the requests to non-active players) might prevent some weird desyncs but probably not.

I don't think I have tested this enough yet for a proper release but I have not had any issues arise. I will be monitoring the effects. I did uncomment some commented code and it does make me nervous as to why it was commented out in the first place!