### PR TITLE
Reorganize DifficultyMod.xml & Small Fixes

### DIFF
--- a/Community Balance Patch/Balance Changes/Difficulty/DifficultyMod.xml
+++ b/Community Balance Patch/Balance Changes/Difficulty/DifficultyMod.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Created by ModBuddy on 7/13/2015 9:15:47 PM -->
+<!-- VP players and modders: for a guide on what these difficulty settings do and how to customize them, see https://civ-5-cbp.fandom.com/wiki/Customizing_Difficulty_Levels -->
 <GameData>
 	<HandicapInfos>
 		<Row>
@@ -7,60 +8,83 @@
 			<Type>HANDICAP_SETTLER</Type>
 			<Description>TXT_KEY_HANDICAP_SETTLER</Description>
 			<Help>TXT_KEY_HANDICAP_SETTLER_HELP</Help>
-			<StartingLocPercent>50</StartingLocPercent>
-			<AdvancedStartPointsMod>90</AdvancedStartPointsMod>
+			<!-- Player Bonuses -->
 			<HappinessDefault>12</HappinessDefault>
 			<HappinessDefaultCapital>2</HappinessDefaultCapital>
-			<NumCitiesUnhappinessMod>100</NumCitiesUnhappinessMod>
+			<PopulationUnhappinessMod>-20</PopulationUnhappinessMod>
+			<ExtraHappinessPerLuxury>0</ExtraHappinessPerLuxury>
+			<StartingPolicyPoints>0</StartingPolicyPoints>
+			<FreeCulturePerTurn>0</FreeCulturePerTurn>
 			<Gold>0</Gold>
 			<GoldFreeUnits>0</GoldFreeUnits>
 			<ProductionFreeUnits>9</ProductionFreeUnits>
-			<ProductionFreeUnitsPopulationPercent>35</ProductionFreeUnitsPopulationPercent>
 			<ProductionFreeUnitsPerCity>1</ProductionFreeUnitsPerCity>
+			<ProductionFreeUnitsPopulationPercent>35</ProductionFreeUnitsPopulationPercent>
+			<StartingDefenseUnits>0</StartingDefenseUnits>
+			<StartingExploreUnits>0</StartingExploreUnits>
+			<StartingWorkerUnits>0</StartingWorkerUnits>
 			<RouteCostPercent>75</RouteCostPercent>
 			<UnitCostPercent>90</UnitCostPercent>
 			<BuildingCostPercent>100</BuildingCostPercent>
-			<ResearchPercent>100</ResearchPercent>
 			<PolicyPercent>90</PolicyPercent>
+			<ResearchPercent>100</ResearchPercent>
 			<ImprovementCostPercent>100</ImprovementCostPercent>
+
+			<!-- City-State Bonuses -->
+			<StartingMinorDefenseUnits>0</StartingMinorDefenseUnits>
+
+			<!-- AI Bonuses -->
 			<CityProductionNumOptionsConsidered>3</CityProductionNumOptionsConsidered>
 			<TechNumOptionsConsidered>3</TechNumOptionsConsidered>
 			<PolicyNumOptionsConsidered>3</PolicyNumOptionsConsidered>
-			<!--<InflationPercent>100</InflationPercent>-->
-			<AttitudeChange>1</AttitudeChange>
-			<NoTechTradeModifier>50</NoTechTradeModifier>
-			<BarbCampGold>30</BarbCampGold>
-			<BarbSpawnMod>0</BarbSpawnMod>
-			<StartingMinorDefenseUnits>0</StartingMinorDefenseUnits>
-			<BarbarianBonus>50</BarbarianBonus>
-			<AIBarbarianBonus>0</AIBarbarianBonus>
-			<EarliestBarbarianReleaseTurn>30</EarliestBarbarianReleaseTurn>
-			<BarbarianLandTargetRange>5</BarbarianLandTargetRange>
-			<BarbarianSeaTargetRange>14</BarbarianSeaTargetRange>
-			<AIStartingDefenseUnits>1</AIStartingDefenseUnits>
 			<AIDeclareWarProb>50</AIDeclareWarProb>
+			<AIStartingDefenseUnits>1</AIStartingDefenseUnits>
+			<AIStartingExploreUnits>0</AIStartingExploreUnits>
+			<AIStartingWorkerUnits>0</AIStartingWorkerUnits>
+			<AIStartingUnitMultiplier>0</AIStartingUnitMultiplier>
 			<AIWorkRateModifier>0</AIWorkRateModifier>
-			<PopulationUnhappinessMod>-20</PopulationUnhappinessMod>
 			<AIUnhappinessPercent>5</AIUnhappinessPercent>
 			<AIGrowthPercent>100</AIGrowthPercent>
-			<AITrainPercent>110</AITrainPercent>
-			<AIWorldTrainPercent>110</AIWorldTrainPercent>
-			<AIConstructPercent>110</AIConstructPercent>
-			<AIWorldConstructPercent>110</AIWorldConstructPercent>
-			<AICreatePercent>110</AICreatePercent>
-			<AIWorldCreatePercent>110</AIWorldCreatePercent>
-			<AIBuildingCostPercent>100</AIBuildingCostPercent>
 			<AIUnitCostPercent>100</AIUnitCostPercent>
-			<AIUnitSupplyPercent>0</AIUnitSupplyPercent>
+			<AIBuildingCostPercent>100</AIBuildingCostPercent>
 			<AIUnitUpgradePercent>100</AIUnitUpgradePercent>
-			<!--<AIInflationPercent>80</AIInflationPercent>-->
-			<AIPerEraModifier>0</AIPerEraModifier>
-			<AIAdvancedStartPercent>100</AIAdvancedStartPercent>
+			<AIWorldConstructPercent>110</AIWorldConstructPercent>
+			<AIWorldCreatePercent>110</AIWorldCreatePercent>
 			<AIFreeXP>0</AIFreeXP>
+			<AIFreeXPPercent>0</AIFreeXPPercent>
+			<VisionBonus>0</VisionBonus>
+			<!-- Per Era Bonuses -->	
+			<AITrainPercent>110</AITrainPercent>
+			<AIConstructPercent>110</AIConstructPercent>
+			<AICreatePercent>110</AICreatePercent>
+			<AIUnitSupplyPercent>0</AIUnitSupplyPercent>
+			<AIPerEraModifier>0</AIPerEraModifier>
+			<!-- CBP Difficulty Bonus -->
 			<DifficultyBonusBase>0</DifficultyBonusBase>
 			<DifficultyBonusA>325</DifficultyBonusA>
 			<DifficultyBonusB>175</DifficultyBonusB>
 			<DifficultyBonusC>100</DifficultyBonusC>
+
+			<!-- Barbarians -->
+			<EarliestBarbarianReleaseTurn>30</EarliestBarbarianReleaseTurn>
+			<BarbarianBonus>50</BarbarianBonus>
+			<AIBarbarianBonus>0</AIBarbarianBonus>
+			<BarbCampGold>30</BarbCampGold>
+			<BarbSpawnMod>0</BarbSpawnMod>
+			<BarbarianLandTargetRange>5</BarbarianLandTargetRange>
+			<BarbarianSeaTargetRange>14</BarbarianSeaTargetRange>
+
+			<!-- Unused Values -->
+			<StartingLocPercent>0</StartingLocPercent>
+			<AdvancedStartPointsMod>0</AdvancedStartPointsMod>
+			<AIAdvancedStartPercent>0</AIAdvancedStartPercent>
+			<NumCitiesUnhappinessMod>100</NumCitiesUnhappinessMod>
+			<AttitudeChange>0</AttitudeChange>
+			<TechTradeKnownModifier>0</TechTradeKnownModifier>
+			<NoTechTradeModifier>0</NoTechTradeModifier>
+			<AIWorldTrainPercent>100</AIWorldTrainPercent>
+			<!--<InflationPercent>100</InflationPercent>-->
+			<!--<AIInflationPercent>100</AIInflationPercent>-->
 			<IconAtlas>DIFFICULTY_ATLAS</IconAtlas>
 			<PortraitIndex>0</PortraitIndex>
 		</Row>
@@ -68,61 +92,83 @@
 			<Type>HANDICAP_CHIEFTAIN</Type>
 			<Description>TXT_KEY_HANDICAP_CHIEFTAIN</Description>
 			<Help>TXT_KEY_HANDICAP_CHIEFTAIN_HELP</Help>
-			<StartingLocPercent>50</StartingLocPercent>
-			<AdvancedStartPointsMod>85</AdvancedStartPointsMod>
+			<!-- Player Bonuses -->
 			<HappinessDefault>11</HappinessDefault>
 			<HappinessDefaultCapital>2</HappinessDefaultCapital>
-			<NumCitiesUnhappinessMod>100</NumCitiesUnhappinessMod>
+			<PopulationUnhappinessMod>-15</PopulationUnhappinessMod>
+			<ExtraHappinessPerLuxury>0</ExtraHappinessPerLuxury>
+			<StartingPolicyPoints>0</StartingPolicyPoints>
+			<FreeCulturePerTurn>0</FreeCulturePerTurn>
 			<Gold>0</Gold>
 			<GoldFreeUnits>0</GoldFreeUnits>
 			<ProductionFreeUnits>9</ProductionFreeUnits>
-			<ProductionFreeUnitsPopulationPercent>30</ProductionFreeUnitsPopulationPercent>
 			<ProductionFreeUnitsPerCity>1</ProductionFreeUnitsPerCity>
+			<ProductionFreeUnitsPopulationPercent>30</ProductionFreeUnitsPopulationPercent>
+			<StartingDefenseUnits>0</StartingDefenseUnits>
+			<StartingExploreUnits>0</StartingExploreUnits>
+			<StartingWorkerUnits>0</StartingWorkerUnits>
 			<RouteCostPercent>100</RouteCostPercent>
 			<UnitCostPercent>100</UnitCostPercent>
 			<BuildingCostPercent>100</BuildingCostPercent>
-			<ResearchPercent>100</ResearchPercent>
 			<PolicyPercent>100</PolicyPercent>
+			<ResearchPercent>100</ResearchPercent>
 			<ImprovementCostPercent>100</ImprovementCostPercent>
+
+			<!-- City-State Bonuses -->
+			<StartingMinorDefenseUnits>0</StartingMinorDefenseUnits>
+
+			<!-- AI Bonuses -->
 			<CityProductionNumOptionsConsidered>3</CityProductionNumOptionsConsidered>
 			<TechNumOptionsConsidered>3</TechNumOptionsConsidered>
 			<PolicyNumOptionsConsidered>3</PolicyNumOptionsConsidered>
-			<!--<InflationPercent>100</InflationPercent>-->
-			<AttitudeChange>-1</AttitudeChange>
-			<NoTechTradeModifier>40</NoTechTradeModifier>
-			<BarbCampGold>30</BarbCampGold>
-			<BarbSpawnMod>0</BarbSpawnMod>
-			<BarbarianBonus>40</BarbarianBonus>
-			<StartingMinorDefenseUnits>0</StartingMinorDefenseUnits>
-			<AIBarbarianBonus>5</AIBarbarianBonus>
-			<EarliestBarbarianReleaseTurn>25</EarliestBarbarianReleaseTurn>
-			<BarbarianLandTargetRange>6</BarbarianLandTargetRange>
-			<BarbarianSeaTargetRange>16</BarbarianSeaTargetRange>
-			<AIStartingDefenseUnits>1</AIStartingDefenseUnits>
 			<AIDeclareWarProb>75</AIDeclareWarProb>
+			<AIStartingDefenseUnits>1</AIStartingDefenseUnits>
+			<AIStartingExploreUnits>0</AIStartingExploreUnits>
+			<AIStartingWorkerUnits>0</AIStartingWorkerUnits>
+			<AIStartingUnitMultiplier>0</AIStartingUnitMultiplier>
 			<AIWorkRateModifier>10</AIWorkRateModifier>
