### PR TITLE
Minor Bugfixes and Optimizations

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.h
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.h
@@ -1296,7 +1296,7 @@ public:
 	int GetLiberatedCitiesScore(PlayerTypes ePlayer);
 	int GetEmbassyScore(PlayerTypes ePlayer);
 	int GetForgaveForSpyingScore(PlayerTypes ePlayer);
-	int GetNoSetterRequestScore(PlayerTypes ePlayer);
+	int GetNoSettleRequestScore(PlayerTypes ePlayer);
 	int GetStopSpyingRequestScore(PlayerTypes ePlayer);
 	int GetDemandEverMadeScore(PlayerTypes ePlayer);
 	int GetTimesCultureBombedScore(PlayerTypes ePlayer);

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -9867,6 +9867,9 @@ void CvPlayer::DoLiberatePlayer(PlayerTypes ePlayer, int iOldCityID, bool bForce
 
 			pDiploAI->SetPlayerNoSettleRequestCounter(eMePlayer, -1);
 			pDiploAI->SetPlayerStopSpyingRequestCounter(eMePlayer, -1);
+#if defined(MOD_BALANCE_CORE)
+			pDiploAI->SetNumDemandEverMade(eMePlayer, -pDiploAI->GetNumDemandEverMade(eMePlayer));
+#endif
 			pDiploAI->SetDemandCounter(eMePlayer, -1);
 			pDiploAI->ChangeNumTimesCultureBombed(eMePlayer, -pDiploAI->GetNumTimesCultureBombed(eMePlayer));
 			pDiploAI->ChangeNegativeReligiousConversionPoints(eMePlayer, -pDiploAI->GetNegativeReligiousConversionPoints(eMePlayer));


### PR DESCRIPTION
Thought I'd make a contribution to my most frequently-consulted file.

I'm no expert in C++ so these changes were made by examining the surrounding code and extrapolating from it - please verify that these are actually written correctly! :)

Fixes the following issues:

- Minor text fixes for comments

- Fixed typo in function name for GetNoSettleRequestScore (was GetNoSetterRequestScore)

- Commented out GetGaveAssistanceToScore and GetPaidTributeToScore in GetMajorCivOpinionWeight function, since those functions always return 0 and there is no code for their functioning - so no need to perform that check for every major civ every turn

- Master war/hostile weight towards vassals: now checks for number of capital cities being greater than 0, not if the original capital was conquered (for Domination Victory reasons)

- Removed duplicate if defined checks in GetBestApproachTowardsMajorCiv

- DoUpdateVictoryDisputeLevels no longer factors in Barbarians (looks like an oversight, considering DoUpdateVictoryBlockLevels had this check)

- Declaring war on a friend (except through a Defensive Pact) now adds 300 recent assist value, the same as breaking a DoF

- When an AI breaks a DoF with another AI, it now adds 300 recent assist value, not 500 (equal to humans, plus 300 is the maximum so 500 is pointless)

- Modifier for returning civilians is now halved/removed if it's been greater than a deal duration (not greater than or equal to) like the other temporary positive modifiers

- Fixed "DiplpEmphasisLatePolicies" typo even if it's vanilla and doesn't affect anything, cause it's annoying to look at :)

- Removed duplicate if defined check in GetTimesIntrigueSharedScore

- Renamed iNumCivs to iNumIntrigue in GetIntrigueSharedScore (probably a copypaste issue)

- Slight optimization to if statements for military promise opinion weight; was badly written

- Capitulated vassals and resurrected players now reset the number of demands made correctly. For vassals, vanilla C4DF sets the demand counter to -1, which removed the demand penalty, but the CBP uses the SetNumDemandEverMade mechanic, so that's now added