### PR TITLE
Enabled Events in MP

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvCity.h
+++ b/CvGameCoreDLL_Expansion2/CvCity.h
@@ -115,7 +115,7 @@ public:
 	bool IsCityEventChoiceValid(CityEventChoiceTypes eEventChoice, CityEventTypes eParentEvent);
 	void DoCancelEventChoice(CityEventChoiceTypes eEventChoice);
 	void DoStartEvent(CityEventTypes eEvent);
-	void DoEventChoice(CityEventChoiceTypes eEventChoice, CityEventTypes eCityEvent = NO_EVENT_CITY);
+	void DoEventChoice(CityEventChoiceTypes eEventChoice, CityEventTypes eCityEvent = NO_EVENT_CITY, bool bSendMsg = true);
 	CvString GetScaledHelpText(CityEventChoiceTypes eEventChoice, bool bYieldsOnly);
 	CvString GetDisabledTooltip(CityEventChoiceTypes eEventChoice);
 

--- a/CvGameCoreDLL_Expansion2/CvDllNetMessageExt.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDllNetMessageExt.cpp
@@ -1,0 +1,94 @@
+#include "CvGameCoreDLLPCH.h"
+#include "CvDllNetMessageExt.h"
+
+namespace NetMessageExt
+{		
+	// Nothing fancy now and should probably have some more machinery if there end up being more of these implemented.
+	namespace Flags
+	{
+		enum FromDiplomacyFromUI
+		{
+			// Best not to use 255 since it could be confused with NO_PLAYER
+			None = 0,
+			DoEventChoice,
+			DoCityEventChoice,	// Could use the same id but I doubt we will use more than 254		
+		};
+	}
+
+	namespace Process
+	{
+		bool FromDiplomacyFromUI(PlayerTypes ePlayer, PlayerTypes eOtherPlayer, FromUIDiploEventTypes eEvent, int iArg1, int iArg2) {
+			Flags::FromDiplomacyFromUI flag = Flags::FromDiplomacyFromUI(static_cast<unsigned int>(eOtherPlayer) >> 24);
+			switch (flag)
+			{
+				case Flags::None:
+					return false;
+
+				case Flags::DoEventChoice:				
+				{
+					PlayerTypes eActualPlayer = static_cast<PlayerTypes>(eOtherPlayer & 0xFF);
+					EventTypes ePlayerEvent = static_cast<EventTypes>(eEvent);
+					EventChoiceTypes eEventChoice = static_cast<EventChoiceTypes>(iArg2);
+					Response::DoEventChoice(eActualPlayer, eEventChoice, ePlayerEvent);					
+					break;
+				}
+				case Flags::DoCityEventChoice:
+				{
+					PlayerTypes eActualPlayer = static_cast<PlayerTypes>(eOtherPlayer & 0xFF);
+					int iCityID = iArg1;
+					CityEventTypes eCityEvent = static_cast<CityEventTypes>(eEvent);
+					CityEventChoiceTypes eEventChoice = static_cast<CityEventChoiceTypes>(iArg2);
+					Response::DoCityEventChoice(eActualPlayer, iCityID, eEventChoice, eCityEvent);
+					break;
+				}
+			}
+			return true;
+		}
+	}
+	
+
+	namespace Send
+	{
+		void DoEventChoice(PlayerTypes ePlayer, EventChoiceTypes eEventChoice, EventTypes eEvent)
+		{
+			CvAssertMsg((ePlayer & 0xFFFFFF00) == 0, "ePlayer representation outside of expected range");
+
+			unsigned int uiMsgFlagAndPlayer = static_cast<unsigned int>(Flags::DoEventChoice << 24 | ePlayer);			
+			gDLL->sendFromUIDiploEvent(static_cast<PlayerTypes>(uiMsgFlagAndPlayer), static_cast<FromUIDiploEventTypes>(eEvent), -1, static_cast<int>(eEventChoice));
+		}
+		void DoCityEventChoice(PlayerTypes ePlayer, int iCityID, CityEventChoiceTypes eEventChoice, CityEventTypes eCityEvent)
+		{
+			CvAssertMsg((ePlayer & 0xFFFFFF00) == 0, "ePlayer representation outside of expected range");
+			CvAssertMsg(iCityID >= 0, "iCityID outside of expected range");
+			
+			unsigned int uiMsgFlagAndPlayer = static_cast<unsigned int>(Flags::DoCityEventChoice << 24 | ePlayer);
+			gDLL->sendFromUIDiploEvent(static_cast<PlayerTypes>(uiMsgFlagAndPlayer), static_cast<FromUIDiploEventTypes>(eCityEvent), iCityID, static_cast<int>(eEventChoice));
+		}
+	}
+
+	namespace Response
+	{
+
+		void DoEventChoice(PlayerTypes ePlayer, EventChoiceTypes eEventChoice, EventTypes eEvent)
+		{
+			CvPlayer& kActualPlayer = GET_PLAYER(ePlayer);
+			kActualPlayer.DoEventChoice(eEventChoice, eEvent, false);
+		}
+
+		void DoCityEventChoice(PlayerTypes ePlayer, int iCityID, CityEventChoiceTypes eEventChoice, CityEventTypes eCityEvent)
+		{
+			CvPlayer& kActualPlayer = GET_PLAYER(ePlayer);
+			int iLoop;
+			CvCity* pLoopCity;
+			for (pLoopCity = kActualPlayer.firstCity(&iLoop); pLoopCity != NULL; pLoopCity = kActualPlayer.nextCity(&iLoop))
+			{
+				if (pLoopCity->GetID() == iCityID)
+				{
+					pLoopCity->DoEventChoice(eEventChoice, eCityEvent, false);
+					break;
+				}
+
+			}
+		}
+	}
+}

