### PR TITLE
Promotion: Fortification Yield

### DIFF
--- a/Community Patch/Core Files/Core Tables/CoreTableAdditions.xml
+++ b/Community Patch/Core Files/Core Tables/CoreTableAdditions.xml
@@ -1118,6 +1118,12 @@
 		<Column name="YieldType" type="text" reference="Yields(Type)"/>
 		<Column name="Yield" type="integer"/>
 	</Table>
+	<!-- Promotion: City gains extra yield if unit is on tile with a fort or citadel -->
+	<Table name="UnitPromotions_FortificationYield">
+		<Column name="PromotionType" type="text" reference="UnitPromotions(Type)"/>
+		<Column name="YieldType" type="text" reference="Yields(Type)"/>
+		<Column name="Yield" type="integer"/>
+	</Table>
 	<!-- Promotion: City gains %Yield modifier from a Unit in this city (unit can be combat or civilian) -->
 	<Table name="UnitPromotions_YieldModifiers">
 		<Column name="PromotionType" type="text" reference="UnitPromotions(Type)"/>

--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -9650,6 +9650,9 @@ int CvPlot::calculateNatureYield(YieldTypes eYield, PlayerTypes ePlayer, const C
 	int iYield;
 	TeamTypes eTeam = (ePlayer!=NO_PLAYER) ? GET_PLAYER(ePlayer).getTeam() : NO_TEAM;
 
+	ImprovementTypes eFort = (ImprovementTypes)GC.getInfoTypeForString("IMPROVEMENT_FORT");
+	ImprovementTypes eCitadel = (ImprovementTypes)GC.getInfoTypeForString("IMPROVEMENT_CITADEL");
+
 	const CvYieldInfo& kYield = *GC.getYieldInfo(eYield);
 	CvAssertMsg(getTerrainType() != NO_TERRAIN, "TerrainType is not assigned a valid value");
 
@@ -9805,6 +9808,15 @@ int CvPlot::calculateNatureYield(YieldTypes eYield, PlayerTypes ePlayer, const C
 				{
 					int iGarrisonstrength = pUnit->GetBaseCombatStrength();
 					iYield += ((pUnit->GetGarrisonYieldChange(eYield) * iGarrisonstrength) / 8);
+				}
+			}
+			if (pOwningCity->plot()->getImprovementType() == eFort || pOwningCity->plot()->getImprovementType() == eCitadel)
+			{
+				CvUnit* pUnit = pOwningCity->plot()->getCenterUnit();
+				if (pUnit != NULL && pUnit->GetFortificationYieldChange(eYield) > 0)
+				{
+					int iUnitStrength = pUnit->GetBaseCombatStrength();
+					iYield += ((pUnit->GetFortificationYieldChange(eYield) * iUnitStrength) / 8);
 				}
 			}
 		}

--- a/CvGameCoreDLL_Expansion2/CvPromotionClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPromotionClasses.cpp
@@ -283,6 +283,7 @@ CvPromotionEntry::CvPromotionEntry():
 	m_piYieldFromKills(NULL),
 	m_piYieldFromBarbarianKills(NULL),
 	m_piGarrisonYield(NULL),
+	m_piFortificationYield(NULL),
 #endif
 	m_piUnitCombatModifierPercent(NULL),
 	m_piUnitClassModifierPercent(NULL),
@@ -335,6 +336,7 @@ CvPromotionEntry::~CvPromotionEntry(void)
 	SAFE_DELETE_ARRAY(m_piYieldFromKills);
 	SAFE_DELETE_ARRAY(m_piYieldFromBarbarianKills);
 	SAFE_DELETE_ARRAY(m_piGarrisonYield);
+	SAFE_DELETE_ARRAY(m_piFortificationYield);
 #endif
 	SAFE_DELETE_ARRAY(m_piUnitCombatModifierPercent);
 	SAFE_DELETE_ARRAY(m_piUnitClassModifierPercent);
