### PR TITLE
DealAI bHideTrueFeelings Approach Valuation Fix

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvDealAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDealAI.cpp
@@ -2695,11 +2695,17 @@ int CvDealAI::GetEmbassyValue(bool bFromMe, PlayerTypes eOtherPlayer, bool bUseE
 		// Approach is important
 		switch(GetPlayer()->GetDiplomacyAI()->GetMajorCivApproach(eOtherPlayer, /*bHideTrueFeelings*/ false))
 		{
+		case MAJOR_CIV_APPROACH_WAR:
+			iItemValue *= 100;
+			break;
 		case MAJOR_CIV_APPROACH_HOSTILE:
 			iItemValue *= 250;
 			break;
 		case MAJOR_CIV_APPROACH_GUARDED:
 			iItemValue *= 130;
+			break;
+		case MAJOR_CIV_APPROACH_DECEPTIVE:
+			iItemValue *= 100;
 			break;
 		case MAJOR_CIV_APPROACH_AFRAID:
 			iItemValue *= 80;
@@ -2711,7 +2717,7 @@ int CvDealAI::GetEmbassyValue(bool bFromMe, PlayerTypes eOtherPlayer, bool bUseE
 			iItemValue *= 100;
 			break;
 		default:
-			CvAssertMsg(false, "DEAL_AI: AI player has no valid Approach for Research Agreement valuation.  Please send Jon this with your last 5 autosaves and what changelist # you're playing.")
+			CvAssertMsg(false, "DEAL_AI: AI player has no valid Approach for Embassy valuation.  Please send Jon this with your last 5 autosaves and what changelist # you're playing.")
 			iItemValue *= 100;
 			break;
 		}
@@ -2726,11 +2732,17 @@ int CvDealAI::GetEmbassyValue(bool bFromMe, PlayerTypes eOtherPlayer, bool bUseE
 		// Approach is important
 		switch(GetPlayer()->GetDiplomacyAI()->GetMajorCivApproach(eOtherPlayer, /*bHideTrueFeelings*/ false))
 		{
+		case MAJOR_CIV_APPROACH_WAR:
+			iItemValue *= 100;
+			break;
 		case MAJOR_CIV_APPROACH_HOSTILE:
 			iItemValue *= 30;
 			break;
 		case MAJOR_CIV_APPROACH_GUARDED:
 			iItemValue *= 60;
+			break;
+		case MAJOR_CIV_APPROACH_DECEPTIVE:
+			iItemValue *= 100;
 			break;
 		case MAJOR_CIV_APPROACH_AFRAID:
 			iItemValue *= 120;
@@ -2742,7 +2754,7 @@ int CvDealAI::GetEmbassyValue(bool bFromMe, PlayerTypes eOtherPlayer, bool bUseE
 			iItemValue *= 100;
 			break;
 		default:
-			CvAssertMsg(false, "DEAL_AI: AI player has no valid Approach for Research Agreement valuation.  Please send Jon this with your last 5 autosaves and what changelist # you're playing.")
+			CvAssertMsg(false, "DEAL_AI: AI player has no valid Approach for Embassy valuation.  Please send Jon this with your last 5 autosaves and what changelist # you're playing.")
 			iItemValue *= 100;
 			break;
 		}
@@ -2924,6 +2936,7 @@ int CvDealAI::GetOpenBordersValue(bool bFromMe, PlayerTypes eOtherPlayer, bool b
 		switch(eApproach)
 		{
 		//If we don't like him, don't take his borders. It's a trap!
+		case MAJOR_CIV_APPROACH_WAR:
 		case MAJOR_CIV_APPROACH_HOSTILE:
 		case MAJOR_CIV_APPROACH_DECEPTIVE:
 		case MAJOR_CIV_APPROACH_GUARDED:
@@ -3199,10 +3212,16 @@ int CvDealAI::GetResearchAgreementValue(bool bFromMe, PlayerTypes eOtherPlayer, 
 		// Approach is important
 		switch(GetPlayer()->GetDiplomacyAI()->GetMajorCivApproach(eOtherPlayer, /*bHideTrueFeelings*/ false))
 		{
+		case MAJOR_CIV_APPROACH_WAR:
+			iItemValue *= 100;
+			break;
 		case MAJOR_CIV_APPROACH_HOSTILE:
 			iItemValue *= 1000;
 			break;
 		case MAJOR_CIV_APPROACH_GUARDED:
+			iItemValue *= 100;
+			break;
+		case MAJOR_CIV_APPROACH_DECEPTIVE:
 			iItemValue *= 100;
 			break;
 		case MAJOR_CIV_APPROACH_AFRAID:
@@ -3259,11 +3278,17 @@ int CvDealAI::GetTradeAgreementValue(bool bFromMe, PlayerTypes eOtherPlayer, boo
 		// Approach is important
 		switch(GetPlayer()->GetDiplomacyAI()->GetMajorCivApproach(eOtherPlayer, /*bHideTrueFeelings*/ false))
 		{
+		case MAJOR_CIV_APPROACH_WAR:
+			iItemValue *= 100;
+			break;
 		case MAJOR_CIV_APPROACH_HOSTILE:
 			iItemValue *= 250;
 			break;
 		case MAJOR_CIV_APPROACH_GUARDED:
 			iItemValue *= 130;
+			break;
+		case MAJOR_CIV_APPROACH_DECEPTIVE:
+			iItemValue *= 100;
 			break;
 		case MAJOR_CIV_APPROACH_AFRAID:
 			iItemValue *= 80;
@@ -3275,7 +3300,7 @@ int CvDealAI::GetTradeAgreementValue(bool bFromMe, PlayerTypes eOtherPlayer, boo
 			iItemValue *= 110;
 			break;
 		default:
-			CvAssertMsg(false, "DEAL_AI: AI player has no valid Approach for Research Agreement valuation.  Please send Jon this with your last 5 autosaves and what changelist # you're playing.")
+			CvAssertMsg(false, "DEAL_AI: AI player has no valid Approach for Trade Agreement valuation.  Please send Jon this with your last 5 autosaves and what changelist # you're playing.")
 			iItemValue *= 100;
 			break;
 		}
@@ -8647,11 +8672,17 @@ int CvDealAI::GetMapValue(bool bFromMe, PlayerTypes eOtherPlayer, bool bUseEvenV
 		// Approach will modify the deal
 		switch(GetPlayer()->GetDiplomacyAI()->GetMajorCivApproach(eOtherPlayer, /*bHideTrueFeelings*/ false))
 		{
+			case MAJOR_CIV_APPROACH_WAR:
+				iItemValue *= 100;
+				break;
 			case MAJOR_CIV_APPROACH_HOSTILE:
 				iItemValue *= 250;
 				break;
 			case MAJOR_CIV_APPROACH_GUARDED:
 				iItemValue *= 130;
+				break;
+			case MAJOR_CIV_APPROACH_DECEPTIVE:
+				iItemValue *= 100;
 				break;
 			case MAJOR_CIV_APPROACH_AFRAID:
 				iItemValue *= 80;
@@ -8677,11 +8708,17 @@ int CvDealAI::GetMapValue(bool bFromMe, PlayerTypes eOtherPlayer, bool bUseEvenV
 		// Approach will modify the deal
 		switch(GetPlayer()->GetDiplomacyAI()->GetMajorCivApproach(eOtherPlayer, /*bHideTrueFeelings*/ false))
 		{
+			case MAJOR_CIV_APPROACH_WAR:
+				iItemValue *= 100;
+				break;
 			case MAJOR_CIV_APPROACH_HOSTILE:
 				iItemValue *= 25;
 				break;
 			case MAJOR_CIV_APPROACH_GUARDED:
 				iItemValue *= 50;
+				break;
+			case MAJOR_CIV_APPROACH_DECEPTIVE:
+				iItemValue *= 100;
 				break;
 			case MAJOR_CIV_APPROACH_AFRAID:
 				iItemValue *= 75;
@@ -8910,10 +8947,15 @@ int CvDealAI::GetTechValue(TechTypes eTech, bool bFromMe, PlayerTypes eOtherPlay
 #endif
 		switch(GetPlayer()->GetDiplomacyAI()->GetMajorCivApproach(eOtherPlayer, /*bHideTrueFeelings*/ false))
 		{
+			case MAJOR_CIV_APPROACH_WAR:
+				return INT_MAX;
 			case MAJOR_CIV_APPROACH_HOSTILE:
 				return INT_MAX;
 			case MAJOR_CIV_APPROACH_GUARDED:
 				return INT_MAX;
+			case MAJOR_CIV_APPROACH_DECEPTIVE:
+				iItemValue *= 100;
+				break;
 			case MAJOR_CIV_APPROACH_AFRAID:
 				return INT_MAX;
 			case MAJOR_CIV_APPROACH_FRIENDLY:
@@ -8934,11 +8976,17 @@ int CvDealAI::GetTechValue(TechTypes eTech, bool bFromMe, PlayerTypes eOtherPlay
 	{
 		switch(GetPlayer()->GetDiplomacyAI()->GetMajorCivApproach(eOtherPlayer, /*bHideTrueFeelings*/ false))
 		{
+			case MAJOR_CIV_APPROACH_WAR:
+				iItemValue *= 100;
+				break;
 			case MAJOR_CIV_APPROACH_HOSTILE:
 				iItemValue *= 50;
 				break;
 			case MAJOR_CIV_APPROACH_GUARDED:
 				iItemValue *= 75;
+				break;
+			case MAJOR_CIV_APPROACH_DECEPTIVE:
+				iItemValue *= 100;
 				break;
 			case MAJOR_CIV_APPROACH_AFRAID:
 				iItemValue *= 100;
@@ -9062,11 +9110,17 @@ int CvDealAI::GetVassalageValue(bool bFromMe, PlayerTypes eOtherPlayer, bool bUs
 
 		switch (m_pDiploAI->GetMajorCivApproach(eOtherPlayer, /*bHideTrueFeelings*/ false))
 		{
+		case MAJOR_CIV_APPROACH_WAR:
+			iItemValue *= 100;
+			break;
 		case MAJOR_CIV_APPROACH_HOSTILE:
 			iItemValue *= 250;
 			break;
 		case MAJOR_CIV_APPROACH_GUARDED:
 			iItemValue *= 130;
+			break;
+		case MAJOR_CIV_APPROACH_DECEPTIVE:
+			iItemvalue *= 100;
 			break;
 		case MAJOR_CIV_APPROACH_AFRAID:
 			iItemValue *= 75;
@@ -9161,11 +9215,17 @@ int CvDealAI::GetVassalageValue(bool bFromMe, PlayerTypes eOtherPlayer, bool bUs
 
 		switch (m_pDiploAI->GetMajorCivApproach(eOtherPlayer, /*bHideTrueFeelings*/ false))
 		{
+		case MAJOR_CIV_APPROACH_WAR:
+			iItemValue *= 100;
+			break;
 		case MAJOR_CIV_APPROACH_HOSTILE:
 			iItemValue *= 50;
 			break;
 		case MAJOR_CIV_APPROACH_GUARDED:
 			iItemValue *= 60;
+			break;
+		case MAJOR_CIV_APPROACH_DECEPTIVE:
+			iItemValue *= 100;
 			break;
 		case MAJOR_CIV_APPROACH_AFRAID:
 			iItemValue *= 125;
@@ -9304,11 +9364,17 @@ int CvDealAI::GetRevokeVassalageValue(bool bFromMe, PlayerTypes eOtherPlayer, bo
 
 		switch(m_pDiploAI->GetMajorCivApproach(eOtherPlayer, /*bHideTrueFeelings*/ false))
 		{
+			case MAJOR_CIV_APPROACH_WAR:
+				return INT_MAX;
+				break;
 			case MAJOR_CIV_APPROACH_HOSTILE:
 				return INT_MAX;
 				break;
 			case MAJOR_CIV_APPROACH_GUARDED:
 				return INT_MAX;
+				break;
+			case MAJOR_CIV_APPROACH_DECEPTIVE:
+				iItemValue *= 100;
 				break;
 			case MAJOR_CIV_APPROACH_AFRAID:
 				iItemValue *= 60;


### PR DESCRIPTION
All instances of bHideTrueFeelings being set to true when obtaining the AI's approach for deal valuation were removed recently.

As such, this adds a case for WAR and DECEPTIVE in each instance where they're missing.

In these added cases, DECEPTIVE is always set to the default value for the switch statement; WAR is set to INT_MAX where HOSTILE and GUARDED also are, and to the default value otherwise.