### PR TITLE
Adding Tributing UI element to Minor City Banners

### DIFF
--- a/43 Civs CP/43 Civs CP/EUI/CityBannerManager.lua
+++ b/43 Civs CP/43 Civs CP/EUI/CityBannerManager.lua
@@ -800,7 +800,7 @@ end
 -------------------------------------------------
 -- City banner mouseover
 -------------------------------------------------
-local function OnBannerMouseExit()
+local function OnBannerMouseExit( ... ) -- UndeadDevel: using variadic form to pass in plot index
 	if not UI.IsCityScreenUp() then
 
 		ClearHexHighlights()
@@ -817,6 +817,12 @@ local function OnBannerMouseExit()
 		else
 			Events_RequestYieldDisplay( YieldDisplayTypes.AREA, 0 )
 		end
+        	-- UndeadDevel: making sure that info is reset to ensure player never sees historic and thus possibly incorrect info
+        	local instance = g_cityBanners[ (...) ]
+        	if (instance and instance.CityStrengthContainer) then
+        	    instance.CityStrength:SetToolTipString( Locale.ConvertTextKey("TXT_KEY_CITYVIEW_CITY_COMB_STRENGTH_TT") )
+        	    instance.CityStrengthContainer:SetToolTipString( Locale.ConvertTextKey("TXT_KEY_CITYVIEW_CITY_COMB_STRENGTH_TT") )
+        	end
 	end
 end
 
@@ -1152,6 +1158,14 @@ local function RefreshCityBannersNow()
 						local free = pledge and cityOwner:CanMajorWithdrawProtection( g_activePlayerID )
 						instance.Pledge1:SetHide( not pledge or free )
 						instance.Pledge2:SetHide( not free )
+                        			-- UndeadDevel: include tributing information on City Strength element
+                        			local ttText = ""
+                        			if cityOwner.GetMajorBullyGoldDetails then
+                        			    ttText = "[NEWLINE][COLOR_GREY]====================[ENDCOLOR][NEWLINE]" .. cityOwner:GetMajorBullyGoldDetails( g_activePlayerID )
+                        			end
+                        			instance.CityStrength:SetToolTipString( Locale.ConvertTextKey("TXT_KEY_CITYVIEW_CITY_COMB_STRENGTH_TT") .. ttText )
+                        			instance.CityStrengthContainer:SetToolTipString( Locale.ConvertTextKey("TXT_KEY_CITYVIEW_CITY_COMB_STRENGTH_TT") .. ttText )
+                        			-- UndeadDevel end
 					end
 					-- Update Allies
 					allyID = cityOwner:GetAlly()

--- a/43 Civs CP/43 Civs CP/EUI/CityBannerManager.xml
+++ b/43 Civs CP/43 Civs CP/EUI/CityBannerManager.xml
@@ -135,12 +135,12 @@
 	<!--   =========================================================== Other City Banner ===========================================================   -->
 	<Instance Name="OtherCityBanner">
 		<WorldAnchor ID="Anchor">
-			<!-- CityBannerButton -->
-			<Button ID="CityBannerButton" Anchor="C,C" Size="160,48"/>
+			<!-- CityBannerButton        UndeadDevel: stretched this a bit vertically to allow easily extending mouse-over functionality over City Strength label-->
+			<Button ID="CityBannerButton" Anchor="C,C" Offset="0,-8" Size="160,52"/>
 			<Image ID="CityAtWar" Anchor="C,C" Size="160,64" Texture="CityBannerButtonBase.dds" Color="Red.180">
-				<Image Size="48,64" Anchor="L,C" AnchorSide="O.I" Texture="CityBannerButtonBaseLeft.dds" Color="Red.180"/>
-				<Image Size="48,64" Anchor="R,C" AnchorSide="O.I" Texture="CityBannerButtonBaseRight.dds" Color="Red.180"/>
-				<Image Anchor="C,C" Offset="0,-32" Size="128,48" Texture="CityBannerStrengthFrame.dds" Color="Red.180"/>
+				<Image Offset="-1,0" Size="48,64" Anchor="L,C" AnchorSide="O.I" Texture="CityBannerButtonBaseLeft.dds" Color="Red.180"/>
+				<Image Offset="-1,0" Size="48,64" Anchor="R,C" AnchorSide="O.I" Texture="CityBannerButtonBaseRight.dds" Color="Red.180"/>
+				<Image Anchor="C,C" Offset="0,-28" Size="130,48" Texture="CityBannerStrengthFrame.dds" Color="Red.180"/>
 			</Image>
 			<Image ID="CityBannerBackground" Anchor="C,C" Size="32,32" Texture="CityBannerBackground.dds" BranchAlpha="0.7">
 				<Image ID="CityBannerBackgroundHL" Anchor="C,C" Size="32,32" Texture="CityBannerBackgroundHL.dds"/>