-			<PopulationUnhappinessMod>-15</PopulationUnhappinessMod>
 			<AIUnhappinessPercent>0</AIUnhappinessPercent>
 			<AIGrowthPercent>100</AIGrowthPercent>
-			<AITrainPercent>100</AITrainPercent>
-			<AIWorldTrainPercent>100</AIWorldTrainPercent>
-			<AIConstructPercent>100</AIConstructPercent>
-			<AIWorldConstructPercent>100</AIWorldConstructPercent>
-			<AICreatePercent>100</AICreatePercent>
-			<AIWorldCreatePercent>100</AIWorldCreatePercent>
-			<AIBuildingCostPercent>100</AIBuildingCostPercent>
 			<AIUnitCostPercent>100</AIUnitCostPercent>
-			<AIUnitSupplyPercent>5</AIUnitSupplyPercent>
+			<AIBuildingCostPercent>100</AIBuildingCostPercent>
 			<AIUnitUpgradePercent>95</AIUnitUpgradePercent>
-			<!--<AIInflationPercent>80</AIInflationPercent>-->
-			<AIPerEraModifier>-2</AIPerEraModifier>
-			<AIAdvancedStartPercent>135</AIAdvancedStartPercent>
+			<AIWorldConstructPercent>100</AIWorldConstructPercent>
+			<AIWorldCreatePercent>100</AIWorldCreatePercent>
 			<AIFreeXP>5</AIFreeXP>
+			<AIFreeXPPercent>10</AIFreeXPPercent>
+			<VisionBonus>0</VisionBonus>
+			<!-- Per Era Bonuses -->	
+			<AITrainPercent>100</AITrainPercent>
+			<AIConstructPercent>100</AIConstructPercent>
+			<AICreatePercent>100</AICreatePercent>
+			<AIUnitSupplyPercent>5</AIUnitSupplyPercent>
+			<AIPerEraModifier>-2</AIPerEraModifier>
+			<!-- CBP Difficulty Bonus -->
 			<DifficultyBonusBase>1</DifficultyBonusBase>
 			<DifficultyBonusA>325</DifficultyBonusA>
 			<DifficultyBonusB>175</DifficultyBonusB>
 			<DifficultyBonusC>100</DifficultyBonusC>
-			<AIFreeXPPercent>10</AIFreeXPPercent>
+
+			<!-- Barbarians -->
+			<EarliestBarbarianReleaseTurn>25</EarliestBarbarianReleaseTurn>
+			<BarbarianBonus>40</BarbarianBonus>
+			<AIBarbarianBonus>5</AIBarbarianBonus>
+			<BarbCampGold>30</BarbCampGold>
+			<BarbSpawnMod>0</BarbSpawnMod>
+			<BarbarianLandTargetRange>6</BarbarianLandTargetRange>
+			<BarbarianSeaTargetRange>16</BarbarianSeaTargetRange>
+
+			<!-- Unused Values -->
+			<StartingLocPercent>0</StartingLocPercent>
+			<AdvancedStartPointsMod>0</AdvancedStartPointsMod>
+			<AIAdvancedStartPercent>0</AIAdvancedStartPercent>
+			<NumCitiesUnhappinessMod>100</NumCitiesUnhappinessMod>
+			<AttitudeChange>0</AttitudeChange>
+			<TechTradeKnownModifier>0</TechTradeKnownModifier>
+			<NoTechTradeModifier>0</NoTechTradeModifier>
+			<AIWorldTrainPercent>100</AIWorldTrainPercent>
+			<!--<InflationPercent>100</InflationPercent>-->
+			<!--<AIInflationPercent>100</AIInflationPercent>-->
 			<IconAtlas>DIFFICULTY_ATLAS</IconAtlas>
 			<PortraitIndex>1</PortraitIndex>
 		</Row>
@@ -130,61 +176,83 @@
 			<Type>HANDICAP_WARLORD</Type>
 			<Description>TXT_KEY_HANDICAP_WARLORD</Description>
 			<Help>TXT_KEY_HANDICAP_WARLORD_HELP</Help>
-			<StartingLocPercent>50</StartingLocPercent>
-			<AdvancedStartPointsMod>80</AdvancedStartPointsMod>
+			<!-- Player Bonuses -->
 			<HappinessDefault>10</HappinessDefault>
 			<HappinessDefaultCapital>2</HappinessDefaultCapital>
-			<NumCitiesUnhappinessMod>100</NumCitiesUnhappinessMod>
+			<PopulationUnhappinessMod>-10</PopulationUnhappinessMod>
+			<ExtraHappinessPerLuxury>0</ExtraHappinessPerLuxury>
+			<StartingPolicyPoints>0</StartingPolicyPoints>
+			<FreeCulturePerTurn>0</FreeCulturePerTurn>
 			<Gold>0</Gold>
 			<GoldFreeUnits>0</GoldFreeUnits>
 			<ProductionFreeUnits>9</ProductionFreeUnits>
-			<ProductionFreeUnitsPopulationPercent>30</ProductionFreeUnitsPopulationPercent>
 			<ProductionFreeUnitsPerCity>1</ProductionFreeUnitsPerCity>
+			<ProductionFreeUnitsPopulationPercent>30</ProductionFreeUnitsPopulationPercent>
+			<StartingDefenseUnits>0</StartingDefenseUnits>
+			<StartingExploreUnits>0</StartingExploreUnits>
+			<StartingWorkerUnits>0</StartingWorkerUnits>
 			<RouteCostPercent>100</RouteCostPercent>
 			<UnitCostPercent>100</UnitCostPercent>
 			<BuildingCostPercent>100</BuildingCostPercent>
-			<ResearchPercent>100</ResearchPercent>
 			<PolicyPercent>100</PolicyPercent>
+			<ResearchPercent>100</ResearchPercent>
 			<ImprovementCostPercent>100</ImprovementCostPercent>
+
+			<!-- City-State Bonuses -->
+			<StartingMinorDefenseUnits>1</StartingMinorDefenseUnits>
+
+			<!-- AI Bonuses -->
 			<CityProductionNumOptionsConsidered>3</CityProductionNumOptionsConsidered>
 			<TechNumOptionsConsidered>3</TechNumOptionsConsidered>
 			<PolicyNumOptionsConsidered>3</PolicyNumOptionsConsidered>
-			<!--<InflationPercent>100</InflationPercent>-->
-			<AttitudeChange>-1</AttitudeChange>
-			<NoTechTradeModifier>30</NoTechTradeModifier>
-			<BarbCampGold>30</BarbCampGold>
-			<BarbSpawnMod>0</BarbSpawnMod>
-			<BarbarianBonus>30</BarbarianBonus>
-			<AIBarbarianBonus>10</AIBarbarianBonus>
-			<StartingMinorDefenseUnits>1</StartingMinorDefenseUnits>
-			<EarliestBarbarianReleaseTurn>25</EarliestBarbarianReleaseTurn>
-			<BarbarianLandTargetRange>7</BarbarianLandTargetRange>
-			<BarbarianSeaTargetRange>18</BarbarianSeaTargetRange>
-			<AIStartingDefenseUnits>1</AIStartingDefenseUnits>
 			<AIDeclareWarProb>100</AIDeclareWarProb>
+			<AIStartingDefenseUnits>1</AIStartingDefenseUnits>
+			<AIStartingExploreUnits>0</AIStartingExploreUnits>
+			<AIStartingWorkerUnits>0</AIStartingWorkerUnits>
+			<AIStartingUnitMultiplier>0</AIStartingUnitMultiplier>
 			<AIWorkRateModifier>20</AIWorkRateModifier>
-			<PopulationUnhappinessMod>-10</PopulationUnhappinessMod>
 			<AIUnhappinessPercent>0</AIUnhappinessPercent>
 			<AIGrowthPercent>100</AIGrowthPercent>
-			<AITrainPercent>100</AITrainPercent>
-			<AIWorldTrainPercent>100</AIWorldTrainPercent>
-			<AIConstructPercent>100</AIConstructPercent>
-			<AIWorldConstructPercent>100</AIWorldConstructPercent>
-			<AICreatePercent>100</AICreatePercent>
-			<AIWorldCreatePercent>100</AIWorldCreatePercent>
-			<AIBuildingCostPercent>90</AIBuildingCostPercent>
 			<AIUnitCostPercent>90</AIUnitCostPercent>
-			<AIUnitSupplyPercent>10</AIUnitSupplyPercent>
+			<AIBuildingCostPercent>90</AIBuildingCostPercent>
 			<AIUnitUpgradePercent>90</AIUnitUpgradePercent>
-			<!--<AIInflationPercent>80</AIInflationPercent>-->
-			<AIPerEraModifier>-4</AIPerEraModifier>
-			<AIAdvancedStartPercent>155</AIAdvancedStartPercent>
+			<AIWorldConstructPercent>100</AIWorldConstructPercent>
+			<AIWorldCreatePercent>100</AIWorldCreatePercent>
 			<AIFreeXP>10</AIFreeXP>
+			<AIFreeXPPercent>25</AIFreeXPPercent>
+			<VisionBonus>0</VisionBonus>
+			<!-- Per Era Bonuses -->	
+			<AITrainPercent>100</AITrainPercent>
+			<AIConstructPercent>100</AIConstructPercent>
+			<AICreatePercent>100</AICreatePercent>
+			<AIUnitSupplyPercent>10</AIUnitSupplyPercent>
+			<AIPerEraModifier>-4</AIPerEraModifier>
+			<!-- CBP Difficulty Bonus -->
 			<DifficultyBonusBase>2</DifficultyBonusBase>
 			<DifficultyBonusA>325</DifficultyBonusA>
 			<DifficultyBonusB>175</DifficultyBonusB>
 			<DifficultyBonusC>100</DifficultyBonusC>
-			<AIFreeXPPercent>25</AIFreeXPPercent>
+
+			<!-- Barbarians -->
+			<EarliestBarbarianReleaseTurn>25</EarliestBarbarianReleaseTurn>
+			<BarbarianBonus>30</BarbarianBonus>
+			<AIBarbarianBonus>10</AIBarbarianBonus>
+			<BarbCampGold>30</BarbCampGold>
+			<BarbSpawnMod>0</BarbSpawnMod>
+			<BarbarianLandTargetRange>7</BarbarianLandTargetRange>
+			<BarbarianSeaTargetRange>18</BarbarianSeaTargetRange>
+
+			<!-- Unused Values -->
+			<StartingLocPercent>0</StartingLocPercent>
+			<AdvancedStartPointsMod>0</AdvancedStartPointsMod>
+			<AIAdvancedStartPercent>0</AIAdvancedStartPercent>
+			<NumCitiesUnhappinessMod>100</NumCitiesUnhappinessMod>
+			<AttitudeChange>0</AttitudeChange>
+			<TechTradeKnownModifier>0</TechTradeKnownModifier>
+			<NoTechTradeModifier>0</NoTechTradeModifier>
+			<AIWorldTrainPercent>100</AIWorldTrainPercent>
+			<!--<InflationPercent>100</InflationPercent>-->
+			<!--<AIInflationPercent>100</AIInflationPercent>-->
 			<IconAtlas>DIFFICULTY_ATLAS</IconAtlas>
 			<PortraitIndex>2</PortraitIndex>
 		</Row>
@@ -192,61 +260,83 @@
 			<Type>HANDICAP_PRINCE</Type>
 			<Description>TXT_KEY_HANDICAP_PRINCE</Description>
 			<Help>TXT_KEY_HANDICAP_PRINCE_HELP</Help>
-			<StartingLocPercent>50</StartingLocPercent>
-			<AdvancedStartPointsMod>75</AdvancedStartPointsMod>
+			<!-- Player Bonuses -->
 			<HappinessDefault>9</HappinessDefault>
 			<HappinessDefaultCapital>1</HappinessDefaultCapital>
