### PR TITLE
Fix #5646

### DIFF
--- a/(4) Civ IV Diplomatic Features - CBP/XML/Text/en_US/en_US_Text_UIC4DF.xml
+++ b/(4) Civ IV Diplomatic Features - CBP/XML/Text/en_US/en_US_Text_UIC4DF.xml
@@ -11,11 +11,20 @@
 		<Row Tag="TXT_KEY_DIPLO_TRADE_MAP_TT">
 			<Text>Reveals all land explored by this civilization.[NEWLINE][NEWLINE]Note: Will not receive contact with unmet civilizations and city-states.</Text>
 		</Row>
+		<Row Tag="TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_BOTH">
+			<Text>[NEWLINE][NEWLINE]Neither player has the Technology required to trade this item (Military Science).</Text>
+		</Row>
 		<Row Tag="TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_OTHER_PLAYER">
-			<Text>[NEWLINE][NEWLINE]They don't yet have the Technology to sell this item (Military Science).</Text>
+			<Text>[NEWLINE][NEWLINE]They don't yet have the Technology to trade this item (Military Science).</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_PLAYER">
-			<Text>[NEWLINE][NEWLINE]You don't yet have the Technology to sell this item (Military Science).</Text>
+			<Text>[NEWLINE][NEWLINE]You don't yet have the Technology to trade this item (Military Science).</Text>
+		</Row>
+		<Row Tag="TXT_KEY_DIPLO_TRADE_MAPS_THEY_ALREADY_EXPLORED">
+			<Text>[NEWLINE][NEWLINE]They have already explored all of the lands revealed in your World Map.</Text>
+		</Row>
+		<Row Tag="TXT_KEY_DIPLO_TRADE_MAPS_WE_ALREADY_EXPLORED">
+			<Text>[NEWLINE][NEWLINE]We have already explored all of the lands revealed in their World Map.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_GAME_OPTION_NO_TECH_TRADING">
 			<Text>No Tech Trading</Text>

--- a/(4) Civ IV Diplomatic Features - CBP/XML/Text/en_US/en_US_Text_UIC4DF.xml
+++ b/(4) Civ IV Diplomatic Features - CBP/XML/Text/en_US/en_US_Text_UIC4DF.xml
@@ -15,10 +15,10 @@
 			<Text>[NEWLINE][NEWLINE]Neither player has the Technology required to trade this item (Military Science).</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_OTHER_PLAYER">
-			<Text>[NEWLINE][NEWLINE]They don't yet have the Technology to trade this item (Military Science).</Text>
+			<Text>[NEWLINE][NEWLINE]They don't yet have the Technology required to trade this item (Military Science).</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_PLAYER">
-			<Text>[NEWLINE][NEWLINE]You don't yet have the Technology to trade this item (Military Science).</Text>
+			<Text>[NEWLINE][NEWLINE]You don't yet have the Technology required to trade this item (Military Science).</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLO_TRADE_MAPS_THEY_ALREADY_EXPLORED">
 			<Text>[NEWLINE][NEWLINE]They have already explored all of the lands revealed in your World Map.</Text>

--- a/43 Civs CP/43 Civs CP/EUI/TradeLogic.lua
+++ b/43 Civs CP/43 Civs CP/EUI/TradeLogic.lua
@@ -1993,51 +1993,70 @@ function ResetDisplay()
     ---------------------------------------------------------------------------------- 
 
 	local bMapTradingAllowed = g_Deal:IsPossibleToTradeItem(g_iUs, g_iThem, TradeableItems.TRADE_ITEM_MAPS, g_iDealDuration);
-    
-    -- Are we not allowed to give World Map? (already providing it to them?)
+	
     strTooltip = Locale.ConvertTextKey("TXT_KEY_DIPLO_TRADE_MAP_TT", g_iDealDuration);
     
     local strOurTooltip = strTooltip;
     local strTheirTooltip = strTooltip;
-    
-	-- They don't have tech
-    if (not bMapTradingAllowed) then
-		if (not g_pUsTeam:IsMapTrading()) then
-			strOurTooltip = strOurTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey("TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_PLAYER" ) .. "[ENDCOLOR]";
-		end
-	end
-    
-    -- Are we not allowed to give World Map?
-    if (not bMapTradingAllowed) then
+	
+	-- Are we not allowed to give World Map?
+	if (not bMapTradingAllowed) then
 		Controls.UsPocketTradeMap:SetDisabled(true);
 		Controls.UsPocketTradeMap:GetTextControl():SetColorByName("Gray_Black");
-
+	
+		-- We need an embassy with them
 		if (not g_pUsTeam:HasEmbassyAtTeam(g_iThemTeam)) then