@@ -201,7 +201,7 @@
 			<Image ID="GarrisonFrame" Anchor="C,C" Offset="-42,-37" Size="64,64" Texture="GarrisonFrameOther.dds"/>
 			<!--  City Strength -->
 			<Label ID="CityStrength" Anchor="C,C" Offset="6,-24" Font="TwCenMT16" Color0="255,255,200,255" Color1="0,0,0,200" ForceNonIME="1" FontStyle="Stroke" ToolTip="TXT_KEY_CITYVIEW_CITY_COMB_STRENGTH_TT"/>
-			<Container Anchor="C,C" Offset="0,-24" Size="50,20" ToolTip="TXT_KEY_CITYVIEW_CITY_COMB_STRENGTH_TT"/>
+			<Container ID="CityStrengthContainer" Anchor="C,C" Offset="0,-24" Size="50,20" ToolTip="TXT_KEY_CITYVIEW_CITY_COMB_STRENGTH_TT"/>
 			<!-- Lower Icons -->
 			<Stack ID="IconsStack" Anchor="C,T" Offset="0,22" StackGrowth="Left" Padding="0">
 				<TextButton ID="CitySpy" String="[ICON_SPY]" Hidden="1"/>

--- a/EUI Compatibility Files/EUI Compatibility Files/LUA/CityBannerManager.lua
+++ b/EUI Compatibility Files/EUI Compatibility Files/LUA/CityBannerManager.lua
@@ -800,7 +800,7 @@ end
 -------------------------------------------------
 -- City banner mouseover
 -------------------------------------------------
-local function OnBannerMouseExit()
+local function OnBannerMouseExit( ... ) -- UndeadDevel: using variadic form to pass in plot index
 	if not UI.IsCityScreenUp() then
 
 		ClearHexHighlights()
@@ -817,6 +817,12 @@ local function OnBannerMouseExit()
 		else
 			Events_RequestYieldDisplay( YieldDisplayTypes.AREA, 0 )
 		end
+        	-- UndeadDevel: making sure that info is reset to ensure player never sees historic and thus possibly incorrect info
+        	local instance = g_cityBanners[ (...) ]
+        	if (instance and instance.CityStrengthContainer) then
+        	    instance.CityStrength:SetToolTipString( Locale.ConvertTextKey("TXT_KEY_CITYVIEW_CITY_COMB_STRENGTH_TT") )
+        	    instance.CityStrengthContainer:SetToolTipString( Locale.ConvertTextKey("TXT_KEY_CITYVIEW_CITY_COMB_STRENGTH_TT") )
+        	end
 	end
 end
 
@@ -1152,6 +1158,14 @@ local function RefreshCityBannersNow()
 						local free = pledge and cityOwner:CanMajorWithdrawProtection( g_activePlayerID )
 						instance.Pledge1:SetHide( not pledge or free )
 						instance.Pledge2:SetHide( not free )
+                        			-- UndeadDevel: include tributing information on City Strength element
+                        			local ttText = ""
+                        			if cityOwner.GetMajorBullyGoldDetails then
+                        			    ttText = "[NEWLINE][COLOR_GREY]====================[ENDCOLOR][NEWLINE]" .. cityOwner:GetMajorBullyGoldDetails( g_activePlayerID )
+                        			end
+                        			instance.CityStrength:SetToolTipString( Locale.ConvertTextKey("TXT_KEY_CITYVIEW_CITY_COMB_STRENGTH_TT") .. ttText )
+                        			instance.CityStrengthContainer:SetToolTipString( Locale.ConvertTextKey("TXT_KEY_CITYVIEW_CITY_COMB_STRENGTH_TT") .. ttText )
+                        			-- UndeadDevel end
 					end
 					-- Update Allies
 					allyID = cityOwner:GetAlly()

