### PR TITLE
Fix #5658

### DIFF
--- a/43 Civs CP/43 Civs CP/EUI/CityStateDiploPopup.lua
+++ b/43 Civs CP/43 Civs CP/EUI/CityStateDiploPopup.lua
@@ -446,7 +446,12 @@ function OnDisplay()
 				  if (m_PopupInfo.Data3 == 0) then
 					strGiftString = L("TXT_KEY_MINOR_CIV_CONTACT_BONUS_NOTHING")
 				  else
-					strGiftString = L("TXT_KEY_MINOR_CIV_CONTACT_BONUS_FRIENDSHIP", m_PopupInfo.Data3, personalityInfo.title)
+                    			-- UndeadDevel: because of CBP's change to Siam's UA the Friendship boost doesn't actually work for them so the text would be incorrect and misleading, which this fixes.
+                    			if (GameInfo.Civilizations[activePlayer:GetCivilizationType()].Type == "CIVILIZATION_SIAM") then
+                    			    strGiftString = L("TXT_KEY_MINOR_CIV_CONTACT_BONUS_NOTHING")
+                    			else
+                    			    strGiftString = L("TXT_KEY_MINOR_CIV_CONTACT_BONUS_FRIENDSHIP", m_PopupInfo.Data3, personalityInfo.title)
+                    			end
 				  end
 			else
 			  if (m_PopupInfo.Text == "UNIT") then

--- a/43 Civs CP/43 Civs CP/No-EUI/CityStateGreetingPopup.lua
+++ b/43 Civs CP/43 Civs CP/No-EUI/CityStateGreetingPopup.lua
@@ -318,7 +318,13 @@ print(string.format("City State: Need to add a message and a quest"))
           if (popupInfo.Data3 == 0) then
             strGiftString = Locale.ConvertTextKey("TXT_KEY_MINOR_CIV_CONTACT_BONUS_NOTHING")
           else
-            strGiftString = Locale.ConvertTextKey("TXT_KEY_MINOR_CIV_CONTACT_BONUS_FRIENDSHIP", popupInfo.Data3, strPersonalityKey)
+            -- UndeadDevel: because of CBP's change to Siam's UA the Friendship boost doesn't actually work for them so the text would be incorrect and misleading, which this fixes.
+            local activePlayer = Players[iActivePlayer];
+	    if (GameInfo.Civilizations[activePlayer:GetCivilizationType()].Type == "CIVILIZATION_SIAM") then
+                strGiftString = Locale.ConvertTextKey("TXT_KEY_MINOR_CIV_CONTACT_BONUS_NOTHING")
+            else
+                strGiftString = Locale.ConvertTextKey("TXT_KEY_MINOR_CIV_CONTACT_BONUS_FRIENDSHIP", popupInfo.Data3, strPersonalityKey)
+            end
           end
 	else
 	  if (popupInfo.Text == "UNIT") then

--- a/Community Balance Patch/LUA/CityStateGreetingPopup.lua
+++ b/Community Balance Patch/LUA/CityStateGreetingPopup.lua
@@ -318,7 +318,13 @@ print(string.format("City State: Need to add a message and a quest"))
           if (popupInfo.Data3 == 0) then
             strGiftString = Locale.ConvertTextKey("TXT_KEY_MINOR_CIV_CONTACT_BONUS_NOTHING")
           else
-            strGiftString = Locale.ConvertTextKey("TXT_KEY_MINOR_CIV_CONTACT_BONUS_FRIENDSHIP", popupInfo.Data3, strPersonalityKey)
+            -- UndeadDevel: because of CBP's change to Siam's UA the Friendship boost doesn't actually work for them so the text would be incorrect and misleading, which this fixes.
+            local activePlayer = Players[iActivePlayer];
+	    if (GameInfo.Civilizations[activePlayer:GetCivilizationType()].Type == "CIVILIZATION_SIAM") then
+                strGiftString = Locale.ConvertTextKey("TXT_KEY_MINOR_CIV_CONTACT_BONUS_NOTHING")
+            else
+                strGiftString = Locale.ConvertTextKey("TXT_KEY_MINOR_CIV_CONTACT_BONUS_FRIENDSHIP", popupInfo.Data3, strPersonalityKey)
+            end
           end
 	else
 	  if (popupInfo.Text == "UNIT") then

--- a/EUI Compatibility Files/EUI Compatibility Files/LUA/CityStateDiploPopup.lua
+++ b/EUI Compatibility Files/EUI Compatibility Files/LUA/CityStateDiploPopup.lua
@@ -446,7 +446,12 @@ function OnDisplay()
 				  if (m_PopupInfo.Data3 == 0) then
 					strGiftString = L("TXT_KEY_MINOR_CIV_CONTACT_BONUS_NOTHING")
 				  else
-					strGiftString = L("TXT_KEY_MINOR_CIV_CONTACT_BONUS_FRIENDSHIP", m_PopupInfo.Data3, personalityInfo.title)
+                    			-- UndeadDevel: because of CBP's change to Siam's UA the Friendship boost doesn't actually work for them so the text would be incorrect and misleading, which this fixes.
+                    			if (GameInfo.Civilizations[activePlayer:GetCivilizationType()].Type == "CIVILIZATION_SIAM") then
+                    			    strGiftString = L("TXT_KEY_MINOR_CIV_CONTACT_BONUS_NOTHING")
+                    			else
+                    			    strGiftString = L("TXT_KEY_MINOR_CIV_CONTACT_BONUS_FRIENDSHIP", m_PopupInfo.Data3, personalityInfo.title)
+                    			end
 				  end
 			else
 			  if (m_PopupInfo.Text == "UNIT") then

--- a/NoEUI Compatibility Files/Mod Template1/LUA/CityStateGreetingPopup.lua
+++ b/NoEUI Compatibility Files/Mod Template1/LUA/CityStateGreetingPopup.lua
@@ -318,7 +318,13 @@ print(string.format("City State: Need to add a message and a quest"))
           if (popupInfo.Data3 == 0) then
             strGiftString = Locale.ConvertTextKey("TXT_KEY_MINOR_CIV_CONTACT_BONUS_NOTHING")
           else
-            strGiftString = Locale.ConvertTextKey("TXT_KEY_MINOR_CIV_CONTACT_BONUS_FRIENDSHIP", popupInfo.Data3, strPersonalityKey)
+            -- UndeadDevel: because of CBP's change to Siam's UA the Friendship boost doesn't actually work for them so the text would be incorrect and misleading, which this fixes.
+            local activePlayer = Players[iActivePlayer];
+	    if (GameInfo.Civilizations[activePlayer:GetCivilizationType()].Type == "CIVILIZATION_SIAM") then
+                strGiftString = Locale.ConvertTextKey("TXT_KEY_MINOR_CIV_CONTACT_BONUS_NOTHING")
+            else
+                strGiftString = Locale.ConvertTextKey("TXT_KEY_MINOR_CIV_CONTACT_BONUS_FRIENDSHIP", popupInfo.Data3, strPersonalityKey)
+            end
           end
 	else
 	  if (popupInfo.Text == "UNIT") then


### PR DESCRIPTION
Fixes #5658 by adding an exception to the City State greeting message logic for the Siamese Civilization, which, instead of showing incorrectly that a small amount of Influence will be added, if that is the CS's gift, will show that they have no gifts to give (Siam still gets the 40 free Influence, of course).