-			strOurTooltip = strOurTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey("TXT_KEY_DIPLO_YOU_NEED_EMBASSY_TT" ) .. "[ENDCOLOR]";
+			strOurTooltip = strOurTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_YOU_NEED_EMBASSY_TT" ) .. "[ENDCOLOR]";
+		end
+		
+		if (not g_pUsTeam:IsMapTrading()) then
+			-- Neither of us have the required tech
+			if (not g_pThemTeam:IsMapTrading()) then
+				strOurTooltip = strOurTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_BOTH" ) .. "[ENDCOLOR]";
+			-- We don't have the required tech
+			else
+				strOurTooltip = strOurTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_PLAYER" ) .. "[ENDCOLOR]";
+			end
+		-- They don't have the required tech
+		elseif (not g_pThemTeam:IsMapTrading()) then
+			strOurTooltip = strOurTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_OTHER_PLAYER" ) .. "[ENDCOLOR]";
+		-- Our map has no new tiles to reveal
+		elseif (g_pUsTeam:HasEmbassyAtTeam(g_iThemTeam)) then
+			strOurTooltip = strOurTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_THEY_ALREADY_EXPLORED" ) .. "[ENDCOLOR]";
 		end
 	else
 		Controls.UsPocketTradeMap:SetDisabled(false);
 		Controls.UsPocketTradeMap:GetTextControl():SetColorByName("Beige_Black");
-    end
+	end
     
     Controls.UsPocketTradeMap:SetToolTipString(strOurTooltip);
     
     bMapTradingAllowed = g_Deal:IsPossibleToTradeItem(g_iThem, g_iUs, TradeableItems.TRADE_ITEM_MAPS, g_iDealDuration);
-
-	-- We don't have tech
-    if (not bMapTradingAllowed) then
-		if (not g_pThemTeam:IsMapTrading()) then
-			strTheirTooltip = strTheirTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey("TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_OTHER_PLAYER" ) .. "[ENDCOLOR]";
-		end
-	end
-    
-    -- Are they not allowed to give World Map?
-    if (not bMapTradingAllowed) then
+	
+	-- Are they not allowed to give World Map?
+	if (not bMapTradingAllowed) then
 		Controls.ThemPocketTradeMap:SetDisabled(true);
 		Controls.ThemPocketTradeMap:GetTextControl(): SetColorByName("Gray_Black");
 		
+		-- They need an embassy with us
 		if (not g_pThemTeam:HasEmbassyAtTeam(g_iUsTeam)) then
 			strTheirTooltip = strTheirTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_THEY_NEED_EMBASSY_TT" );
+		end
+		
+		if (not g_pThemTeam:IsMapTrading()) then
+			-- Neither of us have the required tech
+			if (not g_pUsTeam:IsMapTrading()) then
+				strTheirTooltip = strTheirTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_BOTH" ) .. "[ENDCOLOR]";
+			-- They don't have the required tech
+			else
+				strTheirTooltip = strTheirTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_OTHER_PLAYER" ) .. "[ENDCOLOR]";
+			end
+		-- We don't have the required tech
+		elseif (not g_pUsTeam:IsMapTrading()) then
+			strTheirTooltip = strTheirTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_PLAYER" ) .. "[ENDCOLOR]";
+		-- Their map has no new tiles to reveal
+		elseif (g_pThemTeam:HasEmbassyAtTeam(g_iUsTeam)) then
+			strTheirTooltip = strTheirTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_WE_ALREADY_EXPLORED" ) .. "[ENDCOLOR]";
 		end
 	else
 		Controls.ThemPocketTradeMap:SetDisabled(false);

--- a/43 Civs CP/43 Civs CP/No-EUI/TradeLogic.lua
+++ b/43 Civs CP/43 Civs CP/No-EUI/TradeLogic.lua
@@ -1971,51 +1971,70 @@ function ResetDisplay()
     ---------------------------------------------------------------------------------- 
 
 	local bMapTradingAllowed = g_Deal:IsPossibleToTradeItem(g_iUs, g_iThem, TradeableItems.TRADE_ITEM_MAPS, g_iDealDuration);
-    
-    -- Are we not allowed to give World Map? (already providing it to them?)
+	
     strTooltip = Locale.ConvertTextKey("TXT_KEY_DIPLO_TRADE_MAP_TT", g_iDealDuration);
     
     local strOurTooltip = strTooltip;
     local strTheirTooltip = strTooltip;
-    
-	-- They don't have tech
-    if (not bMapTradingAllowed) then
-		if (not g_pUsTeam:IsMapTrading()) then
-			strOurTooltip = strOurTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey("TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_PLAYER" ) .. "[ENDCOLOR]";
-		end
-	end
-    
-    -- Are we not allowed to give World Map?
-    if (not bMapTradingAllowed) then
+	
+	-- Are we not allowed to give World Map?
+	if (not bMapTradingAllowed) then
 		Controls.UsPocketTradeMap:SetDisabled(true);
 		Controls.UsPocketTradeMap:GetTextControl():SetColorByName("Gray_Black");
-
+	
+		-- We need an embassy with them
 		if (not g_pUsTeam:HasEmbassyAtTeam(g_iThemTeam)) then
