### PR TITLE
Allow AI to make & use improved Approach guesses

### DIFF
--- a/Community Balance Patch/Balance Changes/Text/en_US/BuildingText.sql
+++ b/Community Balance Patch/Balance Changes/Text/en_US/BuildingText.sql
@@ -516,7 +516,7 @@ SET Text = 'Provides a free Garden in the city in which it is built.'
 WHERE Tag = 'TXT_KEY_WONDER_HANGING_GARDEN_HELP' AND EXISTS (SELECT * FROM COMMUNITY WHERE Type='COMMUNITY_CORE_BALANCE_BUILDINGS' AND Value= 1 );
 
 UPDATE Language_en_US
-SET Text = 'Reduces [ICON_HAPPINESS_3] UnhappinessNeeds Modifier for [ICON_RESEARCH] Illiteracy by 10% in all Cities, and increases the Military Unit Supply Cap by 3 in the city. Creates a copy of each type of military land unit you control and places the unit near the city where the Terracotta Army is constructed. Receive a large sum of [ICON_CULTURE] Culture when completed.'
+SET Text = 'Reduces [ICON_HAPPINESS_3] Unhappiness Needs Modifier for [ICON_RESEARCH] Illiteracy by 10% in all Cities, and increases the Military Unit Supply Cap by 3 in the city. Creates a copy of each type of military land unit you control and places the unit near the city where the Terracotta Army is constructed. Receive a large sum of [ICON_CULTURE] Culture when completed.'
 WHERE Tag = 'TXT_KEY_WONDER_TERRA_COTTA_ARMY_HELP' AND EXISTS (SELECT * FROM COMMUNITY WHERE Type='COMMUNITY_CORE_BALANCE_BUILDINGS' AND Value= 1 );
 
 UPDATE Language_en_US

--- a/Community Balance Patch/Balance Changes/Text/en_US/BuildingText.sql
+++ b/Community Balance Patch/Balance Changes/Text/en_US/BuildingText.sql
@@ -108,7 +108,7 @@ SET Text = 'The Forge improves sources of [ICON_RES_IRON] Iron and [ICON_RES_COP
 WHERE Tag = 'TXT_KEY_BUILDING_FORGE_STRATEGY' AND EXISTS (SELECT * FROM COMMUNITY WHERE Type='COMMUNITY_CORE_BALANCE_BUILDINGS' AND Value= 1 );
 
 UPDATE Language_en_US
-SET Text = '+1 [ICON_PRODUCTION] Production and [ICON_GOLD] Gold from all Forests worked by this City. 1 Specialist in this City no longer produces [ICON_HAPPINESS_3] Unhappiness from Urbanization.[NEWLINE][NEWLINE] Allows [ICON_PRODUCTION] Production to be moved from this city along trade routes inside your civilization. Internal [ICON_INTERNATIONAL_TRADE] Trade Routes to or from this City generate 25 [ICON_PRODUCTION] Production in their Origin City when completed, scaling with Era.'
+SET Text = '+1 [ICON_PRODUCTION] Production and [ICON_GOLD] Gold from all Forests worked by this City. 1 Specialist in this City no longer produces [ICON_HAPPINESS_3] Unhappiness from Urbanization.[NEWLINE][NEWLINE]Allows [ICON_PRODUCTION] Production to be moved from this city along trade routes inside your civilization. Internal [ICON_INTERNATIONAL_TRADE] Trade Routes to or from this City generate 25 [ICON_PRODUCTION] Production in their Origin City when completed, scaling with Era.'
 WHERE Tag = 'TXT_KEY_BUILDING_WORKSHOP_HELP' AND EXISTS (SELECT * FROM COMMUNITY WHERE Type='COMMUNITY_CORE_BALANCE_BUILDINGS' AND Value= 1 );
 	
 UPDATE Language_en_US

