### PR TITLE
Civ background on all MP deal notifications

### DIFF
--- a/43 Civs CP/43 Civs CP/EUI/NotificationPanel.lua
+++ b/43 Civs CP/43 Civs CP/EUI/NotificationPanel.lua
@@ -465,9 +465,8 @@ local function SetupNotification( instance, sequence, Id, type, toolTip, strSumm
 			itemImage = instance.TechAwardImage
 
 		elseif type == NotificationTypes.NOTIFICATION_PLAYER_DEAL_RECEIVED then
-			itemInfo = GameInfo.Leaders[ iGameValue ]
-			itemImage = instance.DiplomacyPlayerImage
-
+			local index = iGameValue;
+			CivIconHookup( index, 80, instance.DiplomacyPlayerImage, instance.CivIconBG, instance.CivIconShadow, false, true );
 		elseif type == NotificationTypes.NOTIFICATION_GREAT_WORK_COMPLETED_ACTIVE_PLAYER then
 			smallCivFrame = instance.WonderSmallCivFrame
 

--- a/CvGameCoreDLL_Expansion2/CvNotifications.cpp
+++ b/CvGameCoreDLL_Expansion2/CvNotifications.cpp
@@ -426,6 +426,17 @@ int CvNotifications::Add(NotificationTypes eNotificationType, const char* strMes
 	newNotification.m_bDismissed = false;
 	newNotification.m_bWaitExtraTurn = false;
 
+#if defined(MOD_ACTIVE_DIPLOMACY)
+	// Hack to get human-human deals showing with the diplomacy icon with proper civ background - otherwise they have the question mark background.
+	// Deals from AI are coming through with the sending player ID in m_iGameDataIndex, but humans have it in iX (and m_iGameDataIndex is -1). I can't see iX myself where I need it in the Lua so I am hacking it across here.
+	// There is probably something else afoot but this seems to work for the minute and appears safe.
+	if (MOD_ACTIVE_DIPLOMACY && GC.getGame().isReallyNetworkMultiPlayer() && newNotification.m_eNotificationType == NOTIFICATION_PLAYER_DEAL_RECEIVED) {
+		if (newNotification.m_iGameDataIndex == -1) {
+			newNotification.m_iGameDataIndex = iX;
+		}
+	}
+#endif
+
 	// Is this notification being added during the player's auto-moves and will it expire at the end of the turn?
 	// If so, set a flag so the notification will stick around for an extra turn.
 	if (GET_PLAYER(m_ePlayer).isTurnActive() && GET_PLAYER(m_ePlayer).isAutoMoves() && IsNotificationTypeEndOfTurnExpired(eNotificationType))

--- a/EUI Compatibility Files/EUI Compatibility Files/LUA/NotificationPanel.lua
+++ b/EUI Compatibility Files/EUI Compatibility Files/LUA/NotificationPanel.lua
@@ -6,6 +6,7 @@
 -- code is common using gk_mode and bnw_mode switches
 -------------------------------------------------
 include( "EUI_tooltips" )
+include( "IconSupport" );
 
 Events.SequenceGameInitComplete.Add(function()
 print("Loading EUI notification panel",ContextPtr,os.clock(),[[ 
@@ -465,8 +466,7 @@ local function SetupNotification( instance, sequence, Id, type, toolTip, strSumm
 			itemImage = instance.TechAwardImage
 
 		elseif type == NotificationTypes.NOTIFICATION_PLAYER_DEAL_RECEIVED then
-			itemInfo = GameInfo.Leaders[ iGameValue ]
-			itemImage = instance.DiplomacyPlayerImage
+      return SimpleCivIconHookup(iGameValue, 80, instance.DiplomacyPlayerImage);
 
 		elseif type == NotificationTypes.NOTIFICATION_GREAT_WORK_COMPLETED_ACTIVE_PLAYER then
 			smallCivFrame = instance.WonderSmallCivFrame

--- a/EUI Compatibility Files/EUI Compatibility Files/LUA/NotificationPanel.lua
+++ b/EUI Compatibility Files/EUI Compatibility Files/LUA/NotificationPanel.lua
@@ -6,7 +6,6 @@
 -- code is common using gk_mode and bnw_mode switches
 -------------------------------------------------
 include( "EUI_tooltips" )
-include( "IconSupport" );
 
 Events.SequenceGameInitComplete.Add(function()
 print("Loading EUI notification panel",ContextPtr,os.clock(),[[ 
@@ -466,8 +465,8 @@ local function SetupNotification( instance, sequence, Id, type, toolTip, strSumm
 			itemImage = instance.TechAwardImage
 
 		elseif type == NotificationTypes.NOTIFICATION_PLAYER_DEAL_RECEIVED then
-      return SimpleCivIconHookup(iGameValue, 80, instance.DiplomacyPlayerImage);
-
+			local index = iGameValue;
+			CivIconHookup( index, 80, instance.DiplomacyPlayerImage, instance.CivIconBG, instance.CivIconShadow, false, true );
 		elseif type == NotificationTypes.NOTIFICATION_GREAT_WORK_COMPLETED_ACTIVE_PLAYER then
 			smallCivFrame = instance.WonderSmallCivFrame
 


### PR DESCRIPTION
Deal notifications all now have the proper civ background, instead of the orange colour.

The code for AI senders was actually present in other versions of the Lua.

The code for the human senders is a bit a hack but safe enough.