-			strOurTooltip = strOurTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey("TXT_KEY_DIPLO_YOU_NEED_EMBASSY_TT" ) .. "[ENDCOLOR]";
+			strOurTooltip = strOurTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_YOU_NEED_EMBASSY_TT" ) .. "[ENDCOLOR]";
+		end
+		
+		if (not g_pUsTeam:IsMapTrading()) then
+			-- Neither of us have the required tech
+			if (not g_pThemTeam:IsMapTrading()) then
+				strOurTooltip = strOurTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_BOTH" ) .. "[ENDCOLOR]";
+			-- We don't have the required tech
+			else
+				strOurTooltip = strOurTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_PLAYER" ) .. "[ENDCOLOR]";
+			end
+		-- They don't have the required tech
+		elseif (not g_pThemTeam:IsMapTrading()) then
+			strOurTooltip = strOurTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_OTHER_PLAYER" ) .. "[ENDCOLOR]";
+		-- Our map has no new tiles to reveal
+		elseif (g_pUsTeam:HasEmbassyAtTeam(g_iThemTeam)) then
+			strOurTooltip = strOurTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_THEY_ALREADY_EXPLORED" ) .. "[ENDCOLOR]";
 		end
 	else
 		Controls.UsPocketTradeMap:SetDisabled(false);
 		Controls.UsPocketTradeMap:GetTextControl():SetColorByName("Beige_Black");
-    end
+	end
     
     Controls.UsPocketTradeMap:SetToolTipString(strOurTooltip);
     
     bMapTradingAllowed = g_Deal:IsPossibleToTradeItem(g_iThem, g_iUs, TradeableItems.TRADE_ITEM_MAPS, g_iDealDuration);
-
-	-- We don't have tech
-    if (not bMapTradingAllowed) then
-		if (not g_pThemTeam:IsMapTrading()) then
-			strTheirTooltip = strTheirTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey("TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_OTHER_PLAYER" ) .. "[ENDCOLOR]";
-		end
-	end
-    
-    -- Are they not allowed to give World Map?
-    if (not bMapTradingAllowed) then
+	
+	-- Are they not allowed to give World Map?
+	if (not bMapTradingAllowed) then
 		Controls.ThemPocketTradeMap:SetDisabled(true);
 		Controls.ThemPocketTradeMap:GetTextControl(): SetColorByName("Gray_Black");
 		
+		-- They need an embassy with us
 		if (not g_pThemTeam:HasEmbassyAtTeam(g_iUsTeam)) then
 			strTheirTooltip = strTheirTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_THEY_NEED_EMBASSY_TT" );
+		end
+		
+		if (not g_pThemTeam:IsMapTrading()) then
+			-- Neither of us have the required tech
+			if (not g_pUsTeam:IsMapTrading()) then
+				strTheirTooltip = strTheirTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_BOTH" ) .. "[ENDCOLOR]";
+			-- They don't have the required tech
+			else
+				strTheirTooltip = strTheirTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_OTHER_PLAYER" ) .. "[ENDCOLOR]";
+			end
+		-- We don't have the required tech
+		elseif (not g_pUsTeam:IsMapTrading()) then
+			strTheirTooltip = strTheirTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_PLAYER" ) .. "[ENDCOLOR]";
+		-- Their map has no new tiles to reveal
+		elseif (g_pThemTeam:HasEmbassyAtTeam(g_iUsTeam)) then
+			strTheirTooltip = strTheirTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_WE_ALREADY_EXPLORED" ) .. "[ENDCOLOR]";
 		end
 	else
 		Controls.ThemPocketTradeMap:SetDisabled(false);

--- a/Civilization IV Diplomatic Features - CP/Build/(1a) Civilization IV Diplomatic Features - CP Only/LUA/TradeLogic.lua
+++ b/Civilization IV Diplomatic Features - CP/Build/(1a) Civilization IV Diplomatic Features - CP Only/LUA/TradeLogic.lua
@@ -1762,51 +1762,70 @@ function ResetDisplay()
     ---------------------------------------------------------------------------------- 
 
 	local bMapTradingAllowed = g_Deal:IsPossibleToTradeItem(g_iUs, g_iThem, TradeableItems.TRADE_ITEM_MAPS, g_iDealDuration);
-    
-    -- Are we not allowed to give World Map? (already providing it to them?)
+	
     strTooltip = Locale.ConvertTextKey("TXT_KEY_DIPLO_TRADE_MAP_TT", g_iDealDuration);
     
     local strOurTooltip = strTooltip;
     local strTheirTooltip = strTooltip;
-    
-	-- They don't have tech
-    if (not bMapTradingAllowed) then
-		if (not g_pUsTeam:IsMapTrading()) then
-			strOurTooltip = strOurTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey("TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_PLAYER" ) .. "[ENDCOLOR]";
-		end
-	end
-    
-    -- Are we not allowed to give World Map?
-    if (not bMapTradingAllowed) then
+	
+	-- Are we not allowed to give World Map?
+	if (not bMapTradingAllowed) then
 		Controls.UsPocketTradeMap:SetDisabled(true);
 		Controls.UsPocketTradeMap:GetTextControl():SetColorByName("Gray_Black");
-
+	
+		-- We need an embassy with them
 		if (not g_pUsTeam:HasEmbassyAtTeam(g_iThemTeam)) then
