### PR TITLE
Diplo Fixes & Improvements

### DIFF
--- a/Community Balance Patch/Balance Changes/Difficulty/DifficultyMod.xml
+++ b/Community Balance Patch/Balance Changes/Difficulty/DifficultyMod.xml
@@ -48,6 +48,7 @@
 			<AIUnitCostPercent>100</AIUnitCostPercent>
 			<AIBuildingCostPercent>100</AIBuildingCostPercent>
 			<AIUnitUpgradePercent>100</AIUnitUpgradePercent>
+			<AICreatePercent>110</AICreatePercent>
 			<AIWorldConstructPercent>110</AIWorldConstructPercent>
 			<AIWorldCreatePercent>110</AIWorldCreatePercent>
 			<AIFreeXP>0</AIFreeXP>
@@ -56,7 +57,6 @@
 			<!-- Per Era Bonuses -->	
 			<AITrainPercent>110</AITrainPercent>
 			<AIConstructPercent>110</AIConstructPercent>
-			<AICreatePercent>110</AICreatePercent>
 			<AIUnitSupplyPercent>0</AIUnitSupplyPercent>
 			<AIPerEraModifier>0</AIPerEraModifier>
 			<!-- CBP Difficulty Bonus -->
@@ -132,6 +132,7 @@
 			<AIUnitCostPercent>100</AIUnitCostPercent>
 			<AIBuildingCostPercent>100</AIBuildingCostPercent>
 			<AIUnitUpgradePercent>95</AIUnitUpgradePercent>
+			<AICreatePercent>100</AICreatePercent>
 			<AIWorldConstructPercent>100</AIWorldConstructPercent>
 			<AIWorldCreatePercent>100</AIWorldCreatePercent>
 			<AIFreeXP>5</AIFreeXP>
@@ -140,7 +141,6 @@
 			<!-- Per Era Bonuses -->	
 			<AITrainPercent>100</AITrainPercent>
 			<AIConstructPercent>100</AIConstructPercent>
-			<AICreatePercent>100</AICreatePercent>
 			<AIUnitSupplyPercent>5</AIUnitSupplyPercent>
 			<AIPerEraModifier>-2</AIPerEraModifier>
 			<!-- CBP Difficulty Bonus -->
@@ -216,6 +216,7 @@
 			<AIUnitCostPercent>90</AIUnitCostPercent>
 			<AIBuildingCostPercent>90</AIBuildingCostPercent>
 			<AIUnitUpgradePercent>90</AIUnitUpgradePercent>
+			<AICreatePercent>100</AICreatePercent>
 			<AIWorldConstructPercent>100</AIWorldConstructPercent>
 			<AIWorldCreatePercent>100</AIWorldCreatePercent>
 			<AIFreeXP>10</AIFreeXP>
@@ -224,7 +225,6 @@
 			<!-- Per Era Bonuses -->	
 			<AITrainPercent>100</AITrainPercent>
 			<AIConstructPercent>100</AIConstructPercent>
-			<AICreatePercent>100</AICreatePercent>
 			<AIUnitSupplyPercent>10</AIUnitSupplyPercent>
 			<AIPerEraModifier>-4</AIPerEraModifier>
 			<!-- CBP Difficulty Bonus -->
@@ -300,6 +300,7 @@
 			<AIUnitCostPercent>90</AIUnitCostPercent>
 			<AIBuildingCostPercent>90</AIBuildingCostPercent>
 			<AIUnitUpgradePercent>85</AIUnitUpgradePercent>
+			<AICreatePercent>100</AICreatePercent>
 			<AIWorldConstructPercent>100</AIWorldConstructPercent>
 			<AIWorldCreatePercent>100</AIWorldCreatePercent>
 			<AIFreeXP>15</AIFreeXP>
@@ -308,7 +309,6 @@
 			<!-- Per Era Bonuses -->	
 			<AITrainPercent>90</AITrainPercent>
 			<AIConstructPercent>90</AIConstructPercent>
-			<AICreatePercent>90</AICreatePercent>
 			<AIUnitSupplyPercent>15</AIUnitSupplyPercent>
 			<AIPerEraModifier>-6</AIPerEraModifier>
 			<!-- CBP Difficulty Bonus -->