-			<NumCitiesUnhappinessMod>100</NumCitiesUnhappinessMod>
+			<PopulationUnhappinessMod>-10</PopulationUnhappinessMod>
+			<ExtraHappinessPerLuxury>0</ExtraHappinessPerLuxury>
+			<StartingPolicyPoints>0</StartingPolicyPoints>
+			<FreeCulturePerTurn>0</FreeCulturePerTurn>
 			<Gold>0</Gold>
 			<GoldFreeUnits>0</GoldFreeUnits>
 			<ProductionFreeUnits>8</ProductionFreeUnits>
-			<ProductionFreeUnitsPopulationPercent>25</ProductionFreeUnitsPopulationPercent>
 			<ProductionFreeUnitsPerCity>1</ProductionFreeUnitsPerCity>
+			<ProductionFreeUnitsPopulationPercent>25</ProductionFreeUnitsPopulationPercent>
+			<StartingDefenseUnits>0</StartingDefenseUnits>
+			<StartingExploreUnits>0</StartingExploreUnits>
+			<StartingWorkerUnits>0</StartingWorkerUnits>
 			<RouteCostPercent>100</RouteCostPercent>
 			<UnitCostPercent>100</UnitCostPercent>
 			<BuildingCostPercent>100</BuildingCostPercent>
-			<ResearchPercent>100</ResearchPercent>
-			<StartingMinorDefenseUnits>1</StartingMinorDefenseUnits>
 			<PolicyPercent>100</PolicyPercent>
+			<ResearchPercent>100</ResearchPercent>
 			<ImprovementCostPercent>100</ImprovementCostPercent>
+
+			<!-- City-State Bonuses -->
+			<StartingMinorDefenseUnits>1</StartingMinorDefenseUnits>
+
+			<!-- AI Bonuses -->
 			<CityProductionNumOptionsConsidered>2</CityProductionNumOptionsConsidered>
 			<TechNumOptionsConsidered>2</TechNumOptionsConsidered>
 			<PolicyNumOptionsConsidered>2</PolicyNumOptionsConsidered>
-			<!--<InflationPercent>100</InflationPercent>-->
-			<AttitudeChange>-1</AttitudeChange>
-			<NoTechTradeModifier>20</NoTechTradeModifier>
-			<BarbCampGold>30</BarbCampGold>
-			<BarbSpawnMod>0</BarbSpawnMod>
-			<BarbarianBonus>30</BarbarianBonus>
-			<AIBarbarianBonus>10</AIBarbarianBonus>
-			<EarliestBarbarianReleaseTurn>20</EarliestBarbarianReleaseTurn>
-			<BarbarianLandTargetRange>8</BarbarianLandTargetRange>
-			<BarbarianSeaTargetRange>20</BarbarianSeaTargetRange>
-			<AIStartingDefenseUnits>1</AIStartingDefenseUnits>
 			<AIDeclareWarProb>125</AIDeclareWarProb>
+			<AIStartingDefenseUnits>1</AIStartingDefenseUnits>
+			<AIStartingExploreUnits>0</AIStartingExploreUnits>
+			<AIStartingWorkerUnits>0</AIStartingWorkerUnits>
+			<AIStartingUnitMultiplier>0</AIStartingUnitMultiplier>
 			<AIWorkRateModifier>30</AIWorkRateModifier>
-			<PopulationUnhappinessMod>-10</PopulationUnhappinessMod>
 			<AIUnhappinessPercent>0</AIUnhappinessPercent>
 			<AIGrowthPercent>100</AIGrowthPercent>
-			<AITrainPercent>90</AITrainPercent>
-			<AIWorldTrainPercent>100</AIWorldTrainPercent>
-			<AIConstructPercent>90</AIConstructPercent>
-			<AIWorldConstructPercent>100</AIWorldConstructPercent>
-			<AICreatePercent>90</AICreatePercent>
-			<AIWorldCreatePercent>100</AIWorldCreatePercent>
-			<AIBuildingCostPercent>90</AIBuildingCostPercent>
 			<AIUnitCostPercent>90</AIUnitCostPercent>
-			<AIUnitSupplyPercent>15</AIUnitSupplyPercent>
+			<AIBuildingCostPercent>90</AIBuildingCostPercent>
 			<AIUnitUpgradePercent>85</AIUnitUpgradePercent>
-			<!--<AIInflationPercent>80</AIInflationPercent>-->
-			<AIPerEraModifier>-6</AIPerEraModifier>
-			<AIAdvancedStartPercent>170</AIAdvancedStartPercent>
+			<AIWorldConstructPercent>100</AIWorldConstructPercent>
+			<AIWorldCreatePercent>100</AIWorldCreatePercent>
 			<AIFreeXP>15</AIFreeXP>
+			<AIFreeXPPercent>33</AIFreeXPPercent>
+			<VisionBonus>0</VisionBonus>
+			<!-- Per Era Bonuses -->	
+			<AITrainPercent>90</AITrainPercent>
+			<AIConstructPercent>90</AIConstructPercent>
+			<AICreatePercent>90</AICreatePercent>
+			<AIUnitSupplyPercent>15</AIUnitSupplyPercent>
+			<AIPerEraModifier>-6</AIPerEraModifier>
+			<!-- CBP Difficulty Bonus -->
 			<DifficultyBonusBase>3</DifficultyBonusBase>
 			<DifficultyBonusA>325</DifficultyBonusA>
 			<DifficultyBonusB>175</DifficultyBonusB>
 			<DifficultyBonusC>100</DifficultyBonusC>
-			<AIFreeXPPercent>33</AIFreeXPPercent>
+
+			<!-- Barbarians -->
+			<EarliestBarbarianReleaseTurn>20</EarliestBarbarianReleaseTurn>
+			<BarbarianBonus>30</BarbarianBonus>
+			<AIBarbarianBonus>10</AIBarbarianBonus>
+			<BarbCampGold>30</BarbCampGold>
+			<BarbSpawnMod>0</BarbSpawnMod>
+			<BarbarianLandTargetRange>8</BarbarianLandTargetRange>
+			<BarbarianSeaTargetRange>20</BarbarianSeaTargetRange>
+
+			<!-- Unused Values -->
+			<StartingLocPercent>0</StartingLocPercent>
+			<AdvancedStartPointsMod>0</AdvancedStartPointsMod>
+			<AIAdvancedStartPercent>0</AIAdvancedStartPercent>
+			<NumCitiesUnhappinessMod>100</NumCitiesUnhappinessMod>
+			<AttitudeChange>0</AttitudeChange>
+			<TechTradeKnownModifier>0</TechTradeKnownModifier>
+			<NoTechTradeModifier>0</NoTechTradeModifier>
+			<AIWorldTrainPercent>100</AIWorldTrainPercent>
+			<!--<InflationPercent>100</InflationPercent>-->
+			<!--<AIInflationPercent>100</AIInflationPercent>-->
 			<IconAtlas>DIFFICULTY_ATLAS</IconAtlas>
 			<PortraitIndex>3</PortraitIndex>
 		</Row>
@@ -254,61 +344,83 @@
 			<Type>HANDICAP_KING</Type>
 			<Description>TXT_KEY_HANDICAP_KING</Description>
 			<Help>TXT_KEY_HANDICAP_KING_HELP</Help>
-			<StartingLocPercent>50</StartingLocPercent>
-			<AdvancedStartPointsMod>65</AdvancedStartPointsMod>
+			<!-- Player Bonuses -->
 			<HappinessDefault>8</HappinessDefault>
 			<HappinessDefaultCapital>1</HappinessDefaultCapital>
-			<NumCitiesUnhappinessMod>100</NumCitiesUnhappinessMod>
+			<PopulationUnhappinessMod>-5</PopulationUnhappinessMod>
+			<ExtraHappinessPerLuxury>0</ExtraHappinessPerLuxury>
+			<StartingPolicyPoints>0</StartingPolicyPoints>
+			<FreeCulturePerTurn>0</FreeCulturePerTurn>
 			<Gold>0</Gold>
 			<GoldFreeUnits>0</GoldFreeUnits>
 			<ProductionFreeUnits>8</ProductionFreeUnits>
-			<ProductionFreeUnitsPopulationPercent>25</ProductionFreeUnitsPopulationPercent>
 			<ProductionFreeUnitsPerCity>1</ProductionFreeUnitsPerCity>
+			<ProductionFreeUnitsPopulationPercent>25</ProductionFreeUnitsPopulationPercent>
+			<StartingDefenseUnits>0</StartingDefenseUnits>
+			<StartingExploreUnits>0</StartingExploreUnits>
+			<StartingWorkerUnits>0</StartingWorkerUnits>
 			<RouteCostPercent>100</RouteCostPercent>
 			<UnitCostPercent>100</UnitCostPercent>
 			<BuildingCostPercent>100</BuildingCostPercent>
-			<ResearchPercent>100</ResearchPercent>
 			<PolicyPercent>100</PolicyPercent>
-			<StartingMinorDefenseUnits>1</StartingMinorDefenseUnits>
+			<ResearchPercent>100</ResearchPercent>
 			<ImprovementCostPercent>100</ImprovementCostPercent>
+
+			<!-- City-State Bonuses -->
+			<StartingMinorDefenseUnits>1</StartingMinorDefenseUnits>
+
+			<!-- AI Bonuses -->
 			<CityProductionNumOptionsConsidered>2</CityProductionNumOptionsConsidered>
 			<TechNumOptionsConsidered>2</TechNumOptionsConsidered>
 			<PolicyNumOptionsConsidered>2</PolicyNumOptionsConsidered>
-			<!--<InflationPercent>100</InflationPercent>-->
-			<AttitudeChange>-1</AttitudeChange>
-			<NoTechTradeModifier>15</NoTechTradeModifier>
-			<BarbCampGold>20</BarbCampGold>
-			<BarbSpawnMod>0</BarbSpawnMod>
-			<BarbarianBonus>20</BarbarianBonus>
-			<AIBarbarianBonus>15</AIBarbarianBonus>
-			<EarliestBarbarianReleaseTurn>20</EarliestBarbarianReleaseTurn>
-			<BarbarianLandTargetRange>9</BarbarianLandTargetRange>
-			<BarbarianSeaTargetRange>22</BarbarianSeaTargetRange>
-			<AIStartingDefenseUnits>1</AIStartingDefenseUnits>
 			<AIDeclareWarProb>150</AIDeclareWarProb>
+			<AIStartingDefenseUnits>1</AIStartingDefenseUnits>
+			<AIStartingExploreUnits>0</AIStartingExploreUnits>
+			<AIStartingWorkerUnits>0</AIStartingWorkerUnits>
+			<AIStartingUnitMultiplier>0</AIStartingUnitMultiplier>
 			<AIWorkRateModifier>40</AIWorkRateModifier>
-			<PopulationUnhappinessMod>-5</PopulationUnhappinessMod>
 			<AIUnhappinessPercent>0</AIUnhappinessPercent>
 			<AIGrowthPercent>100</AIGrowthPercent>
-			<AITrainPercent>90</AITrainPercent>
-			<AIWorldTrainPercent>100</AIWorldTrainPercent>
-			<AIConstructPercent>90</AIConstructPercent>
-			<AIWorldConstructPercent>100</AIWorldConstructPercent>
-			<AICreatePercent>90</AICreatePercent>
-			<AIWorldCreatePercent>100</AIWorldCreatePercent>
-			<AIBuildingCostPercent>90</AIBuildingCostPercent>
 			<AIUnitCostPercent>90</AIUnitCostPercent>
-			<AIUnitSupplyPercent>20</AIUnitSupplyPercent>
+			<AIBuildingCostPercent>90</AIBuildingCostPercent>
 			<AIUnitUpgradePercent>80</AIUnitUpgradePercent>
