### PR TITLE
Improvements to diplo AI military strength estimation

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -21164,7 +21164,7 @@ bool CvCity::DoRazingTurn()
 		// My viewpoint
 		GET_PLAYER(getOwner()).GetDiplomacyAI()->ChangeOtherPlayerWarValueLost(eFormerOwner, getOwner(), iValue);
 		// Bad guy's viewpoint
-		GET_PLAYER(eFormerOwner).GetDiplomacyAI()->ChangeWarValueLost(getOwner(), iValue);
+		GET_PLAYER(eFormerOwner).GetDiplomacyAI()->ChangeWarValueLost(getOwner(), iValue, /*bNoRatingChange*/ true);
 
 		int iEra = GET_PLAYER(eFormerOwner).GetCurrentEra();
 		if(iEra <= 0)

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
@@ -12516,7 +12516,7 @@ void CvDiplomacyAI::ChangeNumWarsDeclaredOnUs(PlayerTypes ePlayer, int iChange)
 }
 
 /// What is the average (living) major civ's military rating?
-int CvDiplomacyAI::ComputeAverageMajorMilitaryRating()
+int CvDiplomacyAI::ComputeAverageMajorMilitaryRating(PlayerTypes eExcludedPlayer /* = NO_PLAYER */)
 {
 	int iTotalRating = 0;
 	int iNumCivs = 0;
@@ -12524,6 +12524,9 @@ int CvDiplomacyAI::ComputeAverageMajorMilitaryRating()
 	for (int iPlayerLoop = 0; iPlayerLoop < MAX_MAJOR_CIVS; iPlayerLoop++)
 	{
 		PlayerTypes eLoopPlayer = (PlayerTypes) iPlayerLoop;
+		
+		if (eLoopPlayer == eExcludedPlayer)
+			continue;
 		
 		if (GET_PLAYER(eLoopPlayer).isAlive() && GET_PLAYER(eLoopPlayer).isMajorCiv())
 		{
@@ -12545,7 +12548,7 @@ int CvDiplomacyAI::ComputeRatingStrengthAdjustment(PlayerTypes ePlayer)
 		return 0;
 	
 	int iCivRating = GET_PLAYER(ePlayer).GetMilitaryRating();
-	int iAverageRating = ComputeAverageMajorMilitaryRating();
+	int iAverageRating = ComputeAverageMajorMilitaryRating(/*eExcludedPlayer*/ ePlayer);
 	
 	if (iAverageRating == 0)
 		iAverageRating = 1;

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
@@ -16247,50 +16247,6 @@ void CvDiplomacyAI::DoRelationshipPairing()
 				iDoFWeight += 10;
 				break;
 			}
-			
-			// What about their (estimated) Approach towards us?
-			if (!GET_PLAYER(ePlayer).isHuman())
-			{
-				switch (GetApproachTowardsUsGuess(ePlayer))
-			{
-			case MAJOR_CIV_APPROACH_WAR:
-			case MAJOR_CIV_APPROACH_HOSTILE:
-				iEnemyWeight += 10;
-				iDPWeight += -15;
-				iDoFWeight += -15;
-				break;
-			case MAJOR_CIV_APPROACH_DECEPTIVE:
-				iEnemyWeight += 5;
-				iDPWeight += -5;
-				iDoFWeight += -5;
-				break;
-			case MAJOR_CIV_APPROACH_GUARDED:
-				iEnemyWeight -= 1;
-				iDPWeight -= 1;
-				iDoFWeight -= 1;
-				break;
-			case MAJOR_CIV_APPROACH_AFRAID:
-				iEnemyWeight += -15;
-				iDPWeight += -10;
-				iDoFWeight += 7;
-				break;
-			case MAJOR_CIV_APPROACH_FRIENDLY:
-				iEnemyWeight += -3;
-				iDPWeight += 2;
-				iDoFWeight += 2;
-				break;
-			case MAJOR_CIV_APPROACH_NEUTRAL:
-				iEnemyWeight += -3;
-				iDPWeight += 1;
-				iDoFWeight += 1;
-				break;
-			default:
-				iEnemyWeight += -3;
-				iDPWeight += 1;
-				iDoFWeight += 1;
-				break;
-			}
-			}
 
 			// Military Strength compared to us
 			switch (GetPlayerMilitaryStrengthComparedToUs(ePlayer))
@@ -17585,6 +17541,7 @@ void CvDiplomacyAI::DoRelationshipPairing()
 			iDoFWeight -= (GetNumDoF() * 15);
 
 			//He hates who we hate? We love this guy!
+			/* try commenting this out to see if it results in more DPs for humans
 			if (!GET_PLAYER(ePlayer).isHuman())
 			{
 				if (GET_PLAYER(ePlayer).GetDiplomacyAI()->GetBiggestCompetitor() == GetBiggestCompetitor())
@@ -17594,6 +17551,7 @@ void CvDiplomacyAI::DoRelationshipPairing()
 					iEnemyWeight += -5;
 				}
 			}
+			*/
 
 			if (GET_PLAYER(ePlayer).GetCulture()->GetInfluenceLevel(GetPlayer()->GetID()) == INFLUENCE_LEVEL_POPULAR)
 			{
@@ -17670,6 +17628,7 @@ void CvDiplomacyAI::DoRelationshipPairing()
 					}
 
 					//We dislike the same people? Good!
+					/* try commenting this out to see if it results in more DPs for humans
 					if (!GET_PLAYER(ePlayer).isHuman())
 					{
 						if (GET_PLAYER(ePlayer).GetDiplomacyAI()->IsMajorCompetitor(eOtherPlayer) && IsMajorCompetitor(eOtherPlayer))
@@ -17679,6 +17638,7 @@ void CvDiplomacyAI::DoRelationshipPairing()
 							iEnemyWeight += -5;
 						}
 					}
+					*/
 
 					//We have defensive pacts with the same people? Good!
 					if (GET_TEAM(GET_PLAYER(ePlayer).getTeam()).IsHasDefensivePact(GET_PLAYER(eOtherPlayer).getTeam()) && GET_TEAM(GetPlayer()->getTeam()).IsHasDefensivePact(GET_PLAYER(eOtherPlayer).getTeam()))

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
@@ -4280,36 +4280,6 @@ MajorCivApproachTypes CvDiplomacyAI::GetBestApproachTowardsMajorCiv(PlayerTypes 
 
 	viApproachWeights[MAJOR_CIV_APPROACH_NEUTRAL] += viApproachWeightsPersonality[MAJOR_CIV_APPROACH_NEUTRAL];
 
-	// Base weight for Opinion to curb AI aggression a bit - not an elegant solution, but will be OK temporarily
-	switch (GetMajorCivOpinion(ePlayer))
-	{
-	case MAJOR_CIV_OPINION_ALLY:
-		viApproachWeights[MAJOR_CIV_APPROACH_FRIENDLY] += (viApproachWeightsPersonality[MAJOR_CIV_APPROACH_FRIENDLY] * 3);
-		break;
-	case MAJOR_CIV_OPINION_FRIEND:
-		viApproachWeights[MAJOR_CIV_APPROACH_FRIENDLY] += (viApproachWeightsPersonality[MAJOR_CIV_APPROACH_FRIENDLY] * 2);
-		break;
-	case MAJOR_CIV_OPINION_FAVORABLE:
-		viApproachWeights[MAJOR_CIV_APPROACH_FRIENDLY] += viApproachWeightsPersonality[MAJOR_CIV_APPROACH_FRIENDLY];
-		viApproachWeights[MAJOR_CIV_APPROACH_NEUTRAL] += viApproachWeightsPersonality[MAJOR_CIV_APPROACH_NEUTRAL];
-		break;
-	case MAJOR_CIV_OPINION_NEUTRAL:
-		viApproachWeights[MAJOR_CIV_APPROACH_NEUTRAL] += viApproachWeightsPersonality[MAJOR_CIV_APPROACH_NEUTRAL];
-		break;
-	case MAJOR_CIV_OPINION_COMPETITOR:
-		viApproachWeights[MAJOR_CIV_APPROACH_NEUTRAL] += viApproachWeightsPersonality[MAJOR_CIV_APPROACH_NEUTRAL];
-		viApproachWeights[MAJOR_CIV_APPROACH_GUARDED] += viApproachWeightsPersonality[MAJOR_CIV_APPROACH_GUARDED];
-		break;
-	case MAJOR_CIV_OPINION_ENEMY:
-		viApproachWeights[MAJOR_CIV_APPROACH_GUARDED] += viApproachWeightsPersonality[MAJOR_CIV_APPROACH_GUARDED];
-		viApproachWeights[MAJOR_CIV_APPROACH_HOSTILE] += viApproachWeightsPersonality[MAJOR_CIV_APPROACH_HOSTILE];
-		break;
-	case MAJOR_CIV_OPINION_UNFORGIVABLE:
-		viApproachWeights[MAJOR_CIV_APPROACH_HOSTILE] += viApproachWeightsPersonality[MAJOR_CIV_APPROACH_HOSTILE];
-		viApproachWeights[MAJOR_CIV_APPROACH_WAR] += viApproachWeightsPersonality[MAJOR_CIV_APPROACH_WAR];
-		break;
-	}
-
 	// If we're planning a war then give it a bias so that we don't get away from it too easily
 	if (eOldApproach == MAJOR_CIV_APPROACH_WAR && GetWarGoal(ePlayer) == WAR_GOAL_PREPARE)
 		viApproachWeights[MAJOR_CIV_APPROACH_WAR] += viApproachWeightsPersonality[MAJOR_CIV_APPROACH_WAR];
@@ -12545,6 +12515,73 @@ void CvDiplomacyAI::ChangeNumWarsDeclaredOnUs(PlayerTypes ePlayer, int iChange)
 	}
 }
 
+/// What is the average (living) major civ's military rating?
+int CvDiplomacyAI::ComputeAverageMajorMilitaryRating()
+{
+	int iTotalRating = 0;
+	int iNumCivs = 0;
+	
+	for (int iPlayerLoop = 0; iPlayerLoop < MAX_MAJOR_CIVS; iPlayerLoop++)
+	{
+		PlayerTypes eLoopPlayer = (PlayerTypes) iPlayerLoop;
+		
+		if (GET_PLAYER(eLoopPlayer).isAlive() && GET_PLAYER(eLoopPlayer).isMajorCiv())
+		{
+			iTotalRating += GET_PLAYER(eLoopPlayer).GetMilitaryRating();
+			iNumCivs++;
+		}
+	}
+	
+	// Prevent division by zero, just in case
+	if (iNumCivs == 0)
+		return 1;
+	
+	return (iTotalRating / iNumCivs);
+}
+
+int CvDiplomacyAI::ComputeRatingStrengthAdjustment(PlayerTypes ePlayer)
+{
+	if (!GET_PLAYER(ePlayer).isMajorCiv())
+		return 0;
+	
+	int iCivRating = GET_PLAYER(ePlayer).GetMilitaryRating();
+	int iAverageRating = ComputeAverageMajorMilitaryRating();
+	
+	if (iAverageRating == 0)
+		iAverageRating = 1;
+	
+	if (iCivRating == iAverageRating)
+		return 0;
+
+	// Calculate the percentage difference from the average
+	int iDifference = iCivRating - iAverageRating;
+	if (iDifference < 0)
+		iDifference *= -1; // need the absolute value
+	
+	int iAverage = ((iCivRating + iAverageRating) / 2);
+	
+	int iValue = iDifference / max(iAverage, 1);
+	iValue *= 100;
+	
+	// If above average, apply the % difference as a positive modifier to strength, cap above at +100%
+	if (iCivRating > iAverageRating)
+	{
+		return min(iValue, 100);
+	}
+	// If below average, apply half the % difference as a negative modifier to strength, cap below at -50%
+	else if (iCivRating < iAverageRating)
+	{
+		iValue *= -1; // flip the sign
+		iValue /= 2;
+		return max(iValue, -50);
+	}
+	else
+	{
+		return 0;
+	}
+}
+
+
 /// What is our assessment of this player's overall Military Strength?
 StrengthTypes CvDiplomacyAI::GetPlayerMilitaryStrengthComparedToUs(PlayerTypes ePlayer) const
 {
@@ -12586,76 +12623,93 @@ void CvDiplomacyAI::DoUpdateOnePlayerMilitaryStrength(PlayerTypes ePlayer)
 
 	int iBase = /*30*/ GC.getMILITARY_STRENGTH_BASE();
 	int iMilitaryStrength = iBase + GetPlayer()->GetMilitaryMight();
+	
+	// Modify strength based on military rating (combat skill)
+	iMilitaryStrength *= (100 + ComputeRatingStrengthAdjustment(GetPlayer()->GetID()));
+	iMilitaryStrength /= 100;
 
-	int iOtherPlayerMilitary;
+	int iOtherPlayerMilitaryStrength;
 	int iMilitaryRatio;
 
-	if(IsPlayerValid(ePlayer, /*bMyTeamIsValid*/ true))
+	if (IsPlayerValid(ePlayer, /*bMyTeamIsValid*/ true))
 	{
-		// Look at player's Military Strength
-		//if (GetPlayer()->GetMilitaryMight() > 0)
-		{
-			iOtherPlayerMilitary = GET_PLAYER(ePlayer).GetMilitaryMight() + iBase;
+		iOtherPlayerMilitaryStrength = GET_PLAYER(ePlayer).GetMilitaryMight() + iBase;
+		
+		// Modify strength based on military rating (combat skill)
+		iOtherPlayerMilitaryStrength *= (100 + ComputeRatingStrengthAdjustment(ePlayer));
+		iOtherPlayerMilitaryStrength /= 100;
 #if defined(MOD_BALANCE_CORE)
-			PlayerTypes eLoopPlayer;
-			int iDPUs = 0;
-			int iDPThem = 0;
-			for(int iPlayerLoop = 0; iPlayerLoop < MAX_CIV_PLAYERS; iPlayerLoop++)
+		PlayerTypes eLoopPlayer;
+		int iDPUs = 0;
+		int iDPThem = 0;
+		int iLoopPlayerStrength = 0;
+		for (int iPlayerLoop = 0; iPlayerLoop < MAX_CIV_PLAYERS; iPlayerLoop++)
+		{
+			eLoopPlayer = (PlayerTypes) iPlayerLoop;
+
+			if (IsPlayerValid(eLoopPlayer, /*bMyTeamIsValid*/ true) && eLoopPlayer != ePlayer && eLoopPlayer != GetPlayer()->GetID())
 			{
-				eLoopPlayer = (PlayerTypes) iPlayerLoop;
-
-				if (eLoopPlayer == GetPlayer()->GetID())
-					continue;
-
-				if (eLoopPlayer != NO_PLAYER && !GET_PLAYER(eLoopPlayer).isMinorCiv() && eLoopPlayer != ePlayer)
+				if ((GET_PLAYER(eLoopPlayer).getTeam() == GET_PLAYER(ePlayer).getTeam()) || (GET_TEAM(GET_PLAYER(eLoopPlayer).getTeam()).IsHasDefensivePact(GET_PLAYER(ePlayer).getTeam())))
 				{
-					if (GET_TEAM(GET_PLAYER(eLoopPlayer).getTeam()).IsHasDefensivePact(GET_PLAYER(ePlayer).getTeam()))
-					{
-						iDPThem += GET_PLAYER(eLoopPlayer).GetMilitaryMight();
-					}
-					if (GET_TEAM(GET_PLAYER(eLoopPlayer).getTeam()).IsHasDefensivePact(m_pPlayer->getTeam()))
-					{
-						iDPUs += GET_PLAYER(eLoopPlayer).GetMilitaryMight();
-					}
-#if defined(MOD_DIPLOMACY_CIV4_FEATURES)
-					if (MOD_DIPLOMACY_CIV4_FEATURES)
-					{
-						if (GET_TEAM(GET_PLAYER(eLoopPlayer).getTeam()).IsVassal(GET_PLAYER(ePlayer).getTeam()))
-						{
-							iDPThem += GET_PLAYER(eLoopPlayer).GetMilitaryMight();
-						}
-					}
-					if (MOD_DIPLOMACY_CIV4_FEATURES)
-					{
-						if (GET_TEAM(GET_PLAYER(eLoopPlayer).getTeam()).IsVassal(m_pPlayer->getTeam()))
-						{
-							iDPUs += GET_PLAYER(eLoopPlayer).GetMilitaryMight();
-						}
-					}
-#endif
+					iLoopPlayerStrength = GET_PLAYER(eLoopPlayer).GetMilitaryMight() + iBase;
+
+					// Modify strength based on military rating (combat skill)
+					iLoopPlayerStrength *= (100 + ComputeRatingStrengthAdjustment(eLoopPlayer));
+					iLoopPlayerStrength /= 100;
+
+					iDPThem += iLoopPlayerStrength;
 				}
-			}
-			if(iDPThem > 0)
-			{
-				iOtherPlayerMilitary *= (int)((iDPThem * .1f) + 100);
-				iOtherPlayerMilitary /= 100;
-			}
-			if(iDPUs > 0)
-			{
-				iMilitaryStrength *= (int)((iDPUs * .1f) + 100);
-				iMilitaryStrength /= 100;
-			}
+				if ((GET_PLAYER(eLoopPlayer).getTeam() == GetPlayer()->getTeam()) || (GET_TEAM(GET_PLAYER(eLoopPlayer).getTeam()).IsHasDefensivePact(m_pPlayer->getTeam())))
+				{
+					iLoopPlayerStrength = GET_PLAYER(eLoopPlayer).GetMilitaryMight() + iBase;
+
+					// Modify strength based on military rating (combat skill)
+					iLoopPlayerStrength *= (100 + ComputeRatingStrengthAdjustment(eLoopPlayer));
+					iLoopPlayerStrength /= 100;
+					
+					iDPUs += iLoopPlayerStrength;
+				}
+#if defined(MOD_DIPLOMACY_CIV4_FEATURES)
+				if (MOD_DIPLOMACY_CIV4_FEATURES)
+				{
+					if (GET_TEAM(GET_PLAYER(eLoopPlayer).getTeam()).IsVassal(GET_PLAYER(ePlayer).getTeam()))
+					{
+						iLoopPlayerStrength = GET_PLAYER(eLoopPlayer).GetMilitaryMight() + iBase;
+
+						// Modify strength based on military rating (combat skill)
+						iLoopPlayerStrength *= (100 + ComputeRatingStrengthAdjustment(eLoopPlayer));
+						iLoopPlayerStrength /= 100;
+
+						iDPThem += iLoopPlayerStrength;
+					}
+
+					if (GET_TEAM(GET_PLAYER(eLoopPlayer).getTeam()).IsVassal(m_pPlayer->getTeam()))
+					{
+						iLoopPlayerStrength = GET_PLAYER(eLoopPlayer).GetMilitaryMight() + iBase;
+
+						// Modify strength based on military rating (combat skill)
+						iLoopPlayerStrength *= (100 + ComputeRatingStrengthAdjustment(eLoopPlayer));
+						iLoopPlayerStrength /= 100;
+						
+						iDPUs += iLoopPlayerStrength;
+					}
+				}
 #endif
-			// Example: If another player has double the Military strength of us, the Ratio will be 200
-			iMilitaryRatio = iOtherPlayerMilitary* /*100*/ GC.getMILITARY_STRENGTH_RATIO_MULTIPLIER() / iMilitaryStrength;
+			}
 		}
-
-		//else
-		//{
-		//	iMilitaryRatio = /*100*/ GC.getMILITARY_STRENGTH_RATIO_MULTIPLIER();
-		//}
-
-		//iMilitaryStrength += iMilitaryRatio;
+		if(iDPThem > 0)
+		{
+			iOtherPlayerMilitaryStrength *= (int)((iDPThem * .1f) + 100);
+			iOtherPlayerMilitaryStrength /= 100;
+		}
+		if(iDPUs > 0)
+		{
+			iMilitaryStrength *= (int)((iDPUs * .1f) + 100);
+			iMilitaryStrength /= 100;
+		}
+#endif
+		// Example: If another player has double the Military strength of us, the Ratio will be 200
+		iMilitaryRatio = iOtherPlayerMilitaryStrength * /*100*/ GC.getMILITARY_STRENGTH_RATIO_MULTIPLIER() / iMilitaryStrength;
 
 		// Now do the final assessment
 		if(iMilitaryRatio >= /*300*/ GC.getMILITARY_STRENGTH_IMMENSE_THRESHOLD())
@@ -19264,7 +19318,7 @@ void CvDiplomacyAI::DoWarDamageDecay()
 					// Make sure it's changing by at least 1
 					iValue = max(1, iValue);
 
-					ChangeWarValueLost(eLoopPlayer, -iValue);
+					ChangeWarValueLost(eLoopPlayer, -iValue, /*bNoRatingChange*/ true);
 				}
 			}
 
@@ -19341,23 +19395,30 @@ void CvDiplomacyAI::SetWarValueLost(PlayerTypes ePlayer, int iValue)
 }
 
 // Changes the value of stuff (Units & Cities) lost in a war against a particular player
