### PR TITLE
Smarter AI approach estimates and a few more diplo changes

### DIFF
--- a/Community Balance Patch/Balance Changes/Text/en_US/BuildingText.sql
+++ b/Community Balance Patch/Balance Changes/Text/en_US/BuildingText.sql
@@ -108,7 +108,7 @@ SET Text = 'The Forge improves sources of [ICON_RES_IRON] Iron and [ICON_RES_COP
 WHERE Tag = 'TXT_KEY_BUILDING_FORGE_STRATEGY' AND EXISTS (SELECT * FROM COMMUNITY WHERE Type='COMMUNITY_CORE_BALANCE_BUILDINGS' AND Value= 1 );
 
 UPDATE Language_en_US
-SET Text = '+1 [ICON_PRODUCTION] Production and [ICON_GOLD] Gold from all Forests worked by this City. 1 Specialist in this City no longer produces [ICON_HAPPINESS_3] Unhappiness from Urbanization.[NEWLINE][NEWLINE] Allows [ICON_PRODUCTION] Production to be moved from this city along trade routes inside your civilization. Internal [ICON_INTERNATIONAL_TRADE] Trade Routes to or from this City generate 25 [ICON_PRODUCTION] Production in their Origin City when completed, scaling with Era.'
+SET Text = '+1 [ICON_PRODUCTION] Production and [ICON_GOLD] Gold from all Forests worked by this City. 1 Specialist in this City no longer produces [ICON_HAPPINESS_3] Unhappiness from Urbanization.[NEWLINE][NEWLINE]Allows [ICON_PRODUCTION] Production to be moved from this city along trade routes inside your civilization. Internal [ICON_INTERNATIONAL_TRADE] Trade Routes to or from this City generate 25 [ICON_PRODUCTION] Production in their Origin City when completed, scaling with Era.'
 WHERE Tag = 'TXT_KEY_BUILDING_WORKSHOP_HELP' AND EXISTS (SELECT * FROM COMMUNITY WHERE Type='COMMUNITY_CORE_BALANCE_BUILDINGS' AND Value= 1 );
 	
 UPDATE Language_en_US
@@ -516,7 +516,7 @@ SET Text = 'Provides a free Garden in the city in which it is built.'
 WHERE Tag = 'TXT_KEY_WONDER_HANGING_GARDEN_HELP' AND EXISTS (SELECT * FROM COMMUNITY WHERE Type='COMMUNITY_CORE_BALANCE_BUILDINGS' AND Value= 1 );
 
 UPDATE Language_en_US
-SET Text = 'Reduces [ICON_HAPPINESS_3] UnhappinessNeeds Modifier for [ICON_RESEARCH] Illiteracy by 10% in all Cities, and increases the Military Unit Supply Cap by 3 in the city. Creates a copy of each type of military land unit you control and places the unit near the city where the Terracotta Army is constructed. Receive a large sum of [ICON_CULTURE] Culture when completed.'
+SET Text = 'Reduces [ICON_HAPPINESS_3] Unhappiness Needs Modifier for [ICON_RESEARCH] Illiteracy by 10% in all Cities, and increases the Military Unit Supply Cap by 3 in the city. Creates a copy of each type of military land unit you control and places the unit near the city where the Terracotta Army is constructed. Receive a large sum of [ICON_CULTURE] Culture when completed.'
 WHERE Tag = 'TXT_KEY_WONDER_TERRA_COTTA_ARMY_HELP' AND EXISTS (SELECT * FROM COMMUNITY WHERE Type='COMMUNITY_CORE_BALANCE_BUILDINGS' AND Value= 1 );
 
 UPDATE Language_en_US