-			<!--<AIInflationPercent>80</AIInflationPercent>-->
+			<AIWorldConstructPercent>100</AIWorldConstructPercent>
+			<AIWorldCreatePercent>100</AIWorldCreatePercent>
+			<AIFreeXP>20</AIFreeXP>
+			<AIFreeXPPercent>50</AIFreeXPPercent>
+			<VisionBonus>0</VisionBonus>
+			<!-- Per Era Bonuses -->	
+			<AITrainPercent>90</AITrainPercent>
+			<AIConstructPercent>90</AIConstructPercent>
+			<AICreatePercent>90</AICreatePercent>
+			<AIUnitSupplyPercent>20</AIUnitSupplyPercent>
 			<AIPerEraModifier>-7</AIPerEraModifier>
-			<AIAdvancedStartPercent>185</AIAdvancedStartPercent>
+			<!-- CBP Difficulty Bonus -->
 			<DifficultyBonusBase>4</DifficultyBonusBase>
 			<DifficultyBonusA>325</DifficultyBonusA>
 			<DifficultyBonusB>175</DifficultyBonusB>
 			<DifficultyBonusC>100</DifficultyBonusC>
-			<AIFreeXP>20</AIFreeXP>
-			<AIFreeXPPercent>50</AIFreeXPPercent>
+
+			<!-- Barbarians -->
+			<EarliestBarbarianReleaseTurn>20</EarliestBarbarianReleaseTurn>
+			<BarbarianBonus>20</BarbarianBonus>
+			<AIBarbarianBonus>15</AIBarbarianBonus>
+			<BarbCampGold>20</BarbCampGold>
+			<BarbSpawnMod>0</BarbSpawnMod>
+			<BarbarianLandTargetRange>9</BarbarianLandTargetRange>
+			<BarbarianSeaTargetRange>22</BarbarianSeaTargetRange>
+
+			<!-- Unused Values -->
+			<StartingLocPercent>0</StartingLocPercent>
+			<AdvancedStartPointsMod>0</AdvancedStartPointsMod>
+			<AIAdvancedStartPercent>0</AIAdvancedStartPercent>
+			<NumCitiesUnhappinessMod>100</NumCitiesUnhappinessMod>
+			<AttitudeChange>0</AttitudeChange>
+			<TechTradeKnownModifier>0</TechTradeKnownModifier>
+			<NoTechTradeModifier>0</NoTechTradeModifier>
+			<AIWorldTrainPercent>100</AIWorldTrainPercent>
+			<!--<InflationPercent>100</InflationPercent>-->
+			<!--<AIInflationPercent>100</AIInflationPercent>-->
 			<IconAtlas>DIFFICULTY_ATLAS</IconAtlas>
 			<PortraitIndex>4</PortraitIndex>
 		</Row>
@@ -316,62 +428,83 @@
 			<Type>HANDICAP_EMPEROR</Type>
 			<Description>TXT_KEY_HANDICAP_EMPEROR</Description>
 			<Help>TXT_KEY_HANDICAP_EMPEROR_HELP</Help>
-			<StartingLocPercent>50</StartingLocPercent>
-			<AdvancedStartPointsMod>55</AdvancedStartPointsMod>
+			<!-- Player Bonuses -->
 			<HappinessDefault>7</HappinessDefault>
 			<HappinessDefaultCapital>0</HappinessDefaultCapital>
-			<NumCitiesUnhappinessMod>100</NumCitiesUnhappinessMod>
+			<PopulationUnhappinessMod>0</PopulationUnhappinessMod>
+			<ExtraHappinessPerLuxury>0</ExtraHappinessPerLuxury>
+			<StartingPolicyPoints>0</StartingPolicyPoints>
+			<FreeCulturePerTurn>0</FreeCulturePerTurn>
 			<Gold>0</Gold>
 			<GoldFreeUnits>0</GoldFreeUnits>
 			<ProductionFreeUnits>7</ProductionFreeUnits>
-			<ProductionFreeUnitsPopulationPercent>20</ProductionFreeUnitsPopulationPercent>
 			<ProductionFreeUnitsPerCity>1</ProductionFreeUnitsPerCity>
+			<ProductionFreeUnitsPopulationPercent>20</ProductionFreeUnitsPopulationPercent>
+			<StartingDefenseUnits>0</StartingDefenseUnits>
+			<StartingExploreUnits>0</StartingExploreUnits>
+			<StartingWorkerUnits>0</StartingWorkerUnits>
 			<RouteCostPercent>100</RouteCostPercent>
 			<UnitCostPercent>100</UnitCostPercent>
 			<BuildingCostPercent>100</BuildingCostPercent>
-			<ResearchPercent>100</ResearchPercent>
-			<StartingMinorDefenseUnits>2</StartingMinorDefenseUnits>
 			<PolicyPercent>100</PolicyPercent>
+			<ResearchPercent>100</ResearchPercent>
 			<ImprovementCostPercent>100</ImprovementCostPercent>
+
+			<!-- City-State Bonuses -->
+			<StartingMinorDefenseUnits>2</StartingMinorDefenseUnits>
+
+			<!-- AI Bonuses -->
 			<CityProductionNumOptionsConsidered>2</CityProductionNumOptionsConsidered>
 			<TechNumOptionsConsidered>2</TechNumOptionsConsidered>
 			<PolicyNumOptionsConsidered>2</PolicyNumOptionsConsidered>
-			<!--<InflationPercent>100</InflationPercent>-->
-			<AttitudeChange>-1</AttitudeChange>
-			<NoTechTradeModifier>10</NoTechTradeModifier>
-			<BarbCampGold>20</BarbCampGold>
-			<BarbSpawnMod>0</BarbSpawnMod>
-			<BarbarianBonus>20</BarbarianBonus>
-			<AIBarbarianBonus>15</AIBarbarianBonus>
-			<EarliestBarbarianReleaseTurn>15</EarliestBarbarianReleaseTurn>
-			<BarbarianLandTargetRange>10</BarbarianLandTargetRange>
-			<BarbarianSeaTargetRange>24</BarbarianSeaTargetRange>
-			<AIStartingDefenseUnits>1</AIStartingDefenseUnits>
-			<AIStartingWorkerUnits>1</AIStartingWorkerUnits>
 			<AIDeclareWarProb>175</AIDeclareWarProb>
+			<AIStartingDefenseUnits>1</AIStartingDefenseUnits>
+			<AIStartingExploreUnits>0</AIStartingExploreUnits>
+			<AIStartingWorkerUnits>1</AIStartingWorkerUnits>
+			<AIStartingUnitMultiplier>0</AIStartingUnitMultiplier>
 			<AIWorkRateModifier>50</AIWorkRateModifier>
-			<PopulationUnhappinessMod>0</PopulationUnhappinessMod>
 			<AIUnhappinessPercent>0</AIUnhappinessPercent>
 			<AIGrowthPercent>100</AIGrowthPercent>
-			<AITrainPercent>80</AITrainPercent>
-			<AIWorldTrainPercent>100</AIWorldTrainPercent>
-			<AIConstructPercent>80</AIConstructPercent>
-			<AIWorldConstructPercent>100</AIWorldConstructPercent>
-			<AICreatePercent>80</AICreatePercent>
-			<AIWorldCreatePercent>100</AIWorldCreatePercent>
-			<AIBuildingCostPercent>80</AIBuildingCostPercent>
 			<AIUnitCostPercent>80</AIUnitCostPercent>
-			<AIUnitSupplyPercent>25</AIUnitSupplyPercent>
+			<AIBuildingCostPercent>80</AIBuildingCostPercent>
 			<AIUnitUpgradePercent>75</AIUnitUpgradePercent>
-			<!--<AIInflationPercent>80</AIInflationPercent>-->
-			<AIPerEraModifier>-8</AIPerEraModifier>
-			<AIAdvancedStartPercent>200</AIAdvancedStartPercent>
+			<AIWorldConstructPercent>100</AIWorldConstructPercent>
+			<AIWorldCreatePercent>100</AIWorldCreatePercent>
 			<AIFreeXP>20</AIFreeXP>
+			<AIFreeXPPercent>66</AIFreeXPPercent>
+			<VisionBonus>0</VisionBonus>
+			<!-- Per Era Bonuses -->	
+			<AITrainPercent>80</AITrainPercent>
+			<AIConstructPercent>80</AIConstructPercent>
+			<AICreatePercent>80</AICreatePercent>
+			<AIUnitSupplyPercent>25</AIUnitSupplyPercent>
+			<AIPerEraModifier>-8</AIPerEraModifier>
+			<!-- CBP Difficulty Bonus -->
 			<DifficultyBonusBase>5</DifficultyBonusBase>
 			<DifficultyBonusA>325</DifficultyBonusA>
 			<DifficultyBonusB>175</DifficultyBonusB>
 			<DifficultyBonusC>100</DifficultyBonusC>
-			<AIFreeXPPercent>66</AIFreeXPPercent>
+
+			<!-- Barbarians -->
+			<EarliestBarbarianReleaseTurn>15</EarliestBarbarianReleaseTurn>
+			<BarbarianBonus>20</BarbarianBonus>
+			<AIBarbarianBonus>15</AIBarbarianBonus>
+			<BarbCampGold>20</BarbCampGold>
+			<BarbSpawnMod>0</BarbSpawnMod>
+			<BarbarianLandTargetRange>10</BarbarianLandTargetRange>
+			<BarbarianSeaTargetRange>24</BarbarianSeaTargetRange>
+
+			<!-- Unused Values -->
+			<StartingLocPercent>0</StartingLocPercent>
+			<AdvancedStartPointsMod>0</AdvancedStartPointsMod>
+			<AIAdvancedStartPercent>0</AIAdvancedStartPercent>
+			<NumCitiesUnhappinessMod>100</NumCitiesUnhappinessMod>
+			<AttitudeChange>0</AttitudeChange>
+			<TechTradeKnownModifier>0</TechTradeKnownModifier>
+			<NoTechTradeModifier>0</NoTechTradeModifier>
+			<AIWorldTrainPercent>100</AIWorldTrainPercent>
+			<!--<InflationPercent>100</InflationPercent>-->
+			<!--<AIInflationPercent>100</AIInflationPercent>-->
 			<IconAtlas>DIFFICULTY_ATLAS</IconAtlas>
 			<PortraitIndex>5</PortraitIndex>
 		</Row>
@@ -379,63 +512,83 @@
 			<Type>HANDICAP_IMMORTAL</Type>
 			<Description>TXT_KEY_HANDICAP_IMMORTAL</Description>
 			<Help>TXT_KEY_HANDICAP_IMMORTAL_HELP</Help>
-			<StartingLocPercent>50</StartingLocPercent>
-			<AdvancedStartPointsMod>50</AdvancedStartPointsMod>
+			<!-- Player Bonuses -->
 			<HappinessDefault>6</HappinessDefault>
 			<HappinessDefaultCapital>0</HappinessDefaultCapital>
-			<NumCitiesUnhappinessMod>100</NumCitiesUnhappinessMod>
+			<PopulationUnhappinessMod>0</PopulationUnhappinessMod>
+			<ExtraHappinessPerLuxury>0</ExtraHappinessPerLuxury>
+			<StartingPolicyPoints>0</StartingPolicyPoints>
+			<FreeCulturePerTurn>0</FreeCulturePerTurn>
 			<Gold>0</Gold>
 			<GoldFreeUnits>0</GoldFreeUnits>
 			<ProductionFreeUnits>6</ProductionFreeUnits>
-			<ProductionFreeUnitsPopulationPercent>20</ProductionFreeUnitsPopulationPercent>
 			<ProductionFreeUnitsPerCity>1</ProductionFreeUnitsPerCity>
+			<ProductionFreeUnitsPopulationPercent>20</ProductionFreeUnitsPopulationPercent>
+			<StartingDefenseUnits>0</StartingDefenseUnits>
+			<StartingExploreUnits>0</StartingExploreUnits>
+			<StartingWorkerUnits>0</StartingWorkerUnits>
 			<RouteCostPercent>100</RouteCostPercent>
 			<UnitCostPercent>100</UnitCostPercent>
