### PR TITLE
Trait: Unable To Cancel Razing

### DIFF
--- a/Community Patch/Core Files/Core Tables/CoreTableEntries.sql
+++ b/Community Patch/Core Files/Core Tables/CoreTableEntries.sql
@@ -236,6 +236,9 @@ ALTER TABLE Traits ADD COLUMN 'GAGarrisonCityRangeStrikeModifier' INTEGER DEFAUL
 -- Player enters a golden age on a declaration of war, either as attacking or defending
 ALTER TABLE Traits ADD COLUMN 'GoldenAgeOnWar' BOOLEAN DEFAULT 0;
 
+-- Is this Civ unable to cancel razing?
+ALTER TABLE Traits ADD COLUMN 'UnableToCancelRazing' BOOLEAN DEFAULT 0;
+
 -- Puppet negative modifiers reduced
 ALTER TABLE Traits ADD COLUMN 'ReducePuppetPenalties' INTEGER DEFAULT 0;
 

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -12910,23 +12910,26 @@ void CvPlayer::raze(CvCity* pCity)
 //	--------------------------------------------------------------------------------
 void CvPlayer::unraze(CvCity* pCity)
 {
-	if (GetPlayerTraits()->IsNoAnnexing())
+	if (GetPlayerTraits()->IsUnableToCancelRazing() == false)
 	{
-		pCity->DoCreatePuppet();
-	}
-	else
-	{
-		pCity->DoAnnex();
-	}
+		if (GetPlayerTraits()->IsNoAnnexing())
+		{
+			pCity->DoCreatePuppet();
+		}
+		else
+		{
+			pCity->DoAnnex();
+		}
 
-	pCity->ChangeRazingTurns(-pCity->GetRazingTurns());
+		pCity->ChangeRazingTurns(-pCity->GetRazingTurns());
 
-	DoUpdateNextPolicyCost();
+		DoUpdateNextPolicyCost();
 
-	// Update City UI
-	if(GetID() == GC.getGame().getActivePlayer())
-	{
-		GC.GetEngineUserInterface()->setDirty(CityInfo_DIRTY_BIT, true);
+		// Update City UI
+		if (GetID() == GC.getGame().getActivePlayer())
+		{
+			GC.GetEngineUserInterface()->setDirty(CityInfo_DIRTY_BIT, true);
+		}
 	}
 }
 

--- a/CvGameCoreDLL_Expansion2/CvTraitClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTraitClasses.cpp
@@ -107,6 +107,7 @@ CvTraitEntry::CvTraitEntry() :
 	m_bNoNaturalReligionSpread(false),
 	m_bNoOpenTrade(false),
 	m_bGoldenAgeOnWar(false),
+	m_bUnableToCancelRazing(false),
 	m_iTourismToGAP(0),
 	m_iGoldToGAP(0),
 	m_iInfluenceMeetCS(0),
@@ -770,6 +771,12 @@ bool CvTraitEntry::IsGoldenAgeOnWar() const
 {
 	return m_bGoldenAgeOnWar;
 }