@@ -384,6 +384,7 @@
 			<AIUnitCostPercent>90</AIUnitCostPercent>
 			<AIBuildingCostPercent>90</AIBuildingCostPercent>
 			<AIUnitUpgradePercent>80</AIUnitUpgradePercent>
+			<AICreatePercent>100</AICreatePercent>
 			<AIWorldConstructPercent>100</AIWorldConstructPercent>
 			<AIWorldCreatePercent>100</AIWorldCreatePercent>
 			<AIFreeXP>20</AIFreeXP>
@@ -392,7 +393,6 @@
 			<!-- Per Era Bonuses -->	
 			<AITrainPercent>90</AITrainPercent>
 			<AIConstructPercent>90</AIConstructPercent>
-			<AICreatePercent>90</AICreatePercent>
 			<AIUnitSupplyPercent>20</AIUnitSupplyPercent>
 			<AIPerEraModifier>-7</AIPerEraModifier>
 			<!-- CBP Difficulty Bonus -->
@@ -468,6 +468,7 @@
 			<AIUnitCostPercent>80</AIUnitCostPercent>
 			<AIBuildingCostPercent>80</AIBuildingCostPercent>
 			<AIUnitUpgradePercent>75</AIUnitUpgradePercent>
+			<AICreatePercent>100</AICreatePercent>
 			<AIWorldConstructPercent>100</AIWorldConstructPercent>
 			<AIWorldCreatePercent>100</AIWorldCreatePercent>
 			<AIFreeXP>20</AIFreeXP>
@@ -476,7 +477,6 @@
 			<!-- Per Era Bonuses -->	
 			<AITrainPercent>80</AITrainPercent>
 			<AIConstructPercent>80</AIConstructPercent>
-			<AICreatePercent>80</AICreatePercent>
 			<AIUnitSupplyPercent>25</AIUnitSupplyPercent>
 			<AIPerEraModifier>-8</AIPerEraModifier>
 			<!-- CBP Difficulty Bonus -->
@@ -552,6 +552,7 @@
 			<AIUnitCostPercent>80</AIUnitCostPercent>
 			<AIBuildingCostPercent>80</AIBuildingCostPercent>
 			<AIUnitUpgradePercent>70</AIUnitUpgradePercent>
+			<AICreatePercent>100</AICreatePercent>
 			<AIWorldConstructPercent>100</AIWorldConstructPercent>
 			<AIWorldCreatePercent>100</AIWorldCreatePercent>
 			<AIFreeXP>25</AIFreeXP>
@@ -560,7 +561,6 @@
 			<!-- Per Era Bonuses -->	
 			<AITrainPercent>80</AITrainPercent>
 			<AIConstructPercent>80</AIConstructPercent>
-			<AICreatePercent>80</AICreatePercent>
 			<AIUnitSupplyPercent>30</AIUnitSupplyPercent>
 			<AIPerEraModifier>-9</AIPerEraModifier>
 			<!-- CBP Difficulty Bonus -->
@@ -636,6 +636,7 @@
 			<AIUnitCostPercent>70</AIUnitCostPercent>
 			<AIBuildingCostPercent>70</AIBuildingCostPercent>
 			<AIUnitUpgradePercent>65</AIUnitUpgradePercent>
+			<AICreatePercent>100</AICreatePercent>
 			<AIWorldConstructPercent>100</AIWorldConstructPercent>
 			<AIWorldCreatePercent>100</AIWorldCreatePercent>
 			<AIFreeXP>30</AIFreeXP>
@@ -644,7 +645,6 @@
 			<!-- Per Era Bonuses -->	
 			<AITrainPercent>70</AITrainPercent>
 			<AIConstructPercent>70</AIConstructPercent>
-			<AICreatePercent>70</AICreatePercent>
 			<AIUnitSupplyPercent>35</AIUnitSupplyPercent>
 			<AIPerEraModifier>-10</AIPerEraModifier>
 			<!-- CBP Difficulty Bonus -->