-			strOurTooltip = strOurTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey("TXT_KEY_DIPLO_YOU_NEED_EMBASSY_TT" ) .. "[ENDCOLOR]";
+			strOurTooltip = strOurTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_YOU_NEED_EMBASSY_TT" ) .. "[ENDCOLOR]";
+		end
+		
+		if (not g_pUsTeam:IsMapTrading()) then
+			-- Neither of us have the required tech
+			if (not g_pThemTeam:IsMapTrading()) then
+				strOurTooltip = strOurTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_BOTH" ) .. "[ENDCOLOR]";
+			-- We don't have the required tech
+			else
+				strOurTooltip = strOurTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_PLAYER" ) .. "[ENDCOLOR]";
+			end
+		-- They don't have the required tech
+		elseif (not g_pThemTeam:IsMapTrading()) then
+			strOurTooltip = strOurTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_OTHER_PLAYER" ) .. "[ENDCOLOR]";
+		-- Our map has no new tiles to reveal
+		elseif (g_pUsTeam:HasEmbassyAtTeam(g_iThemTeam)) then
+			strOurTooltip = strOurTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_THEY_ALREADY_EXPLORED" ) .. "[ENDCOLOR]";
 		end
 	else
 		Controls.UsPocketTradeMap:SetDisabled(false);
 		Controls.UsPocketTradeMap:GetTextControl():SetColorByName("Beige_Black");
-    end
+	end
     
     Controls.UsPocketTradeMap:SetToolTipString(strOurTooltip);
     
     bMapTradingAllowed = g_Deal:IsPossibleToTradeItem(g_iThem, g_iUs, TradeableItems.TRADE_ITEM_MAPS, g_iDealDuration);
-
-	-- We don't have tech
-    if (not bMapTradingAllowed) then
-		if (not g_pThemTeam:IsMapTrading()) then
-			strTheirTooltip = strTheirTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey("TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_OTHER_PLAYER" ) .. "[ENDCOLOR]";
-		end
-	end
-    
-    -- Are they not allowed to give World Map?
-    if (not bMapTradingAllowed) then
+	
+	-- Are they not allowed to give World Map?
+	if (not bMapTradingAllowed) then
 		Controls.ThemPocketTradeMap:SetDisabled(true);
 		Controls.ThemPocketTradeMap:GetTextControl(): SetColorByName("Gray_Black");
 		
+		-- They need an embassy with us
 		if (not g_pThemTeam:HasEmbassyAtTeam(g_iUsTeam)) then
 			strTheirTooltip = strTheirTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_THEY_NEED_EMBASSY_TT" );
+		end
+		
+		if (not g_pThemTeam:IsMapTrading()) then
+			-- Neither of us have the required tech
+			if (not g_pUsTeam:IsMapTrading()) then
+				strTheirTooltip = strTheirTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_BOTH" ) .. "[ENDCOLOR]";
+			-- They don't have the required tech
+			else
+				strTheirTooltip = strTheirTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_OTHER_PLAYER" ) .. "[ENDCOLOR]";
+			end
+		-- We don't have the required tech
+		elseif (not g_pUsTeam:IsMapTrading()) then
+			strTheirTooltip = strTheirTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_PLAYER" ) .. "[ENDCOLOR]";
+		-- Their map has no new tiles to reveal
+		elseif (g_pThemTeam:HasEmbassyAtTeam(g_iUsTeam)) then
+			strTheirTooltip = strTheirTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_WE_ALREADY_EXPLORED" ) .. "[ENDCOLOR]";
 		end
 	else
 		Controls.ThemPocketTradeMap:SetDisabled(false);

--- a/Civilization IV Diplomatic Features - CP/Build/(1a) Civilization IV Diplomatic Features - CP Only/XML/Text/en_US/en_US_Text_UIC4DF.xml
+++ b/Civilization IV Diplomatic Features - CP/Build/(1a) Civilization IV Diplomatic Features - CP Only/XML/Text/en_US/en_US_Text_UIC4DF.xml
@@ -11,11 +11,20 @@
 		<Row Tag="TXT_KEY_DIPLO_TRADE_MAP_TT">
 			<Text>Reveals all land explored by this civilization.[NEWLINE][NEWLINE]Note: Will not receive contact with unmet civilizations and city-states.</Text>
 		</Row>
+		<Row Tag="TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_BOTH">
+			<Text>[NEWLINE][NEWLINE]Neither player has the Technology required to trade this item (Military Science).</Text>
+		</Row>
 		<Row Tag="TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_OTHER_PLAYER">
-			<Text>[NEWLINE][NEWLINE]They don't yet have the Technology to sell this item (Military Science).</Text>
+			<Text>[NEWLINE][NEWLINE]They don't yet have the Technology to trade this item (Military Science).</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_PLAYER">
-			<Text>[NEWLINE][NEWLINE]You don't yet have the Technology to sell this item (Military Science).</Text>
+			<Text>[NEWLINE][NEWLINE]You don't yet have the Technology to trade this item (Military Science).</Text>
+		</Row>
+		<Row Tag="TXT_KEY_DIPLO_TRADE_MAPS_THEY_ALREADY_EXPLORED">
+			<Text>[NEWLINE][NEWLINE]They have already explored all of the lands revealed in your World Map.</Text>
+		</Row>
+		<Row Tag="TXT_KEY_DIPLO_TRADE_MAPS_WE_ALREADY_EXPLORED">
+			<Text>[NEWLINE][NEWLINE]We have already explored all of the lands revealed in their World Map.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_GAME_OPTION_NO_TECH_TRADING">
 			<Text>No Tech Trading</Text>

