### PR TITLE
Remove penalty for stealing territory during war

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -28292,11 +28292,14 @@ void CvCity::BuyPlot(int iPlotX, int iPlotY)
 		//Did we buy this plot from someone? Oh no!
 		if(pPlot != NULL && pPlot->getOwner() != NO_PLAYER && pPlot->getOwner() != getOwner())
 		{
-			if(!GET_PLAYER(pPlot->getOwner()).isHuman())
+			if (!GET_PLAYER(pPlot->getOwner()).isHuman() && !GET_PLAYER(pPlot->getOwner()).isBarbarian())
 			{
 				if(GET_PLAYER(pPlot->getOwner()).isMajorCiv())
 				{
-					GET_PLAYER(pPlot->getOwner()).GetDiplomacyAI()->ChangeNumTimesCultureBombed(getOwner(), 1);
+					if (!GET_TEAM(GET_PLAYER(pPlot->getOwner()).getTeam()).isAtWar(GET_PLAYER(getOwner()).getTeam()))
+					{
+						GET_PLAYER(pPlot->getOwner()).GetDiplomacyAI()->ChangeNumTimesCultureBombed(getOwner(), 1);
+					}
 				}
 				else if(GET_PLAYER(pPlot->getOwner()).isMinorCiv())
 				{

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
@@ -16624,6 +16624,10 @@ void CvDiplomacyAI::DoPlayerDeclaredWarOnSomeone(PlayerTypes ePlayer, TeamTypes 
 					ChangeRecentTradeValue(ePlayer, -GetRecentTradeValue(ePlayer));
 					GET_PLAYER(ePlayer).GetDiplomacyAI()->ChangeRecentTradeValue(eMyPlayer, -GetRecentTradeValue(eMyPlayer));
 					
+					// Clear penalties for stealing territory during peacetime
+					ChangeNumTimesCultureBombed(ePlayer, -GetNumTimesCultureBombed(ePlayer));
+					GET_PLAYER(ePlayer).GetDiplomacyAI()->ChangeNumTimesCultureBombed(eMyPlayer, -GetNumTimesCultureBombed(eMyPlayer));
+					
 #if defined(MOD_BALANCE_CORE_DIPLOMACY)
 					if (!bDefensivePact)
 					{

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -12894,6 +12894,9 @@ void CvUnit::PerformCultureBomb(int iRadius)
 			// Humans can handle their own diplo
 			if(pPlayer->isHuman())
 				continue;
+			
+			if (pPlayer->isBarbarian())
+				continue;
 
 			// Minor civ response
 			if(pPlayer->isMinorCiv())
@@ -12904,7 +12907,10 @@ void CvUnit::PerformCultureBomb(int iRadius)
 			// Major civ response
 			else
 			{
-				pPlayer->GetDiplomacyAI()->ChangeNumTimesCultureBombed(getOwner(), 1);
+				if (!GET_TEAM(eOtherTeam).isAtWar(getTeam()))
+				{
+					pPlayer->GetDiplomacyAI()->ChangeNumTimesCultureBombed(getOwner(), 1);
+				}
 
 				// Message for human
 				if(getTeam() != eOtherTeam && !GET_TEAM(eOtherTeam).isAtWar(getTeam()) && !CvPreGame::isNetworkMultiplayerGame() && GC.getGame().getActivePlayer() == getOwner() && !bAlreadyShownLeader)


### PR DESCRIPTION
Also clears it when war begins.

If you can steal a city without a permanent diplo penalty, you should be able to do the same with land. :)