--- a/Community Balance Patch/Balance Changes/Text/en_US/UIText.sql
+++ b/Community Balance Patch/Balance Changes/Text/en_US/UIText.sql
@@ -495,7 +495,7 @@ WHERE Tag = 'TXT_KEY_TP_CULTURE_FROM_GOLDEN_AGE' AND EXISTS (SELECT * FROM COMMU
 
 -- Update text for top panel depending on which yields you have enabled above. Change as desired.
 UPDATE Language_en_US
-SET Text = 'Your approval rating is less than 50% - your Empire is is in open rebellion! Uprisings may occur with rebel (barbarian) units appearing in your territory, and Cities may abandon your empire and flip to the civilization that is most culturally influential over your people! Additionally, all Cities will [ICON_FOOD] Grow and [ICON_PRODUCTION] Produce Military Units very slowly. [ICON_STRENGTH] Combat effectiveness is also reduced by 20%!'
+SET Text = 'Your approval rating is less than 50% - your Empire is in open rebellion! Uprisings may occur with rebel (barbarian) units appearing in your territory, and Cities may abandon your empire and flip to the civilization that is most culturally influential over your people! Additionally, all Cities will [ICON_FOOD] Grow and [ICON_PRODUCTION] Produce Military Units very slowly. [ICON_STRENGTH] Combat effectiveness is also reduced by 20%!'
 WHERE Tag = 'TXT_KEY_TP_EMPIRE_VERY_UNHAPPY' AND EXISTS (SELECT * FROM COMMUNITY WHERE Type='COMMUNITY_CORE_BALANCE_NATIONAL_HAPPINESS' AND Value= 1 );
 
 UPDATE Language_en_US

--- a/Community Patch/Core Files/Text/CoreText_en_US.xml
+++ b/Community Patch/Core Files/Text/CoreText_en_US.xml
@@ -2798,6 +2798,14 @@
 			<Text>[COLOR_NEGATIVE_TEXT]You have made a Defensive Pact with one of their enemies![ENDCOLOR]</Text>
 		</Row>
 		
+		<!-- Embassy Diplo Mod -->
+		<Row Tag="TXT_KEY_DIPLO_MUTUAL_EMBASSY">
+			<Text>[COLOR_POSITIVE_TEXT]We have shared embassies.[ENDCOLOR]</Text>
+		</Row>
+		<Row Tag="TXT_KEY_DIPLO_WE_HAVE_EMBASSY">
+			<Text>[COLOR_POSITIVE_TEXT]We have an embassy in their capital.[ENDCOLOR]</Text>
+		</Row>
+		
 		<!-- Open Borders Diplo Mod -->
 		<Row Tag="TXT_KEY_DIPLO_OPEN_BORDERS_MUTUAL">
 			<Text>[COLOR_POSITIVE_TEXT]We have opened our borders to each other.[ENDCOLOR]</Text>

--- a/Community Patch/Core Files/Text/CoreText_en_US.xml
+++ b/Community Patch/Core Files/Text/CoreText_en_US.xml
@@ -2786,6 +2786,7 @@
 		<Row Tag="TXT_KEY_NO_ACTION_NO_SUPPLY_PURCHASE">
 			<Text>[NEWLINE]Cannot [ICON_GOLD] Purchase this unit, as you are at your Supply cap!</Text>
 		</Row>
+		
 		<!-- Defensive Pact Bonuses -->
 		<Row Tag="TXT_KEY_DIPLO_DP">
 			<Text>[COLOR_POSITIVE_TEXT]We have made a Defensive Pact![ENDCOLOR]</Text>
@@ -2796,7 +2797,8 @@
 		<Row Tag="TXT_KEY_DIPLO_DP_WITH_ENEMY">
 			<Text>[COLOR_NEGATIVE_TEXT]You have made a Defensive Pact with one of their enemies![ENDCOLOR]</Text>
 		</Row>
-		<!-- Open Borders Diplo Mod-->
+		
+		<!-- Open Borders Diplo Mod -->
 		<Row Tag="TXT_KEY_DIPLO_OPEN_BORDERS_MUTUAL">
 			<Text>[COLOR_POSITIVE_TEXT]We have opened our borders to each other.[ENDCOLOR]</Text>
 		</Row>
@@ -2807,12 +2809,15 @@
 			<Text>[COLOR_POSITIVE_TEXT]They have opened their borders to us.[ENDCOLOR]</Text>
 		</Row>
 
+		<!-- Social Policies Diplo Mod -->
 		<Row Tag="TXT_KEY_DIPLO_SAME_POLICIES">
 			<Text>[COLOR_POSITIVE_TEXT]We have similar Social Policies.[ENDCOLOR]</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLO_DIFFERENT_POLICIES">
 			<Text>[COLOR_NEGATIVE_TEXT]We have divergent Social Policies.[ENDCOLOR]</Text>
 		</Row>
+		
+		<!-- PTP Same CS Diplo Mod -->
 		<Row Tag="TXT_KEY_DIPLO_SAME_PTP">
 			<Text>[COLOR_NEGATIVE_TEXT]We have Pledged to Protect the same City-States.[ENDCOLOR]</Text>
 		</Row>
@@ -2838,7 +2843,8 @@
 		<Row Tag="TXT_KEY_DEFENSE_PACT_OFFER_4">
 			<Text>The tyrants of the world would tremble at our feet, if only we were allied. Do you see the value in a Defensive Pact?</Text>
 		</Row>
-		<!-- Cities/3rd Party War and Peace Offers-->
+		
+		<!-- Cities/3rd Party War and Peace Offers -->
 		<Row Tag="TXT_KEY_CITY_TRADE_OFFER_1">
 			<Text>A sale of territory is in order. I think you will find this offer quite suitable, no?</Text>
 		</Row>

--- a/Community Patch/Core Files/Text/CoreText_en_US.xml
+++ b/Community Patch/Core Files/Text/CoreText_en_US.xml
@@ -2787,6 +2787,11 @@
 			<Text>[NEWLINE]Cannot [ICON_GOLD] Purchase this unit, as you are at your Supply cap!</Text>
 		</Row>
 		
+		<!-- Opinion "Modifier" for Human Teammate -->
+		<Row Tag="TXT_KEY_DIPLO_OPINION_HUMAN_TEAMMATE">
+			<Text>[COLOR_POSITIVE_TEXT]We are on the same team.[ENDCOLOR]</Text>
+		</Row>
+		
 		<!-- Defensive Pact Bonuses -->
 		<Row Tag="TXT_KEY_DIPLO_DP">
 			<Text>[COLOR_POSITIVE_TEXT]We have made a Defensive Pact![ENDCOLOR]</Text>

--- a/CvGameCoreDLL_Expansion2/CvDealAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDealAI.cpp
@@ -81,7 +81,7 @@ CvPlayer* CvDealAI::GetPlayer()
 	return m_pPlayer;
 }
 