--- a/Civilization IV Diplomatic Features - CP/Build/(1a) Civilization IV Diplomatic Features - CP Only/XML/Text/en_US/en_US_Text_UIC4DF.xml
+++ b/Civilization IV Diplomatic Features - CP/Build/(1a) Civilization IV Diplomatic Features - CP Only/XML/Text/en_US/en_US_Text_UIC4DF.xml
@@ -15,10 +15,10 @@
 			<Text>[NEWLINE][NEWLINE]Neither player has the Technology required to trade this item (Military Science).</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_OTHER_PLAYER">
-			<Text>[NEWLINE][NEWLINE]They don't yet have the Technology to trade this item (Military Science).</Text>
+			<Text>[NEWLINE][NEWLINE]They don't yet have the Technology required to trade this item (Military Science).</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_PLAYER">
-			<Text>[NEWLINE][NEWLINE]You don't yet have the Technology to trade this item (Military Science).</Text>
+			<Text>[NEWLINE][NEWLINE]You don't yet have the Technology required to trade this item (Military Science).</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLO_TRADE_MAPS_THEY_ALREADY_EXPLORED">
 			<Text>[NEWLINE][NEWLINE]They have already explored all of the lands revealed in your World Map.</Text>

--- a/Civilization IV Diplomatic Features - CP/Civilization IV Diplomatic Features - CP/LUA/TradeLogic.lua
+++ b/Civilization IV Diplomatic Features - CP/Civilization IV Diplomatic Features - CP/LUA/TradeLogic.lua
@@ -1762,51 +1762,70 @@ function ResetDisplay()
     ---------------------------------------------------------------------------------- 
 
 	local bMapTradingAllowed = g_Deal:IsPossibleToTradeItem(g_iUs, g_iThem, TradeableItems.TRADE_ITEM_MAPS, g_iDealDuration);
-    
-    -- Are we not allowed to give World Map? (already providing it to them?)
+	
     strTooltip = Locale.ConvertTextKey("TXT_KEY_DIPLO_TRADE_MAP_TT", g_iDealDuration);
     
     local strOurTooltip = strTooltip;
     local strTheirTooltip = strTooltip;
-    
-	-- They don't have tech
-    if (not bMapTradingAllowed) then
-		if (not g_pUsTeam:IsMapTrading()) then
-			strOurTooltip = strOurTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey("TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_PLAYER" ) .. "[ENDCOLOR]";
-		end
-	end
-    
-    -- Are we not allowed to give World Map?
-    if (not bMapTradingAllowed) then
+	
+	-- Are we not allowed to give World Map?
+	if (not bMapTradingAllowed) then
 		Controls.UsPocketTradeMap:SetDisabled(true);
 		Controls.UsPocketTradeMap:GetTextControl():SetColorByName("Gray_Black");
-
+	
+		-- We need an embassy with them
 		if (not g_pUsTeam:HasEmbassyAtTeam(g_iThemTeam)) then
-			strOurTooltip = strOurTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey("TXT_KEY_DIPLO_YOU_NEED_EMBASSY_TT" ) .. "[ENDCOLOR]";
+			strOurTooltip = strOurTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_YOU_NEED_EMBASSY_TT" ) .. "[ENDCOLOR]";
+		end
+		
+		if (not g_pUsTeam:IsMapTrading()) then
+			-- Neither of us have the required tech
+			if (not g_pThemTeam:IsMapTrading()) then
+				strOurTooltip = strOurTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_BOTH" ) .. "[ENDCOLOR]";
+			-- We don't have the required tech
+			else
+				strOurTooltip = strOurTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_PLAYER" ) .. "[ENDCOLOR]";
+			end
+		-- They don't have the required tech
+		elseif (not g_pThemTeam:IsMapTrading()) then
+			strOurTooltip = strOurTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_OTHER_PLAYER" ) .. "[ENDCOLOR]";
+		-- Our map has no new tiles to reveal
+		elseif (g_pUsTeam:HasEmbassyAtTeam(g_iThemTeam)) then
+			strOurTooltip = strOurTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_THEY_ALREADY_EXPLORED" ) .. "[ENDCOLOR]";
 		end
 	else
 		Controls.UsPocketTradeMap:SetDisabled(false);
 		Controls.UsPocketTradeMap:GetTextControl():SetColorByName("Beige_Black");
-    end
+	end
     
     Controls.UsPocketTradeMap:SetToolTipString(strOurTooltip);
     
     bMapTradingAllowed = g_Deal:IsPossibleToTradeItem(g_iThem, g_iUs, TradeableItems.TRADE_ITEM_MAPS, g_iDealDuration);
-
-	-- We don't have tech
-    if (not bMapTradingAllowed) then
-		if (not g_pThemTeam:IsMapTrading()) then
-			strTheirTooltip = strTheirTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey("TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_OTHER_PLAYER" ) .. "[ENDCOLOR]";
-		end
-	end
-    
-    -- Are they not allowed to give World Map?
-    if (not bMapTradingAllowed) then
+	
+	-- Are they not allowed to give World Map?
+	if (not bMapTradingAllowed) then
 		Controls.ThemPocketTradeMap:SetDisabled(true);
 		Controls.ThemPocketTradeMap:GetTextControl(): SetColorByName("Gray_Black");
 		