-			<StartingMinorDefenseUnits>2</StartingMinorDefenseUnits>
 			<BuildingCostPercent>100</BuildingCostPercent>
-			<ResearchPercent>100</ResearchPercent>
 			<PolicyPercent>100</PolicyPercent>
+			<ResearchPercent>100</ResearchPercent>
 			<ImprovementCostPercent>100</ImprovementCostPercent>
+
+			<!-- City-State Bonuses -->
+			<StartingMinorDefenseUnits>2</StartingMinorDefenseUnits>
+
+			<!-- AI Bonuses -->
 			<CityProductionNumOptionsConsidered>1</CityProductionNumOptionsConsidered>
 			<TechNumOptionsConsidered>1</TechNumOptionsConsidered>
 			<PolicyNumOptionsConsidered>1</PolicyNumOptionsConsidered>
-			<!--<InflationPercent>100</InflationPercent>-->
-			<AttitudeChange>-1</AttitudeChange>
-			<NoTechTradeModifier>5</NoTechTradeModifier>
-			<BarbCampGold>20</BarbCampGold>
-			<BarbSpawnMod>0</BarbSpawnMod>
-			<BarbarianBonus>10</BarbarianBonus>
-			<AIBarbarianBonus>20</AIBarbarianBonus>
-			<EarliestBarbarianReleaseTurn>10</EarliestBarbarianReleaseTurn>
-			<BarbarianLandTargetRange>11</BarbarianLandTargetRange>
-			<BarbarianSeaTargetRange>26</BarbarianSeaTargetRange>
-			<AIStartingDefenseUnits>2</AIStartingDefenseUnits>
-			<AIStartingWorkerUnits>1</AIStartingWorkerUnits>
 			<AIDeclareWarProb>200</AIDeclareWarProb>
+			<AIStartingDefenseUnits>2</AIStartingDefenseUnits>
+			<AIStartingExploreUnits>0</AIStartingExploreUnits>
+			<AIStartingWorkerUnits>1</AIStartingWorkerUnits>
+			<AIStartingUnitMultiplier>0</AIStartingUnitMultiplier>
 			<AIWorkRateModifier>60</AIWorkRateModifier>
-			<PopulationUnhappinessMod>0</PopulationUnhappinessMod>
 			<AIUnhappinessPercent>-5</AIUnhappinessPercent>
 			<AIGrowthPercent>100</AIGrowthPercent>
-			<AITrainPercent>80</AITrainPercent>
-			<AIWorldTrainPercent>100</AIWorldTrainPercent>
-			<AIConstructPercent>80</AIConstructPercent>
-			<AIWorldConstructPercent>100</AIWorldConstructPercent>
-			<AICreatePercent>80</AICreatePercent>
-			<AIWorldCreatePercent>100</AIWorldCreatePercent>
-			<AIBuildingCostPercent>80</AIBuildingCostPercent>
 			<AIUnitCostPercent>80</AIUnitCostPercent>
-			<AIUnitSupplyPercent>30</AIUnitSupplyPercent>
+			<AIBuildingCostPercent>80</AIBuildingCostPercent>
 			<AIUnitUpgradePercent>70</AIUnitUpgradePercent>
-			<!--<AIInflationPercent>80</AIInflationPercent>-->
-			<AIPerEraModifier>-9</AIPerEraModifier>
-			<AIAdvancedStartPercent>215</AIAdvancedStartPercent>
+			<AIWorldConstructPercent>100</AIWorldConstructPercent>
+			<AIWorldCreatePercent>100</AIWorldCreatePercent>
 			<AIFreeXP>25</AIFreeXP>
+			<AIFreeXPPercent>75</AIFreeXPPercent>
+			<VisionBonus>1</VisionBonus>
+			<!-- Per Era Bonuses -->	
+			<AITrainPercent>80</AITrainPercent>
+			<AIConstructPercent>80</AIConstructPercent>
+			<AICreatePercent>80</AICreatePercent>
+			<AIUnitSupplyPercent>30</AIUnitSupplyPercent>
+			<AIPerEraModifier>-9</AIPerEraModifier>
+			<!-- CBP Difficulty Bonus -->
 			<DifficultyBonusBase>6</DifficultyBonusBase>
 			<DifficultyBonusA>325</DifficultyBonusA>
 			<DifficultyBonusB>175</DifficultyBonusB>
 			<DifficultyBonusC>100</DifficultyBonusC>
-			<AIFreeXPPercent>75</AIFreeXPPercent>
-			<VisionBonus>1</VisionBonus>
+
+			<!-- Barbarians -->
+			<EarliestBarbarianReleaseTurn>10</EarliestBarbarianReleaseTurn>
+			<BarbarianBonus>10</BarbarianBonus>
+			<AIBarbarianBonus>20</AIBarbarianBonus>
+			<BarbCampGold>20</BarbCampGold>
+			<BarbSpawnMod>0</BarbSpawnMod>
+			<BarbarianLandTargetRange>11</BarbarianLandTargetRange>
+			<BarbarianSeaTargetRange>26</BarbarianSeaTargetRange>
+
+			<!-- Unused Values -->
+			<StartingLocPercent>0</StartingLocPercent>
+			<AdvancedStartPointsMod>0</AdvancedStartPointsMod>
+			<AIAdvancedStartPercent>0</AIAdvancedStartPercent>
+			<NumCitiesUnhappinessMod>100</NumCitiesUnhappinessMod>
+			<AttitudeChange>0</AttitudeChange>
+			<TechTradeKnownModifier>0</TechTradeKnownModifier>
+			<NoTechTradeModifier>0</NoTechTradeModifier>
+			<AIWorldTrainPercent>100</AIWorldTrainPercent>
+			<!--<InflationPercent>100</InflationPercent>-->
+			<!--<AIInflationPercent>100</AIInflationPercent>-->
 			<IconAtlas>DIFFICULTY_ATLAS</IconAtlas>
 			<PortraitIndex>6</PortraitIndex>
 		</Row>
@@ -443,63 +596,83 @@
 			<Type>HANDICAP_DEITY</Type>
 			<Description>TXT_KEY_HANDICAP_DEITY</Description>
 			<Help>TXT_KEY_HANDICAP_DEITY_HELP</Help>
-			<StartingLocPercent>50</StartingLocPercent>
-			<AdvancedStartPointsMod>45</AdvancedStartPointsMod>
+			<!-- Player Bonuses -->
 			<HappinessDefault>6</HappinessDefault>
 			<HappinessDefaultCapital>0</HappinessDefaultCapital>
-			<NumCitiesUnhappinessMod>100</NumCitiesUnhappinessMod>
+			<PopulationUnhappinessMod>0</PopulationUnhappinessMod>
+			<ExtraHappinessPerLuxury>0</ExtraHappinessPerLuxury>
+			<StartingPolicyPoints>0</StartingPolicyPoints>
+			<FreeCulturePerTurn>0</FreeCulturePerTurn>
 			<Gold>0</Gold>
 			<GoldFreeUnits>0</GoldFreeUnits>
 			<ProductionFreeUnits>6</ProductionFreeUnits>
-			<ProductionFreeUnitsPopulationPercent>20</ProductionFreeUnitsPopulationPercent>
 			<ProductionFreeUnitsPerCity>1</ProductionFreeUnitsPerCity>
+			<ProductionFreeUnitsPopulationPercent>20</ProductionFreeUnitsPopulationPercent>
+			<StartingDefenseUnits>0</StartingDefenseUnits>
+			<StartingExploreUnits>0</StartingExploreUnits>
+			<StartingWorkerUnits>0</StartingWorkerUnits>
 			<RouteCostPercent>100</RouteCostPercent>
 			<UnitCostPercent>100</UnitCostPercent>
 			<BuildingCostPercent>100</BuildingCostPercent>
-			<ResearchPercent>100</ResearchPercent>
-			<StartingMinorDefenseUnits>3</StartingMinorDefenseUnits>
 			<PolicyPercent>100</PolicyPercent>
+			<ResearchPercent>100</ResearchPercent>
 			<ImprovementCostPercent>100</ImprovementCostPercent>
+
+			<!-- City-State Bonuses -->
+			<StartingMinorDefenseUnits>3</StartingMinorDefenseUnits>
+
+			<!-- AI Bonuses -->
 			<CityProductionNumOptionsConsidered>1</CityProductionNumOptionsConsidered>
 			<TechNumOptionsConsidered>1</TechNumOptionsConsidered>
 			<PolicyNumOptionsConsidered>1</PolicyNumOptionsConsidered>
-			<!--<InflationPercent>100</InflationPercent>-->
-			<AttitudeChange>-1</AttitudeChange>
-			<NoTechTradeModifier>1</NoTechTradeModifier>
-			<BarbCampGold>15</BarbCampGold>
-			<BarbSpawnMod>0</BarbSpawnMod>
-			<BarbarianBonus>0</BarbarianBonus>
-			<AIBarbarianBonus>25</AIBarbarianBonus>
-			<EarliestBarbarianReleaseTurn>10</EarliestBarbarianReleaseTurn>
-			<BarbarianLandTargetRange>12</BarbarianLandTargetRange>
-			<BarbarianSeaTargetRange>28</BarbarianSeaTargetRange>
-			<AIStartingDefenseUnits>2</AIStartingDefenseUnits>
-			<AIStartingWorkerUnits>1</AIStartingWorkerUnits>
 			<AIDeclareWarProb>225</AIDeclareWarProb>
+			<AIStartingDefenseUnits>2</AIStartingDefenseUnits>
+			<AIStartingExploreUnits>0</AIStartingExploreUnits>
+			<AIStartingWorkerUnits>1</AIStartingWorkerUnits>
+			<AIStartingUnitMultiplier>0</AIStartingUnitMultiplier>
 			<AIWorkRateModifier>70</AIWorkRateModifier>
-			<PopulationUnhappinessMod>0</PopulationUnhappinessMod>
 			<AIUnhappinessPercent>-10</AIUnhappinessPercent>
 			<AIGrowthPercent>100</AIGrowthPercent>
-			<AITrainPercent>70</AITrainPercent>
-			<AIWorldTrainPercent>100</AIWorldTrainPercent>
-			<AIConstructPercent>70</AIConstructPercent>
-			<AIWorldConstructPercent>100</AIWorldConstructPercent>
-			<AICreatePercent>70</AICreatePercent>
-			<AIWorldCreatePercent>100</AIWorldCreatePercent>
-			<AIBuildingCostPercent>70</AIBuildingCostPercent>
 			<AIUnitCostPercent>70</AIUnitCostPercent>
-			<AIUnitSupplyPercent>35</AIUnitSupplyPercent>
+			<AIBuildingCostPercent>70</AIBuildingCostPercent>
 			<AIUnitUpgradePercent>65</AIUnitUpgradePercent>
-			<!--<AIInflationPercent>80</AIInflationPercent>-->
-			<AIPerEraModifier>-10</AIPerEraModifier>
-			<AIAdvancedStartPercent>230</AIAdvancedStartPercent>
+			<AIWorldConstructPercent>100</AIWorldConstructPercent>
+			<AIWorldCreatePercent>100</AIWorldCreatePercent>
 			<AIFreeXP>30</AIFreeXP>
 			<AIFreeXPPercent>100</AIFreeXPPercent>
+			<VisionBonus>2</VisionBonus>
+			<!-- Per Era Bonuses -->	
+			<AITrainPercent>70</AITrainPercent>
+			<AIConstructPercent>70</AIConstructPercent>
+			<AICreatePercent>70</AICreatePercent>
+			<AIUnitSupplyPercent>35</AIUnitSupplyPercent>
+			<AIPerEraModifier>-10</AIPerEraModifier>
+			<!-- CBP Difficulty Bonus -->
 			<DifficultyBonusBase>8</DifficultyBonusBase>
 			<DifficultyBonusA>350</DifficultyBonusA>
 			<DifficultyBonusB>200</DifficultyBonusB>
 			<DifficultyBonusC>125</DifficultyBonusC>
