### PR TITLE
Tweak Reckless Expander Penalty

### DIFF
--- a/Community Balance Patch/Balance Changes/Text/en_US/CivText.sql
+++ b/Community Balance Patch/Balance Changes/Text/en_US/CivText.sql
@@ -336,7 +336,7 @@ WHERE Tag = 'TXT_KEY_UNIT_ENGLISH_SHIPOFTHELINE_STRATEGY' AND EXISTS (SELECT * F
 -- Ethiopia
 --------------------
 UPDATE Language_en_US
-SET Text = 'When you complete a Policy Branch, adopt a Belief, or choose your first Ideology, receive a free Technology. +1 [ICON_PEACE] Faith from Strategic Resources.'
+SET Text = 'When you complete a Policy Branch, adopt a Belief, or choose your first Ideology, receive a free Technology.'
 WHERE Tag = 'TXT_KEY_TRAIT_BONUS_AGAINST_TECH' AND EXISTS (SELECT * FROM COMMUNITY WHERE Type='COMMUNITY_CORE_BALANCE_LEADERS' AND Value= 1 );
 
 UPDATE Language_en_US

--- a/Community Patch/Core Files/Text/CoreText_en_US.sql
+++ b/Community Patch/Core Files/Text/CoreText_en_US.sql
@@ -403,6 +403,10 @@ WHERE Tag = 'TXT_KEY_SPY_NAME_BRAZIL_8';
 
 -- Trade Routes
 UPDATE Language_en_US
+SET Text = 'You must be at war with the trade route owner.'
+WHERE Tag = 'TXT_KEY_MISSION_PLUNDER_TRADE_ROUTE_DISABLED_HELP';
+
+UPDATE Language_en_US
 SET Text = 'You have discovered {1_Num} technologies that {2_CivName} does not know.[NEWLINE]They are receiving +{3_Num} [ICON_RESEARCH] Science on this route due to their Cultural Influence over you.'
 WHERE Tag = 'TXT_KEY_CHOOSE_INTERNATIONAL_TRADE_ROUTE_ITEM_TT_THEIR_SCIENCE_EXPLAINED';
 

--- a/Community Patch/Core Files/Text/CoreText_en_US.sql
+++ b/Community Patch/Core Files/Text/CoreText_en_US.sql
@@ -553,6 +553,11 @@ UPDATE Language_en_US
 SET Text = '[COLOR_NEGATIVE_TEXT]You are competing for World Wonders.[ENDCOLOR]'
 WHERE Tag = 'TXT_KEY_DIPLO_WONDER_DISPUTE';
 
+-- Reckless Expansion
+UPDATE Language_en_US
+SET Text = '[COLOR_NEGATIVE_TEXT]They believe we are expanding our empire too aggressively![ENDCOLOR]'
+WHERE Tag = 'TXT_KEY_DIPLO_RECKLESS_EXPANDER';
+
 -- Spying
 UPDATE Language_en_US
 SET Text = '[COLOR_NEGATIVE_TEXT]You asked them not to spy on you.[ENDCOLOR]'

--- a/Community Patch/Core Files/Text/CoreText_en_US.sql
+++ b/Community Patch/Core Files/Text/CoreText_en_US.sql
@@ -709,6 +709,11 @@ UPDATE Language_en_US
 SET Text = 'It appears that you do have a reason for existing: to make this deal with me.'
 WHERE Tag = 'TXT_KEY_LEADER_NEBUCHADNEZZAR_TRADEREQUEST_HAPPY';
 
+-- Offer Trade (Neutral)
+UPDATE Language_en_US
+SET Text = 'This offer will not be open long; think about it.'
+WHERE Tag = 'TXT_KEY_LEADER_ENRICO_DANDOLO_TRADEREQUEST_NEUTRAL';
+
 -- Offer Trade (Hostile)
 UPDATE Language_en_US
 SET Text = 'You would do well to agree to our very fair and reasonable terms.'

--- a/NoEUI Compatibility Files/Mod Template1/LUA/EnemyUnitPanel.lua
+++ b/NoEUI Compatibility Files/Mod Template1/LUA/EnemyUnitPanel.lua
@@ -892,7 +892,7 @@ function UpdateCombatOddsUnitVsCity(pMyUnit, pCity)
 				bonusCount = bonusCount + 1;
 			end
 			
-			-- Displays miscellaneous bonus if there are more than 4 bonuses
+			-- Displays miscellaneous bonus here if there are more than 4 bonuses
 			if (bonusCount > maxBonusDisplay) then
 				controlTable = g_MyCombatDataIM:GetInstance();
 				controlTable.Text:LocalizeAndSetText("TXT_KEY_MISC_BONUS" );
@@ -1967,7 +1967,7 @@ function UpdateCombatOddsUnitVsUnit(pMyUnit, pTheirUnit)
 				bonusCount = bonusCount + 1;
 			end
 			
-			-- Displays miscellaneous bonus if there are more than 4 bonuses
+			-- Displays miscellaneous bonus here if there are more than 4 bonuses
 			if (bonusCount > maxBonusDisplay) then
 				controlTable = g_MyCombatDataIM:GetInstance();
 				controlTable.Text:LocalizeAndSetText("TXT_KEY_MISC_BONUS" );
@@ -2687,7 +2687,7 @@ function UpdateCombatOddsUnitVsUnit(pMyUnit, pTheirUnit)
 					bonusCount = bonusCount + 1;							
 				end
 				
-				-- Displays miscellaneous bonus if there are more than 4 bonuses
+				-- Displays miscellaneous bonus here if there are more than 4 bonuses
 				if (bonusCount > maxBonusDisplay) then
 					controlTable = g_TheirCombatDataIM:GetInstance();
 					controlTable.Text:LocalizeAndSetText(  "TXT_KEY_MISC_BONUS" );
@@ -3143,7 +3143,7 @@ function UpdateCombatOddsCityVsUnit(myCity, theirUnit)
 			bonusCount = bonusCount + 1;		
 		end
 		
-		-- Displays miscellaneous bonus if there are more than 4 bonuses
+		-- Displays miscellaneous bonus here if there are more than 4 bonuses
 		if (bonusCount > maxBonusDisplay) then
 			controlTable = g_TheirCombatDataIM:GetInstance();
 			controlTable.Text:LocalizeAndSetText(  "TXT_KEY_MISC_BONUS" );
@@ -3237,7 +3237,7 @@ function UpdateCombatOddsCityVsUnit(myCity, theirUnit)
 			end
 		end
 		
-		-- Displays miscellaneous bonus if there are more than 4 bonuses
+		-- Displays miscellaneous bonus here if there are more than 4 bonuses
 		if (bonusCount > maxBonusDisplay) then
 			controlTable = g_MyCombatDataIM:GetInstance();
 			controlTable.Text:LocalizeAndSetText(  "TXT_KEY_MISC_BONUS" );


### PR DESCRIPTION
Clarify reckless expander text key

Fix issue #5421 

Typo fixes

Fix Ethiopia UA description

Removed reckless expander penalty for teammates

Reckless expander average no longer factors in Barbarians, players with no cities (a possible occurrence with Complete Kills enabled), and unmet players

In the unlikely event that a player has the HOSTILE approach at the time of ending a DoF for any reason, it won't be set to GUARDED upon ending it, and same for the war face.