### PR TITLE
Proposed Barbarian Spawn Changes

### DIFF
--- a/43 Civs CP/43 Civs CP/EUI/TopPanel.lua
+++ b/43 Civs CP/43 Civs CP/EUI/TopPanel.lua
@@ -1155,10 +1155,14 @@ if civ5_mode then
 
 		-- CBP EDITS HERE
 
-			if g_activePlayer:IsEmpireSuperUnhappy() then
+			if g_activePlayer:IsEmpireSuperUnhappy() and not Game.IsOption(GameOptionTypes.GAMEOPTION_NO_BARBARIANS) then
 					tips:insert( "[COLOR:255:60:60:255]" .. L("TXT_KEY_TP_EMPIRE_SUPER_UNHAPPY")  .. "[ENDCOLOR]" )
-			elseif g_activePlayer:IsEmpireVeryUnhappy() then	
-				tips:insert("[COLOR:255:60:60:255]" .. L("TXT_KEY_TP_EMPIRE_VERY_UNHAPPY") .. "[ENDCOLOR]" )
+			else if g_activePlayer:IsEmpireSuperUnhappy() and Game.IsOption(GameOptionTypes.GAMEOPTION_NO_BARBARIANS) then
+					tips:insert( "[COLOR:255:60:60:255]" .. L("TXT_KEY_TP_EMPIRE_SUPER_UNHAPPY_NO_REBELS")  .. "[ENDCOLOR]" )
+			else if g_activePlayer:IsEmpireVeryUnhappy() and not Game.IsOption(GameOptionTypes.GAMEOPTION_NO_BARBARIANS) then
+					tips:insert( "[COLOR:255:60:60:255]" .. L("TXT_KEY_TP_EMPIRE_VERY_UNHAPPY")  .. "[ENDCOLOR]" )
+			else if g_activePlayer:IsEmpireVeryUnhappy() and Game.IsOption(GameOptionTypes.GAMEOPTION_NO_BARBARIANS) then
+					tips:insert( "[COLOR:255:60:60:255]" .. L("TXT_KEY_TP_EMPIRE_VERY_UNHAPPY_NO_REBELS")  .. "[ENDCOLOR]" )
 			elseif g_activePlayer:IsEmpireUnhappy() then
 				tips:insert( "[COLOR:255:60:60:255]" .. L("TXT_KEY_TP_EMPIRE_UNHAPPY") .. "[ENDCOLOR]" )
 			else

--- a/43 Civs CP/43 Civs CP/No-EUI/TopPanel.lua
+++ b/43 Civs CP/43 Civs CP/No-EUI/TopPanel.lua
@@ -756,10 +756,14 @@ function HappinessTipHandler( control )
 		local iPlayerID = Game.GetActivePlayer();
 		local pPlayer = Players[iPlayerID];
 		
-		if (pPlayer:IsEmpireSuperUnhappy()) then
+		if (pPlayer:IsEmpireSuperUnhappy() and not Game.IsOption(GameOptionTypes.GAMEOPTION_NO_BARBARIANS)) then
 			strText = strText .. "[COLOR:255:60:60:255]" .. Locale.ConvertTextKey("TXT_KEY_TP_EMPIRE_SUPER_UNHAPPY") .. "[/COLOR]";
-		elseif (pPlayer:IsEmpireVeryUnhappy()) then			
+		elseif (pPlayer:IsEmpireSuperUnhappy() and Game.IsOption(GameOptionTypes.GAMEOPTION_NO_BARBARIANS)) then
+			strText = strText .. "[COLOR:255:60:60:255]" .. Locale.ConvertTextKey("TXT_KEY_TP_EMPIRE_SUPER_UNHAPPY_NO_REBELS") .. "[/COLOR]";
+		elseif (pPlayer:IsEmpireVeryUnhappy() and not Game.IsOption(GameOptionTypes.GAMEOPTION_NO_BARBARIANS)) then			
 			strText = strText .. "[COLOR:255:60:60:255]" .. Locale.ConvertTextKey("TXT_KEY_TP_EMPIRE_VERY_UNHAPPY") .. "[/COLOR]";
