### PR TITLE
Diplo Fixes & Improvements

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
@@ -36276,6 +36276,10 @@ bool CvDiplomacyAI::IsDoFBroken(PlayerTypes ePlayer) const
 	CvAssertMsg(ePlayer >= 0, "DIPLOMACY_AI: Invalid Player Index.  Please send Jon this with your last 5 autosaves and what changelist # you're playing.");
 	CvAssertMsg(ePlayer < MAX_MAJOR_CIVS, "DIPLOMACY_AI: Invalid Player Index.  Please send Jon this with your last 5 autosaves and what changelist # you're playing.");
 	
+	// Vassals can't be untrustworthy, they have no rights.
+	if (GET_TEAM(GET_PLAYER(ePlayer).getTeam()).IsVassalOfSomeone())
+		return false;
+	
 	if (GetPlayer()->isHuman() && GET_PLAYER(ePlayer).isHuman())
 	{
 		return false;
@@ -36347,9 +36351,13 @@ void CvDiplomacyAI::SetDoFBroken(PlayerTypes ePlayer, bool bValue)
 			}
 		}
 		
-		if (bValue && (GetPlayer()->isHuman() && GET_PLAYER(ePlayer).isHuman()))
+		if (bValue)
 		{
-			return;
+			if (GetPlayer()->isHuman() && GET_PLAYER(ePlayer).isHuman())
+				return;
+			
+			if (GET_TEAM(GET_PLAYER(ePlayer).getTeam()).IsVassalOfSomeone())
+				return;
 		}
 		
 		m_pabDoFBroken[ePlayer] = bValue;
@@ -37969,8 +37977,14 @@ void CvDiplomacyAI::SetFriendDenouncedUs(PlayerTypes ePlayer, bool bValue)
 	CvAssertMsg(ePlayer >= 0, "DIPLOMACY_AI: Invalid Player Index.  Please send Jon this with your last 5 autosaves and what changelist # you're playing.");
 	CvAssertMsg(ePlayer < MAX_MAJOR_CIVS, "DIPLOMACY_AI: Invalid Player Index.  Please send Jon this with your last 5 autosaves and what changelist # you're playing.");
 	
-	if (bValue && (GetPlayer()->isHuman() && GET_PLAYER(ePlayer).isHuman()))
-		return;
+	if (bValue)
+	{
+		if (GetPlayer()->isHuman() && GET_PLAYER(ePlayer).isHuman())
+			return;
+		
+		if (GET_TEAM(GET_PLAYER(ePlayer).getTeam()).IsVassalOfSomeone())
+			return;
+	}
 
 	m_pabFriendDenouncedUs[ePlayer] = bValue;
 
@@ -38045,8 +38059,14 @@ void CvDiplomacyAI::SetFriendDeclaredWarOnUs(PlayerTypes ePlayer, bool bValue)
 	CvAssertMsg(ePlayer >= 0, "DIPLOMACY_AI: Invalid Player Index.  Please send Jon this with your last 5 autosaves and what changelist # you're playing.");
 	CvAssertMsg(ePlayer < MAX_MAJOR_CIVS, "DIPLOMACY_AI: Invalid Player Index.  Please send Jon this with your last 5 autosaves and what changelist # you're playing.");
 	
-	if (bValue && (GetPlayer()->isHuman() && GET_PLAYER(ePlayer).isHuman()))
-		return;
+	if (bValue)
+	{
+		if (GetPlayer()->isHuman() && GET_PLAYER(ePlayer).isHuman())
+			return;
+		
+		if (GET_TEAM(GET_PLAYER(ePlayer).getTeam()).IsVassalOfSomeone())
+			return;
+	}
 
 	m_pabFriendDeclaredWarOnUs[ePlayer] = bValue;
 	
