### PR TITLE
Revert "Added extra condition for the ending of the first MP turn to prevent double AI turn bug with Pitboss"

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvDllNetMessageExt.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDllNetMessageExt.cpp
@@ -12,7 +12,6 @@ namespace NetMessageExt
 			None = 0,
 			DoEventChoice,
 			DoCityEventChoice,	// Could use the same id but I doubt we will use more than 254		
-			PlayerFirstEndTurn,
 		};
 	}
 
@@ -42,11 +41,6 @@ namespace NetMessageExt
 					Response::DoCityEventChoice(eActualPlayer, iCityID, eEventChoice, eCityEvent);
 					break;
 				}
-				case Flags::PlayerFirstEndTurn:
-				{					
-					Response::PlayerFirstEndTurn(ePlayer);
-					break;
-				}
 			}
 			return true;
 		}
@@ -69,10 +63,6 @@ namespace NetMessageExt
 			
 			unsigned int uiMsgFlagAndPlayer = static_cast<unsigned int>(Flags::DoCityEventChoice << 24 | ePlayer);
 			gDLL->sendFromUIDiploEvent(static_cast<PlayerTypes>(uiMsgFlagAndPlayer), static_cast<FromUIDiploEventTypes>(eCityEvent), iCityID, static_cast<int>(eEventChoice));
-		}
-		void PlayerFirstEndTurn() {
-			unsigned int uiMsgFlagAndPlayer = static_cast<unsigned int>(Flags::PlayerFirstEndTurn << 24 | GC.getGame().getActivePlayer());
-			gDLL->sendFromUIDiploEvent(static_cast<PlayerTypes>(uiMsgFlagAndPlayer), static_cast<FromUIDiploEventTypes>(-1), -1, static_cast<int>(-1));
 		}
 	}
 
@@ -99,10 +89,6 @@ namespace NetMessageExt
 				}
 
 			}
-		}
-
-		void PlayerFirstEndTurn(PlayerTypes ePlayer) {
-			GET_PLAYER(ePlayer).SetReceivedFirstEndTurnMessage();
 		}
 	}
 }

--- a/CvGameCoreDLL_Expansion2/CvDllNetMessageExt.h
+++ b/CvGameCoreDLL_Expansion2/CvDllNetMessageExt.h
@@ -14,7 +14,7 @@ namespace NetMessageExt
 	{
 		void DoEventChoice(PlayerTypes ePlayer, EventChoiceTypes eEventChoice, EventTypes eEvent);
 		void DoCityEventChoice(PlayerTypes ePlayer, int iCityID, CityEventChoiceTypes eEventChoice, CityEventTypes eCityEvent);
-		void PlayerFirstEndTurn();
+		void RefreshTradeRouteCache(PlayerTypes ePlayer);
 	}
 
 	// Used to respond to sent messages in the normal fashion
@@ -22,7 +22,7 @@ namespace NetMessageExt
 	{
 		void DoEventChoice(PlayerTypes ePlayer, EventChoiceTypes eEventChoice, EventTypes eEvent);
 		void DoCityEventChoice(PlayerTypes ePlayer, int iCityID, CityEventChoiceTypes eEventChoice, CityEventTypes eCityEvent);
-		void PlayerFirstEndTurn(PlayerTypes ePlayer);
+		void RefreshTradeRouteCache(PlayerTypes ePlayer);
 	}
 }
 

--- a/CvGameCoreDLL_Expansion2/CvGame.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGame.cpp
@@ -3779,12 +3779,6 @@ void CvGame::doControl(ControlTypes eControl)
 #if !defined(NO_ACHIEVEMENTS)
 			kActivePlayer.GetPlayerAchievements().EndTurn();
 #endif
-
-#if defined(MOD_BUGFIX_AI_DOUBLE_TURN_MP_LOAD)
-			// Send a message so that this and all other clients will allow the player to end their turn. 
-			// There is a condition in setEndTurn that prevents ending until this message is sent (when simul/hybrid turns and human player).
-			kActivePlayer.SendFirstEndTurnMessage();
-#endif
 			gDLL->sendTurnComplete();
 #if !defined(NO_ACHIEVEMENTS)
 			CvAchievementUnlocker::EndTurn();

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -2366,11 +2366,6 @@ void CvPlayer::reset(PlayerTypes eID, bool bConstructorCall)
 		m_aUnitExtraCosts.clear();
 
 		AI_reset();
-
-#if defined(MOD_BUGFIX_AI_DOUBLE_TURN_MP_LOAD)
-		sentFirstEndTurnMessage = false;
-		receivedFirstEndTurnMessage = false;
-#endif		
 	}
 }
 