+		-- They need an embassy with us
 		if (not g_pThemTeam:HasEmbassyAtTeam(g_iUsTeam)) then
 			strTheirTooltip = strTheirTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_THEY_NEED_EMBASSY_TT" );
+		end
+		
+		if (not g_pThemTeam:IsMapTrading()) then
+			-- Neither of us have the required tech
+			if (not g_pUsTeam:IsMapTrading()) then
+				strTheirTooltip = strTheirTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_BOTH" ) .. "[ENDCOLOR]";
+			-- They don't have the required tech
+			else
+				strTheirTooltip = strTheirTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_OTHER_PLAYER" ) .. "[ENDCOLOR]";
+			end
+		-- We don't have the required tech
+		elseif (not g_pUsTeam:IsMapTrading()) then
+			strTheirTooltip = strTheirTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_PLAYER" ) .. "[ENDCOLOR]";
+		-- Their map has no new tiles to reveal
+		elseif (g_pThemTeam:HasEmbassyAtTeam(g_iUsTeam)) then
+			strTheirTooltip = strTheirTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_WE_ALREADY_EXPLORED" ) .. "[ENDCOLOR]";
 		end
 	else
 		Controls.ThemPocketTradeMap:SetDisabled(false);

--- a/Civilization IV Diplomatic Features - CP/Civilization IV Diplomatic Features - CP/XML/Text/en_US/en_US_Text_UIC4DF.xml
+++ b/Civilization IV Diplomatic Features - CP/Civilization IV Diplomatic Features - CP/XML/Text/en_US/en_US_Text_UIC4DF.xml
@@ -11,11 +11,20 @@
 		<Row Tag="TXT_KEY_DIPLO_TRADE_MAP_TT">
 			<Text>Reveals all land explored by this civilization.[NEWLINE][NEWLINE]Note: Will not receive contact with unmet civilizations and city-states.</Text>
 		</Row>
+		<Row Tag="TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_BOTH">
+			<Text>[NEWLINE][NEWLINE]Neither player has the Technology required to trade this item (Military Science).</Text>
+		</Row>
 		<Row Tag="TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_OTHER_PLAYER">
-			<Text>[NEWLINE][NEWLINE]They don't yet have the Technology to sell this item (Military Science).</Text>
+			<Text>[NEWLINE][NEWLINE]They don't yet have the Technology to trade this item (Military Science).</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_PLAYER">
-			<Text>[NEWLINE][NEWLINE]You don't yet have the Technology to sell this item (Military Science).</Text>
+			<Text>[NEWLINE][NEWLINE]You don't yet have the Technology to trade this item (Military Science).</Text>
+		</Row>
+		<Row Tag="TXT_KEY_DIPLO_TRADE_MAPS_THEY_ALREADY_EXPLORED">
+			<Text>[NEWLINE][NEWLINE]They have already explored all of the lands revealed in your World Map.</Text>
+		</Row>
+		<Row Tag="TXT_KEY_DIPLO_TRADE_MAPS_WE_ALREADY_EXPLORED">
+			<Text>[NEWLINE][NEWLINE]We have already explored all of the lands revealed in their World Map.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_GAME_OPTION_NO_TECH_TRADING">
 			<Text>No Tech Trading</Text>

--- a/Civilization IV Diplomatic Features - CP/Civilization IV Diplomatic Features - CP/XML/Text/en_US/en_US_Text_UIC4DF.xml
+++ b/Civilization IV Diplomatic Features - CP/Civilization IV Diplomatic Features - CP/XML/Text/en_US/en_US_Text_UIC4DF.xml
@@ -15,10 +15,10 @@
 			<Text>[NEWLINE][NEWLINE]Neither player has the Technology required to trade this item (Military Science).</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_OTHER_PLAYER">
-			<Text>[NEWLINE][NEWLINE]They don't yet have the Technology to trade this item (Military Science).</Text>
+			<Text>[NEWLINE][NEWLINE]They don't yet have the Technology required to trade this item (Military Science).</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_PLAYER">
-			<Text>[NEWLINE][NEWLINE]You don't yet have the Technology to trade this item (Military Science).</Text>
+			<Text>[NEWLINE][NEWLINE]You don't yet have the Technology required to trade this item (Military Science).</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLO_TRADE_MAPS_THEY_ALREADY_EXPLORED">
 			<Text>[NEWLINE][NEWLINE]They have already explored all of the lands revealed in your World Map.</Text>

