### PR TITLE
Fix issue 32/64 bit bit shifting when keep civs unmet pregame

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvDllNetInitInfo.h
+++ b/CvGameCoreDLL_Expansion2/CvDllNetInitInfo.h
@@ -84,12 +84,12 @@ private:
 #if defined(MOD_KEEP_CIVS_UNKNOWN_PREGAME)
 
 #if MAX_MAJOR_CIVS <= 32
-	typedef unsigned long KnownPlayersBitArray;
+	typedef uint32 KnownPlayersBitArray;
 #elif MAX_MAJOR_CIVS <= 64
-	typedef unsigned long long KnownPlayersBitArray;
+	typedef uint64 KnownPlayersBitArray;
 #else
 	// In the highly unlikely event...
-#error need different storage for CvPreGame::s_metCivs now that MAX_MAJOR_CIVS is > 64
+#error need different storage for CvPreGame::s_metCivs now that MAX_MAJOR_CIVS is > 64, e.g. bitarray
 #endif
 
 	// this is not an FAutoVariable since it doesn't need syncing since it is just derived data.

--- a/CvGameCoreDLL_Expansion2/CvPreGame.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPreGame.cpp
@@ -3578,7 +3578,7 @@ void updateKnownPlayersTable()
 
 		for (int j = 0; j < MAX_MAJOR_CIVS; j++) {
 			if (i == j || kTeam.isHasMet((TeamTypes)j))
-				bitarray |= 1 << j;
+				bitarray |= KnownPlayersBitArray(1) << j;
 		}
 		s_knownPlayersTable[i] = bitarray;
 	}
@@ -3606,7 +3606,7 @@ bool isKnownPlayer(PlayerTypes eA, PlayerTypes eB) {
 	if (s_knownPlayersTable.empty()) return true;
 	if (eA < 0 || eB < 0) return true; // erring on the side of caution
 	if ((size_t)eA >= s_knownPlayersTable.size() || (size_t)eB >= s_knownPlayersTable.size()) return true; // erring on the side of caution
-	bool bKnown = s_knownPlayersTable[eA] & (1 << eB);
+	bool bKnown = s_knownPlayersTable[eA] & (KnownPlayersBitArray(1) << eB);
 	return bKnown;
 }
 #endif

--- a/CvGameCoreDLL_Expansion2/CvPreGame.h
+++ b/CvGameCoreDLL_Expansion2/CvPreGame.h
@@ -302,12 +302,12 @@ int readActiveSlotCountFromSaveGame(FDataStream& loadFrom, bool bReadVersion);
 #if defined(MOD_KEEP_CIVS_UNKNOWN_PREGAME)
 
 #if MAX_MAJOR_CIVS <= 32
-typedef unsigned long KnownPlayersBitArray;
+typedef uint32 KnownPlayersBitArray;
 #elif MAX_MAJOR_CIVS <= 64
-typedef unsigned long long KnownPlayersBitArray;
+typedef uint64 KnownPlayersBitArray;
 #else
 // In the highly unlikely event...
-#error need different storage for CvPreGame::s_metCivs now that MAX_MAJOR_CIVS is > 64
+#error need different storage for CvPreGame::s_metCivs now that MAX_MAJOR_CIVS is > 64, e.g. bitarray
 #endif
 
 void SetKnownPlayersTable(const std::vector<KnownPlayersBitArray>& aiKnownPlayersTable);


### PR DESCRIPTION
Fix issue with 32-bit shift for 32-bit value in code to keep civs unmet in pregame

Also, using more sensible types now.