### PR TITLE
Fix numeric sorting in Religion Overview

### DIFF
--- a/43 Civs CP/43 Civs CP/CP Only/ReligionOverview.lua
+++ b/43 Civs CP/43 Civs CP/CP Only/ReligionOverview.lua
@@ -671,7 +671,7 @@ end
 function NumericSortFunction(field, direction)
 	if(direction == "asc") then
 		return function(a,b)
-			return a[field] <= b[field];
+			return a[field] < b[field];
 		end
 	elseif(direction == "desc") then
 		return function(a,b)
@@ -706,7 +706,7 @@ function GetSortFunction(sortOptions)
 	local orderBy = nil;
 	for i,v in ipairs(sortOptions) do
 		if(v.CurrentDirection ~= nil) then
-			if(v.SortType == "Numeric") then
+			if(v.SortType == "numeric") then
 				return NumericSortFunction(v.Column, v.CurrentDirection);
 			else
 				return AlphabeticalSortFunction(v.Column, v.CurrentDirection);

--- a/43 Civs CP/43 Civs CP/EUI/ReligionOverview.lua
+++ b/43 Civs CP/43 Civs CP/EUI/ReligionOverview.lua
@@ -671,7 +671,7 @@ end
 function NumericSortFunction(field, direction)
 	if(direction == "asc") then
 		return function(a,b)
-			return a[field] <= b[field];
+			return a[field] < b[field];
 		end
 	elseif(direction == "desc") then
 		return function(a,b)
@@ -706,7 +706,7 @@ function GetSortFunction(sortOptions)
 	local orderBy = nil;
 	for i,v in ipairs(sortOptions) do
 		if(v.CurrentDirection ~= nil) then
-			if(v.SortType == "Numeric") then
+			if(v.SortType == "numeric") then
 				return NumericSortFunction(v.Column, v.CurrentDirection);
 			else
 				return AlphabeticalSortFunction(v.Column, v.CurrentDirection);

--- a/43 Civs CP/43 Civs CP/No-EUI/ReligionOverview.lua
+++ b/43 Civs CP/43 Civs CP/No-EUI/ReligionOverview.lua
@@ -671,7 +671,7 @@ end
 function NumericSortFunction(field, direction)
 	if(direction == "asc") then
 		return function(a,b)
-			return a[field] <= b[field];
+			return a[field] < b[field];
 		end
 	elseif(direction == "desc") then
 		return function(a,b)
@@ -706,7 +706,7 @@ function GetSortFunction(sortOptions)
 	local orderBy = nil;
 	for i,v in ipairs(sortOptions) do
 		if(v.CurrentDirection ~= nil) then
-			if(v.SortType == "Numeric") then
+			if(v.SortType == "numeric") then
 				return NumericSortFunction(v.Column, v.CurrentDirection);
 			else
 				return AlphabeticalSortFunction(v.Column, v.CurrentDirection);

--- a/Community Balance Patch/LUA/ReligionOverview.lua
+++ b/Community Balance Patch/LUA/ReligionOverview.lua
@@ -671,7 +671,7 @@ end
 function NumericSortFunction(field, direction)
 	if(direction == "asc") then
 		return function(a,b)
-			return a[field] <= b[field];
+			return a[field] < b[field];
 		end
 	elseif(direction == "desc") then
 		return function(a,b)
@@ -706,7 +706,7 @@ function GetSortFunction(sortOptions)
 	local orderBy = nil;
 	for i,v in ipairs(sortOptions) do
 		if(v.CurrentDirection ~= nil) then
-			if(v.SortType == "Numeric") then
+			if(v.SortType == "numeric") then
 				return NumericSortFunction(v.Column, v.CurrentDirection);
 			else
 				return AlphabeticalSortFunction(v.Column, v.CurrentDirection);

--- a/Community Patch/LUA/ReligionOverview.lua
+++ b/Community Patch/LUA/ReligionOverview.lua
@@ -671,7 +671,7 @@ end
 function NumericSortFunction(field, direction)
 	if(direction == "asc") then
 		return function(a,b)
-			return a[field] <= b[field];
+			return a[field] < b[field];
 		end
 	elseif(direction == "desc") then
 		return function(a,b)
@@ -706,7 +706,7 @@ function GetSortFunction(sortOptions)
 	local orderBy = nil;
 	for i,v in ipairs(sortOptions) do
 		if(v.CurrentDirection ~= nil) then
-			if(v.SortType == "Numeric") then
+			if(v.SortType == "numeric") then
 				return NumericSortFunction(v.Column, v.CurrentDirection);
 			else
 				return AlphabeticalSortFunction(v.Column, v.CurrentDirection);

--- a/EUI Compatibility Files/EUI Compatibility Files/LUA/ReligionOverview.lua
+++ b/EUI Compatibility Files/EUI Compatibility Files/LUA/ReligionOverview.lua
@@ -671,7 +671,7 @@ end
 function NumericSortFunction(field, direction)
 	if(direction == "asc") then
 		return function(a,b)
-			return a[field] <= b[field];
+			return a[field] < b[field];
 		end
 	elseif(direction == "desc") then
 		return function(a,b)
@@ -706,7 +706,7 @@ function GetSortFunction(sortOptions)
 	local orderBy = nil;
 	for i,v in ipairs(sortOptions) do
 		if(v.CurrentDirection ~= nil) then
-			if(v.SortType == "Numeric") then
+			if(v.SortType == "numeric") then
 				return NumericSortFunction(v.Column, v.CurrentDirection);
 			else
 				return AlphabeticalSortFunction(v.Column, v.CurrentDirection);

--- a/NoEUI Compatibility Files/Mod Template1/LUA/ReligionOverview.lua
+++ b/NoEUI Compatibility Files/Mod Template1/LUA/ReligionOverview.lua
@@ -671,7 +671,7 @@ end
 function NumericSortFunction(field, direction)
 	if(direction == "asc") then
 		return function(a,b)
-			return a[field] <= b[field];
+			return a[field] < b[field];
 		end
 	elseif(direction == "desc") then
 		return function(a,b)
@@ -706,7 +706,7 @@ function GetSortFunction(sortOptions)
 	local orderBy = nil;
 	for i,v in ipairs(sortOptions) do
 		if(v.CurrentDirection ~= nil) then
-			if(v.SortType == "Numeric") then
+			if(v.SortType == "numeric") then
 				return NumericSortFunction(v.Column, v.CurrentDirection);
 			else
 				return AlphabeticalSortFunction(v.Column, v.CurrentDirection);


### PR DESCRIPTION
This fixes issue #6048.
I have tested these changes in my current game successfully; I also checked the vanilla files and this actually seems to be a vanilla bug.

Since this is my first pull request, please let me know if I did everything correctly; I hope I didn't miss any file or other change that I was supposed to do. Implementing this by editing the ReligionOverview.lua file in my MODS folder (of the last overriding mod, which in my case is the Religion Spread mod), clearing the cache and running the game shows that the issue is successfully fixed.