+		elseif (pPlayer:IsEmpireVeryUnhappy() and Game.IsOption(GameOptionTypes.GAMEOPTION_NO_BARBARIANS)) then
+			strText = strText .. "[COLOR:255:60:60:255]" .. Locale.ConvertTextKey("TXT_KEY_TP_EMPIRE_VERY_UNHAPPY_NO_REBELS") .. "[/COLOR]";
 		elseif (pPlayer:IsEmpireUnhappy()) then
 			strText = strText .. "[COLOR:255:60:60:255]" .. Locale.ConvertTextKey("TXT_KEY_TP_EMPIRE_UNHAPPY") .. "[/COLOR]";
 		else

--- a/Community Balance Patch/Balance Changes/Text/en_US/UIText.sql
+++ b/Community Balance Patch/Balance Changes/Text/en_US/UIText.sql
@@ -495,12 +495,11 @@ WHERE Tag = 'TXT_KEY_TP_CULTURE_FROM_GOLDEN_AGE' AND EXISTS (SELECT * FROM COMMU
 
 -- Update text for top panel depending on which yields you have enabled above. Change as desired.
 UPDATE Language_en_US
-SET Text = 'Your approval rating is less than 35% - your Empire is fracturing! Rebels (barbarians) will spawn more frequently and Cities will quickly start to abandon your Empire and flip to the Civilization that is most culturally influential over your people! Additionally, all Cities will [ICON_FOOD] Grow more slowly and have increased Military Unit and Settler costs. [ICON_STRENGTH] Combat effectiveness is also reduced by 20%!'
+SET Text = 'Your approval rating is less than 35% - your Empire is in open rebellion! Uprisings may occur with rebel (barbarian) units appearing in your territory, and Cities may abandon your Empire and flip to the Civilization that is most culturally influential over your people! Additionally, all Cities will [ICON_FOOD] Grow very slowly and have increased Military Unit and Settler costs. [ICON_STRENGTH] Combat effectiveness is also reduced by 20%!'
 WHERE Tag = 'TXT_KEY_TP_EMPIRE_VERY_UNHAPPY' AND EXISTS (SELECT * FROM COMMUNITY WHERE Type='COMMUNITY_CORE_BALANCE_NATIONAL_HAPPINESS' AND Value= 1 );
 
-
 UPDATE Language_en_US
-SET Text = 'Your approval rating is less than 20% - your Empire is in open rebellion! Uprisings may occur with rebel (barbarian) units appearing in your territory, and Cities may abandon your Empire and flip to the Civilization that is most culturally influential over your people! Additionally, all Cities will [ICON_FOOD] Grow very slowly and have increased Military Unit and Settler costs. [ICON_STRENGTH] Combat effectiveness is also reduced by 20%!'
+SET Text = 'Your approval rating is less than 20% - your Empire is fracturing! Rebels (barbarians) will spawn more frequently and Cities will quickly start to abandon your Empire and flip to the Civilization that is most culturally influential over your people! Additionally, all Cities will [ICON_FOOD] Grow more slowly and have increased Military Unit and Settler costs. [ICON_STRENGTH] Combat effectiveness is also reduced by 20%!'
 WHERE Tag = 'TXT_KEY_TP_EMPIRE_SUPER_UNHAPPY' AND EXISTS (SELECT * FROM COMMUNITY WHERE Type='COMMUNITY_CORE_BALANCE_NATIONAL_HAPPINESS' AND Value= 1 );
 	
 -- Update text for top panel depending on which yields you have enabled above. Change as desired.

--- a/Community Balance Patch/Balance Changes/Text/en_US/UIText.xml
+++ b/Community Balance Patch/Balance Changes/Text/en_US/UIText.xml
@@ -964,6 +964,14 @@
 		<Row Tag="TXT_KEY_TP_UNHAPPINESS_MINORITY">
 			<Text>{1_Num} from [ICON_RELIGION] Religious Unrest.</Text>
 		</Row>
+		
+		<!-- Top Panel Tooltips for Very/Super Unhappy (Barbarians Disabled) -->
+		<Row Tag="TXT_KEY_TP_EMPIRE_VERY_UNHAPPY_NO_REBELS">
+			<Text>Your approval rating is less than 35% - your Empire is in open rebellion! Cities may abandon your Empire and flip to the Civilization that is most culturally influential over your people! Additionally, all Cities will [ICON_FOOD] Grow very slowly and have increased Military Unit and Settler costs. [ICON_STRENGTH] Combat effectiveness is also reduced by 20%!</Text>
+		</Row>
+		<Row Tag="TXT_KEY_TP_EMPIRE_SUPER_UNHAPPY_NO_REBELS">
+			<Text>Your approval rating is less than 20% - your Empire is fracturing! Cities will quickly start to abandon your Empire and flip to the Civilization that is most culturally influential over your people! Additionally, all Cities will [ICON_FOOD] Grow more slowly and have increased Military Unit and Settler costs. [ICON_STRENGTH] Combat effectiveness is also reduced by 20%!</Text>
+		</Row>
 
 		<!-- Economic Overview -->
 		<Row Tag="TXT_KEY_EO_CITY_IS_NOT_OCCUPIED">

--- a/Community Balance Patch/LUA/TopPanel.lua
+++ b/Community Balance Patch/LUA/TopPanel.lua
@@ -667,10 +667,14 @@ function HappinessTipHandler( control )
 		local iPlayerID = Game.GetActivePlayer();
 		local pPlayer = Players[iPlayerID];
 		
-		if (pPlayer:IsEmpireSuperUnhappy()) then
+		if (pPlayer:IsEmpireSuperUnhappy() and not Game.IsOption(GameOptionTypes.GAMEOPTION_NO_BARBARIANS)) then
 			strText = strText .. "[COLOR:255:60:60:255]" .. Locale.ConvertTextKey("TXT_KEY_TP_EMPIRE_SUPER_UNHAPPY") .. "[/COLOR]";
-		elseif (pPlayer:IsEmpireVeryUnhappy()) then			
+		elseif (pPlayer:IsEmpireSuperUnhappy() and Game.IsOption(GameOptionTypes.GAMEOPTION_NO_BARBARIANS)) then
+			strText = strText .. "[COLOR:255:60:60:255]" .. Locale.ConvertTextKey("TXT_KEY_TP_EMPIRE_SUPER_UNHAPPY_NO_REBELS") .. "[/COLOR]";
+		elseif (pPlayer:IsEmpireVeryUnhappy() and not Game.IsOption(GameOptionTypes.GAMEOPTION_NO_BARBARIANS)) then			
 			strText = strText .. "[COLOR:255:60:60:255]" .. Locale.ConvertTextKey("TXT_KEY_TP_EMPIRE_VERY_UNHAPPY") .. "[/COLOR]";
+		elseif (pPlayer:IsEmpireVeryUnhappy() and Game.IsOption(GameOptionTypes.GAMEOPTION_NO_BARBARIANS)) then
+			strText = strText .. "[COLOR:255:60:60:255]" .. Locale.ConvertTextKey("TXT_KEY_TP_EMPIRE_VERY_UNHAPPY_NO_REBELS") .. "[/COLOR]";
 		elseif (pPlayer:IsEmpireUnhappy()) then
 			strText = strText .. "[COLOR:255:60:60:255]" .. Locale.ConvertTextKey("TXT_KEY_TP_EMPIRE_UNHAPPY") .. "[/COLOR]";
 		else

--- a/Community Patch/Core Files/Text/CoreText_en_US.sql
+++ b/Community Patch/Core Files/Text/CoreText_en_US.sql
@@ -4,6 +4,14 @@ INSERT INTO Language_en_US
 			(Tag,											Text)
 VALUES		('TXT_KEY_GAME_OPTION_BARB_GG_GA_POINTS',		'Barbarian GG/GA Points'),
 			('TXT_KEY_GAME_OPTION_BARB_GG_GA_POINTS_HELP',	'Allows all players to accumulate Great General and Great Admiral points from fighting Barbarians.');
+			
+UPDATE Language_en_US
+SET Text = 'Barbarians and their Encampments do not appear on the map. [ICON_HAPPINESS_4] Uprisings do not occur.'
+WHERE Tag = 'TXT_KEY_GAME_OPTION_NO_BARBARIANS_HELP' AND EXISTS (SELECT * FROM COMMUNITY WHERE Type='COMMUNITY_CORE_BALANCE_NATIONAL_HAPPINESS' AND Value= 1 );
+
+UPDATE Language_en_US
+SET Text = 'The rate at which Barbarians spawn is greatly increased, and camps spawn three units when created. [ICON_HAPPINESS_4] Uprisings occur more often.'
+WHERE Tag = 'TXT_KEY_GAME_OPTION_RAGING_BARBARIANS_HELP' AND EXISTS (SELECT * FROM COMMUNITY WHERE Type='COMMUNITY_CORE_BALANCE_NATIONAL_HAPPINESS' AND Value= 1 );
 
 -- Leaders
 

--- a/Community Patch/Core Files/Text/CoreText_en_US.xml
+++ b/Community Patch/Core Files/Text/CoreText_en_US.xml
@@ -6927,7 +6927,7 @@
 			<Text>Chill Barbarians</Text>
 		</Row>
 		<Row Tag="TXT_KEY_GAMEOPTION_CHILL_BARBARIANS_HELP">
-			<Text>Barbarian spawn rates reduced slightly, and camps do not spawn two units when created. Groovy, man.</Text>
+			<Text>Barbarian spawn rates are reduced slightly, [ICON_HAPPINESS_4] Uprisings occur less often, and camps do not spawn two units when created. Groovy, man.</Text>
 		</Row>
 
 		<Row Tag="TXT_KEY_GAMEOPTION_RANDOM_VICTORY">

--- a/CvGameCoreDLL_Expansion2/CvBarbarians.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBarbarians.cpp
@@ -221,10 +221,8 @@ void CvBarbarians::DoCampActivationNotice(CvPlot* pPlot)
 	//	iNumTurnsToSpawn += auto_ptr<ICvGame1> pGame = GameCore::GetGame();\n.getJonRandNum(4, "Early game Barb Spawn Rand call");
 	//}
 
-	// Difficulty level can add time between spawns (e.g. Settler is +8 turns)
-	CvHandicapInfo* pHandicapInfo = GC.getHandicapInfo(kGame.getHandicapType());
-	if (pHandicapInfo)
-		iNumTurnsToSpawn += pHandicapInfo->getBarbSpawnMod();
+	// Difficulty level can add time between spawns
+	iNumTurnsToSpawn += GC.getGame().getHandicapInfo().getBarbSpawnMod();
 
 	// Game Speed can increase or decrease amount of time between spawns (ranges from 67 on Quick to 400 on Marathon)
 	CvGameSpeedInfo* pGameSpeedInfo = GC.getGameSpeedInfo(kGame.getGameSpeedType());
@@ -238,7 +236,7 @@ void CvBarbarians::DoCampActivationNotice(CvPlot* pPlot)
 }
 #if defined(MOD_DIPLOMACY_CITYSTATES_QUESTS)
 //	--------------------------------------------------------------------------------