-			<VisionBonus>2</VisionBonus>
+
+			<!-- Barbarians -->
+			<EarliestBarbarianReleaseTurn>10</EarliestBarbarianReleaseTurn>
+			<BarbarianBonus>0</BarbarianBonus>
+			<AIBarbarianBonus>25</AIBarbarianBonus>
+			<BarbCampGold>15</BarbCampGold>
+			<BarbSpawnMod>0</BarbSpawnMod>
+			<BarbarianLandTargetRange>12</BarbarianLandTargetRange>
+			<BarbarianSeaTargetRange>28</BarbarianSeaTargetRange>
+
+			<!-- Unused Values -->
+			<StartingLocPercent>0</StartingLocPercent>
+			<AdvancedStartPointsMod>0</AdvancedStartPointsMod>
+			<AIAdvancedStartPercent>0</AIAdvancedStartPercent>
+			<NumCitiesUnhappinessMod>100</NumCitiesUnhappinessMod>
+			<AttitudeChange>0</AttitudeChange>
+			<TechTradeKnownModifier>0</TechTradeKnownModifier>
+			<NoTechTradeModifier>0</NoTechTradeModifier>
+			<AIWorldTrainPercent>100</AIWorldTrainPercent>
+			<!--<InflationPercent>100</InflationPercent>-->
+			<!--<AIInflationPercent>100</AIInflationPercent>-->
 			<IconAtlas>DIFFICULTY_ATLAS</IconAtlas>
 			<PortraitIndex>7</PortraitIndex>
 		</Row>
@@ -507,53 +680,83 @@
 			<Type>HANDICAP_AI_DEFAULT</Type>
 			<Description>TXT_KEY_HANDICAP_AI_DEFAULT</Description>
 			<Help>TXT_KEY_HANDICAP_AI_DEFAULT_HELP</Help>
-			<StartingLocPercent>50</StartingLocPercent>
-			<AdvancedStartPointsMod>100</AdvancedStartPointsMod>
+			<!-- Player Bonuses -->
 			<HappinessDefault>10</HappinessDefault>
 			<HappinessDefaultCapital>2</HappinessDefaultCapital>
-			<NumCitiesUnhappinessMod>100</NumCitiesUnhappinessMod>
+			<PopulationUnhappinessMod>0</PopulationUnhappinessMod>
+			<ExtraHappinessPerLuxury>0</ExtraHappinessPerLuxury>
+			<StartingPolicyPoints>0</StartingPolicyPoints>
+			<FreeCulturePerTurn>0</FreeCulturePerTurn>
 			<Gold>0</Gold>
 			<GoldFreeUnits>0</GoldFreeUnits>
 			<ProductionFreeUnits>7</ProductionFreeUnits>
-			<ProductionFreeUnitsPopulationPercent>25</ProductionFreeUnitsPopulationPercent>
 			<ProductionFreeUnitsPerCity>1</ProductionFreeUnitsPerCity>
+			<ProductionFreeUnitsPopulationPercent>25</ProductionFreeUnitsPopulationPercent>
+			<StartingDefenseUnits>0</StartingDefenseUnits>
+			<StartingExploreUnits>0</StartingExploreUnits>
+			<StartingWorkerUnits>0</StartingWorkerUnits>
 			<RouteCostPercent>100</RouteCostPercent>
 			<UnitCostPercent>100</UnitCostPercent>
 			<BuildingCostPercent>100</BuildingCostPercent>
-			<ResearchPercent>100</ResearchPercent>
 			<PolicyPercent>100</PolicyPercent>
+			<ResearchPercent>100</ResearchPercent>
 			<ImprovementCostPercent>100</ImprovementCostPercent>
+
+			<!-- City-State Bonuses -->
+			<StartingMinorDefenseUnits>0</StartingMinorDefenseUnits>
+
+			<!-- AI Bonuses -->
 			<CityProductionNumOptionsConsidered>2</CityProductionNumOptionsConsidered>
 			<TechNumOptionsConsidered>2</TechNumOptionsConsidered>
 			<PolicyNumOptionsConsidered>2</PolicyNumOptionsConsidered>
-			<AttitudeChange>-1</AttitudeChange>
-			<NoTechTradeModifier>70</NoTechTradeModifier>
-			<BarbCampGold>50</BarbCampGold>
-			<BarbSpawnMod>0</BarbSpawnMod>
-			<BarbarianBonus>0</BarbarianBonus>
-			<AIBarbarianBonus>25</AIBarbarianBonus>
-			<EarliestBarbarianReleaseTurn>0</EarliestBarbarianReleaseTurn>
-			<BarbarianLandTargetRange>6</BarbarianLandTargetRange>
-			<BarbarianSeaTargetRange>18</BarbarianSeaTargetRange>
 			<AIDeclareWarProb>100</AIDeclareWarProb>
-			<PopulationUnhappinessMod>0</PopulationUnhappinessMod>
+			<AIStartingDefenseUnits>0</AIStartingDefenseUnits>
+			<AIStartingExploreUnits>0</AIStartingExploreUnits>
+			<AIStartingWorkerUnits>0</AIStartingWorkerUnits>
+			<AIStartingUnitMultiplier>0</AIStartingUnitMultiplier>
+			<AIWorkRateModifier>0</AIWorkRateModifier>
 			<AIUnhappinessPercent>0</AIUnhappinessPercent>
 			<AIGrowthPercent>100</AIGrowthPercent>
-			<AITrainPercent>100</AITrainPercent>
-			<AIWorldTrainPercent>100</AIWorldTrainPercent>
-			<AIConstructPercent>100</AIConstructPercent>
-			<AIWorldConstructPercent>100</AIWorldConstructPercent>
-			<AICreatePercent>100</AICreatePercent>
-			<AIWorldCreatePercent>100</AIWorldCreatePercent>
-			<AIBuildingCostPercent>100</AIBuildingCostPercent>
 			<AIUnitCostPercent>100</AIUnitCostPercent>
-			<AIUnitSupplyPercent>0</AIUnitSupplyPercent>
+			<AIBuildingCostPercent>100</AIBuildingCostPercent>
 			<AIUnitUpgradePercent>100</AIUnitUpgradePercent>
-			<AIAdvancedStartPercent>100</AIAdvancedStartPercent>
+			<AIWorldConstructPercent>100</AIWorldConstructPercent>
+			<AIWorldCreatePercent>100</AIWorldCreatePercent>
+			<AIFreeXP>0</AIFreeXP>
+			<AIFreeXPPercent>0</AIFreeXPPercent>
+			<VisionBonus>0</VisionBonus>
+			<!-- Per Era Bonuses -->	
+			<AITrainPercent>100</AITrainPercent>
+			<AIConstructPercent>100</AIConstructPercent>
+			<AICreatePercent>100</AICreatePercent>
+			<AIUnitSupplyPercent>0</AIUnitSupplyPercent>
+			<AIPerEraModifier>0</AIPerEraModifier>
+			<!-- CBP Difficulty Bonus -->
 			<DifficultyBonusBase>0</DifficultyBonusBase>
 			<DifficultyBonusA>325</DifficultyBonusA>
 			<DifficultyBonusB>175</DifficultyBonusB>
 			<DifficultyBonusC>100</DifficultyBonusC>
+
+			<!-- Barbarians -->
+			<EarliestBarbarianReleaseTurn>0</EarliestBarbarianReleaseTurn>
+			<BarbarianBonus>0</BarbarianBonus>
+			<AIBarbarianBonus>25</AIBarbarianBonus>
+			<BarbCampGold>50</BarbCampGold>
+			<BarbSpawnMod>0</BarbSpawnMod>
+			<BarbarianLandTargetRange>6</BarbarianLandTargetRange>
+			<BarbarianSeaTargetRange>18</BarbarianSeaTargetRange>
+
+			<!-- Unused Values -->
+			<StartingLocPercent>0</StartingLocPercent>
+			<AdvancedStartPointsMod>0</AdvancedStartPointsMod>
+			<AIAdvancedStartPercent>0</AIAdvancedStartPercent>
+			<NumCitiesUnhappinessMod>100</NumCitiesUnhappinessMod>
+			<AttitudeChange>0</AttitudeChange>
+			<TechTradeKnownModifier>0</TechTradeKnownModifier>
+			<NoTechTradeModifier>0</NoTechTradeModifier>
+			<AIWorldTrainPercent>100</AIWorldTrainPercent>
+			<!--<InflationPercent>100</InflationPercent>-->
+			<!--<AIInflationPercent>100</AIInflationPercent>-->
 			<IconAtlas>DIFFICULTY_ATLAS</IconAtlas>
 		</Row>
 	</HandicapInfos>

--- a/Community Balance Patch/Balance Changes/Difficulty/DifficultyMod.xml
+++ b/Community Balance Patch/Balance Changes/Difficulty/DifficultyMod.xml
@@ -26,9 +26,9 @@
 			<RouteCostPercent>75</RouteCostPercent>
 			<UnitCostPercent>90</UnitCostPercent>
 			<BuildingCostPercent>100</BuildingCostPercent>
+			<ImprovementCostPercent>100</ImprovementCostPercent>
 			<PolicyPercent>90</PolicyPercent>
 			<ResearchPercent>100</ResearchPercent>
-			<ImprovementCostPercent>100</ImprovementCostPercent>
 
 			<!-- City-State Bonuses -->
 			<StartingMinorDefenseUnits>0</StartingMinorDefenseUnits>
@@ -110,9 +110,9 @@
 			<RouteCostPercent>100</RouteCostPercent>
 			<UnitCostPercent>100</UnitCostPercent>
 			<BuildingCostPercent>100</BuildingCostPercent>
+			<ImprovementCostPercent>100</ImprovementCostPercent>
 			<PolicyPercent>100</PolicyPercent>
 			<ResearchPercent>100</ResearchPercent>
-			<ImprovementCostPercent>100</ImprovementCostPercent>
 
 			<!-- City-State Bonuses -->
 			<StartingMinorDefenseUnits>0</StartingMinorDefenseUnits>
@@ -194,9 +194,9 @@
 			<RouteCostPercent>100</RouteCostPercent>
 			<UnitCostPercent>100</UnitCostPercent>
 			<BuildingCostPercent>100</BuildingCostPercent>
+			<ImprovementCostPercent>100</ImprovementCostPercent>
 			<PolicyPercent>100</PolicyPercent>
 			<ResearchPercent>100</ResearchPercent>
-			<ImprovementCostPercent>100</ImprovementCostPercent>
 
 			<!-- City-State Bonuses -->
 			<StartingMinorDefenseUnits>1</StartingMinorDefenseUnits>
@@ -278,9 +278,9 @@
 			<RouteCostPercent>100</RouteCostPercent>
 			<UnitCostPercent>100</UnitCostPercent>
 			<BuildingCostPercent>100</BuildingCostPercent>
+			<ImprovementCostPercent>100</ImprovementCostPercent>
 			<PolicyPercent>100</PolicyPercent>
 			<ResearchPercent>100</ResearchPercent>
-			<ImprovementCostPercent>100</ImprovementCostPercent>
 
 			<!-- City-State Bonuses -->
 			<StartingMinorDefenseUnits>1</StartingMinorDefenseUnits>
@@ -362,9 +362,9 @@
 			<RouteCostPercent>100</RouteCostPercent>
 			<UnitCostPercent>100</UnitCostPercent>
 			<BuildingCostPercent>100</BuildingCostPercent>
+			<ImprovementCostPercent>100</ImprovementCostPercent>
 			<PolicyPercent>100</PolicyPercent>
 			<ResearchPercent>100</ResearchPercent>
-			<ImprovementCostPercent>100</ImprovementCostPercent>
 
 			<!-- City-State Bonuses -->
 			<StartingMinorDefenseUnits>1</StartingMinorDefenseUnits>
