### PR TITLE
Diplo Fixes & Improvements

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.h
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.h
@@ -493,6 +493,7 @@ public:
 
 	int GetCompetitorValue(PlayerTypes ePlayer);
 	PlayerTypes GetBiggestCompetitor();
+	bool IsMajorCompetitor(PlayerTypes ePlayer);
 #endif
 
 	// Victory Dispute

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
@@ -12987,6 +12987,7 @@ int CvLuaPlayer::lGetOpinionTable(lua_State* L)
 		aOpinions.push_back(kOpinion);
 	}
 
+	/*
 	iValue = pDiploAI->GetIgnoredMilitaryPromiseScore(eWithPlayer);
 	if (iValue != 0)
 	{
@@ -12995,6 +12996,7 @@ int CvLuaPlayer::lGetOpinionTable(lua_State* L)
 		kOpinion.m_str = Localization::Lookup("TXT_KEY_DIPLO_MILITARY_PROMISE_IGNORED");
 		aOpinions.push_back(kOpinion);
 	}
+	*/
 	
 	iValue = pDiploAI->GetBrokenExpansionPromiseScore(eWithPlayer);
 	if (iValue != 0)


### PR DESCRIPTION
Fixed IsWantsToConquer conflict issues.

Added IsMajorCompetitor function to discern if another player is a major enemy/competitor (true) or not (false).

Replaced a few checks with IsMajorCompetitor.

Fixed AI cheating with dogpiling approach check (was counting unmet players) and fixed a bug.

AI will no longer declare war based on an insult if it means breaking its own DoFs/DPs or declaring war on powerful neighbors. AI is now more reluctant to do so when its approach towards a player is AFRAID.

AIs will now refrain from starting coop wars with players who are likely to betray them (approach guess WAR or HOSTILE).

Removed opinion penalty for ignoring a military promise.

Removed backstabbing penalties between humans.