--- a/CvGameCoreDLL_Expansion2/CvDllNetMessageExt.h
+++ b/CvGameCoreDLL_Expansion2/CvDllNetMessageExt.h
@@ -1,0 +1,28 @@
+#pragma once
+
+namespace NetMessageExt
+{
+	// Used in CvDllNetMessageHandler response functions to detect and translate message to the correct Response function instead of executing the normal handling code
+	// All return true if the message was detected and the calling function should return immediately if that is the case.
+	namespace Process
+	{
+		bool FromDiplomacyFromUI(PlayerTypes ePlayer, PlayerTypes eOtherPlayer, FromUIDiploEventTypes eEvent, int iArg1, int iArg2);
+	}
+
+	// Used to send messages by encoding values so that they can safely be transmitted via DLL calls that were designed for a different purpose
+	namespace Send
+	{
+		void DoEventChoice(PlayerTypes ePlayer, EventChoiceTypes eEventChoice, EventTypes eEvent);
+		void DoCityEventChoice(PlayerTypes ePlayer, int iCityID, CityEventChoiceTypes eEventChoice, CityEventTypes eCityEvent);
+		void RefreshTradeRouteCache(PlayerTypes ePlayer);
+	}
+
+	// Used to respond to sent messages in the normal fashion
+	namespace Response
+	{
+		void DoEventChoice(PlayerTypes ePlayer, EventChoiceTypes eEventChoice, EventTypes eEvent);
+		void DoCityEventChoice(PlayerTypes ePlayer, int iCityID, CityEventChoiceTypes eEventChoice, CityEventTypes eCityEvent);
+		void RefreshTradeRouteCache(PlayerTypes ePlayer);
+	}
+}
+

--- a/CvGameCoreDLL_Expansion2/CvDllNetMessageHandler.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDllNetMessageHandler.cpp
@@ -12,6 +12,8 @@
 #include "CvDiplomacyAI.h"
 #include "CvTypes.h"
 #include "CvGameCoreUtils.h"
+#include "CvDllNetMessageExt.h"
+
 
 CvDllNetMessageHandler::CvDllNetMessageHandler()
 {
@@ -237,6 +239,9 @@ void CvDllNetMessageHandler::ResponseDestroyUnit(PlayerTypes ePlayer, int iUnitI
 //------------------------------------------------------------------------------
 void CvDllNetMessageHandler::ResponseDiplomacyFromUI(PlayerTypes ePlayer, PlayerTypes eOtherPlayer, FromUIDiploEventTypes eEvent, int iArg1, int iArg2)
 {
+	// hijacks message for MP events since it has a few args and is sent to everyone
+	if (NetMessageExt::Process::FromDiplomacyFromUI(ePlayer, eOtherPlayer, eEvent, iArg1, iArg2))
+		return;
 	GET_PLAYER(eOtherPlayer).GetDiplomacyAI()->DoFromUIDiploEvent(ePlayer, eEvent, iArg1, iArg2);
 }
 //------------------------------------------------------------------------------

--- a/CvGameCoreDLL_Expansion2/CvPlayer.h
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.h
@@ -149,7 +149,7 @@ public:
 	bool IsEventValid(EventTypes eEvent);
 	bool IsEventChoiceValid(EventChoiceTypes eEventChoice, EventTypes eParentEvent);
 	void DoStartEvent(EventTypes eEvent);
-	void DoEventChoice(EventChoiceTypes eEventChoice, EventTypes eEvent = NO_EVENT);
+	void DoEventChoice(EventChoiceTypes eEventChoice, EventTypes eEvent = NO_EVENT, bool bSendMsg = true);
 	void DoEventSyncChoices(EventChoiceTypes eEventChoice, CvCity* pCity);
 	CvString GetScaledHelpText(EventChoiceTypes eEventChoice, bool bYieldsOnly);
 	CvString GetDisabledTooltip(EventChoiceTypes eEventChoice);

--- a/CvGameCoreDLL_Expansion2/VoxPopuli.vcxproj
+++ b/CvGameCoreDLL_Expansion2/VoxPopuli.vcxproj
@@ -307,6 +307,7 @@
     <ClCompile Include="CvDllNetLoadGameInfo.cpp">
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">CvGameCoreDLLPCH.h</PrecompiledHeaderFile>
     </ClCompile>
+    <ClCompile Include="CvDllNetMessageExt.cpp" />
     <ClCompile Include="CvDllNetMessageHandler.cpp">
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">CvGameCoreDLLPCH.h</PrecompiledHeaderFile>
     </ClCompile>
@@ -779,6 +780,7 @@
     <ClInclude Include="CvDllMissionInfo.h" />
     <ClInclude Include="CvDllNetInitInfo.h" />
     <ClInclude Include="CvDllNetLoadGameInfo.h" />
+    <ClInclude Include="CvDllNetMessageExt.h" />
     <ClInclude Include="CvDllNetMessageHandler.h" />
     <ClInclude Include="CvDllNetworkSyncronization.h" />
     <ClInclude Include="CvDllPathFinderUpdate.h" />


### PR DESCRIPTION
Added code to send Event related messages to remote players. However, this is done via the foul means of hijacking the DiplomacyFromUI message and giving it a dual purpose. Event messages are have a flag encoded into one of the arguments and this is detected and handled appropriately on the clients. I understand this is unappealing but I believe it to be safe and the nastiness is tucked away.

Seems to work fine but maybe some events are problematic as I wouldn't have encountered all variations of mechanisms in limited testing (only 2 players!).

Added code is nothing fancy and can be improved if we want to send more
of messages in this manner, such as making the Trade Route cache invalidation when opening the TR popup propagate to other clients.