--- a/CvGameCoreDLL_Expansion2/CvDealClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDealClasses.cpp
@@ -454,7 +454,7 @@ bool CvDeal::IsPossibleToTradeItem(PlayerTypes ePlayer, PlayerTypes eToPlayer, T
 		if(!MOD_DIPLOMACY_CIV4_FEATURES)
 			return false;
 
-		// Both need tech for Embassy trading
+		// Both need tech for Map trading
 		if (!pToTeam->isMapTrading() || !pFromTeam->isMapTrading())
 			return false;
 

--- a/EUI Compatibility Files/EUI Compatibility Files/LUA/TradeLogic.lua
+++ b/EUI Compatibility Files/EUI Compatibility Files/LUA/TradeLogic.lua
@@ -1906,51 +1906,70 @@ function ResetDisplay()
     ---------------------------------------------------------------------------------- 
 
 	local bMapTradingAllowed = g_Deal:IsPossibleToTradeItem(g_iUs, g_iThem, TradeableItems.TRADE_ITEM_MAPS, g_iDealDuration);
-    
-    -- Are we not allowed to give World Map? (already providing it to them?)
+	
     strTooltip = Locale.ConvertTextKey("TXT_KEY_DIPLO_TRADE_MAP_TT", g_iDealDuration);
     
     local strOurTooltip = strTooltip;
     local strTheirTooltip = strTooltip;
-    
-	-- They don't have tech
-    if (not bMapTradingAllowed) then
-		if (not g_pUsTeam:IsMapTrading()) then
-			strOurTooltip = strOurTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey("TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_PLAYER" ) .. "[ENDCOLOR]";
-		end
-	end
-    
-    -- Are we not allowed to give World Map?
-    if (not bMapTradingAllowed) then
+	
+	-- Are we not allowed to give World Map?
+	if (not bMapTradingAllowed) then
 		Controls.UsPocketTradeMap:SetDisabled(true);
 		Controls.UsPocketTradeMap:GetTextControl():SetColorByName("Gray_Black");
-
+	
+		-- We need an embassy with them
 		if (not g_pUsTeam:HasEmbassyAtTeam(g_iThemTeam)) then
-			strOurTooltip = strOurTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey("TXT_KEY_DIPLO_YOU_NEED_EMBASSY_TT" ) .. "[ENDCOLOR]";
+			strOurTooltip = strOurTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_YOU_NEED_EMBASSY_TT" ) .. "[ENDCOLOR]";
+		end
+		
+		if (not g_pUsTeam:IsMapTrading()) then
+			-- Neither of us have the required tech
+			if (not g_pThemTeam:IsMapTrading()) then
+				strOurTooltip = strOurTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_BOTH" ) .. "[ENDCOLOR]";
+			-- We don't have the required tech
+			else
+				strOurTooltip = strOurTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_PLAYER" ) .. "[ENDCOLOR]";
+			end
+		-- They don't have the required tech
+		elseif (not g_pThemTeam:IsMapTrading()) then
+			strOurTooltip = strOurTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_OTHER_PLAYER" ) .. "[ENDCOLOR]";
+		-- Our map has no new tiles to reveal
+		elseif (g_pUsTeam:HasEmbassyAtTeam(g_iThemTeam)) then
+			strOurTooltip = strOurTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_THEY_ALREADY_EXPLORED" ) .. "[ENDCOLOR]";
 		end
 	else
 		Controls.UsPocketTradeMap:SetDisabled(false);
 		Controls.UsPocketTradeMap:GetTextControl():SetColorByName("Beige_Black");
-    end
+	end
     
     Controls.UsPocketTradeMap:SetToolTipString(strOurTooltip);
     
     bMapTradingAllowed = g_Deal:IsPossibleToTradeItem(g_iThem, g_iUs, TradeableItems.TRADE_ITEM_MAPS, g_iDealDuration);
-
-	-- We don't have tech
-    if (not bMapTradingAllowed) then
-		if (not g_pThemTeam:IsMapTrading()) then
-			strTheirTooltip = strTheirTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey("TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_OTHER_PLAYER" ) .. "[ENDCOLOR]";
-		end
-	end
-    
-    -- Are they not allowed to give World Map?
-    if (not bMapTradingAllowed) then
+	
+	-- Are they not allowed to give World Map?
+	if (not bMapTradingAllowed) then
 		Controls.ThemPocketTradeMap:SetDisabled(true);
 		Controls.ThemPocketTradeMap:GetTextControl(): SetColorByName("Gray_Black");
 		
+		-- They need an embassy with us
 		if (not g_pThemTeam:HasEmbassyAtTeam(g_iUsTeam)) then
 			strTheirTooltip = strTheirTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_THEY_NEED_EMBASSY_TT" );
+		end
+		
+		if (not g_pThemTeam:IsMapTrading()) then
+			-- Neither of us have the required tech
+			if (not g_pUsTeam:IsMapTrading()) then
+				strTheirTooltip = strTheirTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_BOTH" ) .. "[ENDCOLOR]";
+			-- They don't have the required tech
+			else
+				strTheirTooltip = strTheirTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_OTHER_PLAYER" ) .. "[ENDCOLOR]";
+			end
+		-- We don't have the required tech
+		elseif (not g_pUsTeam:IsMapTrading()) then
+			strTheirTooltip = strTheirTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_PLAYER" ) .. "[ENDCOLOR]";
+		-- Their map has no new tiles to reveal
+		elseif (g_pThemTeam:HasEmbassyAtTeam(g_iUsTeam)) then
+			strTheirTooltip = strTheirTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_WE_ALREADY_EXPLORED" ) .. "[ENDCOLOR]";
 		end
 	else
 		Controls.ThemPocketTradeMap:SetDisabled(false);

--- a/NoEUI Compatibility Files/Mod Template1/LUA/TradeLogic.lua
+++ b/NoEUI Compatibility Files/Mod Template1/LUA/TradeLogic.lua
@@ -1885,51 +1885,70 @@ function ResetDisplay()
     ---------------------------------------------------------------------------------- 
 
 	local bMapTradingAllowed = g_Deal:IsPossibleToTradeItem(g_iUs, g_iThem, TradeableItems.TRADE_ITEM_MAPS, g_iDealDuration);
-    
-    -- Are we not allowed to give World Map? (already providing it to them?)
+	
     strTooltip = Locale.ConvertTextKey("TXT_KEY_DIPLO_TRADE_MAP_TT", g_iDealDuration);
     
     local strOurTooltip = strTooltip;
     local strTheirTooltip = strTooltip;
-    
-	-- They don't have tech
-    if (not bMapTradingAllowed) then
-		if (not g_pUsTeam:IsMapTrading()) then
-			strOurTooltip = strOurTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey("TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_PLAYER" ) .. "[ENDCOLOR]";
-		end
-	end
-    
-    -- Are we not allowed to give World Map?
-    if (not bMapTradingAllowed) then
+	
+	-- Are we not allowed to give World Map?
+	if (not bMapTradingAllowed) then
 		Controls.UsPocketTradeMap:SetDisabled(true);
 		Controls.UsPocketTradeMap:GetTextControl():SetColorByName("Gray_Black");
-
+	
+		-- We need an embassy with them
 		if (not g_pUsTeam:HasEmbassyAtTeam(g_iThemTeam)) then
-			strOurTooltip = strOurTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey("TXT_KEY_DIPLO_YOU_NEED_EMBASSY_TT" ) .. "[ENDCOLOR]";
+			strOurTooltip = strOurTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_YOU_NEED_EMBASSY_TT" ) .. "[ENDCOLOR]";
+		end
+		
+		if (not g_pUsTeam:IsMapTrading()) then
+			-- Neither of us have the required tech
+			if (not g_pThemTeam:IsMapTrading()) then
+				strOurTooltip = strOurTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_BOTH" ) .. "[ENDCOLOR]";
+			-- We don't have the required tech
+			else
+				strOurTooltip = strOurTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_PLAYER" ) .. "[ENDCOLOR]";
+			end
+		-- They don't have the required tech
+		elseif (not g_pThemTeam:IsMapTrading()) then
+			strOurTooltip = strOurTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_OTHER_PLAYER" ) .. "[ENDCOLOR]";
+		-- Our map has no new tiles to reveal
+		elseif (g_pUsTeam:HasEmbassyAtTeam(g_iThemTeam)) then
+			strOurTooltip = strOurTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_THEY_ALREADY_EXPLORED" ) .. "[ENDCOLOR]";
 		end
 	else
 		Controls.UsPocketTradeMap:SetDisabled(false);
 		Controls.UsPocketTradeMap:GetTextControl():SetColorByName("Beige_Black");
-    end
+	end
     
     Controls.UsPocketTradeMap:SetToolTipString(strOurTooltip);
     
     bMapTradingAllowed = g_Deal:IsPossibleToTradeItem(g_iThem, g_iUs, TradeableItems.TRADE_ITEM_MAPS, g_iDealDuration);
-
-	-- We don't have tech
-    if (not bMapTradingAllowed) then
-		if (not g_pThemTeam:IsMapTrading()) then
-			strTheirTooltip = strTheirTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey("TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_OTHER_PLAYER" ) .. "[ENDCOLOR]";
-		end
-	end
-    
-    -- Are they not allowed to give World Map?
-    if (not bMapTradingAllowed) then
+	
+	-- Are they not allowed to give World Map?
+	if (not bMapTradingAllowed) then
 		Controls.ThemPocketTradeMap:SetDisabled(true);
 		Controls.ThemPocketTradeMap:GetTextControl(): SetColorByName("Gray_Black");
 		
+		-- They need an embassy with us
 		if (not g_pThemTeam:HasEmbassyAtTeam(g_iUsTeam)) then
 			strTheirTooltip = strTheirTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_THEY_NEED_EMBASSY_TT" );
+		end
+		
+		if (not g_pThemTeam:IsMapTrading()) then
+			-- Neither of us have the required tech
+			if (not g_pUsTeam:IsMapTrading()) then
+				strTheirTooltip = strTheirTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_BOTH" ) .. "[ENDCOLOR]";
+			-- They don't have the required tech
+			else
+				strTheirTooltip = strTheirTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_OTHER_PLAYER" ) .. "[ENDCOLOR]";
+			end
+		-- We don't have the required tech
+		elseif (not g_pUsTeam:IsMapTrading()) then
+			strTheirTooltip = strTheirTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_NO_TECH_PLAYER" ) .. "[ENDCOLOR]";
+		-- Their map has no new tiles to reveal
+		elseif (g_pThemTeam:HasEmbassyAtTeam(g_iUsTeam)) then
+			strTheirTooltip = strTheirTooltip .. " [COLOR_WARNING_TEXT]" .. Locale.ConvertTextKey( "TXT_KEY_DIPLO_TRADE_MAPS_WE_ALREADY_EXPLORED" ) .. "[ENDCOLOR]";
 		end
 	else
 		Controls.ThemPocketTradeMap:SetDisabled(false);


### PR DESCRIPTION
Fixes the World Map trade item tooltip being greyed out with no explanation. This fixes both the tech requirement issue described here and the "all lands are already revealed" issue (#4539).

(I hope I did this correctly)