+
+bool CvTraitEntry::IsUnableToCancelRazing() const
+{
+	return m_bUnableToCancelRazing;
+}
+
 int CvTraitEntry::GetTourismGABonus() const
 {
 	return m_iTourismGABonus;
@@ -2274,6 +2281,7 @@ bool CvTraitEntry::CacheResults(Database::Results& kResults, CvDatabaseUtility& 
 	m_bNoNaturalReligionSpread				= kResults.GetBool("NoNaturalReligionSpread");
 	m_bNoOpenTrade							= kResults.GetBool("NoOpenTrade");
 	m_bGoldenAgeOnWar						= kResults.GetBool("GoldenAgeOnWar");
+	m_bUnableToCancelRazing                 = kResults.GetBool("UnableToCancelRazing");
 	m_iInfluenceMeetCS						= kResults.GetInt("InfluenceMeetCS");
 	m_iTourismToGAP							= kResults.GetInt("TourismToGAP");
 	m_iGoldToGAP							 = kResults.GetInt("GoldToGAP");
@@ -4126,6 +4134,9 @@ void CvPlayerTraits::InitPlayerTraits()
 			if (trait->IsGoldenAgeOnWar())
 			{
 				m_bGoldenAgeOnWar = true;
+			}
+			if (trait->IsUnableToCancelRazing) {
+				m_bUnableToCancelRazing = true;
 			}
 			if (trait->IsBestUnitSpawnOnImprovementDOW())
 			{
@@ -7037,6 +7048,7 @@ void CvPlayerTraits::Read(FDataStream& kStream)
 	MOD_SERIALIZE_READ(66, kStream, m_bNoNaturalReligionSpread, false);
 	MOD_SERIALIZE_READ(66, kStream, m_bNoOpenTrade, false);
 	MOD_SERIALIZE_READ(66, kStream, m_bGoldenAgeOnWar, false);
+	MOD_SERIALIZE_READ(66, kStream, m_bUnableToCancelRazing, false);
 	MOD_SERIALIZE_READ(66, kStream, m_iWLTKDGPImprovementModifier, 0);
 	MOD_SERIALIZE_READ(66, kStream, m_iGrowthBoon, 0);
 	MOD_SERIALIZE_READ(66, kStream, m_iAllianceCSDefense, 0);
@@ -7654,6 +7666,7 @@ void CvPlayerTraits::Write(FDataStream& kStream)
 	MOD_SERIALIZE_WRITE(kStream, m_bNoNaturalReligionSpread);
 	MOD_SERIALIZE_WRITE(kStream, m_bNoOpenTrade);
 	MOD_SERIALIZE_WRITE(kStream, m_bGoldenAgeOnWar);
+	MOD_SERIALIZE_WRITE(kStream, m_bUnableToCancelRazing);
 	MOD_SERIALIZE_WRITE(kStream, m_iWLTKDGPImprovementModifier);
 	MOD_SERIALIZE_WRITE(kStream, m_iGrowthBoon);
 	MOD_SERIALIZE_WRITE(kStream, m_iAllianceCSDefense);

--- a/CvGameCoreDLL_Expansion2/CvTraitClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvTraitClasses.h
@@ -128,6 +128,7 @@ public:
 	bool IsNoNaturalReligionSpread() const;
 	bool IsNoOpenTrade() const;
 	bool IsGoldenAgeOnWar() const;
+	bool IsUnableToCancelRazing() const;
 	int GetWLTKDGPImprovementModifier() const;
 	int GetGrowthBoon() const;
 	int GetAllianceCSDefense() const;
@@ -496,6 +497,7 @@ protected:
 	bool m_bNoNaturalReligionSpread;
 	bool m_bNoOpenTrade;
 	bool m_bGoldenAgeOnWar;
+	bool m_bUnableToCancelRazing;
 	int m_iTourismToGAP;
 	int m_iGoldToGAP;
 	int m_iInfluenceMeetCS;
@@ -1118,6 +1120,10 @@ public:
 	{
 		return m_bGoldenAgeOnWar;
 	};
+	bool IsUnableToCancelRazing() const
+	{
+		return m_bUnableToCancelRazing;
+	}
 	int GetWLTKDGPImprovementModifier() const
 	{
 		return m_iWLTKDGPImprovementModifier;
@@ -2032,6 +2038,7 @@ private:
 	bool m_bNoNaturalReligionSpread;
 	bool m_bNoOpenTrade;
 	bool m_bGoldenAgeOnWar;
+	bool m_bUnableToCancelRazing;
 	int m_iTourismToGAP;
 	int m_iGoldToGAP;
 	int m_iInfluenceMeetCS;


### PR DESCRIPTION
Another request from pineappledan. "A trait that disables a player’s ability to stop razing once it has started"

It's intended for his Timurid mod. Only thing that is a concern is the UI not having the "stop razing" button greyed out.