### PR TITLE
Improve Diplo AI Trade Check

### DIFF
--- a/Community Patch/Core Files/Text/CoreText_en_US.sql
+++ b/Community Patch/Core Files/Text/CoreText_en_US.sql
@@ -768,7 +768,7 @@ WHERE Tag = 'TXT_KEY_LEADER_NEBUCHADNEZZAR_TRADE_YES_HAPPY';
 
 UPDATE Language_en_US
 SET Text = 'Your offer pleases me. Well done.'
-WHERE Tag ='TXT_KEY_LEADER_RAMESSES_TRADE_YES_HAPPY';
+WHERE Tag = 'TXT_KEY_LEADER_RAMESSES_TRADE_YES_HAPPY';
 
 UPDATE Language_en_US
 SET Text = 'Happily agreed.'

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
@@ -4223,20 +4223,28 @@ MajorCivApproachTypes CvDiplomacyAI::GetBestApproachTowardsMajorCiv(PlayerTypes 
 	}
 
 	////////////////////////////////////
-	// Are we getting money from trade with them?
+	// Are we getting yields from trade with them?
 	////////////////////////////////////
-	int iCurrentTradeValueIn = GetPlayer()->GetTrade()->GetAllTradeValueFromPlayerTimes100(YIELD_GOLD, ePlayer) + 
-				GetPlayer()->GetTrade()->GetAllTradeValueFromPlayerTimes100(YIELD_CULTURE, ePlayer) + 
-				GetPlayer()->GetTrade()->GetAllTradeValueFromPlayerTimes100(YIELD_SCIENCE, ePlayer);
-	int iCurrentTradeValueOut = GET_PLAYER(ePlayer).GetTrade()->GetAllTradeValueFromPlayerTimes100(YIELD_GOLD, GetPlayer()->GetID()) + 
-				GET_PLAYER(ePlayer).GetTrade()->GetAllTradeValueFromPlayerTimes100(YIELD_CULTURE, GetPlayer()->GetID()) + 
-				GET_PLAYER(ePlayer).GetTrade()->GetAllTradeValueFromPlayerTimes100(YIELD_SCIENCE, GetPlayer()->GetID());
-
+	int iCurrentGoldIn = GetPlayer()->GetTrade()->GetAllTradeValueFromPlayerTimes100(YIELD_GOLD, ePlayer);
+	int iCurrentGoldOut = GET_PLAYER(ePlayer).GetTrade()->GetAllTradeValueFromPlayerTimes100(YIELD_GOLD, GetPlayer()->GetID());
+	
+	int iCurrentScienceIn = GetPlayer()->GetTrade()->GetAllTradeValueFromPlayerTimes100(YIELD_SCIENCE, ePlayer);
+	int iCurrentScienceOut = GET_PLAYER(ePlayer).GetTrade()->GetAllTradeValueFromPlayerTimes100(YIELD_SCIENCE, GetPlayer()->GetID());
+	
+	int iCurrentCultureIn = GetPlayer()->GetTrade()->GetAllTradeValueFromPlayerTimes100(YIELD_CULTURE, ePlayer);
+	int iCurrentCultureOut = GET_PLAYER(ePlayer).GetTrade()->GetAllTradeValueFromPlayerTimes100(YIELD_CULTURE, GetPlayer()->GetID());
+	
+	int iGDPEstimate = GetPlayer()->GetTreasury()->GetGoldFromCitiesTimes100();
+	int iScienceEstimate = GetPlayer()->GetScienceFromCitiesTimes100();
+	int iCultureEstimate = GetPlayer()->GetJONSCultureFromCitiesTimes100() + (GetPlayer()->GetJONSCulturePerTurnForFree() * 100);
+	
 	// Scale factor is hard to guess ...
-	int iGdpEstimate = GetPlayer()->GetTreasury()->GetGoldFromCitiesTimes100();
-	int iTradeDelta = (5 * (iCurrentTradeValueIn - iCurrentTradeValueOut)) / max(iGdpEstimate,1);
-
-	if(iTradeDelta > 0)
+	int iGoldDelta = (5 * (iCurrentGoldIn - iCurrentGoldOut)) / max(iGDPEstimate,1);
+	int iScienceDelta = (5 * (iCurrentScienceIn - iCurrentScienceOut)) / max(iScienceEstimate,1);
+	int iCultureDelta = (5 * (iCurrentCultureIn - iCurrentCultureOut)) / max(iCultureEstimate,1);
+	
+	int iTradeDelta = iGoldDelta + iScienceDelta + iCultureDelta;
+	if (iTradeDelta > 0)
 	{
 		viApproachWeights[MAJOR_CIV_APPROACH_FRIENDLY] += iTradeDelta;
 	}
@@ -5494,7 +5502,7 @@ MinorCivApproachTypes CvDiplomacyAI::GetBestApproachTowardsMinorCiv(PlayerTypes 
 		}
 	}
 
-	// Are we getting money from trade with them?
+	// Are we getting yields from trade with them?
 	int iCurrentTradeValue = GetPlayer()->GetTrade()->GetAllTradeValueFromPlayerTimes100(YIELD_GOLD, ePlayer) +
 							GetPlayer()->GetTrade()->GetAllTradeValueFromPlayerTimes100(YIELD_CULTURE, ePlayer) + 
 							GetPlayer()->GetTrade()->GetAllTradeValueFromPlayerTimes100(YIELD_SCIENCE, ePlayer);

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -18557,6 +18557,23 @@ int CvPlayer::GetJONSCulturePerTurnFromCities() const
 }
 
 //	--------------------------------------------------------------------------------
+/// Culture per turn from Cities times 100
+int CvPlayer::GetJONSCultureFromCitiesTimes100(bool bIgnoreTrade) const
+{
+	int iCulture = 0;
+
+	const CvCity* pLoopCity;
+
+	int iLoop;
+	for(pLoopCity = firstCity(&iLoop); pLoopCity != NULL; pLoopCity = nextCity(&iLoop))
+	{
+		iCulture += pLoopCity->getYieldRateTimes100(YIELD_CULTURE, bIgnoreTrade);
+	}
+
+	return iCulture;
+}
+
+//	--------------------------------------------------------------------------------
 /// Special bonus which adds excess Happiness to Culture?
 int CvPlayer::GetJONSCulturePerTurnFromExcessHappiness() const
 {

--- a/CvGameCoreDLL_Expansion2/CvPlayer.h
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.h
@@ -492,6 +492,7 @@ public:
 
 
 	int GetJONSCulturePerTurnFromCities() const;
+	int GetJONSCultureFromCitiesTimes100(bool bIgnoreTrade) const;
 
 	int GetJONSCulturePerTurnFromExcessHappiness() const;
 	int GetJONSCulturePerTurnFromTraits() const;


### PR DESCRIPTION
Separates yield evaluations for Gold, Science and Culture in the diplo AI's trade check as discussed in #5717. Maybe you want to adjust the scaling factor to reflect the separation?

Ready for you to add in the yields from deals, G.
