### PR TITLE
Temporary bugfix for warmongering penalties on first contact

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
@@ -15934,6 +15934,14 @@ void CvDiplomacyAI::DoFirstContactInitRelationship(PlayerTypes ePlayer)
 			GetPlayer()->SetApproachScratchValue(ePlayer, (MajorCivApproachTypes)iApproachLoop, 0);
 		}
 #endif
+		// temporary bugfix for civs that have warmonger penalties despite not having met a player
+		SetWarmongerThreat(ePlayer, THREAT_NONE);
+		SetOtherPlayerNumMajorsAttacked(ePlayer, 0);
+		SetOtherPlayerNumMajorsConquered(ePlayer, 0);
+		SetOtherPlayerNumMinorsAttacked(ePlayer, 0);
+		SetOtherPlayerNumMinorsConquered(ePlayer, 0);
+		SetOtherPlayerWarmongerAmountTimes100(ePlayer, 0);
+		
 		DoUpdateOnePlayerOpinion(ePlayer);
 
 		/////////////////


### PR DESCRIPTION
Ref. #5552

Not sure what is causing this to happen (perhaps a mod conflict, or some change to the city capture code), since I don't remember altering this at all

However, this should fix it, regardless of what the cause is. I would look more into it, but I'm going on vacation without computer access for a while as of tomorrow, so this'll have to do for now unless someone else wants to take a look at it :) 