### PR TITLE
Promotion: Free Embark

### DIFF
--- a/Community Patch/Core Files/Core Tables/CoreTableEntries.sql
+++ b/Community Patch/Core Files/Core Tables/CoreTableEntries.sql
@@ -935,6 +935,9 @@ ALTER TABLE UnitPromotions ADD COLUMN 'NearbyHealFriendlyTerritory' INTEGER DEFA
 -- Double Movement on Mountains
 ALTER TABLE UnitPromotions ADD COLUMN 'MountainsDoubleMove' BOOLEAN DEFAULT 0;
 
+-- No Movement Points Used On Embark
+ALTER TABLE UnitPromotions ADD COLUMN 'FreeEmbark' BOOLEAN DEFAULT 0;
+
 -- Admirals can use their repair fleet action multiple times before expending.
 ALTER TABLE UnitPromotions ADD COLUMN 'NumRepairCharges' INTEGER DEFAULT 0;
 

--- a/CvGameCoreDLL_Expansion2/CvPromotionClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPromotionClasses.cpp
@@ -189,6 +189,7 @@ CvPromotionEntry::CvPromotionEntry():
 	m_iLandAirDefenseValue(0),
 	m_iDamageReductionCityAssault(0),
 	m_bMountainsDoubleMove(false),
+	m_bFreeEmbark(false),
 	m_bMountedOnly(false),
 #endif
 #if defined(MOD_PROMOTIONS_CROSS_MOUNTAINS)
