### PR TITLE
Improvement: Body of Water Makes Valid

### DIFF
--- a/Community Patch/Core Files/Core Tables/CoreTableEntries.sql
+++ b/Community Patch/Core Files/Core Tables/CoreTableEntries.sql
@@ -262,6 +262,9 @@ ALTER TABLE Improvements ADD COLUMN 'GAUnitPlotExperience' INTEGER DEFAULT 0;
 -- Improvement grants extra moves when unit is on this plot
 ALTER TABLE Improvements ADD COLUMN 'MovesChange' INTEGER DEFAULT 0;
 
+-- Improvement requires any body of water adjacent to it in order to be built
+ALTER TABLE Improvements ADD COLUMN 'AnyBodyOfWaterMakesValid' BOOLEAN DEFAULT 0;
+
 -- Allows you to set a tech that makes an impassable terrain/feature element passable.
 ALTER TABLE Features ADD COLUMN 'PassableTechFeature' TEXT DEFAULT NULL;
 

--- a/CvGameCoreDLL_Expansion2/CvImprovementClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvImprovementClasses.cpp
@@ -116,6 +116,7 @@ CvImprovementEntry::CvImprovementEntry(void):
 #if defined(MOD_GLOBAL_PASSABLE_FORTS)
 	m_bMakesPassable(false),
 #endif
+	m_bAnyBodyOfWaterMakesValid(false),
 	m_bFreshWaterMakesValid(false),
 	m_bRiverSideMakesValid(false),
 	m_bNoFreshWater(false),
@@ -288,6 +289,7 @@ bool CvImprovementEntry::CacheResults(Database::Results& kResults, CvDatabaseUti
 #if defined(MOD_GLOBAL_PASSABLE_FORTS)
 	m_bMakesPassable = kResults.GetBool("MakesPassable");
 #endif
+	m_bAnyBodyOfWaterMakesValid = kResults.GetBool("AnyBodyOfWaterMakesValid");
 	m_bFreshWaterMakesValid = kResults.GetBool("FreshWaterMakesValid");
 	m_bRiverSideMakesValid = kResults.GetBool("RiverSideMakesValid");
 	m_bNoFreshWater = kResults.GetBool("NoFreshWater");
@@ -1023,6 +1025,12 @@ bool CvImprovementEntry::IsMakesPassable() const
 	return m_bMakesPassable;
 }
 #endif
+
+// Requires any body of water to build
+bool CvImprovementEntry::IsAnyBodyOfWaterMakesValid() const
+{
+	return m_bAnyBodyOfWaterMakesValid;
+}
 
 /// Requires fresh water to build
 bool CvImprovementEntry::IsFreshWaterMakesValid() const

--- a/CvGameCoreDLL_Expansion2/CvImprovementClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvImprovementClasses.h
@@ -116,6 +116,7 @@ public:
 #if defined(MOD_GLOBAL_PASSABLE_FORTS)
 	bool IsMakesPassable() const;
 #endif
+	bool IsAnyBodyOfWaterMakesValid() const;
 	bool IsFreshWaterMakesValid() const;
 	bool IsRiverSideMakesValid() const;
 	bool IsNoFreshWater() const;
@@ -288,6 +289,7 @@ protected:
 #if defined(MOD_GLOBAL_PASSABLE_FORTS)
 	bool m_bMakesPassable;
 #endif
+	bool m_bAnyBodyOfWaterMakesValid;
 	bool m_bFreshWaterMakesValid;
 	bool m_bRiverSideMakesValid;
 	bool m_bNoFreshWater;

--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -2425,6 +2425,14 @@ bool CvPlot::canHaveImprovement(ImprovementTypes eImprovement, PlayerTypes ePlay
 		bValid = true;
 	}
 
+	if(pkImprovementInfo->IsAnyBodyOfWaterMakesValid())
+	{
+		if (isCoastalLand() || isFreshWater() || isRiver()) 
+		{
+			bValid = true;
+		}
+	}
+
 	if(pkImprovementInfo->IsFreshWaterMakesValid() && isFreshWater())
 	{
 		bValid = true;


### PR DESCRIPTION
I have added the table entry.

I'm sorry if I still messed it up. New territory for me.

Once again, the goal was for "a build requirement for a unique improvement that allows it to be built next to any water: Lakes, rivers, coast. AnyWater exists for buildings, but not for Improvements"