--- a/Community Patch/Core Files/Text/CoreText_en_US.xml
+++ b/Community Patch/Core Files/Text/CoreText_en_US.xml
@@ -2786,6 +2786,7 @@
 		<Row Tag="TXT_KEY_NO_ACTION_NO_SUPPLY_PURCHASE">
 			<Text>[NEWLINE]Cannot [ICON_GOLD] Purchase this unit, as you are at your Supply cap!</Text>
 		</Row>
+		
 		<!-- Defensive Pact Bonuses -->
 		<Row Tag="TXT_KEY_DIPLO_DP">
 			<Text>[COLOR_POSITIVE_TEXT]We have made a Defensive Pact![ENDCOLOR]</Text>
@@ -2796,7 +2797,8 @@
 		<Row Tag="TXT_KEY_DIPLO_DP_WITH_ENEMY">
 			<Text>[COLOR_NEGATIVE_TEXT]You have made a Defensive Pact with one of their enemies![ENDCOLOR]</Text>
 		</Row>
-		<!-- Open Borders Diplo Mod-->
+		
+		<!-- Open Borders Diplo Mod -->
 		<Row Tag="TXT_KEY_DIPLO_OPEN_BORDERS_MUTUAL">
 			<Text>[COLOR_POSITIVE_TEXT]We have opened our borders to each other.[ENDCOLOR]</Text>
 		</Row>
@@ -2807,12 +2809,15 @@
 			<Text>[COLOR_POSITIVE_TEXT]They have opened their borders to us.[ENDCOLOR]</Text>
 		</Row>
 
+		<!-- Social Policies Diplo Mod -->
 		<Row Tag="TXT_KEY_DIPLO_SAME_POLICIES">
 			<Text>[COLOR_POSITIVE_TEXT]We have similar Social Policies.[ENDCOLOR]</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLO_DIFFERENT_POLICIES">
 			<Text>[COLOR_NEGATIVE_TEXT]We have divergent Social Policies.[ENDCOLOR]</Text>
 		</Row>
+		
+		<!-- PTP Same CS Diplo Mod -->
 		<Row Tag="TXT_KEY_DIPLO_SAME_PTP">
 			<Text>[COLOR_NEGATIVE_TEXT]We have Pledged to Protect the same City-States.[ENDCOLOR]</Text>
 		</Row>
@@ -2838,7 +2843,8 @@
 		<Row Tag="TXT_KEY_DEFENSE_PACT_OFFER_4">
 			<Text>The tyrants of the world would tremble at our feet, if only we were allied. Do you see the value in a Defensive Pact?</Text>
 		</Row>
-		<!-- Cities/3rd Party War and Peace Offers-->
+		
+		<!-- Cities/3rd Party War and Peace Offers -->
 		<Row Tag="TXT_KEY_CITY_TRADE_OFFER_1">
 			<Text>A sale of territory is in order. I think you will find this offer quite suitable, no?</Text>
 		</Row>

--- a/CvGameCoreDLL_Expansion2/CvDealAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDealAI.cpp
@@ -81,7 +81,7 @@ CvPlayer* CvDealAI::GetPlayer()
 	return m_pPlayer;
 }
 
