### PR TITLE
Fix #5801: add war info to war icon tool tip

### DIFF
--- a/43 Civs CP/43 Civs CP/EUI/NotificationPanel.lua
+++ b/43 Civs CP/43 Civs CP/EUI/NotificationPanel.lua
@@ -1006,16 +1006,120 @@ local g_civListInstanceToolTips = { -- the tooltip function names need to match 
 
 	War = function( control )
 		local player = FindPlayer( g_majorControlTable, control )
-		local tips = table( L( "TXT_KEY_AT_WAR_WITH", player:GetCivilizationShortDescriptionKey() ) )
+		local playerID = FindPlayerID( g_majorControlTable, control ) -- UndeadDevel
+		local tips = table() -- UndeadDevel: don't initialize with a first element since it doesn't seem to work anyway
 		local teamID = player:GetTeam()
 		local lockedWarTurns = g_activeTeam:GetNumTurnsLockedIntoWar( teamID )
 		if lockedWarTurns > 0 then
-			tips:insert( L( "TXT_KEY_DIPLO_NEGOTIATE_PEACE_BLOCKED_TT", lockedWarTurns ) )
+			tips:insert( L( "TXT_KEY_DIPLO_NEGOTIATE_PEACE_BLOCKED_TT", lockedWarTurns ) .. "[NEWLINE][NEWLINE]") -- UndeadDevel: add newlines here instead to avoid having unused space
 		elseif not g_activeTeam:CanChangeWarPeace( teamID ) then
-			tips:insert( L"TXT_KEY_PEACE_BLOCKED" )
+			tips:insert( L"TXT_KEY_PEACE_BLOCKED"  .. "[NEWLINE][NEWLINE]") -- UndeadDevel: add newlines here instead to avoid having unused space
 		end
+				
+-- UndeadDevel: add WarInfo to tool tip
+		local strWarInfo = "";
+
+		if(player:IsWillingToMakePeaceWithHuman(g_activePlayerID)) then
+			local iPeaceValue = player:GetTreatyWillingToOffer(g_activePlayerID);
+			if(iPeaceValue >  PeaceTreatyTypes.PEACE_TREATY_WHITE_PEACE) then
+				if( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_ARMISTICE ) then
+					strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_ARMISTICE" );
+				elseif( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_SETTLEMENT ) then
+					strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_SETTLEMENT" );
+				elseif( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_BACKDOWN ) then
+					strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_BACKDOWN" );
+				elseif( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_SUBMISSION ) then
+					strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_SUBMISSION" );
+				elseif( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_SURRENDER ) then
+					strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_SURRENDER" );
+				elseif( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_CESSION ) then
+					strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_CESSION" );
+				elseif( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_CAPITULATION ) then
+					strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_CAPITULATION" );
+				elseif( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_UNCONDITIONAL_SURRENDER ) then
+					strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_UNCONDITIONAL_SURRENDER" );
+				end
+			end
+		else
+			strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_WAR_NO_PEACE_OFFER" );
+		end
+				
+		local iStrengthAverage = g_activePlayer:GetPlayerMilitaryStrengthComparedToUs(playerID);
+		if( iStrengthAverage == StrengthTypes.STRENGTH_PATHETIC ) then
+			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_STRENGTH_PATHETIC" );
+		elseif( iStrengthAverage == StrengthTypes.STRENGTH_WEAK ) then
+			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_STRENGTH_WEAK" );
+		elseif( iStrengthAverage == StrengthTypes.STRENGTH_POOR ) then
+			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_STRENGTH_POOR" );
+		elseif( iStrengthAverage == StrengthTypes.STRENGTH_AVERAGE ) then
+			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_STRENGTH_AVERAGE" );
+		elseif( iStrengthAverage == StrengthTypes.STRENGTH_STRONG ) then
+			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_STRENGTH_STRONG" );
+		elseif( iStrengthAverage == StrengthTypes.STRENGTH_POWERFUL ) then
+			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_STRENGTH_POWERFUL" );
+		elseif( iStrengthAverage == StrengthTypes.STRENGTH_IMMENSE ) then
+			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_STRENGTH_IMMENSE" );
+		end
+				
+		local iEconomicAverage = g_activePlayer:GetPlayerEconomicStrengthComparedToUs(playerID);
+		if( iEconomicAverage == StrengthTypes.STRENGTH_PATHETIC ) then
+			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_ECONOMY_PATHETIC" );
+		elseif( iEconomicAverage == StrengthTypes.STRENGTH_WEAK ) then
+			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_ECONOMY_WEAK" );
+		elseif( iEconomicAverage == StrengthTypes.STRENGTH_POOR ) then
+			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_ECONOMY_POOR" );
+		elseif( iEconomicAverage == StrengthTypes.STRENGTH_AVERAGE ) then
+			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_ECONOMY_AVERAGE" );
+		elseif( iEconomicAverage == StrengthTypes.STRENGTH_STRONG ) then
+			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_ECONOMY_STRONG" );
+		elseif( iEconomicAverage == StrengthTypes.STRENGTH_POWERFUL ) then
+			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_ECONOMY_POWERFUL" );
+		elseif( iEconomicAverage == StrengthTypes.STRENGTH_IMMENSE ) then
+			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_ECONOMY_IMMENSE" );
+		end
+				
+		local iUsWarDamage = player:GetWarDamageLevel(g_activePlayerID);
+		local iThemWarDamage = g_activePlayer:GetWarDamageLevel(playerID);
+		if(iUsWarDamage > WarDamageLevelTypes.WAR_DAMAGE_LEVEL_NONE)then
+			if( iUsWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_MINOR ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_US_MINOR" );
+			elseif( iUsWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_MAJOR ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_US_MAJOR" );
+			elseif( iUsWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_SERIOUS ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_US_SERIOUS" );
+			elseif( iUsWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_CRIPPLED ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_US_CRIPPLED" );
+			end
+		elseif(iThemWarDamage > WarDamageLevelTypes.WAR_DAMAGE_LEVEL_NONE)then
+			if( iThemWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_MINOR ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_THEM_MINOR" );
+			elseif( iThemWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_MAJOR ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_THEM_MAJOR" );
+			elseif( iThemWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_SERIOUS ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_THEM_SERIOUS" );
+			elseif( iThemWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_CRIPPLED ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_THEM_CRIPPLED" );
+			end
+		end
+				
+		local iTheirWarWeariness = player:GetWarWeariness();
+		if(iTheirWarWeariness <= 0)then
+			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_WEARINESS_THEM_NONE" );
+		elseif( iTheirWarWeariness <= 25 ) then
+			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_WEARINESS_THEM_MINOR" );
+		elseif( iTheirWarWeariness <= 50 ) then
+			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_WEARINESS_THEM_MAJOR" );
+		elseif( iTheirWarWeariness <= 75 ) then
+			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_WEARINESS_THEM_SERIOUS" );
+		elseif( iTheirWarWeariness > 75 ) then
+			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_WEARINESS_THEM_CRIPPLED" );
+		end
+				
+		tips:insert(strWarInfo);
+-- UndeadDevel end
+				
 -- todo TradeableItems.TRADE_ITEM_THIRD_PARTY_WAR & permanent war
-		ShowSimpleTip( tips:concat("[NEWLINE]" ) )
+		ShowSimpleTip( tips:concat() ) -- UndeadDevel: don't add new lines here...there will be empty lines at the top of the tool tip otherwise
 	end;
 
 	Score = function( control )

--- a/EUI Compatibility Files/EUI Compatibility Files/LUA/NotificationPanel.lua
+++ b/EUI Compatibility Files/EUI Compatibility Files/LUA/NotificationPanel.lua
@@ -1006,16 +1006,120 @@ local g_civListInstanceToolTips = { -- the tooltip function names need to match 
 
 	War = function( control )
 		local player = FindPlayer( g_majorControlTable, control )
-		local tips = table( L( "TXT_KEY_AT_WAR_WITH", player:GetCivilizationShortDescriptionKey() ) )
+		local playerID = FindPlayerID( g_majorControlTable, control ) -- UndeadDevel
+		local tips = table() -- UndeadDevel: don't initialize with a first element since it doesn't seem to work anyway
 		local teamID = player:GetTeam()
 		local lockedWarTurns = g_activeTeam:GetNumTurnsLockedIntoWar( teamID )
 		if lockedWarTurns > 0 then
-			tips:insert( L( "TXT_KEY_DIPLO_NEGOTIATE_PEACE_BLOCKED_TT", lockedWarTurns ) )
+			tips:insert( L( "TXT_KEY_DIPLO_NEGOTIATE_PEACE_BLOCKED_TT", lockedWarTurns ) .. "[NEWLINE][NEWLINE]") -- UndeadDevel: add newlines here instead to avoid having unused space
 		elseif not g_activeTeam:CanChangeWarPeace( teamID ) then
-			tips:insert( L"TXT_KEY_PEACE_BLOCKED" )
+			tips:insert( L"TXT_KEY_PEACE_BLOCKED"  .. "[NEWLINE][NEWLINE]") -- UndeadDevel: add newlines here instead to avoid having unused space
 		end
+				
+-- UndeadDevel: add WarInfo to tool tip
+		local strWarInfo = "";
+
+		if(player:IsWillingToMakePeaceWithHuman(g_activePlayerID)) then
+			local iPeaceValue = player:GetTreatyWillingToOffer(g_activePlayerID);
+			if(iPeaceValue >  PeaceTreatyTypes.PEACE_TREATY_WHITE_PEACE) then
+				if( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_ARMISTICE ) then
+					strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_ARMISTICE" );
+				elseif( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_SETTLEMENT ) then
+					strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_SETTLEMENT" );
+				elseif( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_BACKDOWN ) then
+					strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_BACKDOWN" );
+				elseif( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_SUBMISSION ) then
+					strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_SUBMISSION" );
+				elseif( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_SURRENDER ) then
+					strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_SURRENDER" );
+				elseif( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_CESSION ) then
+					strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_CESSION" );
+				elseif( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_CAPITULATION ) then
+					strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_CAPITULATION" );
+				elseif( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_UNCONDITIONAL_SURRENDER ) then
+					strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_UNCONDITIONAL_SURRENDER" );
+				end
+			end
+		else
+			strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_WAR_NO_PEACE_OFFER" );
+		end
+				
+		local iStrengthAverage = g_activePlayer:GetPlayerMilitaryStrengthComparedToUs(playerID);
+		if( iStrengthAverage == StrengthTypes.STRENGTH_PATHETIC ) then
+			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_STRENGTH_PATHETIC" );
+		elseif( iStrengthAverage == StrengthTypes.STRENGTH_WEAK ) then
+			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_STRENGTH_WEAK" );
+		elseif( iStrengthAverage == StrengthTypes.STRENGTH_POOR ) then
+			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_STRENGTH_POOR" );
+		elseif( iStrengthAverage == StrengthTypes.STRENGTH_AVERAGE ) then
+			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_STRENGTH_AVERAGE" );
+		elseif( iStrengthAverage == StrengthTypes.STRENGTH_STRONG ) then
+			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_STRENGTH_STRONG" );
+		elseif( iStrengthAverage == StrengthTypes.STRENGTH_POWERFUL ) then
+			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_STRENGTH_POWERFUL" );
+		elseif( iStrengthAverage == StrengthTypes.STRENGTH_IMMENSE ) then
+			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_STRENGTH_IMMENSE" );
+		end
+				
+		local iEconomicAverage = g_activePlayer:GetPlayerEconomicStrengthComparedToUs(playerID);
+		if( iEconomicAverage == StrengthTypes.STRENGTH_PATHETIC ) then
+			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_ECONOMY_PATHETIC" );
+		elseif( iEconomicAverage == StrengthTypes.STRENGTH_WEAK ) then
+			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_ECONOMY_WEAK" );
+		elseif( iEconomicAverage == StrengthTypes.STRENGTH_POOR ) then
+			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_ECONOMY_POOR" );
+		elseif( iEconomicAverage == StrengthTypes.STRENGTH_AVERAGE ) then
+			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_ECONOMY_AVERAGE" );
+		elseif( iEconomicAverage == StrengthTypes.STRENGTH_STRONG ) then
+			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_ECONOMY_STRONG" );
+		elseif( iEconomicAverage == StrengthTypes.STRENGTH_POWERFUL ) then
+			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_ECONOMY_POWERFUL" );
+		elseif( iEconomicAverage == StrengthTypes.STRENGTH_IMMENSE ) then
+			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_ECONOMY_IMMENSE" );
+		end
+				
+		local iUsWarDamage = player:GetWarDamageLevel(g_activePlayerID);
+		local iThemWarDamage = g_activePlayer:GetWarDamageLevel(playerID);
+		if(iUsWarDamage > WarDamageLevelTypes.WAR_DAMAGE_LEVEL_NONE)then
+			if( iUsWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_MINOR ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_US_MINOR" );
+			elseif( iUsWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_MAJOR ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_US_MAJOR" );
+			elseif( iUsWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_SERIOUS ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_US_SERIOUS" );
+			elseif( iUsWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_CRIPPLED ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_US_CRIPPLED" );
+			end
+		elseif(iThemWarDamage > WarDamageLevelTypes.WAR_DAMAGE_LEVEL_NONE)then
+			if( iThemWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_MINOR ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_THEM_MINOR" );
+			elseif( iThemWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_MAJOR ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_THEM_MAJOR" );
+			elseif( iThemWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_SERIOUS ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_THEM_SERIOUS" );
+			elseif( iThemWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_CRIPPLED ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_THEM_CRIPPLED" );
+			end
+		end
+				
+		local iTheirWarWeariness = player:GetWarWeariness();
+		if(iTheirWarWeariness <= 0)then
+			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_WEARINESS_THEM_NONE" );
+		elseif( iTheirWarWeariness <= 25 ) then
+			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_WEARINESS_THEM_MINOR" );
+		elseif( iTheirWarWeariness <= 50 ) then
+			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_WEARINESS_THEM_MAJOR" );
+		elseif( iTheirWarWeariness <= 75 ) then
+			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_WEARINESS_THEM_SERIOUS" );
+		elseif( iTheirWarWeariness > 75 ) then
+			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_WEARINESS_THEM_CRIPPLED" );
+		end
+				
+		tips:insert(strWarInfo);
+-- UndeadDevel end
+
 -- todo TradeableItems.TRADE_ITEM_THIRD_PARTY_WAR & permanent war
-		ShowSimpleTip( tips:concat("[NEWLINE]" ) )
+		ShowSimpleTip( tips:concat() ) -- UndeadDevel: don't add new lines here...there will be empty lines at the top of the tool tip otherwise
 	end;
 
 	Score = function( control )


### PR DESCRIPTION
Fixes #5801 by adding the war info that is otherwise only shown in the Leaderscreen to the war icon tool tip, which otherwise contains either no or almost no information and often shows an empty tool tip. Also fixes the first line of the tool tip always being empty and removes the "at war with" line, which wasn't being loaded anyway. Tested and verified locally. See how it looks:

![War_Tooltip](https://user-images.githubusercontent.com/30495439/72055512-e1b4fb00-32c2-11ea-81bc-71f36db72051.jpg)