@@ -899,6 +901,33 @@ bool CvPromotionEntry::CacheResults(Database::Results& kResults, CvDatabaseUtili
 		pResults->Bind(1, szPromotionType);
 
 		while(pResults->Step())
+		{
+			const int iYieldID = pResults->GetInt("YieldID");
+			CvAssert(iYieldID > -1 && iYieldID < NUM_YIELD_TYPES);
+
+			const int iYield = pResults->GetInt("Yield");
+			m_piGarrisonYield[iYieldID] = iYield;
+		}
+	}
+
+	//UnitPromotions_FortificationYield
+	{
+		kUtility.InitializeArray(m_piFortificationYield, NUM_YIELD_TYPES, 0);
+
+		std::string sqlKey = "UnitPromotions_FortificationYield";
+		Database::Results* pResults = kUtility.GetResults(sqlKey);
+		if (pResults == NULL)
+		{
+			const char* szSQL = "select Yields.ID as YieldID, UnitPromotions_FortificationYield.* from UnitPromotions_FortificationYield inner join Yields on YieldType = Yields.Type where PromotionType = ?";
+			pResults = kUtility.PrepareResults(sqlKey, szSQL);
+		}
+
+		CvAssert(pResults);
+		if (!pResults) return false;
+
+		pResults->Bind(1, szPromotionType);
+
+		while (pResults->Step())
 		{
 			const int iYieldID = pResults->GetInt("YieldID");
 			CvAssert(iYieldID > -1 && iYieldID < NUM_YIELD_TYPES);
@@ -2613,6 +2642,19 @@ int CvPromotionEntry::GetGarrisonYield(int i) const
 	if(i > -1 && i < NUM_YIELD_TYPES && m_piGarrisonYield)
 	{
 		return m_piGarrisonYield[i];
+	}
+
+	return 0;
+}
+
+int CvPromotionEntry::GetFortificationYield(int i) const
+{
+	CvAssertMsg(i < NUM_YIELD_TYPES, "Index out of bounds");
+	CvAssertMsg(i > -1, "Index out of bounds");
+
+	if (i > -1 && i < NUM_YIELD_TYPES && m_piFortificationYield)
+	{
+		return m_piFortificationYield[i];
 	}
 
 	return 0;

--- a/CvGameCoreDLL_Expansion2/CvPromotionClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvPromotionClasses.h
@@ -317,6 +317,7 @@ public:
 	int GetYieldFromKills(int i) const;
 	int GetYieldFromBarbarianKills(int i) const;
 	int GetGarrisonYield(int i) const;
+	int GetFortificationYield(int i) const;
 #endif
 	int GetUnitCombatModifierPercent(int i) const;
 	int GetUnitClassModifierPercent(int i) const;
@@ -631,6 +632,7 @@ protected:
 	int* m_piYieldFromKills;
 	int* m_piYieldFromBarbarianKills;
 	int* m_piGarrisonYield;
+	int* m_piFortificationYield;
 #endif
 	int* m_piUnitCombatModifierPercent;
 	int* m_piUnitClassModifierPercent;

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -350,6 +350,7 @@ CvUnit::CvUnit() :
 	, m_YieldModifier()
 	, m_YieldChange()
 	, m_iGarrisonYieldChange()
+	, m_iFortificationYieldChange()
 	, m_strScriptData("CvUnit::m_szScriptData", m_syncArchive)
 	, m_iScenarioData("CvUnit::m_iScenarioData", m_syncArchive)
 	, m_terrainDoubleMoveCount("CvUnit::m_terrainDoubleMoveCount", m_syncArchive)
@@ -1736,11 +1737,13 @@ void CvUnit::reset(int iID, UnitTypes eUnit, PlayerTypes eOwner, bool bConstruct
 	m_YieldModifier.clear();
 	m_YieldChange.clear();
 	m_iGarrisonYieldChange.clear();
+	m_iFortificationYieldChange.clear();
 	for (iI = 0; iI < NUM_YIELD_TYPES; iI++)
 	{
 		m_YieldModifier.push_back(0);
 		m_YieldChange.push_back(0);
 		m_iGarrisonYieldChange.push_back(0);
+		m_iFortificationYieldChange.clear();
 	}
 
 #if defined(MOD_PROMOTIONS_UNIT_NAMING)
@@ -19079,6 +19082,22 @@ void CvUnit::SetGarrisonYieldChange(YieldTypes eYield, int iValue)
 	m_iGarrisonYieldChange[eYield] = (m_iGarrisonYieldChange[eYield] + iValue);
 }
 
+int CvUnit::GetFortificationYieldChange(YieldTypes eYield) const
+{
+	VALIDATE_OBJECT
+		CvAssertMsg(eYield >= 0, "eYield is expected to be non-negative (invalid Index)");
+	CvAssertMsg(eYield < NUM_YIELD_TYPES, "eYield is expected to be within maximum bounds (invalid Index)");
+	return m_iFortificationYieldChange[eYield];
+}
+//	--------------------------------------------------------------------------------
+void CvUnit::SetFortificationYieldChange(YieldTypes eYield, int iValue)
+{
+	VALIDATE_OBJECT
+		CvAssertMsg(eYield >= 0, "eYield is expected to be non-negative (invalid Index)");
+	CvAssertMsg(eYield < NUM_YIELD_TYPES, "eYield is expected to be within maximum bounds (invalid Index)");
+	m_iFortificationYieldChange[eYield] = (m_iFortificationYieldChange[eYield] + iValue);
+}
+
 //	--------------------------------------------------------------------------------
 #if defined(MOD_CARGO_SHIPS)
 SpecialUnitTypes CvUnit::specialUnitCargoLoad() const
@@ -27026,6 +27045,7 @@ void CvUnit::setHasPromotion(PromotionTypes eIndex, bool bNewValue)
 			SetYieldModifier(((YieldTypes)iI), (thisPromotion.GetYieldModifier(iI) * iChange));
 			SetYieldChange(((YieldTypes)iI), (thisPromotion.GetYieldChange(iI) * iChange));
 			SetGarrisonYieldChange(((YieldTypes)iI), (thisPromotion.GetGarrisonYield(iI) * iChange));
+			SetFortificationYieldChange(((YieldTypes)iI), (thisPromotion.GetFortificationYield(iI) * iChange));
 #if defined(MOD_API_UNIFIED_YIELDS)
 			changeYieldFromKills(((YieldTypes)iI), (thisPromotion.GetYieldFromKills(iI) * iChange));
 			changeYieldFromBarbarianKills(((YieldTypes)iI), (thisPromotion.GetYieldFromBarbarianKills(iI) * iChange));
@@ -27320,6 +27340,7 @@ void CvUnit::read(FDataStream& kStream)
 	kStream >> m_YieldModifier;
 	kStream >> m_YieldChange;
 	kStream >> m_iGarrisonYieldChange;
+	kStream >> m_iFortificationYieldChange;
 	MOD_SERIALIZE_READ(78, kStream, m_iMaxHitPointsBase, m_pUnitInfo->GetMaxHitPoints());
 #endif
 
@@ -27402,6 +27423,7 @@ void CvUnit::write(FDataStream& kStream) const
 	kStream << m_YieldModifier;
 	kStream << m_YieldChange;
 	kStream << m_iGarrisonYieldChange;
+	kStream << m_iFortificationYieldChange;
 #if defined(MOD_UNITS_MAX_HP)
 	MOD_SERIALIZE_WRITE(kStream, m_iMaxHitPointsBase);
 #endif

--- a/CvGameCoreDLL_Expansion2/CvUnit.h
+++ b/CvGameCoreDLL_Expansion2/CvUnit.h
@@ -948,6 +948,9 @@ public:
 	int GetGarrisonYieldChange(YieldTypes eYield) const;
 	void SetGarrisonYieldChange(YieldTypes eYield, int iValue);
 
+	int GetFortificationYieldChange(YieldTypes eYield) const;
+	void SetFortificationYieldChange(YieldTypes eYield, int iValue);
+
 	inline int GetID() const
 	{
 		return m_iID;
@@ -2244,6 +2247,7 @@ protected:
 	std::vector<int> m_YieldModifier;
 	std::vector<int> m_YieldChange;
 	std::vector<int> m_iGarrisonYieldChange;
+	std::vector<int> m_iFortificationYieldChange;
 
 	FAutoVariable<CvString, CvUnit> m_strScriptData;
 	FAutoVariable<int, CvUnit> m_iScenarioData;


### PR DESCRIPTION
Another request from pineappledan. "A promotion table that lets you define a yield that the player gets every turn if that unit is garrisoned in a city, Fort, or citadel." Considering there's already a promotion table for garrisons, I simply added one for fortifications.

I'm not sure if I did the correct logic for getting the combat unit on the plot. Specifically line 9815 of "CvPlot.cpp".