### PR TITLE
making sure peace willingness evaluation has up-to-date info

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
@@ -29249,8 +29249,8 @@ void CvDiplomacyAI::DoBeginDiploWithHuman()
 		PlayerTypes ePlayer = GC.getGame().getActivePlayer();
 		if(ePlayer != NO_PLAYER && GET_PLAYER(ePlayer).isHuman() && IsAtWar(ePlayer))
 		{
-			DoUpdatePeaceTreatyWillingness();
 			DoUpdateWarDamageLevel();
+			DoUpdatePeaceTreatyWillingness();
 		}
 #endif
 #if defined(MOD_ACTIVE_DIPLOMACY)


### PR DESCRIPTION
Fixes the issue mentioned [here](https://github.com/LoneGazebo/Community-Patch-DLL/issues/6118#issuecomment-574640843): war damage level should be updated before assessing peace willingness, as is correctly done in the DoTurn method of the diplo AI.