### PR TITLE
More Promise Fixes & Improvements to DoPlayerDeclaredWarOnSomeone

### DIFF
--- a/Community Patch/Core Files/Text/CoreText_en_US.xml
+++ b/Community Patch/Core Files/Text/CoreText_en_US.xml
@@ -2943,7 +2943,7 @@
 		</Row>
 		<!-- Diplo Modifier Texts-->
 		<Row Tag="TXT_KEY_DIPLO_DISCUSS_MESSAGE_END_DEC_FRIENDSHIP_TT">
-			<Text>This action cancels your current Declaration of Friendship and breaks your Defensive Pact (if you have one). This action will assuredly anger your friend, and may have severe global diplomatic repercussions.</Text>
+			<Text>This action cancels your current Declaration of Friendship, breaks your Defensive Pact (if you have one) and breaks any promises to go to war with others (unless already at war). This action will assuredly anger your friend, and may have severe global diplomatic repercussions.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_DOF_BROKEN">
 			<Text>{1_CivName:textkey} and {2_CivName:textkey} have [COLOR_NEGATIVE_TEXT]broken[ENDCOLOR] their public Declaration of Friendship, citing diplomatic tension as the cause.</Text>

--- a/CvGameCoreDLL_Expansion2/CvTeam.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTeam.cpp
@@ -1496,11 +1496,8 @@ void CvTeam::DoDeclareWar(TeamTypes eTeam, bool bDefensivePact, bool bMinorAllyP
 						{
 							kDefendingPlayer.GetMilitaryAI()->SetupDefenses(eAttackingPlayer);
 						}
-						// Forget any of that liberation crud!
-						int iNumCitiesLiberated = kDefendingPlayer.GetDiplomacyAI()->GetNumCitiesLiberated(eAttackingPlayer);
-						kDefendingPlayer.GetDiplomacyAI()->ChangeNumCitiesLiberated(eAttackingPlayer, -iNumCitiesLiberated);
 
-						//Update Diplo.
+						// Update Diplo.
 						kDefendingPlayer.GetDiplomacyAI()->DoSomeoneDeclaredWarOnMe(GetID());
 #if defined(MOD_BALANCE_CORE)
 						//Do a golden age on war if we can
@@ -1664,7 +1661,7 @@ void CvTeam::DoDeclareWar(TeamTypes eTeam, bool bDefensivePact, bool bMinorAllyP
 			if (MOD_DIPLOMACY_CIV4_FEATURES && GET_TEAM((TeamTypes)iI).IsVassal(eTeam))
 			{
 #if defined(MOD_EVENTS_WAR_AND_PEACE)
-				GET_TEAM((TeamTypes)iI).DoDeclareWar(eOriginatingPlayer, bAggressor, GetID(), /*bDefensivePact*/ false);
+				GET_TEAM((TeamTypes)iI).DoDeclareWar(eOriginatingPlayer, bAggressor, GetID(), /*bDefensivePact*/ true);
 #else
 				GET_TEAM((TeamTypes)iI).DoDeclareWar(eTeam, /*bDefensivePact*/ false);
 #endif
@@ -1673,7 +1670,7 @@ void CvTeam::DoDeclareWar(TeamTypes eTeam, bool bDefensivePact, bool bMinorAllyP
 			if (MOD_DIPLOMACY_CIV4_FEATURES && GET_TEAM((TeamTypes)iI).IsVassal(GetID()))
 			{
 #if defined(MOD_EVENTS_WAR_AND_PEACE)
-				GET_TEAM((TeamTypes)iI).DoDeclareWar(eOriginatingPlayer, bAggressor, eTeam, /*bDefensivePact*/ false);
+				GET_TEAM((TeamTypes)iI).DoDeclareWar(eOriginatingPlayer, bAggressor, eTeam, /*bDefensivePact*/ true);
 #else
 				GET_TEAM((TeamTypes)iI).DoDeclareWar(eTeam, /*bDefensivePact*/ false);
 #endif
@@ -1773,6 +1770,7 @@ void CvTeam::DoDeclareWar(TeamTypes eTeam, bool bDefensivePact, bool bMinorAllyP
 							// Have I actually met this player declaring war?
 							if (GET_TEAM(GET_PLAYER((PlayerTypes)iMajorCivLoop2).getTeam()).isHasMet(GET_PLAYER((PlayerTypes)iMajorCivLoop).getTeam()))
 							{
+								// Update Diplo stuff
 #if defined(MOD_BALANCE_CORE)
 								GET_PLAYER((PlayerTypes)iMajorCivLoop2).GetDiplomacyAI()->DoPlayerDeclaredWarOnSomeone((PlayerTypes)iMajorCivLoop, eTeam, bDefensivePact);
 #else


### PR DESCRIPTION
Fix exploit where players who promised not to attack the AI would null their war/hostile weight

Fix issue where AIs that made a military promise wouldn't reduce their war/hostile weight

Fix issue where AIs that made a military promise wouldn't factor this in when declaring war or starting a coop war

Cleaned up syntax in DoPlayerDeclaredWarOnSomeone, was messy with unnecessary variables

Moved city liberation bonus removal to DoPlayerDeclaredWarOnSomeone

AI will now recognize when a player has broken a coop war promise by declaring war on them, and penalize them accordingly

AI will end all coop war agreements when a DoF is ended by either party. The party who ended the DoF will receive a penalty for breaking the promise. (Modified the text key to make this change clear to the human)

Reset expansion, border, spy and military promises for both player on war declaration

bDefensivePact now removes the penalty for breaking a military promise as well

NoSettle/StopSpying/MoveTroops flags now set correctly for both players upon a war declaration

AI will now update its opinions and approaches immediately when a human DoF with them is ended

AI will end DPs correctly if a DoF is ended

Fix syntax typos in DoDenouncePlayer function

Misc fixes & improvements