-// Helper function which returns this player's TeamType
+/// Helper function which returns this player's TeamType
 TeamTypes CvDealAI::GetTeam()
 {
 	return m_pPlayer->getTeam();
@@ -1311,7 +1311,7 @@ int CvDealAI::GetDealValue(CvDeal* pDeal, int& iValueImOffering, int& iValueThey
 
 #if defined(MOD_DIPLOMACY_CIV4_FEATURES)
 		if (MOD_DIPLOMACY_CIV4_FEATURES) {
-			// Item is worth 20% less if it's owner is a vassal
+			// Item is worth 20% less if its owner is a vassal
 			if(bFromMe)
 			{
 				// If it's my item and I'm the vassal of the other player, reduce it.
@@ -1431,7 +1431,7 @@ int CvDealAI::GetGoldForForValueExchange(int iGoldOrValue, bool bNumGoldFromValu
 	// Convert based on the rules above
 	int iReturnValue = iGoldOrValue * iMultiplier;
 
-	// Sometimes we want to round up.  Let's say a the AI offers a deal to the human.  We have to ensure that the human can also offer that deal back and the AI will accept (and vice versa)
+	// Sometimes we want to round up. Let's say the AI offers a deal to the human. We have to ensure that the human can also offer that deal back and the AI will accept (and vice versa)
 	if(bRoundUp)
 	{
 		iReturnValue += 99;
@@ -1476,7 +1476,7 @@ int CvDealAI::GetGPTforForValueExchange(int iGPTorValue, bool bNumGPTFromValue, 
 		iValueTimes100 = (iGPTorValue * iNumTurns);
 	}
 
-	// Sometimes we want to round up.  Let's say a the AI offers a deal to the human.  We have to ensure that the human can also offer that deal back and the AI will accept (and vice versa)
+	// Sometimes we want to round up. Let's say the AI offers a deal to the human. We have to ensure that the human can also offer that deal back and the AI will accept (and vice versa)
 	if(bRoundUp)
 	{
 		iValueTimes100 += 99;
@@ -2667,7 +2667,6 @@ int CvDealAI::GetEmbassyValue(bool bFromMe, PlayerTypes eOtherPlayer, bool bUseE
 
 #if defined(MOD_DIPLOMACY_CIV4_FEATURES)
 	if (MOD_DIPLOMACY_CIV4_FEATURES) {
-		// Item is worth 20% less if it's owner is a vassal
 		if (bFromMe)
 		{
 			// If it's my item and I'm the vassal of the other player, accept it.
@@ -2719,7 +2718,7 @@ int CvDealAI::GetEmbassyValue(bool bFromMe, PlayerTypes eOtherPlayer, bool bUseE
 		iItemValue /= 100;
 	}
 #if defined(MOD_BALANCE_CORE)
-	if(!bFromMe)  // they want to build an embassy with us.
+	if(!bFromMe)  // they want to give us an embassy in their capital
 	{
 		if(GetPlayer()->GetDiplomacyAI()->IsDenouncedPlayer(eOtherPlayer) || GET_PLAYER(eOtherPlayer).GetDiplomacyAI()->IsDenouncedPlayer(GetPlayer()->GetID()))
 			return INT_MAX;
@@ -2785,7 +2784,6 @@ int CvDealAI::GetOpenBordersValue(bool bFromMe, PlayerTypes eOtherPlayer, bool b
 
 #if defined(MOD_DIPLOMACY_CIV4_FEATURES)
 	if (MOD_DIPLOMACY_CIV4_FEATURES) {
-		// Item is worth 20% less if it's owner is a vassal
 		if (bFromMe)
 		{
 			// If it's my item and I'm the vassal of the other player, accept it.
@@ -4649,7 +4647,7 @@ int CvDealAI::GetVoteCommitmentValue(bool bFromMe, PlayerTypes eOtherPlayer, int
 	return iValue;
 }
 
-/// See if adding Vote Commitment to their side of the deal helps even out pDeal
+/// See if adding a Vote Commitment to their side of the deal helps even out pDeal
 void CvDealAI::DoAddVoteCommitmentToThem(CvDeal* pDeal, PlayerTypes eThem, bool bDontChangeTheirExistingItems, int& iTotalValue, int& iValueImOffering, int& iValueTheyreOffering, int iAmountOverWeWillRequest, bool bUseEvenValue)
 {
 	CvAssert(eThem >= 0);
@@ -7535,7 +7533,7 @@ bool CvDealAI::MakeOfferForEmbassy(PlayerTypes eOtherPlayer, CvDeal* pDeal)
 	CvAssert(eOtherPlayer >= 0);
 	CvAssert(eOtherPlayer < MAX_MAJOR_CIVS);
 
-	// Don't ask for Open Borders if we're hostile or planning war
+	// Don't ask for an embassy if we're hostile or planning war
 	MajorCivApproachTypes eApproach = GetPlayer()->GetDiplomacyAI()->GetMajorCivApproach(eOtherPlayer, /*bHideTrueFeelings*/ false);
 	if(eApproach == MAJOR_CIV_APPROACH_HOSTILE ||
 	        eApproach == MAJOR_CIV_APPROACH_WAR		||
@@ -7550,7 +7548,7 @@ bool CvDealAI::MakeOfferForEmbassy(PlayerTypes eOtherPlayer, CvDeal* pDeal)
 		return false;
 	}
 
-	// Do we actually want OB with eOtherPlayer?
+	// Do we actually want an embassy with eOtherPlayer?
 	if(GetPlayer()->GetDiplomacyAI()->WantsEmbassyAtPlayer(eOtherPlayer))
 	{
 		// Seed the deal with the item we want
@@ -7596,7 +7594,7 @@ bool CvDealAI::IsMakeOfferForOpenBorders(PlayerTypes eOtherPlayer, CvDeal* pDeal
 	}
 
 #if defined(MOD_BALANCE_CORE)
-	//Already allows?
+	// Already allowing Open Borders?
 	if(GET_TEAM(GET_PLAYER(eOtherPlayer).getTeam()).IsAllowsOpenBordersToTeam(GetPlayer()->getTeam()))
 	{
 		return false;

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
@@ -32688,7 +32688,12 @@ int CvDiplomacyAI::GetNoSetterRequestScore(PlayerTypes ePlayer)
 {
 	int iOpinionWeight = 0;
 	if(IsPlayerNoSettleRequestEverAsked(ePlayer))
+		// Teammates
+		if(GetPlayer()->getTeam() == GET_PLAYER(ePlayer).getTeam())
+			return 1;
+		
 		iOpinionWeight += /*20*/ GC.getOPINION_WEIGHT_ASKED_NO_SETTLE();
+
 	return iOpinionWeight;
 }
 

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
@@ -3038,7 +3038,7 @@ void CvDiplomacyAI::DoUpdateHumanTradePriority(PlayerTypes ePlayer, int iOpinion
 
 		int turnsPassed = GC.getGame().getGameTurn() - GetNumTurnsSinceSomethingSent(ePlayer);
 
-		m_pDiploData->m_aTradePriority[ePlayer] = 10.0f * opinion + turnsPassed; // faktor in turns since last contact and the optinion to player.
+		m_pDiploData->m_aTradePriority[ePlayer] = 10.0f * opinion + turnsPassed; // factor in turns since last contact and opinion of player
 	}
 }
 #endif
@@ -3090,7 +3090,6 @@ int CvDiplomacyAI::GetMajorCivOpinionWeight(PlayerTypes ePlayer)
 	// Player stole from us
 	//////////////////////////////////////
 	iOpinionWeight += GetTimesCultureBombedScore(ePlayer);
-	iOpinionWeight += GetReligiousConversionPointsScore(ePlayer);
 	iOpinionWeight += GetTimesRobbedScore(ePlayer);
 
 	//////////////////////////////////////
@@ -3098,6 +3097,7 @@ int CvDiplomacyAI::GetMajorCivOpinionWeight(PlayerTypes ePlayer)
 	//////////////////////////////////////
 	iOpinionWeight += GetHasAdoptedHisReligionScore(ePlayer);
 	iOpinionWeight += GetHasAdoptedMyReligionScore(ePlayer);
+	iOpinionWeight += GetReligiousConversionPointsScore(ePlayer);
 	
 #if defined(MOD_BALANCE_CORE)
 	iOpinionWeight += GetPolicyScore(ePlayer);
@@ -3218,7 +3218,7 @@ int CvDiplomacyAI::GetMajorCivOpinionWeight(PlayerTypes ePlayer)
 	//iOpinionWeight += GetPaidTributeToScore(ePlayer);
 
 	//////////////////////////////////////
-	// XP2
+	// XP2 - WORLD CONGRESS
 	//////////////////////////////////////
 
 	iOpinionWeight += GetLikedTheirProposalScore(ePlayer);
@@ -5964,13 +5964,13 @@ void CvDiplomacyAI::DoUpdateDemands()
 		}
 	}
 
-	// We're not hostile towards any one so cancel any demand work we have underway (if there's anything going on)
+	// We're not hostile towards anyone so cancel any demand work we have underway (if there's anything going on)
 	if(bCancelDemand)
 	{
 		DoCancelHaltDemandProcess();
 	}
 
-	// See If we have a demand ready to make
+	// See if we have a demand ready to make
 	DoTestDemandReady();
 }
 
@@ -6464,7 +6464,7 @@ bool CvDiplomacyAI::IsEmbassyExchangeAcceptable(PlayerTypes ePlayer)
 	return false;
 }
 
-/// Do we want to have an embassy in the player's capital?
+/// Do we want to have an embassy in the player's capital? - this is only used for when to trigger an AI request, not whether or not the AI will accept a deal period
 bool CvDiplomacyAI::WantsEmbassyAtPlayer(PlayerTypes ePlayer)
 {
 	CvAssertMsg(ePlayer >= 0, "DIPLOMACY_AI: Invalid Player Index.  Please send Jon this with your last 5 autosaves and what changelist # you're playing.");
@@ -6627,8 +6627,9 @@ bool CvDiplomacyAI::IsWillingToGiveOpenBordersToPlayer(PlayerTypes ePlayer)
 		return false;
 	}
 	if (GET_PLAYER(ePlayer).GetDiplomacyAI()->IsCloseToDominationVictory())
+	{
 		return false;
-
+	}
 	if (GET_TEAM(GetTeam()).IsHasDefensivePact(GET_PLAYER(ePlayer).getTeam()) || IsDoFAccepted(ePlayer))
 	{
 		return true;

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
@@ -5705,7 +5705,7 @@ bool CvDiplomacyAI::IsHasActiveGoldQuest()
 	return false;
 }
 
-/// Returns our guess as to another player's Approach towards us
+/// Returns ePlayer's visible Approach towards us
 MajorCivApproachTypes CvDiplomacyAI::GetApproachTowardsUsGuess(PlayerTypes ePlayer)
 {
 	CvAssertMsg(ePlayer >= 0, "DIPLOMACY_AI: Invalid Player Index.  Please send Jon this with your last 5 autosaves and what changelist # you're playing.");
@@ -5716,7 +5716,16 @@ MajorCivApproachTypes CvDiplomacyAI::GetApproachTowardsUsGuess(PlayerTypes ePlay
 	//return (MajorCivApproachTypes) m_paeApproachTowardsUsGuess[ePlayer];
 }
 
-/// Sets our guess as to another player's Approach towards us
+/// Returns our guess as to another player's true Approach towards us
+MajorCivApproachTypes CvDiplomacyAI::GetTrueApproachTowardsUsGuess(PlayerTypes ePlayer)
+{
+	CvAssertMsg(ePlayer >= 0, "DIPLOMACY_AI: Invalid Player Index.  Please send Jon this with your last 5 autosaves and what changelist # you're playing.");
+	CvAssertMsg(ePlayer < MAX_MAJOR_CIVS, "DIPLOMACY_AI: Invalid Player Index.  Please send Jon this with your last 5 autosaves and what changelist # you're playing.");
+
+	return (MajorCivApproachTypes) m_paeApproachTowardsUsGuess[ePlayer];
+}
+
+/// Sets our guess as to another player's true Approach towards us
 void CvDiplomacyAI::SetApproachTowardsUsGuess(PlayerTypes ePlayer, MajorCivApproachTypes eApproach)
 {
 	CvAssertMsg(ePlayer >= 0, "DIPLOMACY_AI: Invalid Player Index.  Please send Jon this with your last 5 autosaves and what changelist # you're playing.");
@@ -5726,7 +5735,7 @@ void CvDiplomacyAI::SetApproachTowardsUsGuess(PlayerTypes ePlayer, MajorCivAppro
 	m_paeApproachTowardsUsGuess[ePlayer] = eApproach;
 }
 
-/// Returns how long we've thought ePlayer has had his Approach towards us
+/// Returns how long we've thought ePlayer has had his true Approach towards us
 int CvDiplomacyAI::GetApproachTowardsUsGuessCounter(PlayerTypes ePlayer) const
 {
 	CvAssertMsg(ePlayer >= 0, "DIPLOMACY_AI: Invalid Player Index.  Please send Jon this with your last 5 autosaves and what changelist # you're playing.");
@@ -5734,7 +5743,7 @@ int CvDiplomacyAI::GetApproachTowardsUsGuessCounter(PlayerTypes ePlayer) const
 	return m_paeApproachTowardsUsGuessCounter[ePlayer];
 }
 
-/// Sets how long we've thought ePlayer has had his Approach towards us
+/// Sets how long we've thought ePlayer has had his true Approach towards us
 void CvDiplomacyAI::SetApproachTowardsUsGuessCounter(PlayerTypes ePlayer, int iValue)
 {
 	CvAssertMsg(ePlayer >= 0, "DIPLOMACY_AI: Invalid Player Index.  Please send Jon this with your last 5 autosaves and what changelist # you're playing.");
@@ -5743,16 +5752,23 @@ void CvDiplomacyAI::SetApproachTowardsUsGuessCounter(PlayerTypes ePlayer, int iV
 	m_paeApproachTowardsUsGuessCounter[ePlayer] = iValue;
 }
 
-/// Changes how long we've thought ePlayer has had his Approach towards us
+/// Changes how long we've thought ePlayer has had his true Approach towards us
 void CvDiplomacyAI::ChangeApproachTowardsUsGuessCounter(PlayerTypes ePlayer, int iChange)
 {
 	SetApproachTowardsUsGuessCounter(ePlayer, GetApproachTowardsUsGuessCounter(ePlayer) + iChange);
 }
 
-/// See if there's anything we need to change with our guesses as to other players' Approaches towards us
+/// See if there's anything we need to change with our guesses as to other players' true Approaches towards us
 void CvDiplomacyAI::DoUpdateApproachTowardsUsGuesses()
 {
 	PlayerTypes eLoopPlayer;
+	MajorCivApproachTypes eVisibleApproach;
+	MajorCivApproachTypes eTrueApproachGuess;
+	AggressivePostureTypes eMilitaryAggressivePosture;
+	bool bAtWar = false;
+#if defined(MOD_BALANCE_CORE)
+	bool bJustMadePeace = false;
+#endif
 
 	for(int iPlayerLoop = 0; iPlayerLoop < MAX_MAJOR_CIVS; iPlayerLoop++)
 	{
@@ -5760,15 +5776,234 @@ void CvDiplomacyAI::DoUpdateApproachTowardsUsGuesses()
 
 		if(IsPlayerValid(eLoopPlayer))
 		{
-			// We have a guess as to what another player's Approach is towards us
-			if(GetApproachTowardsUsGuess(eLoopPlayer) != MAJOR_CIV_APPROACH_NEUTRAL)
-			{
-				ChangeApproachTowardsUsGuessCounter(eLoopPlayer, 1);
+			eVisibleApproach = GetApproachTowardsUsGuess(eLoopPlayer);
+			eTrueApproachGuess = GetTrueApproachTowardsUsGuess(eLoopPlayer);
+			bAtWar = GET_TEAM(GetTeam()).isAtWar(GET_PLAYER(eLoopPlayer).getTeam());
 
-				if(GetApproachTowardsUsGuessCounter(eLoopPlayer) > 30)
+#if defined(MOD_BALANCE_CORE)			
+			// Check if we just made peace with this player
+			bJustMadePeace = false;
+			
+			if(GetNumWarsFought(eLoopPlayer) > 0 && GetNumTurnsAtPeace(eLoopPlayer) <= 1)
+				bJustMadePeace = true;
+#endif
+			
+			// If they're at war with us, then their approach is WAR for all practical purposes
+			if(bAtWar && eTrueApproachGuess != MAJOR_CIV_APPROACH_WAR)
+			{
+				SetApproachTowardsUsGuess(eLoopPlayer, MAJOR_CIV_APPROACH_WAR);
+				SetApproachTowardsUsGuessCounter(eLoopPlayer, 1);
+				return;
+			}
+
+#if defined(MOD_BALANCE_CORE)			
+			// If we just made peace, reset any guess for the WAR approach
+			else if(bJustMadePeace && eTrueApproachGuess == MAJOR_CIV_APPROACH_WAR)
+			{
+				eTrueApproachGuess = MAJOR_CIV_APPROACH_NEUTRAL;
+				SetApproachTowardsUsGuess(eLoopPlayer, MAJOR_CIV_APPROACH_NEUTRAL);	
+			}
+#endif
+			
+			else
+			{
+				// Use visible approach for AI players
+				if (!GET_PLAYER(eLoopPlayer).isHuman())
 				{
-					SetApproachTowardsUsGuess(eLoopPlayer, MAJOR_CIV_APPROACH_NEUTRAL);
-					SetApproachTowardsUsGuessCounter(eLoopPlayer, 0);
+					// Are they now AFRAID of us? Then they're being honest.
+					if(eVisibleApproach == MAJOR_CIV_APPROACH_AFRAID && eTrueApproachGuess != MAJOR_CIV_APPROACH_AFRAID)
+					{
+						SetApproachTowardsUsGuess(eLoopPlayer, MAJOR_CIV_APPROACH_AFRAID);
+						SetApproachTowardsUsGuessCounter(eLoopPlayer, 1);
+						return;
+					}
+									
+					// They can't be FRIENDLY or DECEPTIVE if their visible approach isn't FRIENDLY
+					else if(eVisibleApproach != MAJOR_CIV_APPROACH_FRIENDLY && (eTrueApproachGuess == MAJOR_CIV_APPROACH_FRIENDLY || eTrueApproachGuess == MAJOR_CIV_APPROACH_DECEPTIVE))
+					{
+						eTrueApproachGuess = MAJOR_CIV_APPROACH_NEUTRAL;
+						SetApproachTowardsUsGuess(eLoopPlayer, MAJOR_CIV_APPROACH_NEUTRAL);
+					}
+					
+					// For AFRAID, GUARDED or HOSTILE, reset the guess if it doesn't match the visible approach
+					else if(eVisibleApproach != eTrueApproachGuess && (eTrueApproachGuess == MAJOR_CIV_APPROACH_AFRAID || eTrueApproachGuess == MAJOR_CIV_APPROACH_GUARDED || eTrueApproachGuess == MAJOR_CIV_APPROACH_HOSTILE))
+					{
+						eTrueApproachGuess = MAJOR_CIV_APPROACH_NEUTRAL;
+						SetApproachTowardsUsGuess(eLoopPlayer, MAJOR_CIV_APPROACH_NEUTRAL);
+					}
+				}
+				
+				// Human player
+				else
+				{
+					// Reset any guess for the FRIENDLY approach if we have no DoF/DP, and they haven't resurrected us
+					if(eTrueApproachGuess == MAJOR_CIV_APPROACH_FRIENDLY && !IsDoFAccepted(eLoopPlayer) && !GET_PLAYER(eLoopPlayer).GetDiplomacyAI()->IsDoFAccepted(GetPlayer()->GetID()) && !GET_TEAM(GET_PLAYER(eLoopPlayer).getTeam()).IsHasDefensivePact(GetTeam()) && !WasResurrectedBy(eLoopPlayer))
+					{
+						eTrueApproachGuess = MAJOR_CIV_APPROACH_NEUTRAL;
+						SetApproachTowardsUsGuess(eLoopPlayer, MAJOR_CIV_APPROACH_NEUTRAL);
+					}
+					
+					// Reset any guess for the FRIENDLY or DECEPTIVE approach if there's been a denouncement either way
+					else if( (eTrueApproachGuess == MAJOR_CIV_APPROACH_FRIENDLY || eTrueApproachGuess == MAJOR_CIV_APPROACH_DECEPTIVE) && (IsDenouncedPlayer(eLoopPlayer) || GET_PLAYER(eLoopPlayer).GetDiplomacyAI()->IsDenouncedPlayer(GetPlayer()->GetID())) )
+					{
+						eTrueApproachGuess = MAJOR_CIV_APPROACH_NEUTRAL;
+						SetApproachTowardsUsGuess(eLoopPlayer, MAJOR_CIV_APPROACH_NEUTRAL);
+					}	
+					
+					// Reset any guess for the GUARDED approach if they denounced us
+					else if(eTrueApproachGuess == MAJOR_CIV_APPROACH_GUARDED && GET_PLAYER(eLoopPlayer).GetDiplomacyAI()->IsDenouncedPlayer(GetPlayer()->GetID()))
+					{
+						eTrueApproachGuess = MAJOR_CIV_APPROACH_NEUTRAL;
+						SetApproachTowardsUsGuess(eLoopPlayer, MAJOR_CIV_APPROACH_NEUTRAL);
+					}	
+					
+					// Reset any guess for the GUARDED approach if we've no longer denounced or gone to war recently with them
+					else if(eTrueApproachGuess == MAJOR_CIV_APPROACH_GUARDED && !IsDenouncedPlayer(eLoopPlayer))
+#if defined(MOD_BALANCE_CORE)
+					{
+						if(GetNumWarsFought(eLoopPlayer) > 0)
+						{
+							if(GetNumTurnsSincePeace(eLoopPlayer) > 30)
+							{
+								eTrueApproachGuess = MAJOR_CIV_APPROACH_NEUTRAL;
+								SetApproachTowardsUsGuess(eLoopPlayer, MAJOR_CIV_APPROACH_NEUTRAL);
+							}
+						}
+						else
+#endif
+						{
+							eTrueApproachGuess = MAJOR_CIV_APPROACH_NEUTRAL;
+							SetApproachTowardsUsGuess(eLoopPlayer, MAJOR_CIV_APPROACH_NEUTRAL);
+						}
+#if defined(MOD_BALANCE_CORE)
+					}
+#endif
+					
+				}
+			}
+			
+			ChangeApproachTowardsUsGuessCounter(eLoopPlayer, 1);
+
+			// We have no guess, or it's been a while since our last guess...let's make a new one if we can!
+			if(eTrueApproachGuess == MAJOR_CIV_APPROACH_NEUTRAL || GetApproachTowardsUsGuessCounter(eLoopPlayer) > 30)
+			{
+				// Reset the counter so we don't run this check again next turn
+				SetApproachTowardsUsGuessCounter(eLoopPlayer, 0);
+				
+				// At war?
+				if(bAtWar)
+				{
+					SetApproachTowardsUsGuess(eLoopPlayer, MAJOR_CIV_APPROACH_WAR);
+					return;
+				}
+
+				eMilitaryAggressivePosture = GetMilitaryAggressivePosture(eLoopPlayer);
+				
+				// AI player, make a new guess based on visible approach
+				if(!GET_PLAYER(eLoopPlayer).isHuman())
+				{	
+					// If not AFRAID and their military deployment is extremely threatening, assume WAR
+#if defined(MOD_BALANCE_CORE)
+					if(eVisibleApproach != MAJOR_CIV_APPROACH_AFRAID && eMilitaryAggressivePosture >= AGGRESSIVE_POSTURE_HIGH && GetNumTurnsAtPeace(eLoopPlayer) >= 10)
+#else
+	                if(eVisibleApproach != MAJOR_CIV_APPROACH_AFRAID && eMilitaryAggressivePosture >= AGGRESSIVE_POSTURE_HIGH)
+#endif
+					{
+						SetApproachTowardsUsGuess(eLoopPlayer, MAJOR_CIV_APPROACH_WAR);
+					}
+					
+					else
+					{
+						// FRIENDLY? Let's not make the same mistake twice...
+						if(eVisibleApproach == MAJOR_CIV_APPROACH_FRIENDLY)
+						{
+							// If they backstabbed us by declaring war, they'll probably do it again
+							if(IsFriendDeclaredWarOnUs(eLoopPlayer))
+							{
+								SetApproachTowardsUsGuess(eLoopPlayer, MAJOR_CIV_APPROACH_WAR);
+							}
+							
+							// If they're untrustworthy or have denounced us, they're probably DECEPTIVE
+							else if(IsFriendDenouncedUs(eLoopPlayer) || GET_PLAYER(eLoopPlayer).GetDiplomacyAI()->IsUntrustworthyFriend() || GET_PLAYER(eLoopPlayer).GetDiplomacyAI()->IsDenouncedPlayer(GetPlayer()->GetID()))
+							{
+								SetApproachTowardsUsGuess(eLoopPlayer, MAJOR_CIV_APPROACH_DECEPTIVE);
+							}
+							
+							else
+							{
+								SetApproachTowardsUsGuess(eLoopPlayer, MAJOR_CIV_APPROACH_FRIENDLY);
+							}
+						}
+						else
+						{
+							SetApproachTowardsUsGuess(eLoopPlayer, eVisibleApproach);
+						}
+					}
+				}
+				
+				// Human player, make a new guess based on our current status
+				else
+				{	
+					// Their military deployment is extremely threatening, assume WAR
+#if defined(MOD_BALANCE_CORE)
+					if(eMilitaryAggressivePosture >= AGGRESSIVE_POSTURE_HIGH && GetNumTurnsAtPeace(eLoopPlayer) >= 10)
+#else
+					if(eMilitaryAggressivePosture >= AGGRESSIVE_POSTURE_HIGH)
+#endif
+					{
+						SetApproachTowardsUsGuess(eLoopPlayer, MAJOR_CIV_APPROACH_WAR);
+					}
+					
+					// If they denounced us, assume HOSTILE
+					else if(GET_PLAYER(eLoopPlayer).GetDiplomacyAI()->IsDenouncedPlayer(GetPlayer()->GetID()))
+					{
+						SetApproachTowardsUsGuess(eLoopPlayer, MAJOR_CIV_APPROACH_HOSTILE);
+					}
+					
+					// If we denounced them, assume GUARDED
+					else if(IsDenouncedPlayer(eLoopPlayer))
+					{
+						SetApproachTowardsUsGuess(eLoopPlayer, MAJOR_CIV_APPROACH_GUARDED);
+					}
+					
+					// They resurrected us, assume FRIENDLY
+					else if(WasResurrectedBy(eLoopPlayer))
+					{
+						SetApproachTowardsUsGuess(eLoopPlayer, MAJOR_CIV_APPROACH_FRIENDLY);
+					}
+					
+					// We've made a Defensive Pact, assume FRIENDLY
+					else if(GET_TEAM(GET_PLAYER(eLoopPlayer).getTeam()).IsHasDefensivePact(GetTeam()))
+					{
+						SetApproachTowardsUsGuess(eLoopPlayer, MAJOR_CIV_APPROACH_FRIENDLY);
+					}
+					
+					// We're friends, assume FRIENDLY
+					else if(IsDoFAccepted(eLoopPlayer) || GET_PLAYER(eLoopPlayer).GetDiplomacyAI()->IsDoFAccepted(GetPlayer()->GetID()))
+					{
+						// ...unless they're untrustworthy
+						if(IsFriendDenouncedUs(eLoopPlayer) || IsFriendDeclaredWarOnUs(eLoopPlayer) || GET_PLAYER(eLoopPlayer).GetDiplomacyAI()->IsUntrustworthyFriend())
+						{
+							SetApproachTowardsUsGuess(eLoopPlayer, MAJOR_CIV_APPROACH_DECEPTIVE);
+						}
+						else
+						{
+							SetApproachTowardsUsGuess(eLoopPlayer, MAJOR_CIV_APPROACH_FRIENDLY);
+						}
+					}
+#if defined(MOD_BALANCE_CORE)
+					// We've gone to war recently, assume GUARDED
+					else if(GetNumWarsFought(eLoopPlayer) > 0 && GetPlayerNumTurnsAtPeace(eLoopPlayer) <= 30)
+					{
+						SetApproachTowardsUsGuess(eLoopPlayer, MAJOR_CIV_APPROACH_GUARDED);
+					}
+#endif
+					
+					// We have no guess
+					else
+					{
+						SetApproachTowardsUsGuess(eLoopPlayer, MAJOR_CIV_APPROACH_NEUTRAL);
+					}
 				}
 			}
 		}
@@ -6111,6 +6346,10 @@ void CvDiplomacyAI::DoTestDemandReady()
 		pDeal->SetToPlayer(eDemandTarget);
 
 		DoMakeDemand(eDemandTarget, eStatement, pDeal);
+		
+		GET_PLAYER(eDemandTarget).GetDiplomacyAI()->SetApproachTowardsUsGuess(GetPlayer()->GetID(), MAJOR_CIV_APPROACH_HOSTILE);
+		GET_PLAYER(eDemandTarget).GetDiplomacyAI()->SetApproachTowardsUsGuessCounter(GetPlayer()->GetID(), 0);
+		
 	}
 }
 
@@ -25840,6 +26079,14 @@ void CvDiplomacyAI::DoFromUIDiploEvent(PlayerTypes eFromPlayer, FromUIDiploEvent
 			if (!bDeclareWar)
 			{
 				SetMajorCivApproach(eFromPlayer, MAJOR_CIV_APPROACH_NEUTRAL);
+				
+				// If approach towards us isn't already guessed to be WAR, assume it's HOSTILE
+				if(GetTrueApproachTowardsUsGuess(eFromPlayer) != MAJOR_CIV_APPROACH_WAR)
+				{
+					SetApproachTowardsUsGuess(eFromPlayer, MAJOR_CIV_APPROACH_HOSTILE);
+					SetApproachTowardsUsGuessCounter(eFromPlayer, 0);
+				}
+				
 				//If player is offended, AI should take note as penalty to assistance.
 				CvFlavorManager* pFlavorManager = GetPlayer()->GetFlavorManager();
 				int iFlavorOffense = pFlavorManager->GetPersonalityIndividualFlavor((FlavorTypes)GC.getInfoTypeForString("FLAVOR_OFFENSE"));
@@ -28590,6 +28837,9 @@ void CvDiplomacyAI::DoDemandMade(PlayerTypes ePlayer, DemandResponseTypes eDeman
 		ChangeNumTimesDemandedWhileVassal(ePlayer, 1);
 #endif
 	}
+	
+	SetApproachTowardsUsGuess(ePlayer, MAJOR_CIV_APPROACH_HOSTILE);
+	SetApproachTowardsUsGuessCounter(ePlayer, 0);
 
 	// See how long it'll be before we might agree to another demand
 

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
@@ -3063,7 +3063,7 @@ int CvDiplomacyAI::GetMajorCivOpinionWeight(PlayerTypes ePlayer)
 		iOpinionWeight += GetVictoryBlockLevelScore(ePlayer);
 		if(!GET_TEAM(GET_PLAYER(ePlayer).getTeam()).IsAllowsOpenBordersToTeam(m_pPlayer->getTeam()))
 		{
-			iOpinionWeight += (GetMilitaryAggressivePosture(ePlayer) * 2);
+			iOpinionWeight += (GetMilitaryAggressivePosture(ePlayer) * 5);
 		}
 	}
 #endif
@@ -32647,8 +32647,21 @@ int CvDiplomacyAI::GetLiberatedCitiesScore(PlayerTypes ePlayer)
 int CvDiplomacyAI::GetEmbassyScore(PlayerTypes ePlayer)
 {
 	int iOpinionWeight = 0;
+
 	if(GET_TEAM(GET_PLAYER(GetPlayer()->GetID()).getTeam()).HasEmbassyAtTeam(GET_PLAYER(ePlayer).getTeam()))
+	{
+#if defined(MOD_BALANCE_CORE)
+		iOpinionWeight += (/*-1*/ GC.getOPINION_WEIGHT_EMBASSY() * 2); // -2 if AI has an embassy with them
+#else
 		iOpinionWeight += (/*-1*/ GC.getOPINION_WEIGHT_EMBASSY());
+#endif
+	}
+	
+#if defined(MOD_BALANCE_CORE)
+	if(GET_PLAYER(ePlayer).getTeam().HasEmbassyAtTeam(GET_TEAM(GET_PLAYER(GetPlayer()->GetID()).getTeam()))
+		iOpinionWeight += (/*-1*/ GC.getOPINION_WEIGHT_EMBASSY()); // -1 if they have an embassy with AI
+#endif
+	
 	return iOpinionWeight;
 }
 

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.h
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.h
@@ -145,7 +145,8 @@ public:
 	bool IsHasActiveGoldQuest();
 
 	// Our guess as to another player's approach towards us
-	MajorCivApproachTypes GetApproachTowardsUsGuess(PlayerTypes ePlayer) ;
+	MajorCivApproachTypes GetApproachTowardsUsGuess(PlayerTypes ePlayer);
+	MajorCivApproachTypes GetTrueApproachTowardsUsGuess(PlayerTypes ePlayer);
 	void SetApproachTowardsUsGuess(PlayerTypes ePlayer, MajorCivApproachTypes eApproach);
 	int GetApproachTowardsUsGuessCounter(PlayerTypes ePlayer) const;
 	void SetApproachTowardsUsGuessCounter(PlayerTypes ePlayer, int iValue);

--- a/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
@@ -15991,11 +15991,11 @@ bool CvMinorCivAI::CanMajorBullyGold(PlayerTypes ePlayer)
 		return false;
 #endif
 
-	int iScore = CalculateBullyMetric(ePlayer, /*bForUnit*/false);
+	int iScore = CalculateBullyMetric(ePlayer, /*bForUnit*/ false);
 	return CanMajorBullyGold(ePlayer, iScore);
 }
 
-// In case client wants to specify a metric beforehand (ie. they calculated it on their end, for logging purposes etc.)
+// In case client wants to specify a metric beforehand (i.e. they calculated it on their end, for logging purposes etc.)
 bool CvMinorCivAI::CanMajorBullyGold(PlayerTypes ePlayer, int iSpecifiedBullyMetric)
 {
 	CvAssertMsg(ePlayer >= 0, "ePlayer is expected to be non-negative (invalid Index)");
@@ -16064,7 +16064,7 @@ bool CvMinorCivAI::CanMajorBullyUnit(PlayerTypes ePlayer)
 	return CanMajorBullyUnit(ePlayer, iScore);
 }
 
-// In case client wants to specify a metric beforehand (ie. they calculated it on their end, for logging purposes etc.)
+// In case client wants to specify a metric beforehand (i.e. they calculated it on their end, for logging purposes etc.)
 bool CvMinorCivAI::CanMajorBullyUnit(PlayerTypes ePlayer, int iSpecifiedBullyMetric)
 {
 	CvAssertMsg(ePlayer >= 0, "ePlayer is expected to be non-negative (invalid Index)");

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
@@ -12432,6 +12432,15 @@ int CvLuaPlayer::lGetOpinionTable(lua_State* L)
 	int iValue;
 
 	int iVisibleApproach = GET_PLAYER(eWithPlayer).GetDiplomacyAI()->GetApproachTowardsUsGuess(pkPlayer->GetID());
+	
+	if(pkPlayer->getTeam() == GET_PLAYER(eWithPlayer).getTeam())
+	{
+		Opinion kOpinion;
+		kOpinion.m_iValue = -99999;
+		kOpinion.m_str = Localization::Lookup("TXT_KEY_DIPLO_OPINION_HUMAN_TEAMMATE")
+		aOpinions.push_back(kOpinion);
+	}
+	
 	if (GET_TEAM(pkPlayer->getTeam()).isAtWar(GET_PLAYER(eWithPlayer).getTeam()))
 	{
 		iVisibleApproach = MAJOR_CIV_APPROACH_WAR;

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
@@ -12777,10 +12777,34 @@ int CvLuaPlayer::lGetOpinionTable(lua_State* L)
 	iValue = pDiploAI->GetEmbassyScore(eWithPlayer);
 	if (iValue != 0)
 	{
+#if defined(MOD_BALANCE_CORE)
+		if(GET_TEAM(GET_PLAYER(eWithPlayer).getTeam()).HasEmbassyAtTeam(pkPlayer->getTeam()) && GET_TEAM(pkPlayer->getTeam()).HasEmbassyAtTeam(GET_PLAYER(eWithPlayer).getTeam()))
+		{
+			Opinion kOpinion;
+			kOpinion.m_iValue = iValue;
+			kOpinion.m_str = Localization::Lookup("TXT_KEY_DIPLO_MUTUAL_EMBASSY");
+			aOpinions.push_back(kOpinion);
+		}
+		else if(GET_TEAM(pkPlayer->getTeam()).HasEmbassyAtTeam(GET_PLAYER(eWithPlayer).getTeam()))
+		{
+			Opinion kOpinion;
+			kOpinion.m_iValue = iValue;
+			kOpinion.m_str = Localization::Lookup("TXT_KEY_DIPLO_HAS_EMBASSY");
+			aOpinions.push_back(kOpinion);
+		}
+		else if(GET_TEAM(GET_PLAYER(eWithPlayer).getTeam()).HasEmbassyAtTeam(pkPlayer->getTeam()))
+		{
+			Opinion kOpinion;
+			kOpinion.m_iValue = iValue;
+			kOpinion.m_str = Localization::Lookup("TXT_KEY_DIPLO_WE_HAVE_EMBASSY");
+			aOpinions.push_back(kOpinion);
+		}
+#else
 		Opinion kOpinion;
 		kOpinion.m_iValue = iValue;
 		kOpinion.m_str = Localization::Lookup("TXT_KEY_DIPLO_HAS_EMBASSY");
 		aOpinions.push_back(kOpinion);
+#endif
 	}
 
 	iValue = pDiploAI->GetForgaveForSpyingScore(eWithPlayer);

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
@@ -12461,6 +12461,7 @@ int CvLuaPlayer::lGetOpinionTable(lua_State* L)
 		}
 	}
 
+// Hide some modifiers if FRIENDLY (or pretending to be)
 #if defined(MOD_API_LUA_EXTENSIONS) && defined(MOD_DIPLOMACY_CIV4_FEATURES)
 	if (iVisibleApproach != MAJOR_CIV_APPROACH_FRIENDLY || (MOD_DIPLOMACY_CIV4_FEATURES && GC.getGame().isOption(GAMEOPTION_ADVANCED_DIPLOMACY))) 
 #else


### PR DESCRIPTION
Makes the following changes:

**NOTE:** I'm not 100% confident on the syntax for the changes to the Approach guess function and would appreciate if it was looked over, although I tried my best and revised it several times.

Text
- Fixes the typos in the Workshop, Terracotta Army and <50% approval rating descriptions.
- Comment fixes/optimizations.

LuaPlayer
- Added text keys for the improved embassy opinion modifier, see below.
- Added a text key in GetOpinionTable for AI teammates of humans. ("We are on the same team.")

Diplomacy AI
- Adds original capital capturing, ideologies, social policies, and the diplo bonus for a master towards a vassal to the AI's DoEstimateOtherPlayerOpinions function. Working on adding more to this soon.

- Fixes a bug in GetPolicyScore that was preventing iNumPolicies from being factored in to the opinion weight, as appears to be intended (needed to flip the sign).

- Fixes a bug in GetMajorCivOpinionWeight that was adding military aggressive posture * 2 to the opinion weight, when LuaPlayer/Transparent Diplomacy indicated it was * 5.

- Rewrites the DoUpdateApproachTowardsUsGuesses function to allow the AI to make an educated guess as to another player's approach towards them, without conflicting with any other function which sets a given guess. Even though this function isn't used anywhere to my knowledge, I was aiming to make the AI a bit smarter in terms of potential, since the original DoUpdateApproachTowardsUsGuesses function was pitiful. If you like the function, perhaps it could see use elsewhere :)

- Adds a new function to access the memory value for the AI's guess, GetTrueApproachTowardsUsGuess, since GetApproachTowardsUsGuess is used to show the AI's visible approach (originally, GetApproachTowardsUsGuess returned this memory value, but that was apparently commented out).

- When a human player or an AI makes a demand, the target will immediately assume their approach towards them to be HOSTILE.

- When a human player chooses the insulting dialogue option during an AI statement, the AI will now guess that their approach towards them is HOSTILE (if it isn't already WAR).

- Improves the embassy opinion modifier (-3 for mutual embassies, -2 for AI having an embassy with the player, -1 for player having an embassy with the AI) for slightly more realistic and fun diplomacy with negligible impact on gameplay. This is similar to Open Borders, and an extra -2 opinion would rarely change anything, but it does give a small reason to establish an embassy earlier in the game; I noticed some players on the forums talking about there being no reason to set up an embassy unless you're rich or needed to trade things.

- GetNoSetterRequestScore: modifier is now 1 for teammates. This allows the player to see that the request has been made, but it's now dark red rather than bright red, and Transparent Diplomacy will show it as -1, since it is a non-factor when teammates are concerned.