-/// Gameplay informing us when a Camp has either been created or spawned a Unit so we can reseed the spawn counter
+/// Gameplay informing us when a City has either been acquired or spawned a Unit so we can reseed the spawn counter
 void CvBarbarians::DoCityActivationNotice(CvPlot* pPlot)
 {
 	if (!pPlot)
@@ -269,7 +267,6 @@ void CvBarbarians::DoCityActivationNotice(CvPlot* pPlot)
 
 #if defined(MOD_BUGFIX_BARB_CAMP_SPAWNING)
 	if (m_aiPlotBarbCityNumUnitsSpawned == NULL) {
-		// Probably means we are being called as CvWorldBuilderMapLoaded is adding camps, MapInit() will follow soon and set everything up correctly
 		return;
 	}
 #endif
@@ -280,13 +277,11 @@ void CvBarbarians::DoCityActivationNotice(CvPlot* pPlot)
 	// Reduce turns between spawn if we've pumped out more guys (meaning we're further into the game)
 	iNumTurnsToSpawn -= min(3, iNumUnitsSpawned);	// -1 turns if we've spawned one Unit, -3 turns if we've spawned three
 
-	// Increment # of barbs spawned from this camp
-	m_aiPlotBarbCityNumUnitsSpawned[pPlot->GetPlotIndex()]++;	// This starts at -1 so when a camp is first created it will bump up to 0, which is correct
+	// Increment # of barbs spawned from this city
+	m_aiPlotBarbCityNumUnitsSpawned[pPlot->GetPlotIndex()]++;	// This starts at -1 so when a city is first acquired it will bump up to 0, which is correct
 
-	// Difficulty level can add time between spawns (e.g. Settler is +8 turns)
-	CvHandicapInfo* pHandicapInfo = GC.getHandicapInfo(kGame.getHandicapType());
-	if (pHandicapInfo)
-		iNumTurnsToSpawn += pHandicapInfo->getBarbSpawnMod();
+	// Difficulty level can add time between spawns
+	iNumTurnsToSpawn += GC.getGame().getHandicapInfo().getBarbSpawnMod();
 
 	// Game Speed can increase or decrease amount of time between spawns (ranges from 67 on Quick to 400 on Marathon)
 	CvGameSpeedInfo* pGameSpeedInfo = GC.getGameSpeedInfo(kGame.getGameSpeedType());
@@ -299,7 +294,7 @@ void CvBarbarians::DoCityActivationNotice(CvPlot* pPlot)
 	m_aiPlotBarbCitySpawnCounter[pPlot->GetPlotIndex()] = iNumTurnsToSpawn;
 }
 //	--------------------------------------------------------------------------------