@@ -447,6 +448,7 @@ bool CvPromotionEntry::CacheResults(Database::Results& kResults, CvDatabaseUtili
 	m_iLandAirDefenseValue = kResults.GetInt("LandAirDefenseBonus");
 	m_iDamageReductionCityAssault = kResults.GetInt("DamageReductionCityAssault");
 	m_bMountainsDoubleMove = kResults.GetBool("MountainsDoubleMove");
+	m_bFreeEmbark = kResults.GetBool("FreeEmbark");
 	m_bMountedOnly = kResults.GetBool("MountedOnly");
 #endif
 #if defined(MOD_PROMOTIONS_CROSS_MOUNTAINS)
@@ -2124,6 +2126,11 @@ int CvPromotionEntry::GetDamageReductionCityAssault() const
 bool CvPromotionEntry::IsMountainsDoubleMove() const
 {
 	return m_bMountainsDoubleMove;
+}
+
+bool CvPromotionEntry::IsFreeEmbark() const
+{
+	return m_bFreeEmbark;
 }
 
 bool CvPromotionEntry::IsMountedOnly() const

--- a/CvGameCoreDLL_Expansion2/CvPromotionClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvPromotionClasses.h
@@ -182,6 +182,7 @@ public:
 	int GetWonderProductionModifier() const;
 	bool IsStrongerDamaged() const;
 	bool IsMountainsDoubleMove() const;
+	bool IsFreeEmbark() const;
 	bool IsMountedOnly() const;
 	int GetAOEDamageOnKill() const;
 	int GetAoEDamageOnMove() const;
@@ -532,6 +533,7 @@ protected:
 	int m_iLandAirDefenseValue;
 	int m_iDamageReductionCityAssault;
 	bool m_bMountainsDoubleMove;
+	bool m_bFreeEmbark;
 	bool m_bMountedOnly;
 #endif
 #if defined(MOD_PROMOTIONS_CROSS_MOUNTAINS)

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -174,6 +174,7 @@ CvUnit::CvUnit() :
 	, m_iHillsDoubleMoveCount("CvUnit::m_iHillsDoubleMoveCount", m_syncArchive)
 #if defined(MOD_BALANCE_CORE)
 	, m_iMountainsDoubleMoveCount("CvUnit::m_iMountainsDoubleMoveCount", m_syncArchive)
+	, m_iFreeEmbarkMoveCount("CvUnit::m_iFreeEmbarkMoveCount", m_syncArchive)
 	, m_iAOEDamageOnKill("CvUnit::m_iAOEDamageOnKill", m_syncArchive)
 	, m_iAoEDamageOnMove("CvUnit::m_iAoEDamageOnMove", m_syncArchive)
 	, m_iSplashDamage("CvUnit::m_iSplashDamage", m_syncArchive)
@@ -1457,6 +1458,7 @@ void CvUnit::reset(int iID, UnitTypes eUnit, PlayerTypes eOwner, bool bConstruct
 	m_iHillsDoubleMoveCount = 0;
 #if defined(MOD_BALANCE_CORE)
 	m_iMountainsDoubleMoveCount = 0;
+	m_iFreeEmbarkMoveCount = 0;
 	m_iAOEDamageOnKill = 0;
 	m_iAoEDamageOnMove = 0;
 	m_iSplashDamage = 0;
@@ -21868,6 +21870,25 @@ void CvUnit::changeMountainsDoubleMoveCount(int iChange)
 	CvAssert(getMountainsDoubleMoveCount() >= 0);
 }
 
+//	--------------------------------------------------------------------------------
+int CvUnit::getFreeEmbarkMoveCount() const
+{
+	VALIDATE_OBJECT
+		return m_iFreeEmbarkMoveCount;
+}
+//	--------------------------------------------------------------------------------
+bool CvUnit::isFreeEmbark() const
+{
+	VALIDATE_OBJECT
+		return (getFreeEmbarkMoveCount() > 0);
+}
+//	--------------------------------------------------------------------------------
+void CvUnit::changeFreeEmbarkMoveCount(int iChange)
+{
+	VALIDATE_OBJECT
+		m_iFreeEmbarkMoveCount = (m_iFreeEmbarkMoveCount + iChange);
+	CvAssert(getFreeEmbarkMoveCount() >= 0);
+}
 
 //	--------------------------------------------------------------------------------
 int CvUnit::getAOEDamageOnKill() const
@@ -26821,6 +26842,7 @@ void CvUnit::setHasPromotion(PromotionTypes eIndex, bool bNewValue)
 		changeMultiAttackBonus(thisPromotion.GetMultiAttackBonus() *  iChange);
 		changeLandAirDefenseValue(thisPromotion.GetLandAirDefenseValue() *  iChange);
 		changeMountainsDoubleMoveCount((thisPromotion.IsMountainsDoubleMove()) ? iChange : 0);
+		changeFreeEmbarkMoveCount((thisPromotion.IsFreeEmbark()) ? iChange : 0);
 		ChangeCaptureDefeatedEnemyChance((thisPromotion.GetCaptureDefeatedEnemyChance()) * iChange);
 		ChangeBarbarianCombatBonus((thisPromotion.GetBarbarianCombatBonus()) * iChange);
 		ChangeAdjacentEnemySapMovement((thisPromotion.GetAdjacentEnemySapMovement()) * iChange);

--- a/CvGameCoreDLL_Expansion2/CvUnit.h
+++ b/CvGameCoreDLL_Expansion2/CvUnit.h
@@ -1100,6 +1100,10 @@ public:
 	bool isMountainsDoubleMove() const;
 	void changeMountainsDoubleMoveCount(int iChange);
 
+	int getFreeEmbarkMoveCount() const;
+	bool isFreeEmbark() const;
+	void changeFreeEmbarkMoveCount(int iChange);
+
 	int getAOEDamageOnKill() const;
 	void changeAOEDamageOnKill(int iChange);
 	
@@ -1989,6 +1993,7 @@ protected:
 	FAutoVariable<int, CvUnit> m_iHillsDoubleMoveCount;
 #if defined(MOD_BALANCE_CORE)
 	FAutoVariable<int, CvUnit> m_iMountainsDoubleMoveCount;
+	FAutoVariable<int, CvUnit> m_iFreeEmbarkMoveCount;
 	FAutoVariable<int, CvUnit> m_iAOEDamageOnKill;
 	FAutoVariable<int, CvUnit> m_iAoEDamageOnMove;
 	FAutoVariable<int, CvUnit> m_iSplashDamage;

--- a/CvGameCoreDLL_Expansion2/CvUnitMovement.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnitMovement.cpp
@@ -542,6 +542,10 @@ int CvUnitMovement::GetMovementCostMultiplierFromPromotions(const CvUnit* pUnit,
 	{
 		iModifier *= 2;
 	}
+	else if (pPlot->needsEmbarkation(pUnit) && pUnit->isFreeEmbark())
+	{
+		iModifier = 0;
+	}
 
 	return iModifier;
 }


### PR DESCRIPTION
Another request from pineappledan. "The ability to give units free movement points on embarkation, or to not lose movement points if they embark. Whichever is easier."

In this case I made no movement point loss on embarking. I put a counter in like the double movements. Hopefully that's what prevents an infinite movement loop.