### PR TITLE
Fix API Additions

### DIFF
--- a/Community Patch/Core Files/Core Tables/CoreTableEntries.sql
+++ b/Community Patch/Core Files/Core Tables/CoreTableEntries.sql
@@ -941,9 +941,6 @@ ALTER TABLE UnitPromotions ADD COLUMN 'NearbyHealFriendlyTerritory' INTEGER DEFA
 -- Double Movement on Mountains
 ALTER TABLE UnitPromotions ADD COLUMN 'MountainsDoubleMove' BOOLEAN DEFAULT 0;
 
--- No Movement Points Used On Embark
-ALTER TABLE UnitPromotions ADD COLUMN 'FreeEmbark' BOOLEAN DEFAULT 0;
-
 -- Admirals can use their repair fleet action multiple times before expending.
 ALTER TABLE UnitPromotions ADD COLUMN 'NumRepairCharges' INTEGER DEFAULT 0;
 

--- a/Community Patch/Core Files/Core Tables/CoreTableEntries.sql
+++ b/Community Patch/Core Files/Core Tables/CoreTableEntries.sql
@@ -266,7 +266,7 @@ ALTER TABLE Improvements ADD COLUMN 'GAUnitPlotExperience' INTEGER DEFAULT 0;
 ALTER TABLE Improvements ADD COLUMN 'MovesChange' INTEGER DEFAULT 0;
 
 -- Improvement requires fresh water, coast, or river adjacency to make valid.
-ALTER TABLE Improvements ADD COLUMN 'AnyBodyOfWaterMakesValid' BOOLEAN DEFAULT 0;
+ALTER TABLE Improvements ADD COLUMN 'WaterAdjacencyMakesValid' BOOLEAN DEFAULT 0;
 
 -- Allows you to set a tech that makes an impassable terrain/feature element passable.
 ALTER TABLE Features ADD COLUMN 'PassableTechFeature' TEXT DEFAULT NULL;

--- a/Community Patch/Core Files/Core Tables/CoreTableEntries.sql
+++ b/Community Patch/Core Files/Core Tables/CoreTableEntries.sql
@@ -265,7 +265,7 @@ ALTER TABLE Improvements ADD COLUMN 'GAUnitPlotExperience' INTEGER DEFAULT 0;
 -- Improvement grants extra moves when unit is on this plot
 ALTER TABLE Improvements ADD COLUMN 'MovesChange' INTEGER DEFAULT 0;
 
--- Improvement requires any body of water adjacent to it in order to be built
+-- Improvement requires fresh water, coast, or river adjacency to make valid.
 ALTER TABLE Improvements ADD COLUMN 'AnyBodyOfWaterMakesValid' BOOLEAN DEFAULT 0;
 
 -- Allows you to set a tech that makes an impassable terrain/feature element passable.

--- a/Community Patch/Core Files/Core Tables/CoreTableEntries.sql
+++ b/Community Patch/Core Files/Core Tables/CoreTableEntries.sql
@@ -941,6 +941,12 @@ ALTER TABLE UnitPromotions ADD COLUMN 'NearbyHealFriendlyTerritory' INTEGER DEFA
 -- Double Movement on Mountains
 ALTER TABLE UnitPromotions ADD COLUMN 'MountainsDoubleMove' BOOLEAN DEFAULT 0;
 
+-- Embarking Costs One Movement Point
+ALTER TABLE UnitPromotions ADD COLUMN 'EmbarkFlatCost' BOOLEAN DEFAULT 0;
+
+-- Disembarking Costs One Movement Point
+ALTER TABLE UnitPromotions ADD COLUMN 'DisembarkFlatCost' BOOLEAN DEFAULT 0;
+
 -- Admirals can use their repair fleet action multiple times before expending.
 ALTER TABLE UnitPromotions ADD COLUMN 'NumRepairCharges' INTEGER DEFAULT 0;
 