-/// Gameplay informing a camp has been attacked - make it more likely to spawn
+/// Gameplay informing a city has been attacked - make it more likely to spawn
 void CvBarbarians::DoCityAttacked(CvPlot* pPlot)
 {
 	int iCounter = m_aiPlotBarbCitySpawnCounter[pPlot->GetPlotIndex()];
@@ -773,6 +768,11 @@ void CvBarbarians::DoCamps()
 
 						// Add another Unit adjacent to the Camp to stir up some trouble (JON: Disabled for now 09/12/09)
 						if (!GC.getGame().isOption(GAMEOPTION_CHILL_BARBARIANS))
+						{
+							DoSpawnBarbarianUnit(pLoopPlot, true, true);
+						}
+						// Add a third Unit if Raging Barbarians is enabled
+						if (GC.getGame().isOption(GAMEOPTION_RAGING_BARBARIANS))
 						{
 							DoSpawnBarbarianUnit(pLoopPlot, true, true);
 						}

--- a/CvGameCoreDLL_Expansion2/CvEspionageClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvEspionageClasses.cpp
@@ -1696,6 +1696,8 @@ bool CvPlayerEspionage::CanAdvancedAction(uint uiSpyIndex, CvCity* pCity, CvAdva
 			{
 				if (pCity->GetBlockRebellion() > 0)
 					return false;
+				if (GC.getGame().isOption(GAMEOPTION_NO_BARBARIANS))
+					return false;
 				break;
 			}
 		}
@@ -2198,7 +2200,20 @@ void CvPlayerEspionage::DoAdvancedAction(uint uiSpyIndex, CvCity* pCity, CvAdvan
 			int iNumRebelTotal = max(3, iNumRebels);
 			if (iNumRebelTotal > 0)
 			{
-				GC.getGame().DoSpawnUnitsAroundTargetCity(BARBARIAN_PLAYER, pCity, min(6, iNumRebelTotal), false, false, false, false);
+				if (iNumRebelTotal > 1 && GC.getGame().isOption(GAMEOPTION_CHILL_BARBARIANS))
+				{
+					iNumRebelTotal--;
+				}
+				
+				if (GC.getGame().isOption(GAMEOPTION_RAGING_BARBARIANS))
+				{
+					iNumRebelTotal++;
+					GC.getGame().DoSpawnUnitsAroundTargetCity(BARBARIAN_PLAYER, pCity, min(7, iNumRebelTotal), false, false, false, false);
+				}
+				else
+				{
+					GC.getGame().DoSpawnUnitsAroundTargetCity(BARBARIAN_PLAYER, pCity, min(6, iNumRebelTotal), false, false, false, false);
+				}
 
 				CvAssertMsg(pDefendingPlayerEspionage, "Defending player espionage is null");
 				if (pDefendingPlayerEspionage)

--- a/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
@@ -9618,6 +9618,16 @@ void CvMinorCivAI::DoRebellion()
 	int iExtraRoll = GC.getGame().getCurrentEra(); //Increase possible rebel spawns as game continues.
 	iNumRebels += GC.getGame().getSmallFakeRandNum(iExtraRoll,m_pPlayer->GetMilitaryMight()) * 200;
 	iNumRebels /= 100;
+	
+	if (iNumRebels > 1 && GC.getGame().isOption(GAMEOPTION_CHILL_BARBARIANS))
+	{
+		iNumRebels--;
+	}
+	
+	if (GC.getGame().isOption(GAMEOPTION_RAGING_BARBARIANS))
+	{
+		iNumRebels++;
+	}
 
 	// Find a city to pop up a bad man
 	CvCity* pBestCity = GetPlayer()->getCapitalCity();

--- a/EUI Compatibility Files/EUI Compatibility Files/LUA/TopPanel.lua
+++ b/EUI Compatibility Files/EUI Compatibility Files/LUA/TopPanel.lua
@@ -1155,10 +1155,14 @@ if civ5_mode then
 
 		-- CBP EDITS HERE
 
-			if g_activePlayer:IsEmpireSuperUnhappy() then
+			if g_activePlayer:IsEmpireSuperUnhappy() and not Game.IsOption(GameOptionTypes.GAMEOPTION_NO_BARBARIANS) then
 					tips:insert( "[COLOR:255:60:60:255]" .. L("TXT_KEY_TP_EMPIRE_SUPER_UNHAPPY")  .. "[ENDCOLOR]" )
-			elseif g_activePlayer:IsEmpireVeryUnhappy() then	
-				tips:insert("[COLOR:255:60:60:255]" .. L("TXT_KEY_TP_EMPIRE_VERY_UNHAPPY") .. "[ENDCOLOR]" )
+			else if g_activePlayer:IsEmpireSuperUnhappy() and Game.IsOption(GameOptionTypes.GAMEOPTION_NO_BARBARIANS) then
+					tips:insert( "[COLOR:255:60:60:255]" .. L("TXT_KEY_TP_EMPIRE_SUPER_UNHAPPY_NO_REBELS")  .. "[ENDCOLOR]" )
+			else if g_activePlayer:IsEmpireVeryUnhappy() and not Game.IsOption(GameOptionTypes.GAMEOPTION_NO_BARBARIANS) then
+					tips:insert( "[COLOR:255:60:60:255]" .. L("TXT_KEY_TP_EMPIRE_VERY_UNHAPPY")  .. "[ENDCOLOR]" )
+			else if g_activePlayer:IsEmpireVeryUnhappy() and Game.IsOption(GameOptionTypes.GAMEOPTION_NO_BARBARIANS) then
+					tips:insert( "[COLOR:255:60:60:255]" .. L("TXT_KEY_TP_EMPIRE_VERY_UNHAPPY_NO_REBELS")  .. "[ENDCOLOR]" )
 			elseif g_activePlayer:IsEmpireUnhappy() then
 				tips:insert( "[COLOR:255:60:60:255]" .. L("TXT_KEY_TP_EMPIRE_UNHAPPY") .. "[ENDCOLOR]" )
 			else

--- a/NoEUI Compatibility Files/Mod Template1/LUA/TopPanel.lua
+++ b/NoEUI Compatibility Files/Mod Template1/LUA/TopPanel.lua
@@ -756,10 +756,14 @@ function HappinessTipHandler( control )
 		local iPlayerID = Game.GetActivePlayer();
 		local pPlayer = Players[iPlayerID];
 		
-		if (pPlayer:IsEmpireSuperUnhappy()) then
+		if (pPlayer:IsEmpireSuperUnhappy() and not Game.IsOption(GameOptionTypes.GAMEOPTION_NO_BARBARIANS)) then
 			strText = strText .. "[COLOR:255:60:60:255]" .. Locale.ConvertTextKey("TXT_KEY_TP_EMPIRE_SUPER_UNHAPPY") .. "[/COLOR]";
-		elseif (pPlayer:IsEmpireVeryUnhappy()) then			
+		elseif (pPlayer:IsEmpireSuperUnhappy() and Game.IsOption(GameOptionTypes.GAMEOPTION_NO_BARBARIANS)) then
+			strText = strText .. "[COLOR:255:60:60:255]" .. Locale.ConvertTextKey("TXT_KEY_TP_EMPIRE_SUPER_UNHAPPY_NO_REBELS") .. "[/COLOR]";
+		elseif (pPlayer:IsEmpireVeryUnhappy() and not Game.IsOption(GameOptionTypes.GAMEOPTION_NO_BARBARIANS)) then			
 			strText = strText .. "[COLOR:255:60:60:255]" .. Locale.ConvertTextKey("TXT_KEY_TP_EMPIRE_VERY_UNHAPPY") .. "[/COLOR]";
+		elseif (pPlayer:IsEmpireVeryUnhappy() and Game.IsOption(GameOptionTypes.GAMEOPTION_NO_BARBARIANS)) then
+			strText = strText .. "[COLOR:255:60:60:255]" .. Locale.ConvertTextKey("TXT_KEY_TP_EMPIRE_VERY_UNHAPPY_NO_REBELS") .. "[/COLOR]";
 		elseif (pPlayer:IsEmpireUnhappy()) then
 			strText = strText .. "[COLOR:255:60:60:255]" .. Locale.ConvertTextKey("TXT_KEY_TP_EMPIRE_UNHAPPY") .. "[/COLOR]";
 		else


### PR DESCRIPTION
The current situation is as follows:
- Barbarians in uprisings are always land melee units, always the same type of unit, and never Unique or Ranged units.
- Barbarians spawn 2 units when a camp is created; 1 unit if Chill Barbarians is enabled.
- Chill Barbarians increases Barbarian spawn rates from camps & cities by 50%, and has no other effects.
- Raging Barbarians halves Barbarian spawn rates from camps & cities, and has no other effects.
- Barbarians do not spawn a garrison when they take over a city (usually as a result of a Horde/Rebellion quest), which can make them quite vulnerable.
- Barbarians can still spawn even if "No Barbarians" is enabled, from city uprisings (Unhappiness). Chill/Raging Barbarians do not have any effect on city uprisings.

I propose to make the following changes, and have included a pull request for the code work:
- Unit spawns from camps: 1 (Chill), 2 (Normal), 3 (Raging)
- Unit spawns when a city is captured: 1 (Chill), 2 (Normal), 3 (Raging)
- Horde/Rebellion quests: -1 Barb per wave (Chill), +1 Barb per wave (Raging)
- Espionage-induced rebellion: do not occur (No Barbs), -1 Barb (Chill), +1 Barb (Raging)
- Uprisings from Unhappiness: do not occur (No Barbs), are delayed by 50%, and -1 Barb per uprising (Chill), occur twice as often, and +1 Barb per uprising (Raging)
- Barbarian units in uprisings: Each unit in an uprising is of a random type + can be the player's Unique Units, or ranged units.

Rationale for Changes
- Unit spawns from camps: 1/2/3 is a linear progression and allows the player to dynamically adjust how many Barbarians they want to deal with.
- Unit spawns from cities: Same as camps + makes the strategy of waiting for a City-State to be captured, then rushing in to liberate it a little more challenging (currently it's often very easy, particularly with the CS nerf for cities).
- Horde/Rebellion quests: I feel that Chill/Raging Barbarians should impact these quests somewhat, since they deal with Barbarians.
- Espionage-induced rebellion: Same, and if the player has selected No Barbarians, then it makes sense that Barbarians should not be spawned in from espionage.
- Uprisings from Unhappiness: Chill/No Barbarians would now make it easier for new players who are getting a handle on the happiness system, allowing them to manage rebellions more easily. I've seen some complaints from new players about happiness management, so this would give them another tool. Also, since it deals with Barbarians, I feel the spawn rate should be affected by this, and once again, if the player has selected No Barbarians, then it makes sense that Barbarians should not appear. For Raging Barbarians, this would act as a counterbalance for the strategy of "go Authority and turn on Raging Barbarians for massive yield bonuses" - you can still do that, but if you go on a conquering spree and don't make your citizens happy, prepare to deal with more rebels.
- Barbarian units in uprisings: I feel this would be fun and less boring, but it makes karmic sense that warmongers should occasionally have to deal with a rebelling Jaguar or Impi, if they're not managing their empire's happiness well. :)

Also fixes a typo (super & very unhappy text keys were swapped).