-// Helper function which returns this player's TeamType
+/// Helper function which returns this player's TeamType
 TeamTypes CvDealAI::GetTeam()
 {
 	return m_pPlayer->getTeam();
@@ -1311,7 +1311,7 @@ int CvDealAI::GetDealValue(CvDeal* pDeal, int& iValueImOffering, int& iValueThey
 
 #if defined(MOD_DIPLOMACY_CIV4_FEATURES)
 		if (MOD_DIPLOMACY_CIV4_FEATURES) {
-			// Item is worth 20% less if it's owner is a vassal
+			// Item is worth 20% less if its owner is a vassal
 			if(bFromMe)
 			{
 				// If it's my item and I'm the vassal of the other player, reduce it.
@@ -1431,7 +1431,7 @@ int CvDealAI::GetGoldForForValueExchange(int iGoldOrValue, bool bNumGoldFromValu
 	// Convert based on the rules above
 	int iReturnValue = iGoldOrValue * iMultiplier;
 
-	// Sometimes we want to round up.  Let's say a the AI offers a deal to the human.  We have to ensure that the human can also offer that deal back and the AI will accept (and vice versa)
+	// Sometimes we want to round up. Let's say the AI offers a deal to the human. We have to ensure that the human can also offer that deal back and the AI will accept (and vice versa)
 	if(bRoundUp)
 	{
 		iReturnValue += 99;
@@ -1476,7 +1476,7 @@ int CvDealAI::GetGPTforForValueExchange(int iGPTorValue, bool bNumGPTFromValue, 
 		iValueTimes100 = (iGPTorValue * iNumTurns);
 	}
 
-	// Sometimes we want to round up.  Let's say a the AI offers a deal to the human.  We have to ensure that the human can also offer that deal back and the AI will accept (and vice versa)
+	// Sometimes we want to round up. Let's say the AI offers a deal to the human. We have to ensure that the human can also offer that deal back and the AI will accept (and vice versa)
 	if(bRoundUp)
 	{
 		iValueTimes100 += 99;
@@ -2667,7 +2667,6 @@ int CvDealAI::GetEmbassyValue(bool bFromMe, PlayerTypes eOtherPlayer, bool bUseE
 
 #if defined(MOD_DIPLOMACY_CIV4_FEATURES)
 	if (MOD_DIPLOMACY_CIV4_FEATURES) {
-		// Item is worth 20% less if it's owner is a vassal
 		if (bFromMe)
 		{
 			// If it's my item and I'm the vassal of the other player, accept it.
@@ -2719,7 +2718,7 @@ int CvDealAI::GetEmbassyValue(bool bFromMe, PlayerTypes eOtherPlayer, bool bUseE
 		iItemValue /= 100;
 	}
 #if defined(MOD_BALANCE_CORE)
-	if(!bFromMe)  // they want to build an embassy with us.
+	if(!bFromMe)  // they want to give us an embassy in their capital
 	{
 		if(GetPlayer()->GetDiplomacyAI()->IsDenouncedPlayer(eOtherPlayer) || GET_PLAYER(eOtherPlayer).GetDiplomacyAI()->IsDenouncedPlayer(GetPlayer()->GetID()))
 			return INT_MAX;
@@ -2785,7 +2784,6 @@ int CvDealAI::GetOpenBordersValue(bool bFromMe, PlayerTypes eOtherPlayer, bool b
 
 #if defined(MOD_DIPLOMACY_CIV4_FEATURES)
 	if (MOD_DIPLOMACY_CIV4_FEATURES) {
-		// Item is worth 20% less if it's owner is a vassal
 		if (bFromMe)
 		{
 			// If it's my item and I'm the vassal of the other player, accept it.
@@ -4649,7 +4647,7 @@ int CvDealAI::GetVoteCommitmentValue(bool bFromMe, PlayerTypes eOtherPlayer, int
 	return iValue;
 }
 
-/// See if adding Vote Commitment to their side of the deal helps even out pDeal
+/// See if adding a Vote Commitment to their side of the deal helps even out pDeal
 void CvDealAI::DoAddVoteCommitmentToThem(CvDeal* pDeal, PlayerTypes eThem, bool bDontChangeTheirExistingItems, int& iTotalValue, int& iValueImOffering, int& iValueTheyreOffering, int iAmountOverWeWillRequest, bool bUseEvenValue)
 {
 	CvAssert(eThem >= 0);
@@ -7535,7 +7533,7 @@ bool CvDealAI::MakeOfferForEmbassy(PlayerTypes eOtherPlayer, CvDeal* pDeal)
 	CvAssert(eOtherPlayer >= 0);
 	CvAssert(eOtherPlayer < MAX_MAJOR_CIVS);
 
-	// Don't ask for Open Borders if we're hostile or planning war
+	// Don't ask for an embassy if we're hostile or planning war
 	MajorCivApproachTypes eApproach = GetPlayer()->GetDiplomacyAI()->GetMajorCivApproach(eOtherPlayer, /*bHideTrueFeelings*/ false);
 	if(eApproach == MAJOR_CIV_APPROACH_HOSTILE ||
 	        eApproach == MAJOR_CIV_APPROACH_WAR		||
@@ -7550,7 +7548,7 @@ bool CvDealAI::MakeOfferForEmbassy(PlayerTypes eOtherPlayer, CvDeal* pDeal)
 		return false;
 	}
 
-	// Do we actually want OB with eOtherPlayer?
+	// Do we actually want an embassy with eOtherPlayer?
 	if(GetPlayer()->GetDiplomacyAI()->WantsEmbassyAtPlayer(eOtherPlayer))
 	{
 		// Seed the deal with the item we want
@@ -7596,7 +7594,7 @@ bool CvDealAI::IsMakeOfferForOpenBorders(PlayerTypes eOtherPlayer, CvDeal* pDeal
 	}
 
 #if defined(MOD_BALANCE_CORE)
-	//Already allows?
+	// Already allowing Open Borders?
 	if(GET_TEAM(GET_PLAYER(eOtherPlayer).getTeam()).IsAllowsOpenBordersToTeam(GetPlayer()->getTeam()))
 	{
 		return false;

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
@@ -5793,7 +5793,7 @@ void CvDiplomacyAI::DoUpdateApproachTowardsUsGuesses()
 			{
 				eTrueApproachGuess = MAJOR_CIV_APPROACH_WAR;
 				SetApproachTowardsUsGuess(eLoopPlayer, MAJOR_CIV_APPROACH_WAR);
-				SetApproachTowardsUsGuessCounter(eLoopPlayer, -1);
+				SetApproachTowardsUsGuessCounter(eLoopPlayer, 0);
 			}
 
 #if defined(MOD_BALANCE_CORE)			
@@ -5816,7 +5816,7 @@ void CvDiplomacyAI::DoUpdateApproachTowardsUsGuesses()
 					{
 						eTrueApproachGuess = MAJOR_CIV_APPROACH_AFRAID;
 						SetApproachTowardsUsGuess(eLoopPlayer, MAJOR_CIV_APPROACH_AFRAID);
-						SetApproachTowardsUsGuessCounter(eLoopPlayer, -1);
+						SetApproachTowardsUsGuessCounter(eLoopPlayer, 0);
 					}
 									
 					// They can't be FRIENDLY or DECEPTIVE if their visible approach isn't FRIENDLY

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
@@ -5812,7 +5812,7 @@ void CvDiplomacyAI::DoUpdateApproachTowardsUsGuesses()
 				if (!GET_PLAYER(eLoopPlayer).isHuman())
 				{
 					// Are they now AFRAID of us? Then they're being honest.
-					else if(eVisibleApproach == MAJOR_CIV_APPROACH_AFRAID && eTrueApproachGuess != MAJOR_CIV_APPROACH_AFRAID)
+					if(eVisibleApproach == MAJOR_CIV_APPROACH_AFRAID && eTrueApproachGuess != MAJOR_CIV_APPROACH_AFRAID)
 					{
 						eTrueApproachGuess = MAJOR_CIV_APPROACH_AFRAID;
 						SetApproachTowardsUsGuess(eLoopPlayer, MAJOR_CIV_APPROACH_AFRAID);

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
@@ -3038,7 +3038,7 @@ void CvDiplomacyAI::DoUpdateHumanTradePriority(PlayerTypes ePlayer, int iOpinion
 
 		int turnsPassed = GC.getGame().getGameTurn() - GetNumTurnsSinceSomethingSent(ePlayer);
 
-		m_pDiploData->m_aTradePriority[ePlayer] = 10.0f * opinion + turnsPassed; // faktor in turns since last contact and the optinion to player.
+		m_pDiploData->m_aTradePriority[ePlayer] = 10.0f * opinion + turnsPassed; // factor in turns since last contact and opinion of player.
 	}
 }
 #endif
@@ -3090,7 +3090,6 @@ int CvDiplomacyAI::GetMajorCivOpinionWeight(PlayerTypes ePlayer)
 	// Player stole from us
 	//////////////////////////////////////
 	iOpinionWeight += GetTimesCultureBombedScore(ePlayer);
-	iOpinionWeight += GetReligiousConversionPointsScore(ePlayer);
 	iOpinionWeight += GetTimesRobbedScore(ePlayer);
 
 	//////////////////////////////////////
@@ -3098,6 +3097,7 @@ int CvDiplomacyAI::GetMajorCivOpinionWeight(PlayerTypes ePlayer)
 	//////////////////////////////////////
 	iOpinionWeight += GetHasAdoptedHisReligionScore(ePlayer);
 	iOpinionWeight += GetHasAdoptedMyReligionScore(ePlayer);
+	iOpinionWeight += GetReligiousConversionPointsScore(ePlayer);
 	
 #if defined(MOD_BALANCE_CORE)
 	iOpinionWeight += GetPolicyScore(ePlayer);
@@ -3218,7 +3218,7 @@ int CvDiplomacyAI::GetMajorCivOpinionWeight(PlayerTypes ePlayer)
 	//iOpinionWeight += GetPaidTributeToScore(ePlayer);
 
 	//////////////////////////////////////
-	// XP2
+	// XP2 - WORLD CONGRESS
 	//////////////////////////////////////
 
 	iOpinionWeight += GetLikedTheirProposalScore(ePlayer);
@@ -6179,13 +6179,13 @@ void CvDiplomacyAI::DoUpdateDemands()
 		}
 	}
 
-	// We're not hostile towards any one so cancel any demand work we have underway (if there's anything going on)
+	// We're not hostile towards anyone so cancel any demand work we have underway (if there's anything going on)
 	if(bCancelDemand)
 	{
 		DoCancelHaltDemandProcess();
 	}
 
-	// See If we have a demand ready to make
+	// See if we have a demand ready to make
 	DoTestDemandReady();
 }
 
@@ -6679,7 +6679,7 @@ bool CvDiplomacyAI::IsEmbassyExchangeAcceptable(PlayerTypes ePlayer)
 	return false;
 }
 
-/// Do we want to have an embassy in the player's capital?
+/// Do we want to have an embassy in the player's capital? - this is only used for when to trigger an AI request, not whether or not the AI will accept a deal period
 bool CvDiplomacyAI::WantsEmbassyAtPlayer(PlayerTypes ePlayer)
 {
 	CvAssertMsg(ePlayer >= 0, "DIPLOMACY_AI: Invalid Player Index.  Please send Jon this with your last 5 autosaves and what changelist # you're playing.");
@@ -6842,8 +6842,9 @@ bool CvDiplomacyAI::IsWillingToGiveOpenBordersToPlayer(PlayerTypes ePlayer)
 		return false;
 	}
 	if (GET_PLAYER(ePlayer).GetDiplomacyAI()->IsCloseToDominationVictory())
+	{
 		return false;
-
+	}
 	if (GET_TEAM(GetTeam()).IsHasDefensivePact(GET_PLAYER(ePlayer).getTeam()) || IsDoFAccepted(ePlayer))
 	{
 		return true;

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.h
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.h
@@ -145,7 +145,8 @@ public:
 	bool IsHasActiveGoldQuest();
 
 	// Our guess as to another player's approach towards us
-	MajorCivApproachTypes GetApproachTowardsUsGuess(PlayerTypes ePlayer) ;
+	MajorCivApproachTypes GetApproachTowardsUsGuess(PlayerTypes ePlayer);
+	MajorCivApproachTypes GetTrueApproachTowardsUsGuess(PlayerTypes ePlayer);
 	void SetApproachTowardsUsGuess(PlayerTypes ePlayer, MajorCivApproachTypes eApproach);
 	int GetApproachTowardsUsGuessCounter(PlayerTypes ePlayer) const;
 	void SetApproachTowardsUsGuessCounter(PlayerTypes ePlayer, int iValue);

--- a/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
@@ -15991,11 +15991,11 @@ bool CvMinorCivAI::CanMajorBullyGold(PlayerTypes ePlayer)
 		return false;
 #endif
 
-	int iScore = CalculateBullyMetric(ePlayer, /*bForUnit*/false);
+	int iScore = CalculateBullyMetric(ePlayer, /*bForUnit*/ false);
 	return CanMajorBullyGold(ePlayer, iScore);
 }
 
-// In case client wants to specify a metric beforehand (ie. they calculated it on their end, for logging purposes etc.)
+// In case client wants to specify a metric beforehand (i.e. they calculated it on their end, for logging purposes etc.)
 bool CvMinorCivAI::CanMajorBullyGold(PlayerTypes ePlayer, int iSpecifiedBullyMetric)
 {
 	CvAssertMsg(ePlayer >= 0, "ePlayer is expected to be non-negative (invalid Index)");
@@ -16064,7 +16064,7 @@ bool CvMinorCivAI::CanMajorBullyUnit(PlayerTypes ePlayer)
 	return CanMajorBullyUnit(ePlayer, iScore);
 }
 
-// In case client wants to specify a metric beforehand (ie. they calculated it on their end, for logging purposes etc.)
+// In case client wants to specify a metric beforehand (i.e. they calculated it on their end, for logging purposes etc.)
 bool CvMinorCivAI::CanMajorBullyUnit(PlayerTypes ePlayer, int iSpecifiedBullyMetric)
 {
 	CvAssertMsg(ePlayer >= 0, "ePlayer is expected to be non-negative (invalid Index)");

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
@@ -12461,6 +12461,7 @@ int CvLuaPlayer::lGetOpinionTable(lua_State* L)
 		}
 	}
 
+// Hide some modifiers if FRIENDLY (or pretending to be)
 #if defined(MOD_API_LUA_EXTENSIONS) && defined(MOD_DIPLOMACY_CIV4_FEATURES)
 	if (iVisibleApproach != MAJOR_CIV_APPROACH_FRIENDLY || (MOD_DIPLOMACY_CIV4_FEATURES && GC.getGame().isOption(GAMEOPTION_ADVANCED_DIPLOMACY))) 
 #else


### PR DESCRIPTION
**Note:** I tried my best to ensure I used the correct syntax but am not 100% confident, so I'd appreciate if someone could verify as I'm still new to this.

What this pull request does:

- Rewrites the DoUpdateApproachTowardsUsGuesses function to allow the AI to make an educated guess as to another player's approach towards them, without conflicting with any other function which sets a given guess. Even though this function isn't used anywhere to my knowledge, I was aiming to make the AI a bit smarter in terms of potential, since the original DoUpdateApproachTowardsUsGuesses function was pitiful. If you like the function, perhaps it could see use elsewhere :)

- Adds a new function to access the memory value for the AI's guess, GetTrueApproachTowardsUsGuess, since GetApproachTowardsUsGuess is used to show the AI's visible approach (originally, GetApproachTowardsUsGuess returned this memory value, but that was apparently commented out).

- When a human player makes a demand or chooses the insulting dialogue option, the AI will now guess that their approach towards them is HOSTILE.

Let me know if you have any feedback!

Edit: Also fixes the extra space in the Workshop description, and a couple comment fixes.