@@ -32189,33 +32184,7 @@ void CvPlayer::SetHasLostCapital(bool bValue, PlayerTypes eConqueror)
 	}
 }
 
-#if defined(MOD_BUGFIX_AI_DOUBLE_TURN_MP_LOAD)
-bool CvPlayer::WaitingOnFirstEndTurnMessage()
-{
-	if (!GC.getGame().isNetworkMultiPlayer())
-		return false;
-	//if (!GC.getGame().isOption(GAMEOPTION_DYNAMIC_TURNS) && !GC.getGame().isOption(GAMEOPTION_SIMULTANEOUS_TURNS)) // just check isSimultaneousTurns? Do humans who are currently warring with each other have the turn skip issue? Other code seems to think so.
-	if (!isSimultaneousTurns())
-		return false;
-	if (!isHuman() || isObserver())
-		return false;
-	return !receivedFirstEndTurnMessage;
-}
 
-void CvPlayer::SendFirstEndTurnMessage()
-{
-	if (!sentFirstEndTurnMessage)
-	{
-		NetMessageExt::Send::PlayerFirstEndTurn();
-		sentFirstEndTurnMessage = true;
-	}
-}
-
-void CvPlayer::SetReceivedFirstEndTurnMessage()
-{
-	receivedFirstEndTurnMessage = true;
-}
-#endif
 //	--------------------------------------------------------------------------------
 /// Player who first captured our capital
 PlayerTypes CvPlayer::GetCapitalConqueror() const
@@ -33559,24 +33528,12 @@ void CvPlayer::setEndTurn(bool bNewValue)
 {
 	CvGame& game = GC.getGame();
 
-#if defined(MOD_BUGFIX_AI_DOUBLE_TURN_MP_LOAD)			
-	// Extra condition to check that we have received the extra message required to finish the first turn. 
-	// This is required when playing with hybrid/simultaneous turns with pitboss mode to prevent turn from getting skipped when player is not present when host starts.
-	// It might also prevent a potential race condition even when not in pitboss mode.
-	if (bNewValue
-		&& game.isNetworkMultiPlayer()
-		&& WaitingOnFirstEndTurnMessage())
-	{
-		return;
-
-	}
-#endif
-	if (isSimultaneousTurns()
-		&& bNewValue
-		&& game.isNetworkMultiPlayer()
+	if(isSimultaneousTurns()
+		&& bNewValue 
+		&& game.isNetworkMultiPlayer() 
 		&& !gDLL->HasReceivedTurnAllCompleteFromAllPlayers())
 	{//When doing simultaneous turns in multiplayer, we don't want anyone to end their turn until everyone has signalled TurnAllComplete.
-	 // No setting end turn to true until all the players have sent the TurnComplete network message		
+		// No setting end turn to true until all the players have sent the TurnComplete network message
 		return;
 	}
 
@@ -33621,7 +33578,7 @@ void CvPlayer::setEndTurn(bool bNewValue)
 		if(isEndTurn())
 		{
 			if(!GC.getGame().isOption(GAMEOPTION_DYNAMIC_TURNS) && GC.getGame().isOption(GAMEOPTION_SIMULTANEOUS_TURNS))
-			{//fully simultaneous turns only run automoves after every human has moved.				
+			{//fully simultaneous turns only run automoves after every human has moved.
 				checkRunAutoMovesForEveryone();
 			}
 			else

--- a/CvGameCoreDLL_Expansion2/CvPlayer.h
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.h
@@ -2875,13 +2875,6 @@ public:
 	CvCity* GetClosestCityByPlots(const CvPlot* pPlot) const;
 #endif
 
-#if defined(MOD_BUGFIX_AI_DOUBLE_TURN_MP_LOAD)
-	bool WaitingOnFirstEndTurnMessage();
-	void SendFirstEndTurnMessage();
-	void SetReceivedFirstEndTurnMessage();
-
-#endif
-
 protected:
 	class ConqueredByBoolField
 	{
@@ -3733,11 +3726,6 @@ protected:
 	FAutoVariable<int, CvPlayer> m_iMilitarySeaMight;
 	FAutoVariable<int, CvPlayer> m_iMilitaryAirMight;
 	FAutoVariable<int, CvPlayer> m_iMilitaryLandMight;
-#endif
-
-#if defined(MOD_BUGFIX_AI_DOUBLE_TURN_MP_LOAD)
-	bool sentFirstEndTurnMessage;
-	bool receivedFirstEndTurnMessage;
 #endif
 
 };


### PR DESCRIPTION
Reverts LoneGazebo/Community-Patch-DLL#4330

I am getting some strange behavior where the first turn does not progress under certain conditions. I believe it is due to this change as I have not encountered it before now.

Reverting until I can figure it out.