--- a/CvGameCoreDLL_Expansion2/CvImprovementClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvImprovementClasses.cpp
@@ -116,7 +116,7 @@ CvImprovementEntry::CvImprovementEntry(void):
 #if defined(MOD_GLOBAL_PASSABLE_FORTS)
 	m_bMakesPassable(false),
 #endif
-	m_bAnyBodyOfWaterMakesValid(false),
+	m_bWaterAdjacencyMakesValid(false),
 	m_bFreshWaterMakesValid(false),
 	m_bRiverSideMakesValid(false),
 	m_bNoFreshWater(false),
@@ -289,7 +289,7 @@ bool CvImprovementEntry::CacheResults(Database::Results& kResults, CvDatabaseUti
 #if defined(MOD_GLOBAL_PASSABLE_FORTS)
 	m_bMakesPassable = kResults.GetBool("MakesPassable");
 #endif
-	m_bAnyBodyOfWaterMakesValid = kResults.GetBool("AnyBodyOfWaterMakesValid");
+	m_bWaterAdjacencyMakesValid = kResults.GetBool("WaterAdjacencyMakesValid");
 	m_bFreshWaterMakesValid = kResults.GetBool("FreshWaterMakesValid");
 	m_bRiverSideMakesValid = kResults.GetBool("RiverSideMakesValid");
 	m_bNoFreshWater = kResults.GetBool("NoFreshWater");
@@ -1027,9 +1027,9 @@ bool CvImprovementEntry::IsMakesPassable() const
 #endif
 
 // Requires any body of water to build
-bool CvImprovementEntry::IsAnyBodyOfWaterMakesValid() const
+bool CvImprovementEntry::IsWaterAdjacencyMakesValid() const
 {
-	return m_bAnyBodyOfWaterMakesValid;
+	return m_bWaterAdjacencyMakesValid;
 }
 
 /// Requires fresh water to build

--- a/CvGameCoreDLL_Expansion2/CvImprovementClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvImprovementClasses.h
@@ -116,7 +116,7 @@ public:
 #if defined(MOD_GLOBAL_PASSABLE_FORTS)
 	bool IsMakesPassable() const;
 #endif
-	bool IsAnyBodyOfWaterMakesValid() const;
+	bool IsWaterAdjacencyMakesValid() const;
 	bool IsFreshWaterMakesValid() const;
 	bool IsRiverSideMakesValid() const;
 	bool IsNoFreshWater() const;
@@ -289,7 +289,7 @@ protected:
 #if defined(MOD_GLOBAL_PASSABLE_FORTS)
 	bool m_bMakesPassable;
 #endif
-	bool m_bAnyBodyOfWaterMakesValid;
+	bool m_bWaterAdjacencyMakesValid;
 	bool m_bFreshWaterMakesValid;
 	bool m_bRiverSideMakesValid;
 	bool m_bNoFreshWater;

--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -2425,7 +2425,7 @@ bool CvPlot::canHaveImprovement(ImprovementTypes eImprovement, PlayerTypes ePlay
 		bValid = true;
 	}
 
-	if(pkImprovementInfo->IsAnyBodyOfWaterMakesValid())
+	if(pkImprovementInfo->IsWaterAdjacencyMakesValid())
 	{
 		if (isCoastalLand() || isFreshWater() || isRiver()) 
 		{

--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -9820,27 +9820,22 @@ int CvPlot::calculateNatureYield(YieldTypes eYield, PlayerTypes ePlayer, const C
 			}
 			if (pOwningCity->plot()->getImprovementType() == eFort || pOwningCity->plot()->getImprovementType() == eCitadel)
 			{
-				CvUnit* pUnit = pOwningCity->plot()->getCenterUnit();
-				if (pUnit != NULL && pUnit->GetFortificationYieldChange(eYield) > 0)
+				// Don't provide yield if tile is pillaged
+				if (pOwningCity->plot()->IsImprovementPillaged() == false)
 				{
-					int iUnitStrength = pUnit->GetBaseCombatStrength();
-					iYield += ((pUnit->GetFortificationYieldChange(eYield) * iUnitStrength) / 8);
-				}
-			}
-			if (pOwningCity->plot()->getImprovementType() == eFort || pOwningCity->plot()->getImprovementType() == eCitadel)
-			{
-				// If there are any Units here, meet their owners
-				for (int iUnitLoop = 0; iUnitLoop < getNumUnits(); iUnitLoop++)
-				{
-					// If the AI spots a human Unit, don't meet - wait for the human to find the AI
-					CvUnit* loopUnit = getUnitByIndex(iUnitLoop);
-					if (!loopUnit)
-						continue;
-
-					if (loopUnit->GetFortificationYieldChange(eYield) > 0)
+					// If there are any Units here, meet their owners
+					for (int iUnitLoop = 0; iUnitLoop < getNumUnits(); iUnitLoop++)
 					{
-						int iUnitStrength = loopUnit->GetBaseCombatStrength();
-						iYield += ((loopUnit->GetFortificationYieldChange(eYield) * iUnitStrength) / 8);
+						// If the AI spots a human Unit, don't meet - wait for the human to find the AI
+						CvUnit* loopUnit = getUnitByIndex(iUnitLoop);
+						if (!loopUnit)
+							continue;
+
+						if (loopUnit->GetFortificationYieldChange(eYield) > 0)
+						{
+							int iUnitStrength = loopUnit->GetBaseCombatStrength();
+							iYield += ((loopUnit->GetFortificationYieldChange(eYield) * iUnitStrength) / 8);
+						}
 					}
 				}
 			}

--- a/CvGameCoreDLL_Expansion2/CvPromotionClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPromotionClasses.cpp
@@ -189,7 +189,6 @@ CvPromotionEntry::CvPromotionEntry():
 	m_iLandAirDefenseValue(0),
 	m_iDamageReductionCityAssault(0),
 	m_bMountainsDoubleMove(false),
-	m_bFreeEmbark(false),
 	m_bMountedOnly(false),
 #endif
 #if defined(MOD_PROMOTIONS_CROSS_MOUNTAINS)
@@ -450,7 +449,6 @@ bool CvPromotionEntry::CacheResults(Database::Results& kResults, CvDatabaseUtili
 	m_iLandAirDefenseValue = kResults.GetInt("LandAirDefenseBonus");
 	m_iDamageReductionCityAssault = kResults.GetInt("DamageReductionCityAssault");
 	m_bMountainsDoubleMove = kResults.GetBool("MountainsDoubleMove");
-	m_bFreeEmbark = kResults.GetBool("FreeEmbark");
 	m_bMountedOnly = kResults.GetBool("MountedOnly");
 #endif
 #if defined(MOD_PROMOTIONS_CROSS_MOUNTAINS)
@@ -2155,11 +2153,6 @@ int CvPromotionEntry::GetDamageReductionCityAssault() const
 bool CvPromotionEntry::IsMountainsDoubleMove() const
 {
 	return m_bMountainsDoubleMove;
-}
-
-bool CvPromotionEntry::IsFreeEmbark() const
-{
-	return m_bFreeEmbark;
 }
 
 bool CvPromotionEntry::IsMountedOnly() const

--- a/CvGameCoreDLL_Expansion2/CvPromotionClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPromotionClasses.cpp
@@ -189,6 +189,8 @@ CvPromotionEntry::CvPromotionEntry():
 	m_iLandAirDefenseValue(0),
 	m_iDamageReductionCityAssault(0),
 	m_bMountainsDoubleMove(false),
+	m_bEmbarkFlatCost(false),
+	m_bDisembarkFlatCost(false),
 	m_bMountedOnly(false),
 #endif
 #if defined(MOD_PROMOTIONS_CROSS_MOUNTAINS)
@@ -449,6 +451,8 @@ bool CvPromotionEntry::CacheResults(Database::Results& kResults, CvDatabaseUtili
 	m_iLandAirDefenseValue = kResults.GetInt("LandAirDefenseBonus");
 	m_iDamageReductionCityAssault = kResults.GetInt("DamageReductionCityAssault");
 	m_bMountainsDoubleMove = kResults.GetBool("MountainsDoubleMove");
+	m_bEmbarkFlatCost = kResults.GetBool("EmbarkFlatCost");
+	m_bDisembarkFlatCost = kResults.GetBool("DisembarkFlatCost");
 	m_bMountedOnly = kResults.GetBool("MountedOnly");
 #endif
 #if defined(MOD_PROMOTIONS_CROSS_MOUNTAINS)
@@ -2153,6 +2157,16 @@ int CvPromotionEntry::GetDamageReductionCityAssault() const
 bool CvPromotionEntry::IsMountainsDoubleMove() const
 {
 	return m_bMountainsDoubleMove;
+}
+
+bool CvPromotionEntry::IsEmbarkFlatCost() const
+{
+	return m_bEmbarkFlatCost;
+}
+
+bool CvPromotionEntry::IsDisembarkFlatCost() const
+{
+	return m_bDisembarkFlatCost;
 }
 
 bool CvPromotionEntry::IsMountedOnly() const

--- a/CvGameCoreDLL_Expansion2/CvPromotionClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvPromotionClasses.h
@@ -182,7 +182,6 @@ public:
 	int GetWonderProductionModifier() const;
 	bool IsStrongerDamaged() const;
 	bool IsMountainsDoubleMove() const;
-	bool IsFreeEmbark() const;
 	bool IsMountedOnly() const;
 	int GetAOEDamageOnKill() const;
 	int GetAoEDamageOnMove() const;
@@ -534,7 +533,6 @@ protected:
 	int m_iLandAirDefenseValue;
 	int m_iDamageReductionCityAssault;
 	bool m_bMountainsDoubleMove;
-	bool m_bFreeEmbark;
 	bool m_bMountedOnly;
 #endif
 #if defined(MOD_PROMOTIONS_CROSS_MOUNTAINS)

--- a/CvGameCoreDLL_Expansion2/CvPromotionClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvPromotionClasses.h
@@ -182,6 +182,8 @@ public:
 	int GetWonderProductionModifier() const;
 	bool IsStrongerDamaged() const;
 	bool IsMountainsDoubleMove() const;
+	bool IsEmbarkFlatCost() const;
+	bool IsDisembarkFlatCost() const;
 	bool IsMountedOnly() const;
 	int GetAOEDamageOnKill() const;
 	int GetAoEDamageOnMove() const;
@@ -533,6 +535,8 @@ protected:
 	int m_iLandAirDefenseValue;
 	int m_iDamageReductionCityAssault;
 	bool m_bMountainsDoubleMove;
+	bool m_bEmbarkFlatCost;
+	bool m_bDisembarkFlatCost;
 	bool m_bMountedOnly;
 #endif
 #if defined(MOD_PROMOTIONS_CROSS_MOUNTAINS)

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -174,6 +174,8 @@ CvUnit::CvUnit() :
 	, m_iHillsDoubleMoveCount("CvUnit::m_iHillsDoubleMoveCount", m_syncArchive)
 #if defined(MOD_BALANCE_CORE)
 	, m_iMountainsDoubleMoveCount("CvUnit::m_iMountainsDoubleMoveCount", m_syncArchive)
+	, m_iEmbarkFlatCostCount("CvUnit::m_iEmbarkFlatCostCount", m_syncArchive)
+	, m_iDisembarkFlatCostCount("CvUnit::m_iDisembarkFlatCostCount", m_syncArchive)
 	, m_iAOEDamageOnKill("CvUnit::m_iAOEDamageOnKill", m_syncArchive)
 	, m_iAoEDamageOnMove("CvUnit::m_iAoEDamageOnMove", m_syncArchive)
 	, m_iSplashDamage("CvUnit::m_iSplashDamage", m_syncArchive)
@@ -1457,6 +1459,8 @@ void CvUnit::reset(int iID, UnitTypes eUnit, PlayerTypes eOwner, bool bConstruct
 	m_iHillsDoubleMoveCount = 0;
 #if defined(MOD_BALANCE_CORE)
 	m_iMountainsDoubleMoveCount = 0;
+	m_iEmbarkFlatCostCount = 0;
+	m_iDisembarkFlatCostCount = 0;
 	m_iAOEDamageOnKill = 0;
 	m_iAoEDamageOnMove = 0;
 	m_iSplashDamage = 0;
@@ -21871,6 +21875,47 @@ void CvUnit::changeMountainsDoubleMoveCount(int iChange)
 	m_iMountainsDoubleMoveCount = (m_iMountainsDoubleMoveCount + iChange);
 	CvAssert(getMountainsDoubleMoveCount() >= 0);
 }
+
+//	--------------------------------------------------------------------------------
+int CvUnit::getEmbarkFlatCostCount() const
+{
+	VALIDATE_OBJECT
+		return m_iEmbarkFlatCostCount;
+}
+//	--------------------------------------------------------------------------------
+bool CvUnit::isEmbarkFlatCost() const
+{
+	VALIDATE_OBJECT
+		return (getEmbarkFlatCostCount() > 0);
+}
+//	--------------------------------------------------------------------------------
+void CvUnit::changeEmbarkFlatCostCount(int iChange)
+{
+	VALIDATE_OBJECT
+		m_iEmbarkFlatCostCount = (m_iEmbarkFlatCostCount + iChange);
+	CvAssert(getEmbarkFlatCostCount() >= 0);
+}
+
+//	--------------------------------------------------------------------------------
+int CvUnit::getDisembarkFlatCostCount() const
+{
+	VALIDATE_OBJECT
+		return m_iDisembarkFlatCostCount;
+}
+//	--------------------------------------------------------------------------------
+bool CvUnit::isDisembarkFlatCost() const
+{
+	VALIDATE_OBJECT
+		return (getDisembarkFlatCostCount() > 0);
+}
+//	--------------------------------------------------------------------------------
+void CvUnit::changeDisembarkFlatCostCount(int iChange)
+{
+	VALIDATE_OBJECT
+		m_iDisembarkFlatCostCount = (m_iDisembarkFlatCostCount + iChange);
+	CvAssert(getDisembarkFlatCostCount() >= 0);
+}
+
 //	--------------------------------------------------------------------------------
 int CvUnit::getAOEDamageOnKill() const
 {
@@ -26823,6 +26868,8 @@ void CvUnit::setHasPromotion(PromotionTypes eIndex, bool bNewValue)
 		changeMultiAttackBonus(thisPromotion.GetMultiAttackBonus() *  iChange);
 		changeLandAirDefenseValue(thisPromotion.GetLandAirDefenseValue() *  iChange);
 		changeMountainsDoubleMoveCount((thisPromotion.IsMountainsDoubleMove()) ? iChange : 0);
+		changeEmbarkFlatCostCount((thisPromotion.IsEmbarkFlatCost()) ? iChange : 0);
+		changeDisembarkFlatCostCount((thisPromotion.IsDisembarkFlatCost()) ? iChange : 0);
 		ChangeCaptureDefeatedEnemyChance((thisPromotion.GetCaptureDefeatedEnemyChance()) * iChange);
 		ChangeBarbarianCombatBonus((thisPromotion.GetBarbarianCombatBonus()) * iChange);
 		ChangeAdjacentEnemySapMovement((thisPromotion.GetAdjacentEnemySapMovement()) * iChange);

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -174,7 +174,6 @@ CvUnit::CvUnit() :
 	, m_iHillsDoubleMoveCount("CvUnit::m_iHillsDoubleMoveCount", m_syncArchive)
 #if defined(MOD_BALANCE_CORE)
 	, m_iMountainsDoubleMoveCount("CvUnit::m_iMountainsDoubleMoveCount", m_syncArchive)
-	, m_iFreeEmbarkMoveCount("CvUnit::m_iFreeEmbarkMoveCount", m_syncArchive)
 	, m_iAOEDamageOnKill("CvUnit::m_iAOEDamageOnKill", m_syncArchive)
 	, m_iAoEDamageOnMove("CvUnit::m_iAoEDamageOnMove", m_syncArchive)
 	, m_iSplashDamage("CvUnit::m_iSplashDamage", m_syncArchive)
@@ -1458,7 +1457,6 @@ void CvUnit::reset(int iID, UnitTypes eUnit, PlayerTypes eOwner, bool bConstruct
 	m_iHillsDoubleMoveCount = 0;
 #if defined(MOD_BALANCE_CORE)
 	m_iMountainsDoubleMoveCount = 0;
-	m_iFreeEmbarkMoveCount = 0;
 	m_iAOEDamageOnKill = 0;
 	m_iAoEDamageOnMove = 0;
 	m_iSplashDamage = 0;
@@ -21873,27 +21871,6 @@ void CvUnit::changeMountainsDoubleMoveCount(int iChange)
 	m_iMountainsDoubleMoveCount = (m_iMountainsDoubleMoveCount + iChange);
 	CvAssert(getMountainsDoubleMoveCount() >= 0);
 }
-
-//	--------------------------------------------------------------------------------
-int CvUnit::getFreeEmbarkMoveCount() const
-{
-	VALIDATE_OBJECT
-		return m_iFreeEmbarkMoveCount;
-}
-//	--------------------------------------------------------------------------------
-bool CvUnit::isFreeEmbark() const
-{
-	VALIDATE_OBJECT
-		return (getFreeEmbarkMoveCount() > 0);
-}
-//	--------------------------------------------------------------------------------
-void CvUnit::changeFreeEmbarkMoveCount(int iChange)
-{
-	VALIDATE_OBJECT
-		m_iFreeEmbarkMoveCount = (m_iFreeEmbarkMoveCount + iChange);
-	CvAssert(getFreeEmbarkMoveCount() >= 0);
-}
-
 //	--------------------------------------------------------------------------------
 int CvUnit::getAOEDamageOnKill() const
 {
@@ -26846,7 +26823,6 @@ void CvUnit::setHasPromotion(PromotionTypes eIndex, bool bNewValue)
 		changeMultiAttackBonus(thisPromotion.GetMultiAttackBonus() *  iChange);
 		changeLandAirDefenseValue(thisPromotion.GetLandAirDefenseValue() *  iChange);
 		changeMountainsDoubleMoveCount((thisPromotion.IsMountainsDoubleMove()) ? iChange : 0);
-		changeFreeEmbarkMoveCount((thisPromotion.IsFreeEmbark()) ? iChange : 0);
 		ChangeCaptureDefeatedEnemyChance((thisPromotion.GetCaptureDefeatedEnemyChance()) * iChange);
 		ChangeBarbarianCombatBonus((thisPromotion.GetBarbarianCombatBonus()) * iChange);
 		ChangeAdjacentEnemySapMovement((thisPromotion.GetAdjacentEnemySapMovement()) * iChange);

--- a/CvGameCoreDLL_Expansion2/CvUnit.h
+++ b/CvGameCoreDLL_Expansion2/CvUnit.h
@@ -1103,6 +1103,14 @@ public:
 	bool isMountainsDoubleMove() const;
 	void changeMountainsDoubleMoveCount(int iChange);
 
+	int getEmbarkFlatCostCount() const;
+	bool isEmbarkFlatCost() const;
+	void changeEmbarkFlatCostCount(int iChange);
+
+	int getDisembarkFlatCostCount() const;
+	bool isDisembarkFlatCost() const;
+	void changeDisembarkFlatCostCount(int iChange);
+
 	int getAOEDamageOnKill() const;
 	void changeAOEDamageOnKill(int iChange);
 	
@@ -1992,6 +2000,8 @@ protected:
 	FAutoVariable<int, CvUnit> m_iHillsDoubleMoveCount;
 #if defined(MOD_BALANCE_CORE)
 	FAutoVariable<int, CvUnit> m_iMountainsDoubleMoveCount;
+	FAutoVariable<int, CvUnit> m_iEmbarkFlatCostCount;
+	FAutoVariable<int, CvUnit> m_iDisembarkFlatCostCount;
 	FAutoVariable<int, CvUnit> m_iAOEDamageOnKill;
 	FAutoVariable<int, CvUnit> m_iAoEDamageOnMove;
 	FAutoVariable<int, CvUnit> m_iSplashDamage;

--- a/CvGameCoreDLL_Expansion2/CvUnit.h
+++ b/CvGameCoreDLL_Expansion2/CvUnit.h
@@ -1103,10 +1103,6 @@ public:
 	bool isMountainsDoubleMove() const;
 	void changeMountainsDoubleMoveCount(int iChange);
 
-	int getFreeEmbarkMoveCount() const;
-	bool isFreeEmbark() const;
-	void changeFreeEmbarkMoveCount(int iChange);
-
 	int getAOEDamageOnKill() const;
 	void changeAOEDamageOnKill(int iChange);
 	
@@ -1996,7 +1992,6 @@ protected:
 	FAutoVariable<int, CvUnit> m_iHillsDoubleMoveCount;
 #if defined(MOD_BALANCE_CORE)
 	FAutoVariable<int, CvUnit> m_iMountainsDoubleMoveCount;
-	FAutoVariable<int, CvUnit> m_iFreeEmbarkMoveCount;
 	FAutoVariable<int, CvUnit> m_iAOEDamageOnKill;
 	FAutoVariable<int, CvUnit> m_iAoEDamageOnMove;
 	FAutoVariable<int, CvUnit> m_iSplashDamage;

--- a/CvGameCoreDLL_Expansion2/CvUnitMovement.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnitMovement.cpp
@@ -93,7 +93,8 @@ int CvUnitMovement::GetCostsForMove(const CvUnit* pUnit, const CvPlot* pFromPlot
 		if (!bToEmbark && bFromEmbark)
 		{
 			// Is the unit from a civ that can disembark for just 1 MP?
-			if (GET_PLAYER(pUnit->getOwner()).GetPlayerTraits()->IsEmbarkedToLandFlatCost())
+			// Does it have a promotion to do so?
+			if (GET_PLAYER(pUnit->getOwner()).GetPlayerTraits()->IsEmbarkedToLandFlatCost() || pUnit->isDisembarkFlatCost())
 				bCheapEmbarkStateChange = true;
 
 #if defined(MOD_BALANCE_CORE_EMBARK_CITY_NO_COST)
@@ -113,7 +114,8 @@ int CvUnitMovement::GetCostsForMove(const CvUnit* pUnit, const CvPlot* pFromPlot
 		if (bToEmbark && !bFromEmbark)
 		{
 			// Is the unit from a civ that can embark for just 1 MP?
-			if (GET_PLAYER(pUnit->getOwner()).GetPlayerTraits()->IsEmbarkedToLandFlatCost())
+			// Does it have a promotion to do so?
+			if (GET_PLAYER(pUnit->getOwner()).GetPlayerTraits()->IsEmbarkedToLandFlatCost() || pUnit->isEmbarkFlatCost())
 				bCheapEmbarkStateChange = true;
 
 #if defined(MOD_BALANCE_CORE_EMBARK_CITY_NO_COST)

--- a/CvGameCoreDLL_Expansion2/CvUnitMovement.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnitMovement.cpp
@@ -542,10 +542,6 @@ int CvUnitMovement::GetMovementCostMultiplierFromPromotions(const CvUnit* pUnit,
 	{
 		iModifier *= 2;
 	}
-	else if (pPlot->needsEmbarkation(pUnit) && pUnit->isFreeEmbark())
-	{
-		iModifier = 0;
-	}
 
 	return iModifier;
 }


### PR DESCRIPTION
UnableToCancelRazing and AnyBodyOfWaterMakesValid are working. FortificationYield has been fixed with this.
I have removed FreeEmbark and have overhauled it. Now split into EmbarkFlatCost and DisembarkFlatCost. A unit with the EmbarkFlatCost promotions embarks for one movement point. A unit with DisembarkFlatCost disembarks for one movement point.