### PR TITLE
More Minor Diplomacy Tweaks

### DIFF
--- a/Community Patch/Core Files/Text/CoreText_en_US.xml
+++ b/Community Patch/Core Files/Text/CoreText_en_US.xml
@@ -2440,7 +2440,7 @@
 		</Row>
 
 		<Row Tag="TXT_KEY_NOTIFICATION_QUEST_ENDED_CS_OTHER_PEACE_MADE">
-			<Text>The war between {1_Civ} and {2_Civ} was ended, thanks to your the diplomatic actions of {3_Civ}.</Text>
+			<Text>The war between {1_Civ} and {2_Civ} was ended, thanks to the diplomatic actions of {3_Civ}.</Text>
 		</Row>
 
 		<Row Tag="TXT_KEY_NOTIFICATION_QUEST_KILL_CITY_STATE_ATTACKED">
@@ -6264,7 +6264,7 @@
 			<Text>[COLOR_POSITIVE_TEXT]War Score: {1_Num}[ENDCOLOR]</Text>
 		</Row>
 		<Row Tag="TXT_KEY_WAR_SCORE_EXPLANATION">
-			<Text>This value indiates how well your war is going. Ranges between [COLOR_NEGATIVE_TEXT]-100[ENDCOLOR] and [COLOR_POSITIVE_TEXT]100[ENDCOLOR].[NEWLINE][COLOR_POSITIVE_TEXT]Current war information:[ENDCOLOR]</Text>
+			<Text>This value indicates how well your war is going. Ranges between [COLOR_NEGATIVE_TEXT]-100[ENDCOLOR] and [COLOR_POSITIVE_TEXT]100[ENDCOLOR].[NEWLINE][COLOR_POSITIVE_TEXT]Current war information:[ENDCOLOR]</Text>
 		</Row>
 		<Row Tag="TXT_KEY_WAR_STRENGTH_PATHETIC">
 			<Text>[ICON_BULLET] [COLOR_POSITIVE_TEXT][ICON_STRENGTH] Military Power:[ENDCOLOR] They are pathetic!</Text>

--- a/CvGameCoreDLL_Expansion2/CvAIOperation.h
+++ b/CvGameCoreDLL_Expansion2/CvAIOperation.h
@@ -619,7 +619,7 @@ private:
 
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 //  CLASS:      CvAIOperationCivilianConcertTour
-//!  \brief		Send a merchant to a city state
+//!  \brief		Send a Great Musician to a city state
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 class CvAIOperationCivilianConcertTour : public CvAIOperationCivilian
 {
@@ -653,7 +653,7 @@ private:
 
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 //  CLASS:      CvAIOperationCivilianMerchantDelegation
-//!  \brief		Send a merchant to a city state
+//!  \brief		Send a Great Merchant to a city state
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 class CvAIOperationCivilianMerchantDelegation : public CvAIOperationCivilian
 {


### PR DESCRIPTION
- Fixed an issue where breaking a City-State attack promise with one civ gave you immunity to the opinion penalty for ignoring other civs' request to stop attacking a protected CS. As the global opinion penalty for breaking a CS attack promise is 0, it was illogical for it to be cancelling out the ignore penalty - although I left the original code commented out with the syntax fixed.

- Fixed the sloppy syntax for ignored/broken promise opinion modifiers

- A few text fixes

GetMajorCivOpinionWeight:

- Rearranged the order of the modifiers to make it more neat and categorized; changed comment text slightly (does not change the code).

- Commented out GetBrokenAttackCityStatePromiseWithAnybodyScore because it always returns 0.

DoEstimateOtherPlayerOpinions function:
- Now factors in DoF, DP, denouncing (both ways) and the global penalty for breaking a military promise. Should provide slightly more accurate estimates.

Rewrote the GetWeDenouncedFriendScore function as follows:

- If the denouncer is an untrustworthy friend, the full penalty is applied

- Otherwise, the penalty is only applied if this AI likes the denounced friend more than the denouncer, and it is reduced by 5. This allows you to denounce one friend with a lesser diplomacy penalty, but denounce 2 or more and you start getting a larger penalty with all AIs. This is reflective of the AI's approach calculation as well as of the IsUntrustworthyFriend calculation, plus it's in my opinion, more reasonable and a better usage of the DENOUNCED_BY_FRIEND_DONT_LIKE global.

- Also gives a little bit of leeway in the event of the rare "Request to denounce a friend" diplomacy event.

Changed the GetFriendDenouncementScore function as follows:

- No longer gives a bonus to opinion if the player was denounced by one of their friends that the AI likes less than them, because this mechanic is both illogical and invisible to the player.