--- a/EUI Compatibility Files/EUI Compatibility Files/LUA/CityBannerManager.xml
+++ b/EUI Compatibility Files/EUI Compatibility Files/LUA/CityBannerManager.xml
@@ -135,12 +135,12 @@
 	<!--   =========================================================== Other City Banner ===========================================================   -->
 	<Instance Name="OtherCityBanner">
 		<WorldAnchor ID="Anchor">
-			<!-- CityBannerButton -->
-			<Button ID="CityBannerButton" Anchor="C,C" Size="160,48"/>
+			<!-- CityBannerButton        UndeadDevel: stretched this a bit vertically to allow easily extending mouse-over functionality over City Strength label-->
+			<Button ID="CityBannerButton" Anchor="C,C" Offset="0,-8" Size="160,52"/>
 			<Image ID="CityAtWar" Anchor="C,C" Size="160,64" Texture="CityBannerButtonBase.dds" Color="Red.180">
-				<Image Size="48,64" Anchor="L,C" AnchorSide="O.I" Texture="CityBannerButtonBaseLeft.dds" Color="Red.180"/>
-				<Image Size="48,64" Anchor="R,C" AnchorSide="O.I" Texture="CityBannerButtonBaseRight.dds" Color="Red.180"/>
-				<Image Anchor="C,C" Offset="0,-32" Size="128,48" Texture="CityBannerStrengthFrame.dds" Color="Red.180"/>
+				<Image Offset="-1,0" Size="48,64" Anchor="L,C" AnchorSide="O.I" Texture="CityBannerButtonBaseLeft.dds" Color="Red.180"/>
+				<Image Offset="-1,0" Size="48,64" Anchor="R,C" AnchorSide="O.I" Texture="CityBannerButtonBaseRight.dds" Color="Red.180"/>
+				<Image Anchor="C,C" Offset="0,-28" Size="130,48" Texture="CityBannerStrengthFrame.dds" Color="Red.180"/>
 			</Image>
 			<Image ID="CityBannerBackground" Anchor="C,C" Size="32,32" Texture="CityBannerBackground.dds" BranchAlpha="0.7">
 				<Image ID="CityBannerBackgroundHL" Anchor="C,C" Size="32,32" Texture="CityBannerBackgroundHL.dds"/>
@@ -201,7 +201,7 @@
 			<Image ID="GarrisonFrame" Anchor="C,C" Offset="-42,-37" Size="64,64" Texture="GarrisonFrameOther.dds"/>
 			<!--  City Strength -->
 			<Label ID="CityStrength" Anchor="C,C" Offset="6,-24" Font="TwCenMT16" Color0="255,255,200,255" Color1="0,0,0,200" ForceNonIME="1" FontStyle="Stroke" ToolTip="TXT_KEY_CITYVIEW_CITY_COMB_STRENGTH_TT"/>
-			<Container Anchor="C,C" Offset="0,-24" Size="50,20" ToolTip="TXT_KEY_CITYVIEW_CITY_COMB_STRENGTH_TT"/>
+			<Container ID="CityStrengthContainer" Anchor="C,C" Offset="0,-24" Size="50,20" ToolTip="TXT_KEY_CITYVIEW_CITY_COMB_STRENGTH_TT"/>
 			<!-- Lower Icons -->
 			<Stack ID="IconsStack" Anchor="C,T" Offset="0,22" StackGrowth="Left" Padding="0">
 				<TextButton ID="CitySpy" String="[ICON_SPY]" Hidden="1"/>


### PR DESCRIPTION
This adds the functionality presented and discussed in [this forum thread](https://forums.civfanatics.com/threads/community-poll-adding-a-more-easily-visible-tribute-breakdown-to-city-banners.653678/) to the EUI versions; the poll currently shows overwhelming support (21 in favor, 1 against) for it.

The rationale is laid out in the OP of the forum thread. Tested and verified; also makes the war outline for foreign Cities a bit more symmetrical and adjusts a bit the (invisible) outline of the City Banner button.