### PR TITLE
Diplo Fixes & Improvements

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvDealAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDealAI.cpp
@@ -2686,43 +2686,20 @@ int CvDealAI::GetEmbassyValue(bool bFromMe, PlayerTypes eOtherPlayer, bool bUseE
 	}
 #endif
 
-	if(bFromMe)  // giving the other player an embassy in my capital
+	if (bFromMe)  // giving the other player an embassy in my capital
 	{
 #if defined(MOD_BALANCE_CORE)
-		if(GetPlayer()->GetDiplomacyAI()->IsDenouncedPlayer(eOtherPlayer) || GET_PLAYER(eOtherPlayer).GetDiplomacyAI()->IsDenouncedPlayer(GetPlayer()->GetID()))
+		if (GetPlayer()->GetDiplomacyAI()->IsDenouncedPlayer(eOtherPlayer) || GET_PLAYER(eOtherPlayer).GetDiplomacyAI()->IsDenouncedPlayer(GetPlayer()->GetID()))
 			return INT_MAX;
 #endif
 		// Approach is important
-		switch(GetPlayer()->GetDiplomacyAI()->GetMajorCivApproach(eOtherPlayer, /*bHideTrueFeelings*/ false))
+		switch (GetPlayer()->GetDiplomacyAI()->GetMajorCivApproach(eOtherPlayer, /*bHideTrueFeelings*/ true))
 		{
-		case MAJOR_CIV_APPROACH_WAR:
-			switch(GetPlayer()->GetDiplomacyAI()->GetWarFaceWithPlayer(eOtherPlayer))
-			{
-				case WAR_FACE_HOSTILE:
-					iItemValue *= 250;
-					break;
-				case WAR_FACE_GUARDED:
-					iItemValue *= 130;
-					break;
-				case WAR_FACE_NEUTRAL:
-					iItemValue *= 100;
-					break;
-				case WAR_FACE_FRIENDLY:
-					iItemValue *= 100;
-					break;
-				default:
-					iItemValue *= 100;
-					break;
-			}
-			break;
 		case MAJOR_CIV_APPROACH_HOSTILE:
 			iItemValue *= 250;
 			break;
 		case MAJOR_CIV_APPROACH_GUARDED:
 			iItemValue *= 130;
-			break;
-		case MAJOR_CIV_APPROACH_DECEPTIVE:
-			iItemValue *= 100;
 			break;
 		case MAJOR_CIV_APPROACH_AFRAID:
 			iItemValue *= 80;
@@ -2741,42 +2718,19 @@ int CvDealAI::GetEmbassyValue(bool bFromMe, PlayerTypes eOtherPlayer, bool bUseE
 		iItemValue /= 100;
 	}
 #if defined(MOD_BALANCE_CORE)
-	if(!bFromMe)  // they want to give us an embassy in their capital
+	if (!bFromMe)  // they want to give us an embassy in their capital
 	{
-		if(GetPlayer()->GetDiplomacyAI()->IsDenouncedPlayer(eOtherPlayer) || GET_PLAYER(eOtherPlayer).GetDiplomacyAI()->IsDenouncedPlayer(GetPlayer()->GetID()))
+		if (GetPlayer()->GetDiplomacyAI()->IsDenouncedPlayer(eOtherPlayer) || GET_PLAYER(eOtherPlayer).GetDiplomacyAI()->IsDenouncedPlayer(GetPlayer()->GetID()))
 			return INT_MAX;
 
 		// Approach is important
-		switch(GetPlayer()->GetDiplomacyAI()->GetMajorCivApproach(eOtherPlayer, /*bHideTrueFeelings*/ false))
+		switch (GetPlayer()->GetDiplomacyAI()->GetMajorCivApproach(eOtherPlayer, /*bHideTrueFeelings*/ true))
 		{
-		case MAJOR_CIV_APPROACH_WAR:
-			switch(GetPlayer()->GetDiplomacyAI()->GetWarFaceWithPlayer(eOtherPlayer))
-			{
-				case WAR_FACE_HOSTILE:
-					iItemValue *= 30;
-					break;
-				case WAR_FACE_GUARDED:
-					iItemValue *= 60;
-					break;
-				case WAR_FACE_NEUTRAL:
-					iItemValue *= 100;
-					break;
-				case WAR_FACE_FRIENDLY:  // embassies are worth so little that it's not worth revealing deception over
-					iItemValue *= 150;
-					break;
-				default:
-					iItemValue *= 100;
-					break;
-			}
-			break;
 		case MAJOR_CIV_APPROACH_HOSTILE:
 			iItemValue *= 30;
 			break;
 		case MAJOR_CIV_APPROACH_GUARDED:
 			iItemValue *= 60;
-			break;
-		case MAJOR_CIV_APPROACH_DECEPTIVE:  // embassies are worth so little that it's not worth revealing deception over
-			iItemValue *= 150;
 			break;
 		case MAJOR_CIV_APPROACH_AFRAID:
 			iItemValue *= 120;
@@ -2800,7 +2754,7 @@ int CvDealAI::GetEmbassyValue(bool bFromMe, PlayerTypes eOtherPlayer, bool bUseE
 		iItemValue = 15;
 
 	// Are we trying to find the middle point between what we think this item is worth and what another player thinks it's worth?
-	if(bUseEvenValue)
+	if (bUseEvenValue)
 	{
 		int iReverseValue = GET_PLAYER(eOtherPlayer).GetDealAI()->GetEmbassyValue(!bFromMe, GetPlayer()->GetID(), /*bUseEvenValue*/ false);
 		if (iReverseValue == INT_MAX)
@@ -4162,6 +4116,13 @@ int CvDealAI::GetThirdPartyWarValue(bool bFromMe, PlayerTypes eOtherPlayer, Team
 					iItemValue *= 100;
 					break;
 			}
+			
+			// Easy target? Halve the value.
+			if (pDiploAI->IsEasyTarget(eWithPlayer))
+			{
+				iItemValue /= 2;
+			}
+			
 			iItemValue /= 100;
 		}
 	}
@@ -4296,6 +4257,12 @@ int CvDealAI::GetThirdPartyWarValue(bool bFromMe, PlayerTypes eOtherPlayer, Team
 			iItemValue *= 125;
 			iItemValue /= 100;
 		}
+		
+		// Easy target? Halve the value.
+		if (GET_PLAYER(ePlayer).GetDiplomacyAI()->IsEasyTarget(eWithPlayer))
+		{
+			iItemValue /= 2;
+		}
 
 		if(!bMinor)
 		{
@@ -4313,7 +4280,7 @@ int CvDealAI::GetThirdPartyWarValue(bool bFromMe, PlayerTypes eOtherPlayer, Team
 				}
 			}
 			//Not a human? Let's see if he has a valid target...if not, don't accept!
-			if(!GET_PLAYER(eOtherPlayer).isHuman())
+			if (!GET_PLAYER(eOtherPlayer).isHuman())
 			{
 				//No target? Abort!
 				if(!GetPlayer()->GetMilitaryAI()->HaveValidAttackTarget(eWithPlayer))
@@ -4366,22 +4333,6 @@ int CvDealAI::GetThirdPartyWarValue(bool bFromMe, PlayerTypes eOtherPlayer, Team
 				}
 				iItemValue /= 100;
 			}
-		}
-#else
-		// Minor
-		if(bMinor)
-			iItemValue = -100000;
-
-		// Major
-		else
-		{
-			// Modify for our feelings towards the player they would go to war with
-			if(eOpinionTowardsWarPlayer == MAJOR_CIV_OPINION_UNFORGIVABLE)
-				iItemValue = 200;
-			else if(eOpinionTowardsWarPlayer == MAJOR_CIV_OPINION_ENEMY)
-				iItemValue = 100;
-			else
-				iItemValue = -100000;
 		}
 #endif
 	}

--- a/CvGameCoreDLL_Expansion2/CvDealAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDealAI.cpp
@@ -4118,7 +4118,7 @@ int CvDealAI::GetThirdPartyWarValue(bool bFromMe, PlayerTypes eOtherPlayer, Team
 			}
 			
 			// Easy target? Halve the value.
-			if (pDiploAI->IsEasyTarget(eWithPlayer))
+			if (pDiploAI->IsEasyTarget(eWithPlayer, /*bOtherPlayerEstimate*/ false))
 			{
 				iItemValue /= 2;
 			}
@@ -4259,7 +4259,7 @@ int CvDealAI::GetThirdPartyWarValue(bool bFromMe, PlayerTypes eOtherPlayer, Team
 		}
 		
 		// Easy target? Halve the value.
-		if (GET_PLAYER(ePlayer).GetDiplomacyAI()->IsEasyTarget(eWithPlayer))
+		if (GET_PLAYER(ePlayer).GetDiplomacyAI()->IsEasyTarget(eWithPlayer, /*bOtherPlayerEstimate*/ true))
 		{
 			iItemValue /= 2;
 		}

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
@@ -14826,7 +14826,12 @@ bool CvDiplomacyAI::IsEasyTarget(PlayerTypes ePlayer, bool bOtherPlayerEstimate)
 		bWantsConquest = true;
 	}
 	
-	bool bAtWarWithAtLeastOneMajor = MilitaryAIHelpers::IsTestStrategy_AtWar(m_pPlayer, false);
+	bool bAtWarWithAtLeastOneMajor = false;
+	
+	if (!GET_TEAM(GetPlayer()->getTeam()).isAtWar(GET_PLAYER(ePlayer).getTeam()))
+	{
+		bAtWarWithAtLeastOneMajor = MilitaryAIHelpers::IsTestStrategy_AtWar(m_pPlayer, false);
+	}
 	
 	// Compare military and economic strengths to look for opportunities to strike
 	// We sense more opportunities to attack our biggest competitor or people we want to conquer

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
@@ -5024,7 +5024,7 @@ MajorCivApproachTypes CvDiplomacyAI::GetBestApproachTowardsMajorCiv(PlayerTypes 
 	////////////////////////////////////
 	// EASY TARGET
 	////////////////////////////////////
-	bool bIsEasyTarget = IsEasyTarget(ePlayer);
+	bool bIsEasyTarget = IsEasyTarget(ePlayer, /*bOtherPlayerEstimate*/ false);
 	
 	// They're only an easy target if we're not already at war with somebody else.
 	// ...however, if we're already at war with them, let's keep this weight.
@@ -8874,7 +8874,7 @@ void CvDiplomacyAI::DoMakeWarOnPlayer(PlayerTypes eTargetPlayer)
 		}
 		
 		// Don't get into multiple wars at once (unless this is an easy target)
-		if (bWantToAttack && !IsEasyTarget(eTargetPlayer))
+		if (bWantToAttack && !IsEasyTarget(eTargetPlayer, /*bOtherPlayerEstimate*/ false))
 		{
 			bWantToAttack = bWantToAttack && !bAtWarWithAtLeastOneMajor;
 		}
@@ -12049,7 +12049,7 @@ bool CvDiplomacyAI::IsWantsToConquer(PlayerTypes ePlayer) const
 		return false;
 	
 	// They're an easy target, so play offensively!
-	if (IsEasyTarget(ePlayer))
+	if (IsEasyTarget(ePlayer, /*bOtherPlayerEstimate*/ false))
 	{
 		return true;
 	}
@@ -13863,7 +13863,7 @@ void CvDiplomacyAI::DoRelationshipPairing()
 			}
 			
 			// Easy targets don't make good DPs, but friends is fine if we aren't major competitors