-void CvDiplomacyAI::ChangeWarValueLost(PlayerTypes ePlayer, int iChange)
+void CvDiplomacyAI::ChangeWarValueLost(PlayerTypes ePlayer, int iChange, bool bNoRatingChange /* = false */)
 {
 	SetWarValueLost(ePlayer, GetWarValueLost(ePlayer) + iChange);
+	
+	// Update military rating for both players
+	if (!bNoRatingChange)
+	{
+		GET_PLAYER(ePlayer).ChangeMilitaryRating(iChange); // rating up for winner (them)
+		GetPlayer()->ChangeMilitaryRating(-iChange); // rating down for loser (us)
+	}
 
-	if(iChange > 0)
+	if (iChange > 0)
 	{
 		// Loop through all the other major civs and see if any of them are fighting us.  If so, they are happy this player damaged us.
 		PlayerTypes eLoopPlayer;
-		for(int iPlayerLoop = 0; iPlayerLoop < MAX_MAJOR_CIVS; iPlayerLoop++)
+		for (int iPlayerLoop = 0; iPlayerLoop < MAX_MAJOR_CIVS; iPlayerLoop++)
 		{
 			eLoopPlayer = (PlayerTypes) iPlayerLoop;
 
-			if(eLoopPlayer != ePlayer && eLoopPlayer != m_pPlayer->GetID() && IsPlayerValid(eLoopPlayer))
+			if (eLoopPlayer != ePlayer && eLoopPlayer != m_pPlayer->GetID() && IsPlayerValid(eLoopPlayer))
 			{
 				// Are they at war with me too?
 				CvPlayer& kOtherPlayer = GET_PLAYER(eLoopPlayer);
-				if(IsAtWar(eLoopPlayer))
+				if (IsAtWar(eLoopPlayer))
 				{
 					kOtherPlayer.GetDiplomacyAI()->ChangeCommonFoeValue(ePlayer, iChange);
 				}

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.h
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.h
@@ -305,6 +305,10 @@ public:
 	int GetNumWarsDeclaredOnUs(PlayerTypes ePlayer) const;
 	void SetNumWarsDeclaredOnUs(PlayerTypes ePlayer, int iValue);
 	void ChangeNumWarsDeclaredOnUs(PlayerTypes ePlayer, int iChange);
+	
+	// Military Rating: How skilled is ePlayer at war?
+	int ComputeAverageMajorMilitaryRating();
+	int ComputeRatingStrengthAdjustment(PlayerTypes ePlayer);
 
 	// Military Strength: How strong is ePlayer compared to US?
 	StrengthTypes GetPlayerMilitaryStrengthComparedToUs(PlayerTypes ePlayer) const;
@@ -342,7 +346,7 @@ public:
 	// War Value Lost: the int value of damage ePlayer has inflicted on us in war
 	int GetWarValueLost(PlayerTypes ePlayer) const;
 	void SetWarValueLost(PlayerTypes ePlayer, int iValue);
-	void ChangeWarValueLost(PlayerTypes ePlayer, int iChange);
+	void ChangeWarValueLost(PlayerTypes ePlayer, int iChange, bool bNoRatingChange = false);
 
 	// Other Player War Damage Level: how much damage we've inflicted UPON ePlayer
 	WarDamageLevelTypes GetOtherPlayerWarDamageLevel(PlayerTypes ePlayer, PlayerTypes eLostToPlayer) const;

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.h
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.h
@@ -307,7 +307,7 @@ public:
 	void ChangeNumWarsDeclaredOnUs(PlayerTypes ePlayer, int iChange);
 	
 	// Military Rating: How skilled is ePlayer at war?
-	int ComputeAverageMajorMilitaryRating();
+	int ComputeAverageMajorMilitaryRating(PlayerTypes eExcludedPlayer = NO_PLAYER);
 	int ComputeRatingStrengthAdjustment(PlayerTypes ePlayer);
 
 	// Military Strength: How strong is ePlayer compared to US?

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -304,6 +304,7 @@ CvPlayer::CvPlayer() :
 	, m_iConversionTimer("CvPlayer::m_iConversionTimer", m_syncArchive)
 	, m_iCapitalCityID("CvPlayer::m_iCapitalCityID", m_syncArchive)
 	, m_iCitiesLost("CvPlayer::m_iCitiesLost", m_syncArchive)
+	, m_iMilitaryRating("CvPlayer::m_iMilitaryRating", m_syncArchive)
 	, m_iMilitaryMight("CvPlayer::m_iMilitaryMight", m_syncArchive)
 	, m_iEconomicMight("CvPlayer::m_iEconomicMight", m_syncArchive)
 	, m_iProductionMight("CvPlayer::m_iProductionMight", m_syncArchive)
@@ -1618,6 +1619,7 @@ void CvPlayer::uninit()
 	m_iConversionTimer = 0;
 	m_iCapitalCityID = -1;
 	m_iCitiesLost = 0;
+	m_iMilitaryRating = 0;
 	m_iMilitaryMight = 0;
 	m_iEconomicMight = 0;
 	m_iProductionMight = 0;
@@ -32954,6 +32956,29 @@ void CvPlayer::changeCitiesLost(int iChange)
 {
 	m_iCitiesLost = (m_iCitiesLost + iChange);
 }
+
+//	--------------------------------------------------------------------------------
+
+int CvPlayer::GetMilitaryRating() const
+{
+	return m_iMilitaryRating;
+}
+
+//	--------------------------------------------------------------------------------
+
+void CvPlayer::SetMilitaryRating(int iValue)
+{
+	m_iMilitaryRating = iValue;
+}
+
+//	--------------------------------------------------------------------------------
+
+void CvPlayer::ChangeMilitaryRating(int iChange)
+{
+	SetMilitaryRating(GetMilitaryRating() + iChange);
+}
+
+//	--------------------------------------------------------------------------------
 
 void CvPlayer::updateMightStatistics()
 {

--- a/CvGameCoreDLL_Expansion2/CvPlayer.h
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.h
@@ -2561,6 +2561,9 @@ public:
 
 #if defined(MOD_BALANCE_CORE_MILITARY)
 	int GetFractionOriginalCapitalsUnderControl() const;
+	int GetMilitaryRating() const;
+	void SetMilitaryRating(int iValue);
+	void ChangeMilitaryRating(int iChange);
 	void UpdateMilitaryStats();
 	void UpdateAreaEffectUnits();
 	void UpdateAreaEffectUnit(CvUnit* pUnit);
@@ -3363,6 +3366,7 @@ protected:
 	FAutoVariable<int, CvPlayer> m_iConversionTimer;
 	FAutoVariable<int, CvPlayer> m_iCapitalCityID;
 	FAutoVariable<int, CvPlayer> m_iCitiesLost;
+	FAutoVariable<int, CvPlayer> m_iMilitaryRating;
 	FAutoVariable<int, CvPlayer> m_iMilitaryMight;
 	FAutoVariable<int, CvPlayer> m_iEconomicMight;
 	FAutoVariable<int, CvPlayer> m_iProductionMight;

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -2430,10 +2430,10 @@ void CvUnit::kill(bool bDelay, PlayerTypes ePlayer /*= NO_PLAYER*/)
 			iCivValue *= GC.getGame().getGameSpeedInfo().getTrainPercent();
 			iCivValue /= 100;
 
-			// Don't apply the diplo penalty for units stationed in one of the owner's cities, since civilians aren't being targeted in particular
-			if (!plot()->isCity() || (plot()->isCity() && plot()->getOwner() != getOwner()))
+			// Don't apply the diplo penalty for units stationed in a city, since civilians aren't being targeted in particular
+			if (!plot()->isCity())
 			{
-			GET_PLAYER(getOwner()).GetDiplomacyAI()->ChangeNumTimesRazed(ePlayer, iCivValue);
+				GET_PLAYER(getOwner()).GetDiplomacyAI()->ChangeNumTimesRazed(ePlayer, iCivValue);
 			}
 #endif
 			int iWarscoremod = GET_PLAYER(ePlayer).GetWarScoreModifier();


### PR DESCRIPTION
Now factors in military skill through a rating system, equal to total war value gained/lost (not counting decay, razing or Barbarians).

Plus a few small tweaks.

Not savegame compatible (adds new memory value).