### PR TITLE
Bugfixes 26/02/20

### DIFF
--- a/CvGameCoreDLL_Expansion2/CustomMods.h
+++ b/CvGameCoreDLL_Expansion2/CustomMods.h
@@ -963,6 +963,8 @@
 #define MOD_BUGFIX_EXTRA_MISSIONARY_SPREADS			gCustomMods.isBUGFIX_EXTRA_MISSIONARY_SPREADS()
 // Workaround for the AI double turn when loading MP games with simultaneous/hybrid turns
 #define MOD_BUGFIX_AI_DOUBLE_TURN_MP_LOAD (true)
+// Fixes crashing when the AI's latest flavours are all 0, due to division by zero in CvPlayerTechs::AddFlavorAsStrategies
+#define MOD_BUGFIX_NULL_CURRENT_FLAVORS				(true)
 
 #endif // ACHIEVEMENT_HACKS
 

--- a/CvGameCoreDLL_Expansion2/CvGame.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGame.cpp
@@ -14225,12 +14225,17 @@ bool CvGame::CreateFreeCityPlayer(CvCity* pStartingCity, bool bJustChecking)
 	kPlayer.setCapitalCity(pStartingCity);
 	// get the plot before transferring ownership
 	CvPlot *pPlot = pStartingCity->plot();
+
+	// setStartingPlot needs to be before acquireCity, otherwise if this is a maritime city
+	// state, it will crash when the game tries to use the starting plot to look for the
+	// closest city to grant the bonus food for the civ first meeting this city state, before
+	// this function has finished executing.
+	kPlayer.setStartingPlot(pPlot);
 	kPlayer.acquireCity(pStartingCity, false/*bConquest*/, true/*bGift*/);
 	kPlayer.setFoundedFirstCity(true);
 
 	pStartingCity = NULL; //no longer valid
 	//we have to set this here!
-	kPlayer.setStartingPlot(pPlot);
 	kPlayer.getCapitalCity()->ChangeNumTimesOwned(eNewPlayer, 1);
 	kPlayer.getCapitalCity()->setName(kPlayer.getName());
 	kPlayer.getCapitalCity()->SetOccupied(false);

--- a/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
@@ -2118,7 +2118,7 @@ bool CvMinorCivQuest::IsExpired()
 				return true;
 			}
 			// We conquered the city-state. Oops.
-			if(!pTargetCityState->isAlive() && (pPlot->getOwner() == m_eAssignedPlayer))
+			if(!pTargetCityState->isAlive() && pPlot != NULL && (pPlot->getOwner() == m_eAssignedPlayer))
 			{
 				return true;
 			}

--- a/CvGameCoreDLL_Expansion2/CvTechClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTechClasses.cpp
@@ -2126,7 +2126,12 @@ void CvPlayerTechs::AddFlavorAsStrategies(int iPropagatePercent)
 		int iCurrentFlavorValue = GetLatestFlavorValue((FlavorTypes) iFlavor);
 
 		// Scale the current to the same scale as the personality
+#if defined(MOD_BUGFIX_NULL_CURRENT_FLAVORS)
+		// Prevent a divide by zero
+		iCurrentFlavorValue = iBiggestFlavor > 0 ? (iCurrentFlavorValue * 10) / iBiggestFlavor : 0;
+#else
 		iCurrentFlavorValue = (iCurrentFlavorValue * 10) / iBiggestFlavor;
+#endif
 
 #if defined(MOD_AI_SMART_V3)
 		int iPersonalityFlavorValue = m_pPlayer->GetGrandStrategyAI()->GetPersonalityAndGrandStrategy((FlavorTypes) iFlavor, MOD_AI_SMART_V3 /*bBoostGSMainFlavor*/);

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.cpp
@@ -652,6 +652,7 @@ void CvLuaUnit::PushMethods(lua_State* L, int t)
 	Method(IsAdjacentToUnitClass);
 	Method(IsAdjacentToUnitCombatType);
 	Method(IsAdjacentToUnitPromotion);
+	Method(IsWithinDistanceOfCity);
 #endif
 	Method(IsOnImprovement);
 	Method(IsAdjacentToImprovement);
@@ -6353,6 +6354,7 @@ LUAAPIIMPL(Unit, IsAdjacentToUnit)
 LUAAPIIMPL(Unit, IsAdjacentToUnitClass)
 LUAAPIIMPL(Unit, IsAdjacentToUnitCombatType)
 LUAAPIIMPL(Unit, IsAdjacentToUnitPromotion)
+LUAAPIIMPL(Unit, IsWithinDistanceOfCity)
 #endif
 LUAAPIIMPL(Unit, IsOnImprovement)
 LUAAPIIMPL(Unit, IsAdjacentToImprovement)

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.h
@@ -663,6 +663,7 @@ protected:
 	LUAAPIEXTN(IsAdjacentToUnitClass, iUnitClassType, bool, bool);
 	LUAAPIEXTN(IsAdjacentToUnitCombatType, iUnitCombatType, bool, bool);
 	LUAAPIEXTN(IsAdjacentToUnitPromotion, iPromotionType, bool, bool);
+	LUAAPIEXTN(IsWithinDistanceOfCity, iDistance, bool, bool);
 #endif
 	LUAAPIEXTN(IsOnImprovement, bool, iImprovementType);
 	LUAAPIEXTN(IsAdjacentToImprovement, bool, iImprovementType);


### PR DESCRIPTION
- Fixed potential crash due to division by zero in CvPlayerTechs::AddFlavorAsStrategies.
- Fixed missing lua method unit:IsWithinDistanceOfCity.
- Fixed crash when creating free city, when the new free city owner is a maritime city state.
- Fixed potential crash due to null plot in CvMinorCivQuest::IsExpired.