@@ -446,9 +446,9 @@
 			<RouteCostPercent>100</RouteCostPercent>
 			<UnitCostPercent>100</UnitCostPercent>
 			<BuildingCostPercent>100</BuildingCostPercent>
+			<ImprovementCostPercent>100</ImprovementCostPercent>
 			<PolicyPercent>100</PolicyPercent>
 			<ResearchPercent>100</ResearchPercent>
-			<ImprovementCostPercent>100</ImprovementCostPercent>
 
 			<!-- City-State Bonuses -->
 			<StartingMinorDefenseUnits>2</StartingMinorDefenseUnits>
@@ -530,9 +530,9 @@
 			<RouteCostPercent>100</RouteCostPercent>
 			<UnitCostPercent>100</UnitCostPercent>
 			<BuildingCostPercent>100</BuildingCostPercent>
+			<ImprovementCostPercent>100</ImprovementCostPercent>
 			<PolicyPercent>100</PolicyPercent>
 			<ResearchPercent>100</ResearchPercent>
-			<ImprovementCostPercent>100</ImprovementCostPercent>
 
 			<!-- City-State Bonuses -->
 			<StartingMinorDefenseUnits>2</StartingMinorDefenseUnits>
@@ -614,9 +614,9 @@
 			<RouteCostPercent>100</RouteCostPercent>
 			<UnitCostPercent>100</UnitCostPercent>
 			<BuildingCostPercent>100</BuildingCostPercent>
+			<ImprovementCostPercent>100</ImprovementCostPercent>
 			<PolicyPercent>100</PolicyPercent>
 			<ResearchPercent>100</ResearchPercent>
-			<ImprovementCostPercent>100</ImprovementCostPercent>
 
 			<!-- City-State Bonuses -->
 			<StartingMinorDefenseUnits>3</StartingMinorDefenseUnits>
@@ -698,9 +698,9 @@
 			<RouteCostPercent>100</RouteCostPercent>
 			<UnitCostPercent>100</UnitCostPercent>
 			<BuildingCostPercent>100</BuildingCostPercent>
+			<ImprovementCostPercent>100</ImprovementCostPercent>
 			<PolicyPercent>100</PolicyPercent>
 			<ResearchPercent>100</ResearchPercent>
-			<ImprovementCostPercent>100</ImprovementCostPercent>
 
 			<!-- City-State Bonuses -->
 			<StartingMinorDefenseUnits>0</StartingMinorDefenseUnits>

