### PR TITLE
Bugfixes

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvDealClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDealClasses.cpp
@@ -598,7 +598,7 @@ bool CvDeal::IsPossibleToTradeItem(PlayerTypes ePlayer, PlayerTypes eToPlayer, T
 			TechTypes eCityTradeTech = (TechTypes)GC.getResourceInfo(eResource)->getTechCityTrade();
 			if (eCityTradeTech != NO_TECH)
 			{
-				if (!pFromPlayer->HasTech(eCityTradeTech) || !pToPlayer->HasTech(eCityTradeTech))
+				if (!pFromPlayer->HasTech(eCityTradeTech))
 				{
 					return false;
 				}


### PR DESCRIPTION
Players buying resources in trade deals no longer require the city trade tech for that resource.