@@ -38548,6 +38568,10 @@ bool CvDiplomacyAI::IsPlayerBrokenMilitaryPromise(PlayerTypes ePlayer) const
 {
 	CvAssertMsg(ePlayer >= 0, "DIPLOMACY_AI: Invalid Player Index.  Please send Jon this with your last 5 autosaves and what changelist # you're playing.");
 	CvAssertMsg(ePlayer < MAX_MAJOR_CIVS, "DIPLOMACY_AI: Invalid Player Index.  Please send Jon this with your last 5 autosaves and what changelist # you're playing.");
+
+	// Vassals can't be untrustworthy, they have no rights.
+	if (GET_TEAM(GET_PLAYER(ePlayer).getTeam()).IsVassalOfSomeone())
+		return false;
 	
 	if (GetPlayer()->isHuman() && GET_PLAYER(ePlayer).isHuman())
 		return false;
@@ -38579,8 +38603,14 @@ void CvDiplomacyAI::SetPlayerBrokenMilitaryPromise(PlayerTypes ePlayer, bool bVa
 	CvAssertMsg(ePlayer >= 0, "DIPLOMACY_AI: Invalid Player Index.  Please send Jon this with your last 5 autosaves and what changelist # you're playing.");
 	CvAssertMsg(ePlayer < MAX_MAJOR_CIVS, "DIPLOMACY_AI: Invalid Player Index.  Please send Jon this with your last 5 autosaves and what changelist # you're playing.");
 	
-	if (bValue && (GetPlayer()->isHuman() && GET_PLAYER(ePlayer).isHuman()))
-		return;
+	if (bValue)
+	{
+		if (GetPlayer()->isHuman() && GET_PLAYER(ePlayer).isHuman())
+			return;
+		
+		if (GET_TEAM(GET_PLAYER(ePlayer).getTeam()).IsVassalOfSomeone())
+			return;
+	}
 	
 	m_pabPlayerBrokenMilitaryPromise[ePlayer] = bValue;
 
@@ -39061,6 +39091,10 @@ bool CvDiplomacyAI::IsPlayerBrokenAttackCityStatePromise(PlayerTypes ePlayer) co
 {
 	CvAssertMsg(ePlayer >= 0, "DIPLOMACY_AI: Invalid Player Index.  Please send Jon this with your last 5 autosaves and what changelist # you're playing.");
 	CvAssertMsg(ePlayer < MAX_MAJOR_CIVS, "DIPLOMACY_AI: Invalid Player Index.  Please send Jon this with your last 5 autosaves and what changelist # you're playing.");
+
+	// Vassals can't be untrustworthy, they have no rights.
+	if (GET_TEAM(GET_PLAYER(ePlayer).getTeam()).IsVassalOfSomeone())
+		return false;
 	
 	if (GetPlayer()->isHuman() && GET_PLAYER(ePlayer).isHuman())
 		return false;
@@ -39092,8 +39126,14 @@ void CvDiplomacyAI::SetPlayerBrokenAttackCityStatePromise(PlayerTypes ePlayer, b
 	CvAssertMsg(ePlayer >= 0, "DIPLOMACY_AI: Invalid Player Index.  Please send Jon this with your last 5 autosaves and what changelist # you're playing.");
 	CvAssertMsg(ePlayer < MAX_MAJOR_CIVS, "DIPLOMACY_AI: Invalid Player Index.  Please send Jon this with your last 5 autosaves and what changelist # you're playing.");
 	
-	if (bValue && (GetPlayer()->isHuman() && GET_PLAYER(ePlayer).isHuman()))
-		return;
+	if (bValue)
+	{
+		if (GetPlayer()->isHuman() && GET_PLAYER(ePlayer).isHuman())
+			return;
+		
+		if (GET_TEAM(GET_PLAYER(ePlayer).getTeam()).IsVassalOfSomeone())
+			return;
+	}
 	
 	m_pabPlayerBrokenAttackCityStatePromise[ePlayer] = bValue;
 
@@ -50705,6 +50745,10 @@ bool CvDiplomacyAI::IsPlayerBrokenVassalAgreement(PlayerTypes ePlayer) const
 	CvAssertMsg(ePlayer < MAX_MAJOR_CIVS, "DIPLOMACY_AI: Invalid Player Index.  Please send Jon this with your last 5 autosaves and what changelist # you're playing.");
 	
 	if (GetPlayer()->isHuman() && GET_PLAYER(ePlayer).isHuman())
+		return false;
+
+	// Vassals can't be untrustworthy, they have no rights.
+	if (GET_TEAM(GET_PLAYER(ePlayer).getTeam()).IsVassalOfSomeone())
 		return false;
 
 #if defined(MOD_BALANCE_CORE_DIPLOMACY)

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.h
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.h
@@ -955,6 +955,12 @@ public:
 
 	bool IsDoFBroken(PlayerTypes ePlayer) const;
 	void SetDoFBroken(PlayerTypes ePlayer, bool bValue);
+	
+	int GetBrokenMilitaryPromiseTurn(PlayerTypes ePlayer) const;
+	void SetBrokenMilitaryPromiseTurn(PlayerTypes ePlayer, int iValue);
+	
+	int GetBrokenAttackCityStatePromiseTurn(PlayerTypes ePlayer) const;
+	void SetBrokenAttackCityStatePromiseTurn(PlayerTypes ePlayer, int iValue);
 
 	int GetDoFBrokenTurn(PlayerTypes ePlayer) const;
 	void SetDoFBrokenTurn(PlayerTypes ePlayer, int iValue);
@@ -1772,6 +1778,8 @@ private:
 #if defined(MOD_BALANCE_CORE_DIPLOMACY)
 		bool m_abDoFBroken[MAX_MAJOR_CIVS];
 		char m_aeDoFType[MAX_MAJOR_CIVS];
+		short m_aiBrokenMilitaryPromiseTurn[MAX_MAJOR_CIVS];
+		short m_aiBrokenAttackCityStatePromiseTurn[MAX_MAJOR_CIVS];
 		short m_aiDoFBrokenTurn[MAX_MAJOR_CIVS];
 		bool m_abEverBackstabbedBy[MAX_MAJOR_CIVS];
 		short m_aiFriendDenouncedUsTurn[MAX_MAJOR_CIVS];
@@ -2133,6 +2141,8 @@ private:
 #if defined(MOD_BALANCE_CORE_DIPLOMACY)
 	bool* m_pabDoFBroken;
 	char* m_paeDoFType;
+	short* m_paiBrokenMilitaryPromiseTurn;
+	short* m_paiBrokenAttackCityStatePromiseTurn;
 	short* m_paiDoFBrokenTurn;
 	bool* m_pabEverBackstabbedBy;
 	short* m_paiFriendDenouncedUsTurn;

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -3156,6 +3156,16 @@ void CvPlayer::acquireCity(CvCity* pOldCity, bool bConquest, bool bGift)
 			pOldOwnerDiploAI->SetNumCitiesLiberated(GetID(), 0);
 			pOldOwnerDiploAI->SetMasterLiberatedMeFromVassalage(GetID(), false);
 			pOldOwnerDiploAI->SetTurnsSinceVassalagePeacefullyRevoked(GetID(), -1);
+			
+			// clear positive diplomatic values
+			pOldOwnerDiploAI->SetNumCiviliansReturnedToMe(GetID(), 0);
+			pOldOwnerDiploAI->SetNumLandmarksBuiltForMe(GetID(), 0);
+			pOldOwnerDiploAI->SetNumTimesIntrigueSharedBy(GetID(), 0);
+			pOldOwnerDiploAI->SetCommonFoeValue(GetID(), 0);
+			if (pOldOwnerDiploAI->GetRecentAssistValue(GetID()) < 0)
+				pOldOwnerDiploAI->SetRecentAssistValue(GetID(), 0);
+			
+			// increment captured city counter
 			pOldOwnerDiploAI->ChangeNumCitiesCaptured(GetID(), 1);
 
 			iValue = iDefaultCityValue;
@@ -9938,6 +9948,20 @@ void CvPlayer::DoLiberatePlayer(PlayerTypes ePlayer, int iOldCityID, bool bForce
 			pDiploAI->SetEverBackstabbedBy(eMePlayer, false);
 			GetDiplomacyAI()->SetEverBackstabbedBy(ePlayer, false);
 			
+#if defined(MOD_BALANCE_CORE_DIPLOMACY)
+			// Clear certain penalties with third parties
+			for (int iThirdPartyLoop = 0; iThirdPartyLoop < MAX_MAJOR_CIVS; iThirdPartyLoop++)
+			{
+				PlayerTypes eThirdParty = (PlayerTypes) iThirdPartyLoop;
+				
+				if (GET_PLAYER(eThirdParty).isMajorCiv())
+				{
+					// forget any denouncing
+					pDiploAI->SetDenouncedPlayer(eThirdParty, false);
+					GET_PLAYER(eThirdParty).GetDiplomacyAI()->SetDenouncedPlayer(ePlayer, false);
+				}
+			}
+#endif
 			// Update diplo stuff.
 			pDiploAI->DoUpdateTrueApproachTowardsUsGuesses(true);
 			pDiploAI->SetTrueApproachTowardsUsGuess(eMePlayer, MAJOR_CIV_APPROACH_FRIENDLY);


### PR DESCRIPTION
**NOTE**
Adds new memory values; broken military and attack city state promises are now on their own separate counters, since they include a global penalty.

Fixes some issues with backstabbing penalties.

Clears denouncements on player resurrection.

Clears certain positive diplomatic values upon capturing a city from the AI.

Small performance improvements.