--- a/CvGameCoreDLL_Expansion2/CvDealAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDealAI.cpp
@@ -2696,7 +2696,24 @@ int CvDealAI::GetEmbassyValue(bool bFromMe, PlayerTypes eOtherPlayer, bool bUseE
 		switch(GetPlayer()->GetDiplomacyAI()->GetMajorCivApproach(eOtherPlayer, /*bHideTrueFeelings*/ false))
 		{
 		case MAJOR_CIV_APPROACH_WAR:
-			iItemValue *= 100;
+			switch(GetPlayer()->GetDiplomacyAI()->GetWarFaceWithPlayer(eOtherPlayer))
+			{
+				case WAR_FACE_HOSTILE:
+					iItemValue *= 250;
+					break;
+				case WAR_FACE_GUARDED:
+					iItemValue *= 130;
+					break;
+				case WAR_FACE_NEUTRAL:
+					iItemValue *= 100;
+					break;
+				case WAR_FACE_FRIENDLY:
+					iItemValue *= 100;
+					break;
+				default:
+					iItemValue *= 100;
+					break;
+			}
 			break;
 		case MAJOR_CIV_APPROACH_HOSTILE:
 			iItemValue *= 250;
@@ -2733,7 +2750,24 @@ int CvDealAI::GetEmbassyValue(bool bFromMe, PlayerTypes eOtherPlayer, bool bUseE
 		switch(GetPlayer()->GetDiplomacyAI()->GetMajorCivApproach(eOtherPlayer, /*bHideTrueFeelings*/ false))
 		{
 		case MAJOR_CIV_APPROACH_WAR:
-			iItemValue *= 100;
+			switch(GetPlayer()->GetDiplomacyAI()->GetWarFaceWithPlayer(eOtherPlayer))
+			{
+				case WAR_FACE_HOSTILE:
+					iItemValue *= 30;
+					break;
+				case WAR_FACE_GUARDED:
+					iItemValue *= 60;
+					break;
+				case WAR_FACE_NEUTRAL:
+					iItemValue *= 100;
+					break;
+				case WAR_FACE_FRIENDLY:  // embassies are worth so little that it's not worth revealing deception over
+					iItemValue *= 150;
+					break;
+				default:
+					iItemValue *= 100;
+					break;
+			}
 			break;
 		case MAJOR_CIV_APPROACH_HOSTILE:
 			iItemValue *= 30;
@@ -2741,8 +2775,8 @@ int CvDealAI::GetEmbassyValue(bool bFromMe, PlayerTypes eOtherPlayer, bool bUseE
 		case MAJOR_CIV_APPROACH_GUARDED:
 			iItemValue *= 60;
 			break;
-		case MAJOR_CIV_APPROACH_DECEPTIVE:
-			iItemValue *= 100;
+		case MAJOR_CIV_APPROACH_DECEPTIVE:  // embassies are worth so little that it's not worth revealing deception over
+			iItemValue *= 150;
 			break;
 		case MAJOR_CIV_APPROACH_AFRAID:
 			iItemValue *= 120;
@@ -2762,8 +2796,8 @@ int CvDealAI::GetEmbassyValue(bool bFromMe, PlayerTypes eOtherPlayer, bool bUseE
 	}
 #endif
 
-	if (iItemValue <= 25)
-		iItemValue = 25;
+	if (iItemValue <= 15)
+		iItemValue = 15;
 
 	// Are we trying to find the middle point between what we think this item is worth and what another player thinks it's worth?
 	if(bUseEvenValue)

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
@@ -2695,9 +2695,16 @@ void CvDiplomacyAI::DoCounters()
 					if(GetPlayerNoSettleRequestCounter(eLoopPlayer) >= 50)
 					{
 						SetPlayerNoSettleRequestAccepted(eLoopPlayer, false);
-						SetPlayerNoSettleRequestCounter(eLoopPlayer, -666);
 						GET_PLAYER(eLoopPlayer).GetDiplomacyAI()->SetPlayerMadeExpansionPromise(GetPlayer()->GetID(), false);
 					}
+#if defined(MOD_BALANCE_CORE)			
+					if(GetPlayerNoSettleRequestCounter(eLoopPlayer) >= 100)
+					{
+						SetPlayerNoSettleRequestCounter(eLoopPlayer, -1);
+						SetPlayerNoSettleRequestEverAsked(eLoopPlayer, false);
+					}
+#endif
+					
 				}
 
 				// Did this player ask us to stop spying on them?
@@ -2705,12 +2712,18 @@ void CvDiplomacyAI::DoCounters()
 				{
 					ChangePlayerStopSpyingRequestCounter(eLoopPlayer, 1);
 
-					if(GetPlayerStopSpyingRequestCounter(eLoopPlayer) >= /*50*/ GC.getSTOP_SPYING_MEMORY_TURN_EXPIRATION())
+					if(GetPlayerStopSpyingRequestCounter(eLoopPlayer) >= 50)
 					{
 						SetPlayerStopSpyingRequestAccepted(eLoopPlayer, false);
-						SetPlayerStopSpyingRequestCounter(eLoopPlayer, -666);
 						GET_PLAYER(eLoopPlayer).GetDiplomacyAI()->SetPlayerMadeSpyPromise(GetPlayer()->GetID(), false);
 					}
+#if defined(MOD_BALANCE_CORE)
+					if(GetPlayerStopSpyingRequestCounter(eLoopPlayer) >= 100)
+					{
+						SetPlayerStopSpyingRequestCounter(eLoopPlayer, -1);
+						SetPlayerStopSpyingRequestEverAsked(eLoopPlayer, false);
+					}
+#endif
 				}
 #if defined(MOD_BALANCE_CORE)
 				//Is this player a backstabber?
@@ -14980,24 +14993,20 @@ void CvDiplomacyAI::DoPlayerDeclaredWarOnSomeone(PlayerTypes ePlayer, TeamTypes 
 					if(IsPlayerNoSettleRequestAccepted(ePlayer))
 					{
 						SetPlayerNoSettleRequestAccepted(ePlayer, false);
-						SetPlayerNoSettleRequestCounter(ePlayer, -666);
 					}
 					if(GET_PLAYER(ePlayer).GetDiplomacyAI()->IsPlayerNoSettleRequestAccepted(eMyPlayer))
 					{
 						GET_PLAYER(ePlayer).GetDiplomacyAI()->SetPlayerNoSettleRequestAccepted(eMyPlayer, false);
-						GET_PLAYER(ePlayer).GetDiplomacyAI()->SetPlayerNoSettleRequestCounter(eMyPlayer, -666);
 					}
 					
 					// HAD agreed not to spy on each other
 					if(IsPlayerStopSpyingRequestAccepted(ePlayer))
 					{
 						SetPlayerStopSpyingRequestAccepted(ePlayer, false);
-						SetPlayerStopSpyingRequestCounter(ePlayer, -666);
 					}
 					if(GET_PLAYER(ePlayer).GetDiplomacyAI()->IsPlayerStopSpyingRequestAccepted(eMyPlayer))
 					{
 						GET_PLAYER(ePlayer).GetDiplomacyAI()->SetPlayerStopSpyingRequestAccepted(eMyPlayer, false);
-						GET_PLAYER(ePlayer).GetDiplomacyAI()->SetPlayerStopSpyingRequestCounter(eMyPlayer, -666);
 					}
 					
 					// We're no longer trade partners
@@ -16839,12 +16848,10 @@ void CvDiplomacyAI::DoSendStatementToPlayer(PlayerTypes ePlayer, DiploStatementT
 
 		// If we had agreed to not settle near the player, break that off
 		SetPlayerNoSettleRequestAccepted(ePlayer, false);
-		SetPlayerNoSettleRequestCounter(ePlayer, -666);
 		GET_PLAYER(ePlayer).GetDiplomacyAI()->SetPlayerMadeExpansionPromise(eMyPlayer, false);
 
 		// If we had agreed to not spy on the player, break that off
 		SetPlayerStopSpyingRequestAccepted(ePlayer, false);
-		SetPlayerStopSpyingRequestCounter(ePlayer, -666);
 		GET_PLAYER(ePlayer).GetDiplomacyAI()->SetPlayerMadeSpyPromise(eMyPlayer, false);
 		
 #if defined(MOD_BALANCE_CORE_DIPLOMACY_ADVANCED)	
@@ -33396,13 +33403,18 @@ int CvDiplomacyAI::GetForgaveForSpyingScore(PlayerTypes ePlayer)
 
 int CvDiplomacyAI::GetNoSetterRequestScore(PlayerTypes ePlayer)
 {
+	// No penalty for teammates
+	if(GetPlayer()->getTeam() == GET_PLAYER(ePlayer).getTeam())
+		return 0;
+	
 	int iOpinionWeight = 0;
 	if(IsPlayerNoSettleRequestEverAsked(ePlayer))
 		iOpinionWeight += /*20*/ GC.getOPINION_WEIGHT_ASKED_NO_SETTLE();
 	
-	// No penalty for teammates
-	if(GetPlayer()->getTeam() == GET_PLAYER(ePlayer).getTeam())
-		return 0;
+#if defined(MOD_BALANCE_CORE)
+	if(GetPlayerNoSettleRequestCounter(ePlayer) >= 50)
+		iOpinionWeight /= 2;
+#endif
 
 	return iOpinionWeight;
 }
@@ -33412,6 +33424,12 @@ int CvDiplomacyAI::GetStopSpyingRequestScore(PlayerTypes ePlayer)
 	int iOpinionWeight = 0;
 	if(IsPlayerStopSpyingRequestEverAsked(ePlayer))
 		iOpinionWeight += /*20*/ GC.getOPINION_WEIGHT_ASKED_STOP_SPYING();
+	
+#if defined(MOD_BALANCE_CORE)
+	if(GetPlayerStopSpyingRequestCounter(ePlayer) >= 50)
+		iOpinionWeight /= 2;
+#endif
+	
 	return iOpinionWeight;
 }
 
@@ -42976,14 +42994,12 @@ void CvDiplomacyAI::DoWeMadeVassalageWithSomeone(TeamTypes eMasterTeam, bool bVo
 					if(GET_PLAYER(eOtherTeamPlayer).GetDiplomacyAI()->IsPlayerNoSettleRequestAccepted(GetPlayer()->GetID()))
 					{
 						GET_PLAYER(eOtherTeamPlayer).GetDiplomacyAI()->SetPlayerNoSettleRequestAccepted(GetPlayer()->GetID(), false);
-						GET_PLAYER(eOtherTeamPlayer).GetDiplomacyAI()->SetPlayerNoSettleRequestCounter(GetPlayer()->GetID(), -666);
 					}
 
 					// Master had agreed not to spy on them
 					if(GET_PLAYER(eOtherTeamPlayer).GetDiplomacyAI()->IsPlayerStopSpyingRequestAccepted(GetPlayer()->GetID()))
 					{
 						GET_PLAYER(eOtherTeamPlayer).GetDiplomacyAI()->SetPlayerStopSpyingRequestAccepted(GetPlayer()->GetID(), false);
-						GET_PLAYER(eOtherTeamPlayer).GetDiplomacyAI()->SetPlayerStopSpyingRequestCounter(GetPlayer()->GetID(), -666);
 					}
 
 					// Vassal thought they were a liberator, but Master had other plans...

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
@@ -29455,7 +29455,9 @@ void CvDiplomacyAI::ChangeDemandCounter(PlayerTypes ePlayer, int iChange)
 	
 	if (m_paiDemandCounter[ePlayer] > -1 && m_paiDemandCounter[ePlayer] > GetDemandTooSoonNumTurns(ePlayer) * 3)
 	{
-		SetNumDemandEverMade(ePlayer, -1);
+#if defined(MOD_BALANCE_CORE)
+		SetNumDemandEverMade(ePlayer, -GetNumDemandEverMade(ePlayer));
+#endif
 		SetDemandCounter(ePlayer, -1);
 	}
 }

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
@@ -3307,12 +3307,10 @@ int CvDiplomacyAI::GetNumMajorCivOpinion(MajorCivOpinionTypes eOpinion) const
 void CvDiplomacyAI::DoEstimateOtherPlayerOpinions()
 {
 	MajorCivOpinionTypes eOpinion;
-
 	int iOpinionWeight;
 
 	PlayerTypes eLoopOtherPlayer;
 	int iOtherPlayerLoop;
-
 
 	// Loop through all (known) Majors
 	PlayerTypes eLoopPlayer;
@@ -3372,20 +3370,19 @@ void CvDiplomacyAI::DoEstimateOtherPlayerOpinions()
 #if defined(MOD_BALANCE_CORE)
 						// Social Policies?
 						int iNumPolicies = GET_PLAYER(eLoopPlayer).GetDiplomacyAI()->GetNumSamePolicies(eLoopOtherPlayer);
+			
+						// Flip it!
+						iNumPolicies *= -1;
 						
 						// We can't know their neediness so assume the default
-						if(iNumPolicies < 0)
+						if(iNumPolicies > 0)
 						{
-							// Flip it!
-							iNumPolicies *= -1;
 							iOpinionWeight += max(5, (iNumPolicies * 1));
 						}
-						else if(iNumPolicies > 0)
+						else if(iNumPolicies < 0)
 						{
-							// Flip it!
-							iNumPolicies *= -1;
 							iOpinionWeight += min(-5, (iNumPolicies * 1));
-						}			
+						}
 #endif
 						
 #if defined(MOD_DIPLOMACY_CIV4_FEATURES)
@@ -29050,11 +29047,11 @@ bool CvDiplomacyAI::IsCoopWarRequestUnacceptable(PlayerTypes eAskingPlayer, Play
 		return false;
 	// No vassals!
 	if (GET_TEAM(GetPlayer()->getTeam()).IsVassalOfSomeone())
-		return true;
+		return false;
 	if (GET_TEAM(GET_PLAYER(eAskingPlayer).getTeam()).IsVassalOfSomeone())
-		return true;
+		return false;
 	if (GET_TEAM(GET_PLAYER(eTargetPlayer).getTeam()).IsVassalOfSomeone())
-		return true;
+		return false;
 		
 	// If the target is a human, never warn them for now (no textkey/diplo statement)
 	if(GET_PLAYER(eTargetPlayer).isHuman())
@@ -34378,11 +34375,12 @@ int CvDiplomacyAI::GetPolicyScore(PlayerTypes ePlayer)
 
 	int iOpinionWeight = 0;
 	int iNumPolicies = GetNumSamePolicies(ePlayer);
-	if(iNumPolicies < 0)
+	
+	// Flip it!
+	iNumPolicies *= -1;
+	
+	if(iNumPolicies > 0)
 	{
-		// Flip it!
-		iNumPolicies *= -1;
-		
 		if(GetNeediness() > 7)
 		{
 			iOpinionWeight += max(10, (iNumPolicies * 2));
@@ -34392,11 +34390,8 @@ int CvDiplomacyAI::GetPolicyScore(PlayerTypes ePlayer)
 			iOpinionWeight += max(5, (iNumPolicies * 1));
 		}
 	}
-	else if(iNumPolicies > 0)
+	else if(iNumPolicies < 0)
 	{
-		// Flip it!
-		iNumPolicies *= -1;
-		
 		if(GetNeediness() > 7)
 		{
 			iOpinionWeight += min(-10, (iNumPolicies * 2));

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -17590,7 +17590,7 @@ int CvPlayer::calculateTotalYield(YieldTypes eYield) const
 }
 
 //	--------------------------------------------------------------------------------
-/// How much does Production is being eaten up by Units? (cached)
+/// How much Production is being eaten up by Units? (cached)
 int CvPlayer::GetUnitProductionMaintenanceMod() const
 {
 	// Kind of a cop-out, but it fixes some bugs for now
@@ -17598,7 +17598,7 @@ int CvPlayer::GetUnitProductionMaintenanceMod() const
 }
 
 //	--------------------------------------------------------------------------------
-/// How much does Production is being eaten up by Units? (update cache)
+/// How much Production is being eaten up by Units? (update cache)
 void CvPlayer::UpdateUnitProductionMaintenanceMod()
 {
 	m_iUnitProductionMaintenanceMod = calculateUnitProductionMaintenanceMod();
@@ -17611,7 +17611,7 @@ void CvPlayer::UpdateUnitProductionMaintenanceMod()
 }
 
 //	--------------------------------------------------------------------------------
-/// How much does Production is being eaten up by Units?
+/// How much Production is being eaten up by Units?
 int CvPlayer::calculateUnitProductionMaintenanceMod() const
 {
 	int iPaidUnits = GetNumUnitsOutOfSupply();
@@ -17631,7 +17631,7 @@ int CvPlayer::calculateUnitProductionMaintenanceMod() const
 }
 
 //	--------------------------------------------------------------------------------
-/// How much does Production is being eaten up by Units? (cached)
+/// How much Growth is being eaten up by Units? (cached)
 int CvPlayer::GetUnitGrowthMaintenanceMod() const
 {
 	// Kind of a cop-out, but it fixes some bugs for now
@@ -17639,7 +17639,7 @@ int CvPlayer::GetUnitGrowthMaintenanceMod() const
 }
 
 //	--------------------------------------------------------------------------------
-/// How much does Production is being eaten up by Units? (update cache)
+/// How much Growth is being eaten up by Units? (update cache)
 void CvPlayer::UpdateUnitGrowthMaintenanceMod()
 {
 	m_iUnitGrowthMaintenanceMod = calculateUnitGrowthMaintenanceMod();
@@ -17652,7 +17652,7 @@ void CvPlayer::UpdateUnitGrowthMaintenanceMod()
 }
 
 //	--------------------------------------------------------------------------------
-/// How much does Production is being eaten up by Units?
+/// How much Growth is being eaten up by Units?
 int CvPlayer::calculateUnitGrowthMaintenanceMod() const
 {
 	int iPaidUnits = GetNumUnitsOutOfSupply();
@@ -17665,7 +17665,7 @@ int CvPlayer::calculateUnitGrowthMaintenanceMod() const
 }
 
 //	--------------------------------------------------------------------------------
-/// How many Units can we support for free without paying Production?
+/// How many Units can we support for free without losing Production and Growth?
 int CvPlayer::GetNumUnitsSupplied() const
 {
 	if (m_iNumUnitsSuppliedCached == -1)

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -17720,7 +17720,7 @@ int CvPlayer::GetNumUnitsSuppliedByHandicap(bool bIgnoreReduction) const
 }
 
 //	--------------------------------------------------------------------------------
-/// Units supplied from Difficulty Level
+/// Units supplied by Cities
 int CvPlayer::GetNumUnitsSuppliedByCities(bool bIgnoreReduction) const
 {
 	if (MOD_BALANCE_DYNAMIC_UNIT_SUPPLY)
@@ -17739,6 +17739,9 @@ int CvPlayer::GetNumUnitsSuppliedByCities(bool bIgnoreReduction) const
 		if (!bIgnoreReduction)
 		{
 			int iTechProgress = (GET_TEAM(getTeam()).GetTeamTechs()->GetNumTechsKnown() * 100) / GC.getNumTechInfos();
+			if(iTechProgress >= 100)
+				iTechProgress = 100;
+			
 			iTechProgress *= 5;
 			iTechProgress /= 6;
 
@@ -17759,7 +17762,7 @@ int CvPlayer::GetNumUnitsSuppliedByCities(bool bIgnoreReduction) const
 }
 
 //	--------------------------------------------------------------------------------
-/// Units supplied from Difficulty Level
+/// Units supplied by Population
 int CvPlayer::GetNumUnitsSuppliedByPopulation(bool bIgnoreReduction) const
 {
 #if defined(MOD_TRAITS_EXTRA_SUPPLY)
@@ -17790,6 +17793,9 @@ int CvPlayer::GetNumUnitsSuppliedByPopulation(bool bIgnoreReduction) const
 		if (!bIgnoreReduction)
 		{
 			int iTechProgress = (GET_TEAM(getTeam()).GetTeamTechs()->GetNumTechsKnown() * 100) / GC.getNumTechInfos();
+			if(iTechProgress >= 100)
+				iTechProgress = 100;
+			
 			iTechProgress *= 7;
 				
 			iValue *= 100;


### PR DESCRIPTION
Reorganizes DifficultyMod.xml to make it more accessible and customizable to players or modders looking to change the handicap settings.

Categorizes the various bonuses/penalties for easier modification.

Adds certain entries (e.g. FreeCulturePerTurn) that were omitted but functional, although the default values are used, so this will not change gameplay. I have tested the changes and they are functional.

Adds a link to a guide I created on this subject: https://civ-5-cbp.fandom.com/wiki/Customizing_Difficulty_Levels

**(NO BALANCE CHANGES MADE TO DIFFICULTY VALUES)**

According to what you said in April 2018 here (question 35 reply), reorganizing this file is fine as long as no columns are missing :)...and yes, the reason I asked that question was because I intended on making this pull request eventually.

https://forums.civfanatics.com/threads/way-too-many-questions-about-difficulty-handicaps.631797/#post-15113032

-----------
Other small fixes:
- Fix future techs apparently affecting unit supply? (#5643) Added a check to make sure, since in CvTeam, future techs calls the function IncrementTechCount.
- Small improvements to DealAI valuation of embassies
- Fix very minor diplo bug
- Typo fixes