### PR TITLE
fix bug where plot reveal was dependant on active player

### DIFF
--- a/CvGameCoreDLL_Expansion2/CustomMods.h
+++ b/CvGameCoreDLL_Expansion2/CustomMods.h
@@ -971,6 +971,8 @@
 #define MOD_BUGFIX_EXTRA_MISSIONARY_SPREADS			gCustomMods.isBUGFIX_EXTRA_MISSIONARY_SPREADS()
 // Workaround for the AI double turn when loading MP games with simultaneous/hybrid turns
 #define MOD_BUGFIX_AI_DOUBLE_TURN_MP_LOAD (true)
+// Fixes issue where explore plot list was not being consistently updated when a plot was revealed
+#define MOD_BUGFIX_EXPLORE_REVEALED_PLOT	(true)
 
 #endif // ACHIEVEMENT_HACKS
 

--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -11196,22 +11196,13 @@ PlotVisibilityChangeResult CvPlot::changeVisibilityCount(TeamTypes eTeam, int iC
 	if (bOldVisibility == false && isVisible(eTeam))
 	{
 		eResult = VISIBILITY_CHANGE_TO_VISIBLE;
-
+		
+		bool alreadyRevealed = isRevealed(eTeam); // result from setRevealed is not just a simple "we reveled a new plot to the player" and was causing all sorts of issues (poor ai explore decisions, desyncs, etc).
 #if defined(MOD_API_EXTENSIONS)
-		if (setRevealed(eTeam, true, pUnit))	// Change to revealed, returns true if the visibility was changed
+		if (!setRevealed(eTeam, true, pUnit))	// Change to revealed, returns true if the visibility was changed
 #else
-		if (setRevealed(eTeam, true))	// Change to revealed, returns true if the visibility was changed
+		if (!setRevealed(eTeam, true))	// Change to revealed, returns true if the visibility was changed
 #endif
-		{
-			//we are seeing this plot for the first time
-			if (bInformExplorationTracking)
-			{
-				vector<PlayerTypes> vPlayers = GET_TEAM(eTeam).getPlayers();
-				for (size_t i = 0; i < vPlayers.size(); i++)
-					GET_PLAYER(vPlayers[i]).GetEconomicAI()->UpdateExplorePlotsLocally(this);
-			}
-		}
-		else
 		{
 			// The visibility was not changed because it was already revealed, but we are changing to a visible state as well, so we must update.
 			// Just trying to avoid redundant messages.
@@ -11221,6 +11212,14 @@ PlotVisibilityChangeResult CvPlot::changeVisibilityCount(TeamTypes eTeam, int iC
 				updateFog(true);
 				updateVisibility();
 			}
+		}
+
+		//we are seeing this plot for the first time		
+		if (!alreadyRevealed && isRevealed(eTeam) && bInformExplorationTracking)
+		{
+			vector<PlayerTypes> vPlayers = GET_TEAM(eTeam).getPlayers();
+			for (size_t i = 0; i < vPlayers.size(); i++)
+				GET_PLAYER(vPlayers[i]).GetEconomicAI()->UpdateExplorePlotsLocally(this);
 		}
 
 		for (int iI = 0; iI < NUM_DIRECTION_TYPES; ++iI)


### PR DESCRIPTION
Issue when revealing plots during plot visibility count update.

Return value from CvPlot::setRevealed is more nuanced than simply
returning whether the plot is being revealed to the team.

Now using a simple check for when deciding on whether the explore plots list needs amending.

This will be responsible for a large number of desyncs for people who autoexplore. When autoexploring the unit could choose a different plot to explore since it is selecting from a different set of potential plots as the active player has reveal plots that the other machines do not.

This bug causes all sorts of problems, particularly desyncs in MP.
While the position is possibly synced by host, the visibility of the
plots is not. This means things like barb camps get spawned in different
locations on different machines, which is a big problem. I think bug is the catalyst for a great amount of drift of all sorts.


Also, it causes the AI to explore sub optimally...gonna double check this though!

Will result in slightly more processing but it is the right thing to do.

EDIT:
Just remembered that I need to add the preprocessor code for conditional compilation of the bugfix.

Also attempted to be more coherent in the above text.