### PR TITLE
Bugfixes

### DIFF
--- a/Community Balance Patch/Balance Changes/Text/en_US/CivText.sql
+++ b/Community Balance Patch/Balance Changes/Text/en_US/CivText.sql
@@ -336,7 +336,7 @@ WHERE Tag = 'TXT_KEY_UNIT_ENGLISH_SHIPOFTHELINE_STRATEGY' AND EXISTS (SELECT * F
 -- Ethiopia
 --------------------
 UPDATE Language_en_US
-SET Text = 'When you complete a Policy Branch, adopt a Belief, or choose your first Ideology, receive a free Technology. +1 [ICON_PEACE] Faith from Strategic Resources.'
+SET Text = 'When you complete a Policy Branch, adopt a Belief, or choose your first Ideology, receive a free Technology.'
 WHERE Tag = 'TXT_KEY_TRAIT_BONUS_AGAINST_TECH' AND EXISTS (SELECT * FROM COMMUNITY WHERE Type='COMMUNITY_CORE_BALANCE_LEADERS' AND Value= 1 );
 
 UPDATE Language_en_US

--- a/Community Balance Patch/Balance Changes/Text/en_US/UIText.xml
+++ b/Community Balance Patch/Balance Changes/Text/en_US/UIText.xml
@@ -533,35 +533,35 @@
 		<!-- New -->
 
 		<Row Tag="TXT_KEY_NOTIFICATION_CITY_WLTKD_UA_ERA_CHANGE">
-			<Text>Entering a new Era has lead to instability and the rise of a new ruling dynasty. Bonus [ICON_FOOD] Food and [ICON_CULTURE] Culture from Mandate of Heaven are halved in all Cities.</Text>
+			<Text>Entering a new Era has led to instability and the rise of a new ruling dynasty. Bonus [ICON_FOOD] Food and [ICON_GOLD] Gold from Mandate of Heaven is halved in all Cities.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_CITY_SUMMARY_WLTKD_UA_ERA_CHANGE">
 			<Text>Dynastic Transition...</Text>
 		</Row>
 
 		<Row Tag="TXT_KEY_NOTIFICATION_CITY_WLTKD_UA_GREAT_WORK">
-			<Text>The creation of a [ICON_GREAT_WORK] Great Work causes all Cities to enter "We Love the Empress Day" for {1_Num} Turns, increasing their [ICON_FOOD] Food by +{2_Num}%! All Cities gain +1 [ICON_FOOD] Food and +1 [ICON_CULTURE] Culture permanently.</Text>
+			<Text>The creation of a [ICON_GREAT_WORK] Great Work causes all Cities to enter "We Love the Empress Day" for {1_Num} Turns, increasing their [ICON_FOOD] Food by +{2_Num}%! All Cities gain +1 [ICON_FOOD] Food and +1 [ICON_GOLD] Gold.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_CITY_WLTKD_UA_GREAT_WORK">
 			<Text>Mandate of Heaven</Text>
 		</Row>
 		
 		<Row Tag="TXT_KEY_NOTIFICATION_CITY_WLTKD_UA_RESOURCE">
-			<Text>The aquisition of {1_Resource:textkey} causes the city of {2_CityName:textkey} to enter "We Love the Empress Day" for {3_Num} Turns, increasing their [ICON_FOOD] Food by +{4_Num}%!</Text>
+			<Text>The acquisition of {1_Resource:textkey} causes the city of {2_CityName:textkey} to enter "We Love the Empress Day" for {3_Num} Turns, increasing their [ICON_FOOD] Food by +{4_Num}%!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_CITY_WLTKD_UA_RESOURCE">
 			<Text>Mandate of Heaven</Text>
 		</Row>
 
 		<Row Tag="TXT_KEY_NOTIFICATION_CITY_WLTKD_UA_CITY_SETTLING">
-			<Text>The founding of a new City causes all Cities to enter "We Love the Empress Day" for {1_Num} Turns, increasing their [ICON_FOOD] Food by +{2_Num}%! All Cities gain +1 [ICON_FOOD] Food and +1 [ICON_CULTURE] Culture.</Text>
+			<Text>The founding of a new City causes all Cities to enter "We Love the Empress Day" for {1_Num} Turns, increasing their [ICON_FOOD] Food by +{2_Num}%! All Cities gain +1 [ICON_FOOD] Food and +1 [ICON_GOLD] Gold.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_CITY_WLTKD_UA_CITY_SETTLING">
 			<Text>Mandate of Heaven</Text>
 		</Row>
 
 		<Row Tag="TXT_KEY_NOTIFICATION_CITY_WLTKD_UA_CITY_CONQUEST">
-			<Text>The conquest of a City causes all Cities to enter "We Love the Empress Day" for {1_Num} Turns, increasing their [ICON_FOOD] Food by +{2_Num}%! All Cities gain +1 [ICON_FOOD] Food and +1 [ICON_CULTURE] Culture.</Text>
+			<Text>The conquest of a City causes all Cities to enter "We Love the Empress Day" for {1_Num} Turns, increasing their [ICON_FOOD] Food by +{2_Num}%! All Cities gain +1 [ICON_FOOD] Food and +1 [ICON_GOLD] Gold.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_CITY_WLTKD_UA_CITY_CONQUEST">
 			<Text>Mandate of Heaven</Text>

--- a/Community Patch/Core Files/Text/CoreText_en_US.sql
+++ b/Community Patch/Core Files/Text/CoreText_en_US.sql
@@ -326,9 +326,12 @@ WHERE Tag = 'TXT_KEY_DIPLO_REFUSED_REQUESTS';
 -- Diplo Text for DoF changed
 
 UPDATE Language_en_US
+SET Text = '[COLOR_NEGATIVE_TEXT]We made a Declaration of Friendship and then declared war on them![ENDCOLOR]'
+WHERE Tag = 'TXT_KEY_DIPLO_HUMAN_FRIEND_DECLARED_WAR';
+
+UPDATE Language_en_US
 SET Text = '[COLOR_NEGATIVE_TEXT]We made a Declaration of Friendship and then denounced them![ENDCOLOR]'
 WHERE Tag = 'TXT_KEY_DIPLO_HUMAN_FRIEND_DENOUNCED';
-
 
 UPDATE Language_en_US
 SET Text = 'Our Declaration of Friendship must end.'
@@ -446,14 +449,6 @@ WHERE Tag = 'TXT_KEY_UNITS_NATIONAL_HEADING2_BODY';
 UPDATE Language_en_US
 SET Text = 'If another civ has captured a City-State and you capture it from them, you have the option to "liberate" that city-state. If you do so, you will receive a large amount of [ICON_INFLUENCE] Influence from the City-State, usually enough to make you [COLOR_POSITIVE_TEXT]Allies[ENDCOLOR] with it.'
 WHERE Tag = 'TXT_KEY_CITYSTATE_LIBERATING_HEADING2_BODY';
-
-
-UPDATE Language_en_US
-SET Text = '[COLOR_NEGATIVE_TEXT]We made a Declaration of Friendship and then declared war on them![ENDCOLOR]'
-WHERE Tag = 'TXT_KEY_DIPLO_HUMAN_FRIEND_DECLARED_WAR';
-UPDATE Language_en_US
-SET Text = '[COLOR_NEGATIVE_TEXT]We made a Declaration of Friendship and then denounced them!'
-WHERE Tag = 'TXT_KEY_DIPLO_HUMAN_FRIEND_DENOUNCED';
 
 -- Barbarians
 
@@ -575,20 +570,6 @@ WHERE Tag = 'TXT_KEY_NOTIFICATION_CITY_REVOLT' AND EXISTS (SELECT * FROM COMMUNI
 
 
 UPDATE Language_en_US
-SET Text = 'Very well. Not that it will help either of us in the long run...we will all die soon enough.'
-WHERE Tag = 'TXT_KEY_LEADER_NEBUCHADNEZZAR_TRADE_YES_HAPPY';
-
-UPDATE Language_en_US
-SET Text = 'You must be insane to insult me with such an offer. We refuse.'
-WHERE Tag = 'TXT_KEY_LEADER_GENGHIS_TRADE_NO_NEUTRAL';
-
-
-UPDATE Language_en_US
-SET Text = 'It honors my people, helping those in need.'
-WHERE Tag = 'TXT_KEY_LEADER_POCATELLO_TRIBUTE_YES_NEUTRAL';
-
-
-UPDATE Language_en_US
 SET Text = '[COLOR_WARNING_TEXT]{1_Number} Interceptors![ENDCOLOR]'
 WHERE Tag = 'TXT_KEY_EUPANEL_VISIBLE_AA_UNITS';
 
@@ -596,26 +577,6 @@ UPDATE Language_en_US
 SET Text = 'Once you have acquired the Chivalry tech, you may engage in a Defensive Pact. Defensive Pacts are always mutual. If a signatory to a Defensive Pact is attacked, the other partner is automatically at war with the attacker.[NEWLINE][NEWLINE]A Defensive Pact lasts for 30 turns (on standard speed). When that time has elapsed, the pact lapses unless it is renegotiated.'
 WHERE Tag = 'TXT_KEY_DIPLOMACY_DEFENSIVEPACT_HEADING3_BODY';
 
-UPDATE Language_en_US
-SET Text = 'Give me what I want, and I may spare you...for now.'
-WHERE Tag = 'TXT_KEY_LEADER_GAJAH_MADA_DEMANDTRIBUTE_NEUTRAL';
-
-UPDATE Language_en_US
-SET Text = 'Smart move.'
-WHERE Tag = 'TXT_KEY_LEADER_GAJAH_MADA_TRADE_YES_ANGRY';
-
-
-UPDATE Language_en_US
-SET Text = 'Speak: anything to drown out the whispers.'
-WHERE Tag = 'TXT_KEY_LEADER_NEBUCHADNEZZAR_LETSHEARIT_1';
-
-UPDATE Language_en_US
-SET Text = 'You come to mighty Persia as you are? What do you want?'
-WHERE Tag = 'TXT_KEY_LEADER_DARIUS_GREETING_HOSTILE_HELLO_1';
-
-UPDATE Language_en_US
-SET Text = 'Happily agreed.'
-WHERE Tag = 'TXT_KEY_LEADER_SEJONG_TRADE_YES_HAPPY';
 
 -- Production Queue
 
@@ -625,20 +586,84 @@ WHERE Tag = 'TXT_KEY_CITYVIEW_QUEUE_PROD_TT';
 
 -- Civilizations Dialog
 
--- Neutral Tribute
+-- Greeting
 
 UPDATE Language_en_US
-SET Text = 'You may have this bit of material wealth, yes. But such indiscretions are not easily forgotten.'
-WHERE Tag = 'TXT_KEY_LEADER_BOUDICCA_TRIBUTE_YES_NEUTRAL';
+SET Text = 'Well? Speak up. I can barely hear you over the blood pounding in my brain.'
+WHERE Tag = 'TXT_KEY_LEADER_NEBUCHADNEZZAR_GREETING_5'
 
--- Trade Happy
+-- Greeting (Hostile)
+
+UPDATE Language_en_US
+SET Text = 'You come to mighty Persia as you are? What do you want?'
+WHERE Tag = 'TXT_KEY_LEADER_DARIUS_GREETING_HOSTILE_HELLO_1';
+
+-- Open Trade Screen
+
+UPDATE Language_en_US
+SET Text = 'Speak: anything to drown out the whispers.'
+WHERE Tag = 'TXT_KEY_LEADER_NEBUCHADNEZZAR_LETSHEARIT_1';
+
+-- Offer Trade (Happy)
 
 UPDATE Language_en_US
 SET Text = 'Does this trade interest you?'
 WHERE Tag = 'TXT_KEY_LEADER_GENGHIS_TRADEREQUEST_HAPPY';
 
--- Trade Angry
+UPDATE Language_en_US
+SET Text = 'It appears that you do have a reason for existing: to make this deal with me.'
+WHERE Tag = 'TXT_KEY_LEADER_NEBUCHADNEZZAR_TRADEREQUEST_HAPPY'
+
+-- Accept Trade (Happy)
+
+UPDATE Language_en_US
+SET Text = 'Very well. Not that it will help either of us in the long run...we will all die soon enough.'
+WHERE Tag = 'TXT_KEY_LEADER_NEBUCHADNEZZAR_TRADE_YES_HAPPY';
+
+UPDATE Language_en_US
+SET Text = 'Happily agreed.'
+WHERE Tag = 'TXT_KEY_LEADER_SEJONG_TRADE_YES_HAPPY';
+
+-- Accept Trade (Angry)
+
+UPDATE Language_en_US
+SET Text = 'Smart move.'
+WHERE Tag = 'TXT_KEY_LEADER_GAJAH_MADA_TRADE_YES_ANGRY';
+
+-- Decline Trade (Neutral)
+
+UPDATE Language_en_US
+SET Text = 'You must be insane to insult me with such an offer. We refuse.'
+WHERE Tag = 'TXT_KEY_LEADER_GENGHIS_TRADE_NO_NEUTRAL';
+
+-- Decline Trade (Angry)
 
 UPDATE Language_en_US
 SET Text = 'My husband is deceased, you know: Russia is no longer ruled by an idiot. We decline.'
 WHERE Tag = 'TXT_KEY_LEADER_CATHERINE_TRADE_NO_ANGRY';
+
+-- Make Demand
+
+UPDATE Language_en_US
+SET Text = 'Give me what I want, and I may spare you...for now.'
+WHERE Tag = 'TXT_KEY_LEADER_GAJAH_MADA_DEMANDTRIBUTE_NEUTRAL';
+
+-- Accept Demand (Neutral)
+
+UPDATE Language_en_US
+SET Text = 'You may have this bit of material wealth, yes. But such indiscretions are not easily forgotten.'
+WHERE Tag = 'TXT_KEY_LEADER_BOUDICCA_TRIBUTE_YES_NEUTRAL';
+
+UPDATE Language_en_US
+SET Text = 'It honors my people, helping those in need.'
+WHERE Tag = 'TXT_KEY_LEADER_POCATELLO_TRIBUTE_YES_NEUTRAL';
+
+-- Leader Attacked
+
+UPDATE Language_en_US
+SET Text = 'We shall destroy you, you know. Do you care for some cheese?'
+WHERE Tag = 'TXT_KEY_LEADER_NEBUCHADNEZZAR_ATTACKED_2'
+
+UPDATE Language_en_US
+SET Text = 'Oh well. I presume you know what you''re doing.'
+WHERE Tag = 'TXT_KEY_LEADER_NEBUCHADNEZZAR_ATTACKED_3'

--- a/Community Patch/Core Files/Text/CoreText_en_US.sql
+++ b/Community Patch/Core Files/Text/CoreText_en_US.sql
@@ -584,7 +584,21 @@ UPDATE Language_en_US
 SET Text = 'LEFT CLICK adds an additional item to the end of the production queue.[NEWLINE]CTRL + LEFT CLICK adds an additional item in front of the production queue.[NEWLINE]SHIFT + LEFT CLICK replaces everything in the production queue with the chosen item.'
 WHERE Tag = 'TXT_KEY_CITYVIEW_QUEUE_PROD_TT';
 
--- Civilizations Dialog
+-- Leader Dialog
+
+-- First Greeting
+
+UPDATE Language_en_US
+SET Text = 'I am Nebuchadnezzar of Babylon. Those fools outside say I''m a god, but that seems unlikely. Who are you?'
+WHERE Tag = 'TXT_KEY_LEADER_NEBUCHADNEZZAR_FIRSTGREETING_1'
+
+UPDATE Language_en_US
+SET Text = 'I am Nebuchadnezzar. Are you real or just a phantom of my tortured senses?'
+WHERE Tag = 'TXT_KEY_LEADER_NEBUCHADNEZZAR_FIRSTGREETING_3'
+
+UPDATE Language_en_US
+SET Text = 'Greetings, Stranger. I am Pachacuti, ruler of the peerless Incans. If there is any way that we can assist your inferior civilization, please do not hesitate to ask.'
+WHERE Tag = 'TXT_KEY_LEADER_PACHACUTI_FIRSTGREETING_3'
 
 -- Greeting
 
@@ -597,6 +611,26 @@ WHERE Tag = 'TXT_KEY_LEADER_NEBUCHADNEZZAR_GREETING_5'
 UPDATE Language_en_US
 SET Text = 'You come to mighty Persia as you are? What do you want?'
 WHERE Tag = 'TXT_KEY_LEADER_DARIUS_GREETING_HOSTILE_HELLO_1';
+
+-- Agree
+
+UPDATE Language_en_US
+SET Text = 'Very well.'
+WHERE Tag = 'TXT_KEY_LEADER_GENGHIS_AGREE_SHORT_2'
+
+UPDATE Language_en_US
+SET Text = 'What''s the frequency, Kenneth?'
+WHERE Tag = 'TXT_KEY_LEADER_NEBUCHADNEZZAR_AGREE_SHORT_1'
+
+UPDATE Language_en_US
+SET Text = 'Very well.'
+WHERE Tag = 'TXT_KEY_LEADER_PACHACUTI_AGREE_SHORT_2'
+
+-- Disagree
+
+UPDATE Language_en_US
+SET Text = 'Certainly not.'
+WHERE Tag = 'TXT_KEY_LEADER_PACHACUTI_DISAGREE_SHORT_1'
 
 -- Open Trade Screen
 
@@ -614,6 +648,16 @@ UPDATE Language_en_US
 SET Text = 'It appears that you do have a reason for existing: to make this deal with me.'
 WHERE Tag = 'TXT_KEY_LEADER_NEBUCHADNEZZAR_TRADEREQUEST_HAPPY'
 
+-- Offer Trade (Angry)
+
+UPDATE Language_en_US
+SET Text = 'You would do well to agree to our very fair and reasonable terms.'
+WHERE Tag = 'TXT_KEY_LEADER_GENGHIS_TRADEREQUEST_ANGRY'
+
+UPDATE Language_en_US
+SET Text = 'You would allay my all-consuming misery by agreeing to the following.'
+WHERE Tag = 'TXT_KEY_LEADER_NEBUCHADNEZZAR_TRADEREQUEST_ANGRY'
+
 -- Accept Trade (Happy)
 
 UPDATE Language_en_US
@@ -630,11 +674,21 @@ UPDATE Language_en_US
 SET Text = 'Smart move.'
 WHERE Tag = 'TXT_KEY_LEADER_GAJAH_MADA_TRADE_YES_ANGRY';
 
+-- Decline Trade (Happy)
+
+UPDATE Language_en_US
+SET Text = 'I am sorry, but the voices tell me that I must decline your offer.'
+WHERE Tag = 'TXT_KEY_LEADER_NEBUCHADNEZZAR_TRADE_NO_HAPPY'
+
 -- Decline Trade (Neutral)
 
 UPDATE Language_en_US
 SET Text = 'You must be insane to insult me with such an offer. We refuse.'
 WHERE Tag = 'TXT_KEY_LEADER_GENGHIS_TRADE_NO_NEUTRAL';
+
+UPDATE Language_en_US
+SET Text = 'Your offer is declined. I would be insulted, if I cared anything about you.'
+WHERE Tag = 'TXT_KEY_LEADER_NEBUCHADNEZZAR_TRADE_NO_NEUTRAL'
 
 -- Decline Trade (Angry)
 
@@ -642,11 +696,19 @@ UPDATE Language_en_US
 SET Text = 'My husband is deceased, you know: Russia is no longer ruled by an idiot. We decline.'
 WHERE Tag = 'TXT_KEY_LEADER_CATHERINE_TRADE_NO_ANGRY';
 
+UPDATE Language_en_US
+SET Text = 'I have conceived of a blind, almost overpowering dislike for you. The answer is ''no.'''
+WHERE Tag = 'TXT_KEY_LEADER_NEBUCHADNEZZAR_TRADE_NO_ANGRY'
+
 -- Make Demand
 
 UPDATE Language_en_US
 SET Text = 'Give me what I want, and I may spare you...for now.'
 WHERE Tag = 'TXT_KEY_LEADER_GAJAH_MADA_DEMANDTRIBUTE_NEUTRAL';
+
+UPDATE Language_en_US
+SET Text = 'The following tribute would improve my black humor, greatly increasing the odds that you would survive another day.'
+WHERE Tag = 'TXT_KEY_LEADER_NEBUCHADNEZZAR_DEMANDTRIBUTE_NEUTRAL'
 
 -- Accept Demand (Neutral)
 
@@ -655,10 +717,30 @@ SET Text = 'You may have this bit of material wealth, yes. But such indiscretion
 WHERE Tag = 'TXT_KEY_LEADER_BOUDICCA_TRIBUTE_YES_NEUTRAL';
 
 UPDATE Language_en_US
+SET Text = 'I agree; if only to confound my advisors, who urge me to refuse.'
+WHERE Tag = 'TXT_KEY_LEADER_NEBUCHADNEZZAR_TRIBUTE_YES_NEUTRAL'
+
+UPDATE Language_en_US
 SET Text = 'It honors my people, helping those in need.'
 WHERE Tag = 'TXT_KEY_LEADER_POCATELLO_TRIBUTE_YES_NEUTRAL';
 
--- Leader Attacked
+-- War Bluff
+
+UPDATE Language_en_US
+SET Text = 'The drums, the drums! They pound in my brain, drowning out thoughts of vengeance.'
+WHERE Tag = 'TXT_KEY_LEADER_NEBUCHADNEZZAR_WARBLUFF_1'
+
+-- Declare War
+
+UPDATE Language_en_US
+SET Text = 'It was inevitable that we would come to blows, and now is as good a time as another.'
+WHERE Tag = 'TXT_KEY_LEADER_GENGHIS_DECLAREWAR_1'
+
+UPDATE Language_en_US
+SET Text = 'Your people remain backwards and primitive. Clearly a change of regime is in order. Prepare for war!'
+WHERE Tag = 'TXT_KEY_LEADER_PACHACUTI_DECLAREWAR_1'
+
+-- Declared War On
 
 UPDATE Language_en_US
 SET Text = 'We shall destroy you, you know. Do you care for some cheese?'
@@ -667,3 +749,15 @@ WHERE Tag = 'TXT_KEY_LEADER_NEBUCHADNEZZAR_ATTACKED_2'
 UPDATE Language_en_US
 SET Text = 'Oh well. I presume you know what you''re doing.'
 WHERE Tag = 'TXT_KEY_LEADER_NEBUCHADNEZZAR_ATTACKED_3'
+
+-- Win War
+
+UPDATE Language_en_US
+SET Text = 'That was refreshing. If the demons are sated, perhaps they will give us a little respite now.'
+WHERE Tag = 'TXT_KEY_LEADER_NEBUCHADNEZZAR_WINWAR_1'
+
+-- Defeated
+
+UPDATE Language_en_US
+SET Text = 'You have done well. I shall put in a good word for you to the demons.'
+WHERE Tag = 'TXT_KEY_LEADER_NEBUCHADNEZZAR_DEFEATED_1'

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
@@ -32855,11 +32855,13 @@ int CvDiplomacyAI::GetNoSetterRequestScore(PlayerTypes ePlayer)
 {
 	int iOpinionWeight = 0;
 	if(IsPlayerNoSettleRequestEverAsked(ePlayer))
+	{
 		// Teammates
 		if(GetPlayer()->getTeam() == GET_PLAYER(ePlayer).getTeam())
 			return 0;
 		
 		iOpinionWeight += /*20*/ GC.getOPINION_WEIGHT_ASKED_NO_SETTLE();
+	}
 
 	return iOpinionWeight;
 }

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
@@ -3363,16 +3363,17 @@ void CvDiplomacyAI::DoEstimateOtherPlayerOpinions()
 						int iNumPolicies = GET_PLAYER(eLoopPlayer).GetDiplomacyAI()->GetNumSamePolicies(eLoopOtherPlayer);
 						
 						// We can't know their neediness so assume the default
-						if(iNumPolicies != 0)
+						if(iNumPolicies < 0)
 						{
-							if(iNumPolicies < 0)
-							{
-								iOpinionWeight += max(5, (iNumPolicies * -1));
-							}
-							else if(iNumPolicies > 0)
-							{
-								iOpinionWeight += min(-5, (iNumPolicies * -1));
-							}
+							// Flip it!
+							iNumPolicies *= -1;
+							iOpinionWeight += max(5, (iNumPolicies * 1));
+						}
+						else if(iNumPolicies > 0)
+						{
+							// Flip it!
+							iNumPolicies *= -1;
+							iOpinionWeight += min(-5, (iNumPolicies * 1));
 						}			
 #endif
 						
@@ -5820,9 +5821,6 @@ void CvDiplomacyAI::DoUpdateApproachTowardsUsGuesses()
 	AggressivePostureTypes eLastTurnMilitaryAggressivePosture;
 	bool bAtWar = false;
 	bool bHuman = false;
-#if defined(MOD_BALANCE_CORE)
-	bool bJustMadePeace = false;
-#endif
 
 	for(int iPlayerLoop = 0; iPlayerLoop < MAX_MAJOR_CIVS; iPlayerLoop++)
 	{
@@ -5836,14 +5834,6 @@ void CvDiplomacyAI::DoUpdateApproachTowardsUsGuesses()
 			eLastTurnMilitaryAggressivePosture = GetLastTurnMilitaryAggressivePosture(eLoopPlayer);
 			bAtWar = GET_TEAM(GetTeam()).isAtWar(GET_PLAYER(eLoopPlayer).getTeam());
 			bHuman = GET_PLAYER(eLoopPlayer).isHuman();
-
-#if defined(MOD_BALANCE_CORE)			
-			// Check if we just made peace with this player
-			bJustMadePeace = false;
-			
-			if (GetNumWarsFought(eLoopPlayer) > 0 && GetPlayerNumTurnsAtPeace(eLoopPlayer) <= 1)
-				bJustMadePeace = true;
-#endif
 			
 			// If they're at war with us, then their approach is WAR for all practical purposes
 			if(bAtWar && eTrueApproachGuess != MAJOR_CIV_APPROACH_WAR)
@@ -5855,7 +5845,7 @@ void CvDiplomacyAI::DoUpdateApproachTowardsUsGuesses()
 
 #if defined(MOD_BALANCE_CORE)			
 			// If we just made peace, reset any guess for the WAR approach
-			else if(bJustMadePeace && eTrueApproachGuess == MAJOR_CIV_APPROACH_WAR)
+			else if(eTrueApproachGuess == MAJOR_CIV_APPROACH_WAR && (GetNumWarsFought(eLoopPlayer) > 0 && GetPlayerNumTurnsAtPeace(eLoopPlayer) <= 1))
 			{
 				SetApproachTowardsUsGuess(eLoopPlayer, MAJOR_CIV_APPROACH_NEUTRAL);	
 			}
@@ -28734,9 +28724,9 @@ bool CvDiplomacyAI::IsCoopWarRequestUnacceptable(PlayerTypes eAskingPlayer, Play
 	
 	// DoF, DP or ally with the asker? Never warn them.
 	if(IsDoFAccepted(eAskingPlayer) || GET_PLAYER(eAskingPlayer).GetDiplomacyAI()->IsDoFAccepted(GetPlayer()->GetID()) || GET_TEAM(GetPlayer()->getTeam()).IsHasDefensivePact(GET_PLAYER(eAskingPlayer).getTeam()))
-		return true;
+		return false;
 	if(eOpinionOfAsker == MAJOR_CIV_OPINION_ALLY)
-		return true;
+		return false;
 	
 	// If we're afraid of the asker or hate the target, never warn them
 	if(eApproachTowardsAsker == MAJOR_CIV_APPROACH_AFRAID || eApproachTowardsTarget == MAJOR_CIV_APPROACH_HOSTILE || eOpinionOfTarget == MAJOR_CIV_OPINION_UNFORGIVABLE)
@@ -32867,7 +32857,7 @@ int CvDiplomacyAI::GetNoSetterRequestScore(PlayerTypes ePlayer)
 	if(IsPlayerNoSettleRequestEverAsked(ePlayer))
 		// Teammates
 		if(GetPlayer()->getTeam() == GET_PLAYER(ePlayer).getTeam())
-			return 1;
+			return 0;
 		
 		iOpinionWeight += /*20*/ GC.getOPINION_WEIGHT_ASKED_NO_SETTLE();
 
@@ -33798,29 +33788,36 @@ int CvDiplomacyAI::GetPolicyScore(PlayerTypes ePlayer)
 	int iNumPolicies = GetNumSamePolicies(ePlayer);
 	if(iNumPolicies < 0)
 	{
+		// Flip it!
+		iNumPolicies *= -1;
+		
 		if(GetNeediness() > 7)
 		{
-			iOpinionWeight += max(10, (iNumPolicies * -2));
+			iOpinionWeight += max(10, (iNumPolicies * 2));
 		}
 		else
 		{
-			iOpinionWeight += max(5, (iNumPolicies * -1));
+			iOpinionWeight += max(5, (iNumPolicies * 1));
 		}
 	}
 	else if(iNumPolicies > 0)
 	{
+		// Flip it!
+		iNumPolicies *= -1;
+		
 		if(GetNeediness() > 7)
 		{
-			iOpinionWeight += min(-10, (iNumPolicies * -2));
+			iOpinionWeight += min(-10, (iNumPolicies * 2));
 		}
 		else
 		{
-			iOpinionWeight += min(-5, (iNumPolicies * -1));
+			iOpinionWeight += min(-5, (iNumPolicies * 1));
 		}
 	}
 
 	return iOpinionWeight;
 }
+
 int CvDiplomacyAI::GetPtPSameCSScore(PlayerTypes ePlayer)
 {
 	int iOpinionWeight = 0;

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
@@ -12825,9 +12825,18 @@ int CvLuaPlayer::lGetOpinionTable(lua_State* L)
 		aOpinions.push_back(kOpinion);
 	}
 	
-	iValue = pDiploAI->GetNoSetterRequestScore(eWithPlayer);
-	if (iValue != 0)
+	// Asking teammates not to settle nearby = no penalty, but should still be visible
+	if (pDiploAI->IsPlayerNoSettleRequestEverAsked(eWithPlayer))
 	{
+		if(pkPlayer->getTeam() == GET_PLAYER(eWithPlayer).getTeam())
+		{
+			iValue = 0;
+		}
+		else
+		{
+			iValue = pDiploAI->GetNoSetterRequestScore(eWithPlayer);
+		}
+		
 		Opinion kOpinion;
 		kOpinion.m_iValue = iValue;
 		kOpinion.m_str = Localization::Lookup("TXT_KEY_DIPLO_NO_SETTLE_ASKED");


### PR DESCRIPTION
Fixes error in GetNoSetterRequest score function.

Fixes China/Ethiopia UA typos.

Couple fixes for the code I added - looking at it in the big commit view, for some reason, made me realize a few ways I could have improved it.

- Fix a typo; having a DoF, DP or ALLY opinion with the asker should return false, not true, for IsCoopWarRequestUnacceptable.

- Removed unnecessary variable in DoUpdateApproachTowardsUsGuesses.

- Opinion modifier for asking a teammate not to settle nearby should now be 0, but still displayed in the mood table.

- Made policy score calculation slightly more understandable.