### PR TITLE
Fix war icon tool tip issues

### DIFF
--- a/43 Civs CP/43 Civs CP/EUI/NotificationPanel.lua
+++ b/43 Civs CP/43 Civs CP/EUI/NotificationPanel.lua
@@ -1016,108 +1016,114 @@ local g_civListInstanceToolTips = { -- the tooltip function names need to match 
 			tips:insert( L"TXT_KEY_PEACE_BLOCKED"  .. "[NEWLINE][NEWLINE]") -- UndeadDevel: add newlines here instead to avoid having unused space
 		end
 				
--- UndeadDevel: add WarInfo to tool tip
-		local strWarInfo = "";
+-- UndeadDevel: update war status and peace willingness and add war info to tool tip
+		if (not Game.IsOption( GameOptionTypes.GAMEOPTION_ALWAYS_WAR ) and playerID ~= g_leaderID and not g_leaderMode and playerID ~= g_activePlayerID and not player:IsHuman() and not player:IsMinorCiv() and not player:IsBarbarian() and not IsGameCoreBusy()) then
 
-		if(player:IsWillingToMakePeaceWithHuman(g_activePlayerID)) then
-			local iPeaceValue = player:GetTreatyWillingToOffer(g_activePlayerID);
-			if(iPeaceValue >  PeaceTreatyTypes.PEACE_TREATY_WHITE_PEACE) then
-				if( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_ARMISTICE ) then
-					strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_ARMISTICE" );
-				elseif( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_SETTLEMENT ) then
-					strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_SETTLEMENT" );
-				elseif( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_BACKDOWN ) then
-					strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_BACKDOWN" );
-				elseif( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_SUBMISSION ) then
-					strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_SUBMISSION" );
-				elseif( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_SURRENDER ) then
-					strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_SURRENDER" );
-				elseif( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_CESSION ) then
-					strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_CESSION" );
-				elseif( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_CAPITULATION ) then
-					strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_CAPITULATION" );
-				elseif( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_UNCONDITIONAL_SURRENDER ) then
-					strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_UNCONDITIONAL_SURRENDER" );
+			player:DoUpdateWarDamageLevel();
+			player:DoUpdatePeaceTreatyWillingness();
+			
+			local strWarInfo = "";
+	
+			if(player:IsWillingToMakePeaceWithHuman(g_activePlayerID)) then
+				local iPeaceValue = player:GetTreatyWillingToOffer(g_activePlayerID);
+				if(iPeaceValue >  PeaceTreatyTypes.PEACE_TREATY_WHITE_PEACE) then
+					if( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_ARMISTICE ) then
+						strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_ARMISTICE" );
+					elseif( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_SETTLEMENT ) then
+						strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_SETTLEMENT" );
+					elseif( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_BACKDOWN ) then
+						strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_BACKDOWN" );
+					elseif( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_SUBMISSION ) then
+						strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_SUBMISSION" );
+					elseif( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_SURRENDER ) then
+						strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_SURRENDER" );
+					elseif( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_CESSION ) then
+						strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_CESSION" );
+					elseif( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_CAPITULATION ) then
+						strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_CAPITULATION" );
+					elseif( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_UNCONDITIONAL_SURRENDER ) then
+						strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_UNCONDITIONAL_SURRENDER" );
+					end
+				end
+			else
+				strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_WAR_NO_PEACE_OFFER" );
+			end
+					
+			local iStrengthAverage = g_activePlayer:GetPlayerMilitaryStrengthComparedToUs(playerID);
+			if( iStrengthAverage == StrengthTypes.STRENGTH_PATHETIC ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_STRENGTH_PATHETIC" );
+			elseif( iStrengthAverage == StrengthTypes.STRENGTH_WEAK ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_STRENGTH_WEAK" );
+			elseif( iStrengthAverage == StrengthTypes.STRENGTH_POOR ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_STRENGTH_POOR" );
+			elseif( iStrengthAverage == StrengthTypes.STRENGTH_AVERAGE ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_STRENGTH_AVERAGE" );
+			elseif( iStrengthAverage == StrengthTypes.STRENGTH_STRONG ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_STRENGTH_STRONG" );
+			elseif( iStrengthAverage == StrengthTypes.STRENGTH_POWERFUL ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_STRENGTH_POWERFUL" );
+			elseif( iStrengthAverage == StrengthTypes.STRENGTH_IMMENSE ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_STRENGTH_IMMENSE" );
+			end
+					
+			local iEconomicAverage = g_activePlayer:GetPlayerEconomicStrengthComparedToUs(playerID);
+			if( iEconomicAverage == StrengthTypes.STRENGTH_PATHETIC ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_ECONOMY_PATHETIC" );
+			elseif( iEconomicAverage == StrengthTypes.STRENGTH_WEAK ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_ECONOMY_WEAK" );
+			elseif( iEconomicAverage == StrengthTypes.STRENGTH_POOR ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_ECONOMY_POOR" );
+			elseif( iEconomicAverage == StrengthTypes.STRENGTH_AVERAGE ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_ECONOMY_AVERAGE" );
+			elseif( iEconomicAverage == StrengthTypes.STRENGTH_STRONG ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_ECONOMY_STRONG" );
+			elseif( iEconomicAverage == StrengthTypes.STRENGTH_POWERFUL ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_ECONOMY_POWERFUL" );
+			elseif( iEconomicAverage == StrengthTypes.STRENGTH_IMMENSE ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_ECONOMY_IMMENSE" );
+			end
+					
+			local iUsWarDamage = player:GetWarDamageLevel(g_activePlayerID);
+			local iThemWarDamage = g_activePlayer:GetWarDamageLevel(playerID);
+			if(iUsWarDamage > WarDamageLevelTypes.WAR_DAMAGE_LEVEL_NONE)then
+				if( iUsWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_MINOR ) then
+					strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_US_MINOR" );
+				elseif( iUsWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_MAJOR ) then
+					strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_US_MAJOR" );
+				elseif( iUsWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_SERIOUS ) then
+					strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_US_SERIOUS" );
+				elseif( iUsWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_CRIPPLED ) then
+					strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_US_CRIPPLED" );
+				end
+			elseif(iThemWarDamage > WarDamageLevelTypes.WAR_DAMAGE_LEVEL_NONE)then
+				if( iThemWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_MINOR ) then
+					strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_THEM_MINOR" );
+				elseif( iThemWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_MAJOR ) then
+					strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_THEM_MAJOR" );
+				elseif( iThemWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_SERIOUS ) then
+					strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_THEM_SERIOUS" );
+				elseif( iThemWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_CRIPPLED ) then
+					strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_THEM_CRIPPLED" );
 				end
 			end
-		else
-			strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_WAR_NO_PEACE_OFFER" );
-		end
-				
-		local iStrengthAverage = g_activePlayer:GetPlayerMilitaryStrengthComparedToUs(playerID);
-		if( iStrengthAverage == StrengthTypes.STRENGTH_PATHETIC ) then
-			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_STRENGTH_PATHETIC" );
-		elseif( iStrengthAverage == StrengthTypes.STRENGTH_WEAK ) then
-			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_STRENGTH_WEAK" );
-		elseif( iStrengthAverage == StrengthTypes.STRENGTH_POOR ) then
-			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_STRENGTH_POOR" );
-		elseif( iStrengthAverage == StrengthTypes.STRENGTH_AVERAGE ) then
-			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_STRENGTH_AVERAGE" );
-		elseif( iStrengthAverage == StrengthTypes.STRENGTH_STRONG ) then
-			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_STRENGTH_STRONG" );
-		elseif( iStrengthAverage == StrengthTypes.STRENGTH_POWERFUL ) then
-			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_STRENGTH_POWERFUL" );
-		elseif( iStrengthAverage == StrengthTypes.STRENGTH_IMMENSE ) then
-			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_STRENGTH_IMMENSE" );
-		end
-				
-		local iEconomicAverage = g_activePlayer:GetPlayerEconomicStrengthComparedToUs(playerID);
-		if( iEconomicAverage == StrengthTypes.STRENGTH_PATHETIC ) then
-			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_ECONOMY_PATHETIC" );
-		elseif( iEconomicAverage == StrengthTypes.STRENGTH_WEAK ) then
-			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_ECONOMY_WEAK" );
-		elseif( iEconomicAverage == StrengthTypes.STRENGTH_POOR ) then
-			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_ECONOMY_POOR" );
-		elseif( iEconomicAverage == StrengthTypes.STRENGTH_AVERAGE ) then
-			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_ECONOMY_AVERAGE" );
-		elseif( iEconomicAverage == StrengthTypes.STRENGTH_STRONG ) then
-			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_ECONOMY_STRONG" );
-		elseif( iEconomicAverage == StrengthTypes.STRENGTH_POWERFUL ) then
-			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_ECONOMY_POWERFUL" );
-		elseif( iEconomicAverage == StrengthTypes.STRENGTH_IMMENSE ) then
-			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_ECONOMY_IMMENSE" );
-		end
-				
-		local iUsWarDamage = player:GetWarDamageLevel(g_activePlayerID);
-		local iThemWarDamage = g_activePlayer:GetWarDamageLevel(playerID);
-		if(iUsWarDamage > WarDamageLevelTypes.WAR_DAMAGE_LEVEL_NONE)then
-			if( iUsWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_MINOR ) then
-				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_US_MINOR" );
-			elseif( iUsWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_MAJOR ) then
-				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_US_MAJOR" );
-			elseif( iUsWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_SERIOUS ) then
-				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_US_SERIOUS" );
-			elseif( iUsWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_CRIPPLED ) then
-				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_US_CRIPPLED" );
+					
+			local iTheirWarWeariness = player:GetWarWeariness();
+			if(iTheirWarWeariness <= 0)then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_WEARINESS_THEM_NONE" );
+			elseif( iTheirWarWeariness <= 25 ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_WEARINESS_THEM_MINOR" );
+			elseif( iTheirWarWeariness <= 50 ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_WEARINESS_THEM_MAJOR" );
+			elseif( iTheirWarWeariness <= 75 ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_WEARINESS_THEM_SERIOUS" );
+			elseif( iTheirWarWeariness > 75 ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_WEARINESS_THEM_CRIPPLED" );
 			end
-		elseif(iThemWarDamage > WarDamageLevelTypes.WAR_DAMAGE_LEVEL_NONE)then
-			if( iThemWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_MINOR ) then
-				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_THEM_MINOR" );
-			elseif( iThemWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_MAJOR ) then
-				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_THEM_MAJOR" );
-			elseif( iThemWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_SERIOUS ) then
-				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_THEM_SERIOUS" );
-			elseif( iThemWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_CRIPPLED ) then
-				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_THEM_CRIPPLED" );
-			end
-		end
 				
-		local iTheirWarWeariness = player:GetWarWeariness();
-		if(iTheirWarWeariness <= 0)then
-			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_WEARINESS_THEM_NONE" );
-		elseif( iTheirWarWeariness <= 25 ) then
-			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_WEARINESS_THEM_MINOR" );
-		elseif( iTheirWarWeariness <= 50 ) then
-			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_WEARINESS_THEM_MAJOR" );
-		elseif( iTheirWarWeariness <= 75 ) then
-			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_WEARINESS_THEM_SERIOUS" );
-		elseif( iTheirWarWeariness > 75 ) then
-			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_WEARINESS_THEM_CRIPPLED" );
+			tips:insert(strWarInfo);
 		end
-				
-		tips:insert(strWarInfo);
 -- UndeadDevel end
-				
+
 -- todo TradeableItems.TRADE_ITEM_THIRD_PARTY_WAR & permanent war
 		ShowSimpleTip( tips:concat() ) -- UndeadDevel: don't add new lines here...there will be empty lines at the top of the tool tip otherwise
 	end;

--- a/43 Civs CP/43 Civs CP/EUI/NotificationPanel.lua
+++ b/43 Civs CP/43 Civs CP/EUI/NotificationPanel.lua
@@ -1261,6 +1261,8 @@ local g_civListInstanceCallBacks = {-- the callback function table names need to
 				elseif bnw_mode and UI.CtrlKeyDown() and g_activeTeam:CanChangeWarPeace( teamID ) then
 					if g_activeTeam:IsAtWar( teamID ) then
 					-- Asking for Peace (currently at war) - bring up the trade screen
+						player:DoUpdateWarDamageLevel(); -- UndeadDevel: since we're bypassing the default diplo screen, which would update these two things we need to do it manually here
+						player:DoUpdatePeaceTreatyWillingness();
 						Game.DoFromUIDiploEvent( FromUIDiploEventTypes.FROM_UI_DIPLO_EVENT_HUMAN_NEGOTIATE_PEACE, playerID, 0, 0 )
 					elseif g_activeTeam:CanDeclareWar( teamID ) then
 					-- Declaring War - bring up the BNW popup

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
@@ -446,6 +446,8 @@ void CvLuaPlayer::PushMethods(lua_State* L, int t)
 	Method(GetWarDamageLevel);
 	Method(IsWillingToMakePeaceWithHuman);
 	Method(GetTreatyWillingToOffer);
+	Method(DoUpdateWarDamageLevel);
+	Method(DoUpdatePeaceTreatyWillingness);
 	Method(GetDominationResistance);
 #endif
 	Method(GetCombatBonusVsHigherTech);
@@ -530,10 +532,10 @@ void CvLuaPlayer::PushMethods(lua_State* L, int t)
 	Method(ChangeNumUnitGoldenAges);
 	Method(GetStrikeTurns);
 	Method(GetGoldenAgeModifier);
-    Method(GetGoldenAgeTourismModifier);
-    Method(GetGoldenAgeGreatWriterRateModifier);
-    Method(GetGoldenAgeGreatArtistRateModifier);
-    Method(GetGoldenAgeGreatMusicianRateModifier);
+	Method(GetGoldenAgeTourismModifier);
+	Method(GetGoldenAgeGreatWriterRateModifier);
+	Method(GetGoldenAgeGreatArtistRateModifier);
+	Method(GetGoldenAgeGreatMusicianRateModifier);
 #if defined(MOD_BALANCE_CORE)
 	Method(GetGoldenAgeGreatScientistRateModifier);
 	Method(GetGoldenAgeGreatEngineerRateModifier);
@@ -6446,6 +6448,24 @@ int CvLuaPlayer::lGetTreatyWillingToOffer(lua_State* L)
 	const int iResult = pkPlayer->GetDiplomacyAI()->GetTreatyWillingToOffer(ePlayer);
 	lua_pushinteger(L, iResult);
 	return 1;
+}
+
+// void DoUpdateWarDamageLevel();
+int CvLuaPlayer::lDoUpdateWarDamageLevel(lua_State* L)
+{
+	CvPlayerAI* pkPlayer = GetInstance(L);
+	
+	pkPlayer->GetDiplomacyAI()->DoUpdateWarDamageLevel();
+	return 0;
+}
+
+// void DoUpdatePeaceTreatyWillingness();
+int CvLuaPlayer::lDoUpdatePeaceTreatyWillingness(lua_State* L)
+{
+	CvPlayerAI* pkPlayer = GetInstance(L);
+	
+	pkPlayer->GetDiplomacyAI()->DoUpdatePeaceTreatyWillingness();
+	return 0;
 }
 
 int CvLuaPlayer::lGetDominationResistance(lua_State* L)

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.h
@@ -428,6 +428,8 @@ protected:
 	LUAAPIEXTN(GetWarDamageLevel, int);
 	LUAAPIEXTN(IsWillingToMakePeaceWithHuman, bool);
 	LUAAPIEXTN(GetTreatyWillingToOffer, int);
+	LUAAPIEXTN(DoUpdateWarDamageLevel, void);
+	LUAAPIEXTN(DoUpdatePeaceTreatyWillingness, void);
 	LUAAPIEXTN(GetDominationResistance, int);
 	LUAAPIEXTN(GetMajorCivOpinion, int);
 	LUAAPIEXTN(GetMajorityReligion, int);
@@ -1296,7 +1298,7 @@ protected:
 	static int lGetNumInternationalTradeRoutesUsed(lua_State* L);
 	static int lGetNumInternationalTradeRoutesAvailable(lua_State* L);
 #if defined(MOD_API_LUA_EXTENSIONS) && defined(MOD_API_TRADEROUTES)
-    static int GetPotentialInternationalTradeRouteDestinationsHelper(lua_State* L, CvPlayerAI* pkPlayer, CvUnit* pkUnit, CvPlot* pkUnitPlot);
+	static int GetPotentialInternationalTradeRouteDestinationsHelper(lua_State* L, CvPlayerAI* pkPlayer, CvUnit* pkUnit, CvPlot* pkUnitPlot);
 	LUAAPIEXTN(GetPotentialInternationalTradeRouteDestinationsFrom, table, pUnit, pCity);
 #endif
 	static int lGetPotentialInternationalTradeRouteDestinations(lua_State* L);

--- a/EUI Compatibility Files/EUI Compatibility Files/LUA/NotificationPanel.lua
+++ b/EUI Compatibility Files/EUI Compatibility Files/LUA/NotificationPanel.lua
@@ -1261,6 +1261,8 @@ local g_civListInstanceCallBacks = {-- the callback function table names need to
 				elseif bnw_mode and UI.CtrlKeyDown() and g_activeTeam:CanChangeWarPeace( teamID ) then
 					if g_activeTeam:IsAtWar( teamID ) then
 					-- Asking for Peace (currently at war) - bring up the trade screen
+						player:DoUpdateWarDamageLevel(); -- UndeadDevel: since we're bypassing the default diplo screen, which would update these two things we need to do it manually here
+						player:DoUpdatePeaceTreatyWillingness();
 						Game.DoFromUIDiploEvent( FromUIDiploEventTypes.FROM_UI_DIPLO_EVENT_HUMAN_NEGOTIATE_PEACE, playerID, 0, 0 )
 					elseif g_activeTeam:CanDeclareWar( teamID ) then
 					-- Declaring War - bring up the BNW popup

--- a/EUI Compatibility Files/EUI Compatibility Files/LUA/NotificationPanel.lua
+++ b/EUI Compatibility Files/EUI Compatibility Files/LUA/NotificationPanel.lua
@@ -1016,106 +1016,112 @@ local g_civListInstanceToolTips = { -- the tooltip function names need to match 
 			tips:insert( L"TXT_KEY_PEACE_BLOCKED"  .. "[NEWLINE][NEWLINE]") -- UndeadDevel: add newlines here instead to avoid having unused space
 		end
 				
--- UndeadDevel: add WarInfo to tool tip
-		local strWarInfo = "";
+-- UndeadDevel: update war status and peace willingness and add war info to tool tip
+		if (not Game.IsOption( GameOptionTypes.GAMEOPTION_ALWAYS_WAR ) and playerID ~= g_leaderID and not g_leaderMode and playerID ~= g_activePlayerID and not player:IsHuman() and not player:IsMinorCiv() and not player:IsBarbarian() and not IsGameCoreBusy()) then
 
-		if(player:IsWillingToMakePeaceWithHuman(g_activePlayerID)) then
-			local iPeaceValue = player:GetTreatyWillingToOffer(g_activePlayerID);
-			if(iPeaceValue >  PeaceTreatyTypes.PEACE_TREATY_WHITE_PEACE) then
-				if( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_ARMISTICE ) then
-					strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_ARMISTICE" );
-				elseif( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_SETTLEMENT ) then
-					strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_SETTLEMENT" );
-				elseif( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_BACKDOWN ) then
-					strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_BACKDOWN" );
-				elseif( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_SUBMISSION ) then
-					strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_SUBMISSION" );
-				elseif( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_SURRENDER ) then
-					strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_SURRENDER" );
-				elseif( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_CESSION ) then
-					strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_CESSION" );
-				elseif( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_CAPITULATION ) then
-					strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_CAPITULATION" );
-				elseif( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_UNCONDITIONAL_SURRENDER ) then
-					strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_UNCONDITIONAL_SURRENDER" );
+			player:DoUpdateWarDamageLevel();
+			player:DoUpdatePeaceTreatyWillingness();
+			
+			local strWarInfo = "";
+	
+			if(player:IsWillingToMakePeaceWithHuman(g_activePlayerID)) then
+				local iPeaceValue = player:GetTreatyWillingToOffer(g_activePlayerID);
+				if(iPeaceValue >  PeaceTreatyTypes.PEACE_TREATY_WHITE_PEACE) then
+					if( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_ARMISTICE ) then
+						strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_ARMISTICE" );
+					elseif( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_SETTLEMENT ) then
+						strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_SETTLEMENT" );
+					elseif( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_BACKDOWN ) then
+						strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_BACKDOWN" );
+					elseif( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_SUBMISSION ) then
+						strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_SUBMISSION" );
+					elseif( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_SURRENDER ) then
+						strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_SURRENDER" );
+					elseif( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_CESSION ) then
+						strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_CESSION" );
+					elseif( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_CAPITULATION ) then
+						strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_CAPITULATION" );
+					elseif( iPeaceValue == PeaceTreatyTypes.PEACE_TREATY_UNCONDITIONAL_SURRENDER ) then
+						strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_OFFER_PEACE_TREATY_UNCONDITIONAL_SURRENDER" );
+					end
+				end
+			else
+				strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_WAR_NO_PEACE_OFFER" );
+			end
+					
+			local iStrengthAverage = g_activePlayer:GetPlayerMilitaryStrengthComparedToUs(playerID);
+			if( iStrengthAverage == StrengthTypes.STRENGTH_PATHETIC ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_STRENGTH_PATHETIC" );
+			elseif( iStrengthAverage == StrengthTypes.STRENGTH_WEAK ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_STRENGTH_WEAK" );
+			elseif( iStrengthAverage == StrengthTypes.STRENGTH_POOR ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_STRENGTH_POOR" );
+			elseif( iStrengthAverage == StrengthTypes.STRENGTH_AVERAGE ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_STRENGTH_AVERAGE" );
+			elseif( iStrengthAverage == StrengthTypes.STRENGTH_STRONG ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_STRENGTH_STRONG" );
+			elseif( iStrengthAverage == StrengthTypes.STRENGTH_POWERFUL ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_STRENGTH_POWERFUL" );
+			elseif( iStrengthAverage == StrengthTypes.STRENGTH_IMMENSE ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_STRENGTH_IMMENSE" );
+			end
+					
+			local iEconomicAverage = g_activePlayer:GetPlayerEconomicStrengthComparedToUs(playerID);
+			if( iEconomicAverage == StrengthTypes.STRENGTH_PATHETIC ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_ECONOMY_PATHETIC" );
+			elseif( iEconomicAverage == StrengthTypes.STRENGTH_WEAK ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_ECONOMY_WEAK" );
+			elseif( iEconomicAverage == StrengthTypes.STRENGTH_POOR ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_ECONOMY_POOR" );
+			elseif( iEconomicAverage == StrengthTypes.STRENGTH_AVERAGE ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_ECONOMY_AVERAGE" );
+			elseif( iEconomicAverage == StrengthTypes.STRENGTH_STRONG ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_ECONOMY_STRONG" );
+			elseif( iEconomicAverage == StrengthTypes.STRENGTH_POWERFUL ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_ECONOMY_POWERFUL" );
+			elseif( iEconomicAverage == StrengthTypes.STRENGTH_IMMENSE ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_ECONOMY_IMMENSE" );
+			end
+					
+			local iUsWarDamage = player:GetWarDamageLevel(g_activePlayerID);
+			local iThemWarDamage = g_activePlayer:GetWarDamageLevel(playerID);
+			if(iUsWarDamage > WarDamageLevelTypes.WAR_DAMAGE_LEVEL_NONE)then
+				if( iUsWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_MINOR ) then
+					strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_US_MINOR" );
+				elseif( iUsWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_MAJOR ) then
+					strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_US_MAJOR" );
+				elseif( iUsWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_SERIOUS ) then
+					strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_US_SERIOUS" );
+				elseif( iUsWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_CRIPPLED ) then
+					strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_US_CRIPPLED" );
+				end
+			elseif(iThemWarDamage > WarDamageLevelTypes.WAR_DAMAGE_LEVEL_NONE)then
+				if( iThemWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_MINOR ) then
+					strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_THEM_MINOR" );
+				elseif( iThemWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_MAJOR ) then
+					strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_THEM_MAJOR" );
+				elseif( iThemWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_SERIOUS ) then
+					strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_THEM_SERIOUS" );
+				elseif( iThemWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_CRIPPLED ) then
+					strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_THEM_CRIPPLED" );
 				end
 			end
-		else
-			strWarInfo = strWarInfo .. Locale.ConvertTextKey( "TXT_KEY_WAR_NO_PEACE_OFFER" );
-		end
-				
-		local iStrengthAverage = g_activePlayer:GetPlayerMilitaryStrengthComparedToUs(playerID);
-		if( iStrengthAverage == StrengthTypes.STRENGTH_PATHETIC ) then
-			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_STRENGTH_PATHETIC" );
-		elseif( iStrengthAverage == StrengthTypes.STRENGTH_WEAK ) then
-			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_STRENGTH_WEAK" );
-		elseif( iStrengthAverage == StrengthTypes.STRENGTH_POOR ) then
-			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_STRENGTH_POOR" );
-		elseif( iStrengthAverage == StrengthTypes.STRENGTH_AVERAGE ) then
-			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_STRENGTH_AVERAGE" );
-		elseif( iStrengthAverage == StrengthTypes.STRENGTH_STRONG ) then
-			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_STRENGTH_STRONG" );
-		elseif( iStrengthAverage == StrengthTypes.STRENGTH_POWERFUL ) then
-			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_STRENGTH_POWERFUL" );
-		elseif( iStrengthAverage == StrengthTypes.STRENGTH_IMMENSE ) then
-			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_STRENGTH_IMMENSE" );
-		end
-				
-		local iEconomicAverage = g_activePlayer:GetPlayerEconomicStrengthComparedToUs(playerID);
-		if( iEconomicAverage == StrengthTypes.STRENGTH_PATHETIC ) then
-			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_ECONOMY_PATHETIC" );
-		elseif( iEconomicAverage == StrengthTypes.STRENGTH_WEAK ) then
-			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_ECONOMY_WEAK" );
-		elseif( iEconomicAverage == StrengthTypes.STRENGTH_POOR ) then
-			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_ECONOMY_POOR" );
-		elseif( iEconomicAverage == StrengthTypes.STRENGTH_AVERAGE ) then
-			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_ECONOMY_AVERAGE" );
-		elseif( iEconomicAverage == StrengthTypes.STRENGTH_STRONG ) then
-			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_ECONOMY_STRONG" );
-		elseif( iEconomicAverage == StrengthTypes.STRENGTH_POWERFUL ) then
-			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_ECONOMY_POWERFUL" );
-		elseif( iEconomicAverage == StrengthTypes.STRENGTH_IMMENSE ) then
-			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_ECONOMY_IMMENSE" );
-		end
-				
-		local iUsWarDamage = player:GetWarDamageLevel(g_activePlayerID);
-		local iThemWarDamage = g_activePlayer:GetWarDamageLevel(playerID);
-		if(iUsWarDamage > WarDamageLevelTypes.WAR_DAMAGE_LEVEL_NONE)then
-			if( iUsWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_MINOR ) then
-				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_US_MINOR" );
-			elseif( iUsWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_MAJOR ) then
-				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_US_MAJOR" );
-			elseif( iUsWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_SERIOUS ) then
-				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_US_SERIOUS" );
-			elseif( iUsWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_CRIPPLED ) then
-				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_US_CRIPPLED" );
+					
+			local iTheirWarWeariness = player:GetWarWeariness();
+			if(iTheirWarWeariness <= 0)then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_WEARINESS_THEM_NONE" );
+			elseif( iTheirWarWeariness <= 25 ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_WEARINESS_THEM_MINOR" );
+			elseif( iTheirWarWeariness <= 50 ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_WEARINESS_THEM_MAJOR" );
+			elseif( iTheirWarWeariness <= 75 ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_WEARINESS_THEM_SERIOUS" );
+			elseif( iTheirWarWeariness > 75 ) then
+				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_WEARINESS_THEM_CRIPPLED" );
 			end
-		elseif(iThemWarDamage > WarDamageLevelTypes.WAR_DAMAGE_LEVEL_NONE)then
-			if( iThemWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_MINOR ) then
-				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_THEM_MINOR" );
-			elseif( iThemWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_MAJOR ) then
-				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_THEM_MAJOR" );
-			elseif( iThemWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_SERIOUS ) then
-				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_THEM_SERIOUS" );
-			elseif( iThemWarDamage == WarDamageLevelTypes.WAR_DAMAGE_LEVEL_CRIPPLED ) then
-				strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_DAMAGE_THEM_CRIPPLED" );
-			end
-		end
 				
-		local iTheirWarWeariness = player:GetWarWeariness();
-		if(iTheirWarWeariness <= 0)then
-			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_WEARINESS_THEM_NONE" );
-		elseif( iTheirWarWeariness <= 25 ) then
-			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_WEARINESS_THEM_MINOR" );
-		elseif( iTheirWarWeariness <= 50 ) then
-			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_WEARINESS_THEM_MAJOR" );
-		elseif( iTheirWarWeariness <= 75 ) then
-			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_WEARINESS_THEM_SERIOUS" );
-		elseif( iTheirWarWeariness > 75 ) then
-			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey( "TXT_KEY_WAR_WEARINESS_THEM_CRIPPLED" );
+			tips:insert(strWarInfo);
 		end
-				
-		tips:insert(strWarInfo);
 -- UndeadDevel end
 
 -- todo TradeableItems.TRADE_ITEM_THIRD_PARTY_WAR & permanent war


### PR DESCRIPTION
Fixes #6118 

Also fixes a bunch of other potential issues; as described in the relevant issue this adds two new LUA hooks to update war related data in the diplo AI.

I also made sure to make the blanks uniform, which is why some leading spaces are converted to tabs for entries I otherwise didn't modify, as is the case for most of the code, so it's displayed consistently across editors.