-			if (IsEasyTarget(ePlayer))
+			if (IsEasyTarget(ePlayer, /*bOtherPlayerEstimate*/ false))
 			{
 				iDPWeight -= 10;
 				
@@ -14694,7 +14694,7 @@ bool CvDiplomacyAI::IsMajorCompetitor(PlayerTypes ePlayer) const
 }
 
 /// Is this player an easy attack target?
-bool CvDiplomacyAI::IsEasyTarget(PlayerTypes ePlayer) const
+bool CvDiplomacyAI::IsEasyTarget(PlayerTypes ePlayer, bool bOtherPlayerEstimate)
 {
 	if (!IsPlayerValid(ePlayer) || GET_PLAYER(ePlayer).isMinorCiv())
 		return false;
@@ -14767,7 +14767,7 @@ bool CvDiplomacyAI::IsEasyTarget(PlayerTypes ePlayer) const
 		return true;
 	}
 	
-	if (!GET_PLAYER(ePlayer).GetDiplomacyAI()->IsCloseToAnyVictoryCondition() || IsNoVictoryCompetition())
+	if (!bOtherPlayerEstimate && (!GET_PLAYER(ePlayer).GetDiplomacyAI()->IsCloseToAnyVictoryCondition() || IsNoVictoryCompetition()))
 	{
 		// If we would go bankrupt by declaring war on them, they can't be an easy target
 		int iLostGoldPerTurn = CalculateGoldPerTurnLostFromWar(ePlayer, false, false);
@@ -14837,7 +14837,7 @@ bool CvDiplomacyAI::IsEasyTarget(PlayerTypes ePlayer) const
 	
 	// Compare military and economic strengths to look for opportunities to strike
 	// We sense more opportunities to attack our biggest competitor or people we want to conquer
-	if ((GetBiggestCompetitor() == ePlayer || bWantsConquest) && !bAtWarWithAtLeastOneMajor)
+	if ((GetBiggestCompetitor() == ePlayer || bWantsConquest) && !bAtWarWithAtLeastOneMajor && !bOtherPlayerEstimate)
 	{
 		if (eMilitaryStrength <= STRENGTH_POOR && eEconomicStrength <= STRENGTH_POOR)
 		{

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
@@ -4559,7 +4559,7 @@ MajorCivApproachTypes CvDiplomacyAI::GetBestApproachTowardsMajorCiv(PlayerTypes 
 	int iLostGoldPerTurn = CalculateGoldPerTurnLostFromWar(ePlayer, false, false);
 	int iAdjustedGoldPerTurn = GetPlayer()->calculateGoldRate() - iLostGoldPerTurn;
 	
-	if (iLostGoldPerTurn != 0)
+	if (iLostGoldPerTurn <= 0)
 	{
 		if (!GET_PLAYER(ePlayer).GetDiplomacyAI()->IsCloseToAnyVictoryCondition() || IsNoVictoryCompetition())
 		{
@@ -14759,7 +14759,7 @@ bool CvDiplomacyAI::IsEasyTarget(PlayerTypes ePlayer) const
 			int iLostGoldPerTurn = CalculateGoldPerTurnLostFromWar(ePlayer, false, false);
 			int iAdjustedGoldPerTurn = GetPlayer()->calculateGoldRate() - iLostGoldPerTurn;
 			
-			if (iLostGoldPerTurn != 0)
+			if (iLostGoldPerTurn <= 0)
 			{
 #if defined(MOD_BALANCE_CORE)
 				// Factor in instant yields into our income as well (average of recent turns)
@@ -30834,7 +30834,7 @@ int CvDiplomacyAI::GetCoopWarScore(PlayerTypes ePlayer, PlayerTypes eTargetPlaye
 		int iLostGoldPerTurn = CalculateGoldPerTurnLostFromWar(eTargetPlayer, false, false);
 		int iAdjustedGoldPerTurn = GetPlayer()->calculateGoldRate() - iLostGoldPerTurn;
 		
-		if (iLostGoldPerTurn != 0)
+		if (iLostGoldPerTurn <= 0)
 		{
 			if (!GET_PLAYER(eTargetPlayer).GetDiplomacyAI()->IsCloseToAnyVictoryCondition() || IsNoVictoryCompetition())
 			{

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
@@ -14739,6 +14739,22 @@ bool CvDiplomacyAI::IsEasyTarget(PlayerTypes ePlayer) const
 		}
 	}
 	
+	// First check the overall strength estimate (bold AIs will be more aggressive)
+	if (GetBoldness() > 6)
+	{
+		if (GetPlayerTargetValue(ePlayer) == TARGET_VALUE_IMPOSSIBLE)
+		{
+			return false;
+		}
+	}
+	else
+	{
+		if (GetPlayerTargetValue(ePlayer) <= TARGET_VALUE_BAD)
+		{
+			return false;
+		}
+	}
+	
 	bool bIsEasyTarget = false;
 	bool bWantsConquest = false;
 	
@@ -14748,7 +14764,7 @@ bool CvDiplomacyAI::IsEasyTarget(PlayerTypes ePlayer) const
 	if (GetPlayerTargetValue(ePlayer) == TARGET_VALUE_SOFT || GetWarProjection(ePlayer) == WAR_PROJECTION_VERY_GOOD ||
 		eMilitaryStrength == STRENGTH_PATHETIC || eEconomicStrength == STRENGTH_PATHETIC)
 	{
-		bIsEasyTarget = true;
+		return true;
 	}
 	
 	if (!bIsEasyTarget)

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
@@ -14377,13 +14377,6 @@ void CvDiplomacyAI::DoRelationshipPairing()
 				iDoFWeight /= 2;
 				iEnemyWeight /= 2;
 			}
-			
-			// Sanity check - don't want friendship or defensive pacts if we're hostile or want war
-			if (GetMajorCivApproach(ePlayer) <= MAJOR_CIV_APPROACH_HOSTILE)
-			{
-				iDPWeight = 0;
-				iDoFWeight = 0;
-			}	
 		}
 		//Total it up and add it to the pool of values.
 		m_paiCompetitorValue[ePlayer] = iEnemyWeight;

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
@@ -4559,7 +4559,7 @@ MajorCivApproachTypes CvDiplomacyAI::GetBestApproachTowardsMajorCiv(PlayerTypes 
 	int iLostGoldPerTurn = CalculateGoldPerTurnLostFromWar(ePlayer, false, false);
 	int iAdjustedGoldPerTurn = GetPlayer()->calculateGoldRate() - iLostGoldPerTurn;
 	
-	if (iLostGoldPerTurn <= 0)
+	if (iLostGoldPerTurn > 0)
 	{
 		if (!GET_PLAYER(ePlayer).GetDiplomacyAI()->IsCloseToAnyVictoryCondition() || IsNoVictoryCompetition())
 		{
@@ -14759,7 +14759,7 @@ bool CvDiplomacyAI::IsEasyTarget(PlayerTypes ePlayer) const
 			int iLostGoldPerTurn = CalculateGoldPerTurnLostFromWar(ePlayer, false, false);
 			int iAdjustedGoldPerTurn = GetPlayer()->calculateGoldRate() - iLostGoldPerTurn;
 			
-			if (iLostGoldPerTurn <= 0)
+			if (iLostGoldPerTurn > 0)
 			{
 #if defined(MOD_BALANCE_CORE)
 				// Factor in instant yields into our income as well (average of recent turns)
@@ -30834,7 +30834,7 @@ int CvDiplomacyAI::GetCoopWarScore(PlayerTypes ePlayer, PlayerTypes eTargetPlaye
 		int iLostGoldPerTurn = CalculateGoldPerTurnLostFromWar(eTargetPlayer, false, false);
 		int iAdjustedGoldPerTurn = GetPlayer()->calculateGoldRate() - iLostGoldPerTurn;
 		
-		if (iLostGoldPerTurn <= 0)
+		if (iLostGoldPerTurn > 0)
 		{
 			if (!GET_PLAYER(eTargetPlayer).GetDiplomacyAI()->IsCloseToAnyVictoryCondition() || IsNoVictoryCompetition())
 			{

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
@@ -8865,9 +8865,9 @@ void CvDiplomacyAI::DoMakeWarOnPlayer(PlayerTypes eTargetPlayer)
 		bWantToAttack = (eApproach == MAJOR_CIV_APPROACH_WAR || (eApproach <= MAJOR_CIV_APPROACH_HOSTILE && (IsGoingForWorldConquest() || IsCloseToDominationVictory())));
 		
 		// We want to attack more if they're about to win the game (or we're about to win a conquest victory)
-		if (!bWantToAttack && eApproach <= MAJOR_CIV_APPROACH_DECEPTIVE && !IsDoFAccepted(ePlayer) && !GET_PLAYER(ePlayer).GetDiplomacyAI()->IsDoFAccepted(GetPlayer()->GetID()))
+		if (!bWantToAttack && eApproach <= MAJOR_CIV_APPROACH_DECEPTIVE && !IsDoFAccepted(eTargetPlayer) && !GET_PLAYER(eTargetPlayer).GetDiplomacyAI()->IsDoFAccepted(GetPlayer()->GetID()))
 		{
-			if ((IsCloseToDominationVictory() || GET_PLAYER(ePlayer).GetDiplomacyAI()->IsCloseToAnyVictoryCondition()) && !IsNoVictoryCompetition())
+			if ((IsCloseToDominationVictory() || GET_PLAYER(eTargetPlayer).GetDiplomacyAI()->IsCloseToAnyVictoryCondition()) && !IsNoVictoryCompetition())
 			{
 				bWantToAttack = true;
 			}

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.h
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.h
@@ -499,6 +499,7 @@ public:
 	int GetCompetitorValue(PlayerTypes ePlayer) const;
 	PlayerTypes GetBiggestCompetitor() const;
 	bool IsMajorCompetitor(PlayerTypes ePlayer) const;
+	bool IsEasyTarget(PlayerTypes ePlayer) const;
 #endif
 
 	// Victory Dispute
@@ -1415,6 +1416,7 @@ public:
 	bool IsGoingForSpaceshipVictory() const;
 
 #if defined(MOD_BALANCE_CORE)
+	bool IsCloseToAnyVictoryCondition() const;
 	bool IsCloseToSSVictory() const;
 	bool IsCloseToDominationVictory() const;
 	bool IsCloseToCultureVictory() const;

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.h
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.h
@@ -499,7 +499,7 @@ public:
 	int GetCompetitorValue(PlayerTypes ePlayer) const;
 	PlayerTypes GetBiggestCompetitor() const;
 	bool IsMajorCompetitor(PlayerTypes ePlayer) const;
-	bool IsEasyTarget(PlayerTypes ePlayer) const;
+	bool IsEasyTarget(PlayerTypes ePlayer, bool bOtherPlayerEstimate);
 #endif
 
 	// Victory Dispute


### PR DESCRIPTION
AI will be more aggressive with opportunity attacks

Better bloc formation

Better lategame diplomacy

Performance improvements

Remove weight for being close to a disabled victory condition (except domination)

Allow AI to start wars if already at war, but only if conditions are favorable (all war states must be >= OFFENSIVE, proximity must be at least CLOSE and target must be an easy target; experimental - there's approach weight against doing this so it shouldn't be out of hand)