@@ -720,6 +720,7 @@
 			<AIUnitCostPercent>100</AIUnitCostPercent>
 			<AIBuildingCostPercent>100</AIBuildingCostPercent>
 			<AIUnitUpgradePercent>100</AIUnitUpgradePercent>
+			<AICreatePercent>100</AICreatePercent>
 			<AIWorldConstructPercent>100</AIWorldConstructPercent>
 			<AIWorldCreatePercent>100</AIWorldCreatePercent>
 			<AIFreeXP>0</AIFreeXP>
@@ -728,7 +729,6 @@
 			<!-- Per Era Bonuses -->	
 			<AITrainPercent>100</AITrainPercent>
 			<AIConstructPercent>100</AIConstructPercent>
-			<AICreatePercent>100</AICreatePercent>
 			<AIUnitSupplyPercent>0</AIUnitSupplyPercent>
 			<AIPerEraModifier>0</AIPerEraModifier>
 			<!-- CBP Difficulty Bonus -->

--- a/CvGameCoreDLL_Expansion2/CvDealAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDealAI.cpp
@@ -3901,6 +3901,11 @@ int CvDealAI::GetThirdPartyWarValue(bool bFromMe, PlayerTypes eOtherPlayer, Team
 		{
 			return INT_MAX;
 		}
+		//tricksy players wanting us to DoW so they can get the drop on us...don't fall for it!
+		if (pDiploAI->GetTrueApproachTowardsUsGuess(eOtherPlayer) == MAJOR_CIV_APPROACH_WAR || pDiploAI->GetTrueApproachTowardsUsGuess(eOtherPlayer) == MAJOR_CIV_APPROACH_HOSTILE)
+		{
+			return INT_MAX;
+		}
 		//only accept bribes against our biggest competitors. Otherwise, nah.
 		if (pDiploAI->GetBiggestCompetitor() != eWithPlayer)
 		{

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
@@ -13917,20 +13917,11 @@ void CvDiplomacyAI::DoUpdateMinorCivDisputeLevels()
 			for(iMinorCivLoop = MAX_MAJOR_CIVS; iMinorCivLoop < MAX_CIV_PLAYERS; iMinorCivLoop++)
 			{
 				eMinor = (PlayerTypes) iMinorCivLoop;
-#if !defined(MOD_BALANCE_CORE)
-				// We have a PtP with this minor
-				if(GET_PLAYER(eMinor).GetMinorCivAI()->IsProtectedByMajor(GetPlayer()->GetID()))
-				{
-					// Player is Allies with this minor
-					if(GET_PLAYER(eMinor).GetMinorCivAI()->IsAllies(ePlayer))
-						iMinorCivDisputeWeight += iPersonalityMod* /*10*/ GC.getMINOR_CIV_DISPUTE_ALLIES_WEIGHT();
-
-					// Player is Friends with this minor
-					else if(GET_PLAYER(eMinor).GetMinorCivAI()->IsFriends(ePlayer))
-						iMinorCivDisputeWeight += iPersonalityMod* /*5*/ GC.getMINOR_CIV_DISPUTE_FRIENDS_WEIGHT();
-				}
-#endif
 #if defined(MOD_BALANCE_CORE)
+				// Ignore if League resolutions make it irrelevant
+				if (GET_PLAYER(eMinor).GetMinorCivAI()->IsNoAlly() || GET_PLAYER(eMinor).GetMinorCivAI()->GetPermanentAlly() == GetPlayer()->GetID())
+					continue;
+
 				// We are at least friends
 				//if they're constantly affecting our influence, or we're friends.
 				int iThreshold = ((10 - GetMinorCivCompetitiveness()) + GC.getGame().getCurrentEra());
@@ -22407,6 +22398,12 @@ void CvDiplomacyAI::DoMinorCivCompetitionStatement(PlayerTypes ePlayer, DiploSta
 				for(int iMinorLoop = MAX_MAJOR_CIVS; iMinorLoop < MAX_CIV_PLAYERS; iMinorLoop++)
 				{
 					eMinor = (PlayerTypes) iMinorLoop;
+					
+#if defined(MOD_BALANCE_CORE)
+					// Ignore if League resolutions make it irrelevant
+					if (GET_PLAYER(eMinor).GetMinorCivAI()->IsNoAlly() || GET_PLAYER(eMinor).GetMinorCivAI()->GetPermanentAlly() == GetPlayer()->GetID())
+						continue;
+#endif
 
 					// We have a PtP with this minor
 					if(GET_PLAYER(eMinor).GetMinorCivAI()->IsProtectedByMajor(GetPlayer()->GetID()))
@@ -29948,14 +29945,10 @@ bool CvDiplomacyAI::IsDoFAcceptable(PlayerTypes ePlayer)
 	// If player is planning War, always say no
 	if(eApproach == MAJOR_CIV_APPROACH_WAR)
 		return false;
+	
 	// If player is Hostile, always say no
 	else if(eApproach == MAJOR_CIV_APPROACH_HOSTILE)
 		return false;
-	// If player is afraid, always say yes
-#if !defined(MOD_BALANCE_CORE_DIPLOMACY_ADVANCED)
-	else if(eApproach == MAJOR_CIV_APPROACH_AFRAID)
-		return true;
-#endif
 
 	MajorCivOpinionTypes eOpinion = GetMajorCivOpinion(ePlayer);
 #if defined(MOD_BALANCE_CORE_DIPLOMACY_ADVANCED)

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
@@ -29992,6 +29992,10 @@ bool CvDiplomacyAI::IsDoFAcceptable(PlayerTypes ePlayer)
 		return false;
 	if(GET_PLAYER(ePlayer).GetDiplomacyAI()->IsDenouncedPlayer(GetPlayer()->GetID()))
 		return false;
+	
+	// If we're willing to denounce them, don't make friends with them!
+	if(IsDenounceAcceptable(ePlayer) || IsDenounceFriendAcceptable(ePlayer))
+		return false;
 
 	// Are we working AGAINST ePlayer with someone else?
 	//if (IsWorkingAgainstPlayer(ePlayer))
@@ -30443,8 +30447,6 @@ int CvDiplomacyAI::GetNumSamePolicies(PlayerTypes ePlayer)
 /// Are we done with ePlayer, and now want to Denounce him?
 bool CvDiplomacyAI::IsDenounceFriendAcceptable(PlayerTypes ePlayer)
 {
-	CvAssertMsg(IsDoFAccepted(ePlayer), "Diplomacy AI: Testing whether we should Denounce a Friend, but we aren't right now. Please send Jon this with your last 5 autosaves and what changelist # you're playing.");
-
 	// Changed our approach towards ePlayer
 	MajorCivApproachTypes eTrueApproach = GetMajorCivApproach(ePlayer, /*bHideTrueFeelings*/ false);
 	MajorCivApproachTypes eApproach = GetMajorCivApproach(ePlayer, /*bHideTrueFeelings*/ true);

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
@@ -5960,14 +5960,6 @@ void CvDiplomacyAI::DoUpdateApproachTowardsUsGuesses()
 
 		if(IsPlayerValid(eLoopPlayer))
 		{
-			// Always war
-			if((GC.getGame().isOption(GAMEOPTION_ALWAYS_WAR) || GC.getGame().isOption(GAMEOPTION_NO_CHANGING_WAR_PEACE)) && GET_TEAM(GetTeam()).isAtWar(GET_PLAYER(eLoopPlayer).getTeam()))
-			{
-				SetApproachTowardsUsGuess(eLoopPlayer, MAJOR_CIV_APPROACH_WAR);
-				SetApproachTowardsUsGuessCounter(eLoopPlayer, 0);
-				continue;
-			}
-			
 			eVisibleApproach = GetApproachTowardsUsGuess(eLoopPlayer);
 			eTrueApproachGuess = GetTrueApproachTowardsUsGuess(eLoopPlayer);
 			eMilitaryAggressivePosture = GetMilitaryAggressivePosture(eLoopPlayer);

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -5400,7 +5400,7 @@ void CvPlayer::UpdateCityThreatCriteria()
 	if(getNumCities() <= 1)
 		return;
 
-	//Reset the critera.
+	//Reset the criteria.
 	int iLoop;
 	for (CvCity* pLoopCity = firstCity(&iLoop); pLoopCity != NULL; pLoopCity = nextCity(&iLoop))
 	{
@@ -20082,11 +20082,7 @@ int CvPlayer::DoDifficultyBonus(HistoricEventTypes eHistoricEvent)
 	if (eHistoricEvent == HISTORIC_EVENT_DIG || eHistoricEvent == HISTORIC_EVENT_TRADE_CS)
 		return 0;
 
-	int iEra = GetCurrentEra();
-	if(iEra <= 0)
-	{
-		iEra = 1;
-	}
+	int iEra = max(1,GetCurrentEra());
 	int iHandicapBase = 0;
 	int iHandicapA = 0;
 	int iHandicapB = 0;
@@ -31432,7 +31428,7 @@ void CvPlayer::ChangeNumHistoricEvents(HistoricEventTypes eHistoricEvent, int iC
 		}
 	}
 #if defined(MOD_BALANCE_CORE_DIFFICULTY)
-	if (MOD_BALANCE_CORE_DIFFICULTY && !isMinorCiv() && !isHuman() && getNumCities() > 1)
+	if (MOD_BALANCE_CORE_DIFFICULTY && !isMinorCiv() && !isHuman() && !isBarbarian() && getNumCities() > 1)
 	{
 		int iYieldHandicap = DoDifficultyBonus(eHistoricEvent);
 		if (GC.getLogging() && GC.getAILogging())

--- a/CvGameCoreDLL_Expansion2/CvPlayerAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayerAI.cpp
@@ -328,7 +328,7 @@ void CvPlayerAI::AI_conquerCity(CvCity* pCity, PlayerTypes eOldOwner)
 #endif
 
 	// Liberate a city?
-	if(eOriginalOwner != eOldOwner && eOriginalOwner != GetID() && CanLiberatePlayerCity(eOriginalOwner))
+	if(eOriginalOwner != eOldOwner && eOriginalOwner != GetID() && CanLiberatePlayerCity(eOriginalOwner) && getNumCities() > 1)
 	{
 		// minor civ
 		if(GET_PLAYER(eOriginalOwner).isMinorCiv())

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
@@ -13041,6 +13041,7 @@ int CvLuaPlayer::lGetOpinionTable(lua_State* L)
 		aOpinions.push_back(kOpinion);
 	}
 
+	/*
 	iValue = pDiploAI->GetBrokenAttackCityStatePromiseWithAnybodyScore(eWithPlayer);
 	if (iValue != 0)
 	{
@@ -13049,6 +13050,7 @@ int CvLuaPlayer::lGetOpinionTable(lua_State* L)
 		kOpinion.m_str = Localization::Lookup("TXT_KEY_DIPLO_CITY_STATE_PROMISE_BROKEN_WITH_OTHERS");
 		aOpinions.push_back(kOpinion);
 	}
+	*/
 
 	iValue = pDiploAI->GetIgnoredAttackCityStatePromiseScore(eWithPlayer);
 	if (iValue != 0)
@@ -13385,14 +13387,16 @@ int CvLuaPlayer::lGetOpinionTable(lua_State* L)
 	}
 	// TRAITOR END
 
-	//iValue = pDiploAI->GetRequestsRefusedScore(eWithPlayer);
-	//if (iValue != 0)
-	//{
-	//	Opinion kOpinion;
-	//	kOpinion.m_iValue = iValue;
-	//	kOpinion.m_str = Localization::Lookup("TXT_KEY_DIPLO_REFUSED_REQUESTS");
-	//	aOpinions.push_back(kOpinion);
-	//}
+	/*
+	iValue = pDiploAI->GetRequestsRefusedScore(eWithPlayer);
+	if (iValue != 0)
+	{
+		Opinion kOpinion;
+		kOpinion.m_iValue = iValue;
+		kOpinion.m_str = Localization::Lookup("TXT_KEY_DIPLO_REFUSED_REQUESTS");
+		aOpinions.push_back(kOpinion);
+	}
+	*/
 
 	iValue = pDiploAI->GetDenouncedUsScore(eWithPlayer);
 	if (iValue != 0)
@@ -13543,6 +13547,7 @@ int CvLuaPlayer::lGetOpinionTable(lua_State* L)
 		aOpinions.push_back(kOpinion);
 	}
 
+	/*
 	iValue = pDiploAI->GetGaveAssistanceToScore(eWithPlayer);
 	if (iValue != 0)
 	{
@@ -13560,101 +13565,89 @@ int CvLuaPlayer::lGetOpinionTable(lua_State* L)
 		kOpinion.m_str = Localization::Lookup("TXT_KEY_DIPLO_PAID_TRIBUTE");
 		aOpinions.push_back(kOpinion);
 	}
+	*/
 
 	// World Congress >>> United Nations
-	if(GC.getGame().IsUnitedNationsActive())
+	bool bUNActive = GC.getGame().IsUnitedNationsActive();
+	
+	iValue = pDiploAI->GetLikedTheirProposalScore(eWithPlayer);
+	if (iValue != 0)
 	{
-		iValue = pDiploAI->GetLikedTheirProposalScore(eWithPlayer);
-		if (iValue != 0)
+		Opinion kOpinion;
+		kOpinion.m_iValue = iValue;
+		if (bUNActive)
 		{
-			Opinion kOpinion;
-			kOpinion.m_iValue = iValue;
 			kOpinion.m_str = Localization::Lookup("TXT_KEY_DIPLO_LIKED_OUR_PROPOSAL_UN");
-			aOpinions.push_back(kOpinion);
 		}
-		
-		iValue = pDiploAI->GetDislikedTheirProposalScore(eWithPlayer);
-		if (iValue != 0)
+		else
 		{
-			Opinion kOpinion;
-			kOpinion.m_iValue = iValue;
-			kOpinion.m_str = Localization::Lookup("TXT_KEY_DIPLO_DISLIKED_OUR_PROPOSAL_UN");
-			aOpinions.push_back(kOpinion);
-		}
-
-		iValue = pDiploAI->GetSupportedMyProposalScore(eWithPlayer);
-		if (iValue != 0)
-		{
-			Opinion kOpinion;
-			kOpinion.m_iValue = iValue;
-			kOpinion.m_str = Localization::Lookup("TXT_KEY_DIPLO_SUPPORTED_THEIR_PROPOSAL_UN");
-			aOpinions.push_back(kOpinion);
-		}
-
-		iValue = pDiploAI->GetFoiledMyProposalScore(eWithPlayer);
-		if (iValue != 0)
-		{
-			Opinion kOpinion;
-			kOpinion.m_iValue = iValue;
-			kOpinion.m_str = Localization::Lookup("TXT_KEY_DIPLO_FOILED_THEIR_PROPOSAL_UN");
-			aOpinions.push_back(kOpinion);
-		}
-
-		iValue = pDiploAI->GetSupportedMyHostingScore(eWithPlayer);
-		if (iValue != 0)
-		{
-			Opinion kOpinion;
-			kOpinion.m_iValue = iValue;
-			kOpinion.m_str = Localization::Lookup("TXT_KEY_DIPLO_SUPPORTED_THEIR_HOSTING_UN");
-			aOpinions.push_back(kOpinion);
-		}
-	}
-	else
-	{
-		iValue = pDiploAI->GetLikedTheirProposalScore(eWithPlayer);
-		if (iValue != 0)
-		{
-			Opinion kOpinion;
-			kOpinion.m_iValue = iValue;
 			kOpinion.m_str = Localization::Lookup("TXT_KEY_DIPLO_LIKED_OUR_PROPOSAL");
-			aOpinions.push_back(kOpinion);
 		}
-		
-		iValue = pDiploAI->GetDislikedTheirProposalScore(eWithPlayer);
-		if (iValue != 0)
+		aOpinions.push_back(kOpinion);
+	}
+	
+	iValue = pDiploAI->GetDislikedTheirProposalScore(eWithPlayer);
+	if (iValue != 0)
+	{
+		Opinion kOpinion;
+		kOpinion.m_iValue = iValue;
+		if (bUNActive)
 		{
-			Opinion kOpinion;
-			kOpinion.m_iValue = iValue;
+			kOpinion.m_str = Localization::Lookup("TXT_KEY_DIPLO_DISLIKED_OUR_PROPOSAL_UN");
+		}
+		else
+		{
 			kOpinion.m_str = Localization::Lookup("TXT_KEY_DIPLO_DISLIKED_OUR_PROPOSAL");
-			aOpinions.push_back(kOpinion);
 		}
+		aOpinions.push_back(kOpinion);
+	}
 
-		iValue = pDiploAI->GetSupportedMyProposalScore(eWithPlayer);
-		if (iValue != 0)
+	iValue = pDiploAI->GetSupportedMyProposalScore(eWithPlayer);
+	if (iValue != 0)
+	{
+		Opinion kOpinion;
+		kOpinion.m_iValue = iValue;
+		if (bUNActive)
 		{
-			Opinion kOpinion;
-			kOpinion.m_iValue = iValue;
+			kOpinion.m_str = Localization::Lookup("TXT_KEY_DIPLO_SUPPORTED_THEIR_PROPOSAL_UN");
+		}
+		else
+		{
 			kOpinion.m_str = Localization::Lookup("TXT_KEY_DIPLO_SUPPORTED_THEIR_PROPOSAL");
-			aOpinions.push_back(kOpinion);
 		}
+		aOpinions.push_back(kOpinion);
+	}
 
-		iValue = pDiploAI->GetFoiledMyProposalScore(eWithPlayer);
-		if (iValue != 0)
+	iValue = pDiploAI->GetFoiledMyProposalScore(eWithPlayer);
+	if (iValue != 0)
+	{
+		Opinion kOpinion;
+		kOpinion.m_iValue = iValue;
+		if (bUNActive)
 		{
-			Opinion kOpinion;
-			kOpinion.m_iValue = iValue;
+			kOpinion.m_str = Localization::Lookup("TXT_KEY_DIPLO_FOILED_THEIR_PROPOSAL_UN");
+		}
+		else
+		{
 			kOpinion.m_str = Localization::Lookup("TXT_KEY_DIPLO_FOILED_THEIR_PROPOSAL");
-			aOpinions.push_back(kOpinion);
 		}
+		aOpinions.push_back(kOpinion);
+	}
 
-		iValue = pDiploAI->GetSupportedMyHostingScore(eWithPlayer);
-		if (iValue != 0)
+	iValue = pDiploAI->GetSupportedMyHostingScore(eWithPlayer);
+	if (iValue != 0)
+	{
+		Opinion kOpinion;
+		kOpinion.m_iValue = iValue;
+		if (bUNActive)
 		{
-			Opinion kOpinion;
-			kOpinion.m_iValue = iValue;
-			kOpinion.m_str = Localization::Lookup("TXT_KEY_DIPLO_SUPPORTED_THEIR_HOSTING");
-			aOpinions.push_back(kOpinion);
+			kOpinion.m_str = Localization::Lookup("TXT_KEY_DIPLO_SUPPORTED_THEIR_HOSTING_UN");
 		}
+		else
+		{
+			kOpinion.m_str = Localization::Lookup("TXT_KEY_DIPLO_SUPPORTED_THEIR_HOSTING");
+		}
+		aOpinions.push_back(kOpinion);
 	}
 
 #if defined(MOD_EVENTS_DIPLO_MODIFIERS)


### PR DESCRIPTION
Clean up various diplo-related code

Changed the placement of code sections which zero out approach weights to be after the opinion calculation

Changed IsWantsToConquer function:
- AIs locked into a coop war/trade war against the target who are also fiercely competitive with the target will now ignore target value (added this because of a similar check in GetCoopWarScore)

- AIs who are locked into a coop war/trade war against the target but are not fiercely competitive are treated as bold AIs (since they're backed up by another player, after all)

- AIs will always want to conquer major civs they're at permanent war with (set by game options).

- These changes make the AI more likely to carry on with wars that they initiate, since you can only get locked into a coop/trade war by your own choice. Also, for player-created scenarios with the always war option, more aggression is wanted.

Prevent AI from liberating their only city (this is almost unthinkably rare, but possible with Complete Kills enabled)

Remove AI Production discount for projects