### PR TITLE
Difficulty bonuses always trigger (even without tourism bonuses)

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvCultureClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCultureClasses.cpp
@@ -3726,10 +3726,10 @@ void CvPlayerCulture::DoArchaeologyChoice (ArchaeologyChoiceType eChoice)
 	m_pPlayer->SetNumArchaeologyChoices(m_pPlayer->GetNumArchaeologyChoices() - 1);
 	m_pPlayer->GetCulture()->RemoveDigCompletePlot(pPlot);
 #if defined(MOD_BALANCE_CORE)
-	if(m_pPlayer->GetArchaeologicalDigTourism() > 0)
+	m_pPlayer->ChangeNumHistoricEvents(HISTORIC_EVENT_DIG, 1);
+	if (m_pPlayer->GetArchaeologicalDigTourism() > 0)
 	{
 		int iTourism = m_pPlayer->GetHistoricEventTourism(HISTORIC_EVENT_DIG);
-		m_pPlayer->ChangeNumHistoricEvents(HISTORIC_EVENT_DIG, 1);
 		m_pPlayer->GetCulture()->AddTourismAllKnownCivsWithModifiers(iTourism);
 		if(iTourism > 0)
 		{

--- a/CvGameCoreDLL_Expansion2/CvCultureClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCultureClasses.cpp
@@ -3726,10 +3726,10 @@ void CvPlayerCulture::DoArchaeologyChoice (ArchaeologyChoiceType eChoice)
 	m_pPlayer->SetNumArchaeologyChoices(m_pPlayer->GetNumArchaeologyChoices() - 1);
 	m_pPlayer->GetCulture()->RemoveDigCompletePlot(pPlot);
 #if defined(MOD_BALANCE_CORE)
-	m_pPlayer->ChangeNumHistoricEvents(HISTORIC_EVENT_DIG, 1);
 	if (m_pPlayer->GetArchaeologicalDigTourism() > 0)
 	{
 		int iTourism = m_pPlayer->GetHistoricEventTourism(HISTORIC_EVENT_DIG);
+		m_pPlayer->ChangeNumHistoricEvents(HISTORIC_EVENT_DIG, 1);
 		m_pPlayer->GetCulture()->AddTourismAllKnownCivsWithModifiers(iTourism);
 		if(iTourism > 0)
 		{
@@ -3751,6 +3751,12 @@ void CvPlayerCulture::DoArchaeologyChoice (ArchaeologyChoiceType eChoice)
 			}
 		}
 	}
+#if defined(MOD_BALANCE_CORE_DIFFICULTY)
+	else if (MOD_BALANCE_CORE_DIFFICULTY && !m_pPlayer->isHuman() && m_pPlayer->isMajorCiv() && m_pPlayer->getNumCities() > 0)
+	{
+		m_pPlayer->DoDifficultyBonus(HISTORIC_EVENT_DIG);
+	}
+#endif
 	pPlot->setResourceType(NO_RESOURCE, 0);
 #endif
 }

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -19866,7 +19866,7 @@ void CvPlayer::DoWarVictoryBonuses()
 void CvPlayer::DoDifficultyBonus(HistoricEventTypes eHistoricEvent)
 {
 	int iEra = GC.getGame().getCurrentEra();
-	if(iEra <= 0)
+	if (iEra <= 0)
 	{
 		iEra = 1;
 	}
@@ -19879,7 +19879,7 @@ void CvPlayer::DoDifficultyBonus(HistoricEventTypes eHistoricEvent)
 	CvString strLogString;
 
 	CvHandicapInfo* pHandicapInfo = GC.getHandicapInfo(GC.getGame().getHandicapType());
-	if(pHandicapInfo)
+	if (pHandicapInfo)
 	{
 		iHandicapBase = pHandicapInfo->getAIDifficultyBonusBase();
 		iHandicapA = pHandicapInfo->getAIDifficultyBonusEarly();
@@ -19991,12 +19991,27 @@ void CvPlayer::DoDifficultyBonus(HistoricEventTypes eHistoricEvent)
 				break;
 			}
 			case HISTORIC_EVENT_DIG:
+			{
+				GetTreasury()->ChangeGold(iYieldHandicap);
+				strLogString.Format("CBP AI DIFFICULTY BONUS FROM HISTORIC EVENT: DIG - Received Handicap Bonus (%d in Yields): GOLD.", iYieldHandicap);
+				break;
+			}
 			case HISTORIC_EVENT_TRADE_CS:
+			{
+				GetTreasury()->ChangeGold(iYieldHandicap);
+				strLogString.Format("CBP AI DIFFICULTY BONUS FROM HISTORIC EVENT: TRADE (CITY-STATE) - Received Handicap Bonus (%d in Yields): GOLD.", iYieldHandicap);
+				break;
+			}
 			case HISTORIC_EVENT_TRADE_LAND:
+			{
+				GetTreasury()->ChangeGold(iYieldHandicap);
+				strLogString.Format("CBP AI DIFFICULTY BONUS FROM HISTORIC EVENT: TRADE (LAND) - Received Handicap Bonus (%d in Yields): GOLD.", iYieldHandicap);
+				break;
+			}
 			case HISTORIC_EVENT_TRADE_SEA:
 			{
 				GetTreasury()->ChangeGold(iYieldHandicap);
-				strLogString.Format("CBP AI DIFFICULTY BONUS FROM HISTORIC EVENT: DIG/TRADE - Received Handicap Bonus (%d in Yields): GOLD.", iYieldHandicap);
+				strLogString.Format("CBP AI DIFFICULTY BONUS FROM HISTORIC EVENT: TRADE (SEA) - Received Handicap Bonus (%d in Yields): GOLD.", iYieldHandicap);
 				break;
 			}
 			case HISTORIC_EVENT_CITY_FOUND_CAPITAL:
@@ -25288,10 +25303,10 @@ void CvPlayer::changeGoldenAgeTurns(int iChange)
 #endif
 
 #if defined(MOD_BALANCE_CORE)
+			ChangeNumHistoricEvents(HISTORIC_EVENT_GA, 1);
 			if (GetGoldenAgeTourism() > 0)
 			{
 				int iTourism = GetHistoricEventTourism(HISTORIC_EVENT_GA);
-				ChangeNumHistoricEvents(HISTORIC_EVENT_GA, 1);
 				// Culture boost based on previous turns
 				if (iTourism > 0)
 				{
@@ -31655,7 +31670,7 @@ void CvPlayer::ChangeNumHistoricEvents(HistoricEventTypes eHistoricEvent, int iC
 		}
 	}
 #if defined(MOD_BALANCE_CORE_DIFFICULTY)
-	if (MOD_BALANCE_CORE_DIFFICULTY && !isMinorCiv() && !isHuman() && !isBarbarian() && getNumCities() > 0)
+	if (MOD_BALANCE_CORE_DIFFICULTY && !isHuman() && isMajorCiv() && getNumCities() > 0)
 	{
 		DoDifficultyBonus(eHistoricEvent);
 	}

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -25303,10 +25303,10 @@ void CvPlayer::changeGoldenAgeTurns(int iChange)
 #endif
 
 #if defined(MOD_BALANCE_CORE)
-			ChangeNumHistoricEvents(HISTORIC_EVENT_GA, 1);
 			if (GetGoldenAgeTourism() > 0)
 			{
 				int iTourism = GetHistoricEventTourism(HISTORIC_EVENT_GA);
+				ChangeNumHistoricEvents(HISTORIC_EVENT_GA, 1);
 				// Culture boost based on previous turns
 				if (iTourism > 0)
 				{
@@ -25334,6 +25334,12 @@ void CvPlayer::changeGoldenAgeTurns(int iChange)
 					}
 				}
 			}
+#if defined(MOD_BALANCE_CORE_DIFFICULTY)
+			else if (MOD_BALANCE_CORE_DIFFICULTY && !isHuman() && isMajorCiv() && getNumCities() > 0)
+			{
+				DoDifficultyBonus(HISTORIC_EVENT_GA);
+			}
+#endif
 			if (GetPlayerTraits()->GetWLTKDGATimer() > 0)
 			{
 				int iValue2 = GetPlayerTraits()->GetWLTKDGATimer();
@@ -31553,11 +31559,12 @@ void CvPlayer::ChangeNumHistoricEvents(HistoricEventTypes eHistoricEvent, int iC
 		return;
 	}
 	m_iNumHistoricEvent += iChange;
+
 	CvCity* pLoopCity;
 	int iLoop;
-	for(pLoopCity = firstCity(&iLoop); pLoopCity != NULL; pLoopCity = nextCity(&iLoop))
+	for (pLoopCity = firstCity(&iLoop); pLoopCity != NULL; pLoopCity = nextCity(&iLoop))
 	{
-		if(pLoopCity != NULL)
+		if (pLoopCity != NULL)
 		{
 			pLoopCity->GetCityCulture()->CalculateBaseTourismBeforeModifiers();
 			pLoopCity->GetCityCulture()->CalculateBaseTourism();
@@ -31565,7 +31572,7 @@ void CvPlayer::ChangeNumHistoricEvents(HistoricEventTypes eHistoricEvent, int iC
 	}
 	CvCity* pCapital = getCapitalCity();
 	int iEventGP = GetPlayerTraits()->GetEventGP();
-	if(pCapital != NULL && iEventGP > 0)
+	if (pCapital != NULL && iEventGP > 0)
 	{
 		vector<SpecialistTypes> vPossibleSpecialists;
 		for (int iSpecialistLoop = 0; iSpecialistLoop < GC.getNumSpecialistInfos(); iSpecialistLoop++)
@@ -31580,23 +31587,23 @@ void CvPlayer::ChangeNumHistoricEvents(HistoricEventTypes eHistoricEvent, int iC
 					vPossibleSpecialists.push_back(eSpecialist);
 
 					//boost the chance if we have a slot for the corresponding great work
-					if((UnitClassTypes)pkSpecialistInfo->getGreatPeopleUnitClass() == GC.getInfoTypeForString("UNITCLASS_WRITER"))
+					if ((UnitClassTypes)pkSpecialistInfo->getGreatPeopleUnitClass() == GC.getInfoTypeForString("UNITCLASS_WRITER"))
 					{ 
-						if(GetCulture()->GetNumAvailableGreatWorkSlots(CvTypes::getGREAT_WORK_SLOT_LITERATURE()) > 0)
+						if (GetCulture()->GetNumAvailableGreatWorkSlots(CvTypes::getGREAT_WORK_SLOT_LITERATURE()) > 0)
 						{
 							vPossibleSpecialists.push_back(eSpecialist);
 						}
 					}
-					else if((UnitClassTypes)pkSpecialistInfo->getGreatPeopleUnitClass() == GC.getInfoTypeForString("UNITCLASS_ARTIST"))
+					else if ((UnitClassTypes)pkSpecialistInfo->getGreatPeopleUnitClass() == GC.getInfoTypeForString("UNITCLASS_ARTIST"))
 					{
-						if(GetCulture()->GetNumAvailableGreatWorkSlots(CvTypes::getGREAT_WORK_SLOT_ART_ARTIFACT()) > 0)
+						if (GetCulture()->GetNumAvailableGreatWorkSlots(CvTypes::getGREAT_WORK_SLOT_ART_ARTIFACT()) > 0)
 						{
 							vPossibleSpecialists.push_back(eSpecialist);
 						}
 					}
-					else if((UnitClassTypes)pkSpecialistInfo->getGreatPeopleUnitClass() == GC.getInfoTypeForString("UNITCLASS_MUSICIAN"))
+					else if ((UnitClassTypes)pkSpecialistInfo->getGreatPeopleUnitClass() == GC.getInfoTypeForString("UNITCLASS_MUSICIAN"))
 					{
-						if(GetCulture()->GetNumAvailableGreatWorkSlots(CvTypes::getGREAT_WORK_SLOT_MUSIC()) > 0)
+						if (GetCulture()->GetNumAvailableGreatWorkSlots(CvTypes::getGREAT_WORK_SLOT_MUSIC()) > 0)
 						{
 							vPossibleSpecialists.push_back(eSpecialist);
 						}
@@ -31608,10 +31615,10 @@ void CvPlayer::ChangeNumHistoricEvents(HistoricEventTypes eHistoricEvent, int iC
 		//choose one
 		int iChoice = GC.getGame().getSmallFakeRandNum(vPossibleSpecialists.size(), GetPseudoRandomSeed() + GC.getGame().getNumCities() + m_iNumHistoricEvent);
 		SpecialistTypes eBestSpecialist = vPossibleSpecialists.empty() ? NO_SPECIALIST : vPossibleSpecialists[iChoice];
-		if(eBestSpecialist != NO_SPECIALIST)
+		if (eBestSpecialist != NO_SPECIALIST)
 		{
 			CvSpecialistInfo* pkSpecialistInfo = GC.getSpecialistInfo(eBestSpecialist);
-			if(pkSpecialistInfo)
+			if (pkSpecialistInfo)
 			{
 				int iGPThreshold = pCapital->GetCityCitizens()->GetSpecialistUpgradeThreshold((UnitClassTypes)pkSpecialistInfo->getGreatPeopleUnitClass());
 				iGPThreshold *= 100;
@@ -31620,44 +31627,44 @@ void CvPlayer::ChangeNumHistoricEvents(HistoricEventTypes eHistoricEvent, int iC
 				iGPThreshold /= 100;
 				
 				pCapital->GetCityCitizens()->ChangeSpecialistGreatPersonProgressTimes100(eBestSpecialist, iGPThreshold, true);
-				if(GetID() == GC.getGame().getActivePlayer())
+				if (GetID() == GC.getGame().getActivePlayer())
 				{
 					iGPThreshold /= 100;
 					char text[256] = {0};
 					sprintf_s(text, "[COLOR_WHITE]+%d[ENDCOLOR][ICON_GREAT_PEOPLE]", iGPThreshold);
 					SHOW_PLOT_POPUP(pCapital->plot(), GetID(), text);
 					CvNotifications* pNotification = GetNotifications();
-					if(pNotification)
+					if (pNotification)
 					{
 						CvString strMessage = GetLocalizedText("TXT_KEY_TOURISM_EVENT_GP_BONUS", iGPThreshold);
 						CvString strSummary;
 						// Class specific specialist message.
-						if((UnitClassTypes)pkSpecialistInfo->getGreatPeopleUnitClass() == GC.getInfoTypeForString("UNITCLASS_SCIENTIST"))
+						if ((UnitClassTypes)pkSpecialistInfo->getGreatPeopleUnitClass() == GC.getInfoTypeForString("UNITCLASS_SCIENTIST"))
 						{
 							strMessage = GetLocalizedText("TXT_KEY_TOURISM_EVENT_GP_BONUS_SCIENTIST", iGPThreshold);
 						}
-						else if((UnitClassTypes)pkSpecialistInfo->getGreatPeopleUnitClass() == GC.getInfoTypeForString("UNITCLASS_WRITER"))
+						else if ((UnitClassTypes)pkSpecialistInfo->getGreatPeopleUnitClass() == GC.getInfoTypeForString("UNITCLASS_WRITER"))
 						{ 
 							strMessage = GetLocalizedText("TXT_KEY_TOURISM_EVENT_GP_BONUS_WRITER", iGPThreshold);
 						}
-						else if((UnitClassTypes)pkSpecialistInfo->getGreatPeopleUnitClass() == GC.getInfoTypeForString("UNITCLASS_ARTIST"))
+						else if ((UnitClassTypes)pkSpecialistInfo->getGreatPeopleUnitClass() == GC.getInfoTypeForString("UNITCLASS_ARTIST"))
 						{
 							strMessage = GetLocalizedText("TXT_KEY_TOURISM_EVENT_GP_BONUS_ARTIST", iGPThreshold);
 						}
-						else if((UnitClassTypes)pkSpecialistInfo->getGreatPeopleUnitClass() == GC.getInfoTypeForString("UNITCLASS_MUSICIAN"))
+						else if ((UnitClassTypes)pkSpecialistInfo->getGreatPeopleUnitClass() == GC.getInfoTypeForString("UNITCLASS_MUSICIAN"))
 						{
 							strMessage = GetLocalizedText("TXT_KEY_TOURISM_EVENT_GP_BONUS_MUSICIAN", iGPThreshold);
 						}
-						else if((UnitClassTypes)pkSpecialistInfo->getGreatPeopleUnitClass() == GC.getInfoTypeForString("UNITCLASS_MERCHANT"))
+						else if ((UnitClassTypes)pkSpecialistInfo->getGreatPeopleUnitClass() == GC.getInfoTypeForString("UNITCLASS_MERCHANT"))
 						{
 							strMessage = GetLocalizedText("TXT_KEY_TOURISM_EVENT_GP_BONUS_MERCHANT", iGPThreshold);
 						}
-						else if((UnitClassTypes)pkSpecialistInfo->getGreatPeopleUnitClass() == GC.getInfoTypeForString("UNITCLASS_ENGINEER"))
+						else if ((UnitClassTypes)pkSpecialistInfo->getGreatPeopleUnitClass() == GC.getInfoTypeForString("UNITCLASS_ENGINEER"))
 						{
 							strMessage = GetLocalizedText("TXT_KEY_TOURISM_EVENT_GP_BONUS_ENGINEER", iGPThreshold);
 						}
 #if defined(MOD_DIPLOMACY_CITYSTATES)
-						else if(MOD_DIPLOMACY_CITYSTATES && (UnitClassTypes)pkSpecialistInfo->getGreatPeopleUnitClass() == GC.getInfoTypeForString("UNITCLASS_GREAT_DIPLOMAT"))
+						else if (MOD_DIPLOMACY_CITYSTATES && (UnitClassTypes)pkSpecialistInfo->getGreatPeopleUnitClass() == GC.getInfoTypeForString("UNITCLASS_GREAT_DIPLOMAT"))
 						{
 							strMessage = GetLocalizedText("TXT_KEY_TOURISM_EVENT_GP_BONUS_DIPLOMAT", iGPThreshold);
 						}
@@ -31670,7 +31677,7 @@ void CvPlayer::ChangeNumHistoricEvents(HistoricEventTypes eHistoricEvent, int iC
 		}
 	}
 #if defined(MOD_BALANCE_CORE_DIFFICULTY)
-	if (MOD_BALANCE_CORE_DIFFICULTY && !isHuman() && isMajorCiv() && getNumCities() > 0)
+	if (MOD_BALANCE_CORE_DIFFICULTY && !isHuman() && getNumCities() > 0)
 	{
 		DoDifficultyBonus(eHistoricEvent);
 	}

--- a/CvGameCoreDLL_Expansion2/CvTradeClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTradeClasses.cpp
@@ -2515,10 +2515,10 @@ void CvPlayerTrade::MoveUnits (void)
 								{
 									if (pTradeConnection->m_eDomain == DOMAIN_LAND)
 									{
-										GET_PLAYER(pOriginCity->getOwner()).ChangeNumHistoricEvents(HISTORIC_EVENT_TRADE_LAND, 1);
 										int iTourism = GET_PLAYER(pOriginCity->getOwner()).GetHistoricEventTourism(HISTORIC_EVENT_TRADE_LAND, pOriginCity);
 										if (iTourism > 0)
 										{
+											GET_PLAYER(pOriginCity->getOwner()).ChangeNumHistoricEvents(HISTORIC_EVENT_TRADE_LAND, 1);
 											GET_PLAYER(pOriginCity->getOwner()).GetCulture()->ChangeInfluenceOn(pDestCity->getOwner(), iTourism, true, true);
 											GET_PLAYER(pOriginCity->getOwner()).GetCulture()->AddTourismAllKnownCivsOtherCivWithModifiers(pDestCity->getOwner(), iTourism / 3);
 
@@ -2570,13 +2570,19 @@ void CvPlayerTrade::MoveUnits (void)
 												}
 											}
 										}
+#if defined(MOD_BALANCE_CORE_DIFFICULTY)
+										else if (MOD_BALANCE_CORE_DIFFICULTY && !GET_PLAYER(pOriginCity->getOwner()).isHuman() && GET_PLAYER(pOriginCity->getOwner()).isMajorCiv() && GET_PLAYER(pOriginCity->getOwner()).getNumCities() > 0)
+										{
+											GET_PLAYER(pOriginCity->getOwner()).DoDifficultyBonus(HISTORIC_EVENT_TRADE_LAND);
+										}
+#endif
 									}
 									else if (pTradeConnection->m_eDomain == DOMAIN_SEA)
 									{
-										GET_PLAYER(pOriginCity->getOwner()).ChangeNumHistoricEvents(HISTORIC_EVENT_TRADE_SEA, 1);
 										int iTourism = GET_PLAYER(pOriginCity->getOwner()).GetHistoricEventTourism(HISTORIC_EVENT_TRADE_SEA, pOriginCity);
 										if (iTourism > 0)
 										{
+											GET_PLAYER(pOriginCity->getOwner()).ChangeNumHistoricEvents(HISTORIC_EVENT_TRADE_SEA, 1);
 											GET_PLAYER(pOriginCity->getOwner()).GetCulture()->ChangeInfluenceOn(pDestCity->getOwner(), iTourism, true, true);
 											GET_PLAYER(pOriginCity->getOwner()).GetCulture()->AddTourismAllKnownCivsOtherCivWithModifiers(pDestCity->getOwner(), iTourism / 3);
 
@@ -2620,27 +2626,42 @@ void CvPlayerTrade::MoveUnits (void)
 												}
 											}
 										}
+#if defined(MOD_BALANCE_CORE_DIFFICULTY)
+										else if (MOD_BALANCE_CORE_DIFFICULTY && !GET_PLAYER(pOriginCity->getOwner()).isHuman() && GET_PLAYER(pOriginCity->getOwner()).isMajorCiv() && GET_PLAYER(pOriginCity->getOwner()).getNumCities() > 0)
+										{
+											GET_PLAYER(pOriginCity->getOwner()).DoDifficultyBonus(HISTORIC_EVENT_TRADE_SEA);
+										}
+#endif
 									}
 								}
-								else if (GET_PLAYER(pDestCity->getOwner()).isMinorCiv() && GET_PLAYER(pOriginCity->getOwner()).GetEventTourismCS() > 0)
+								else if (GET_PLAYER(pDestCity->getOwner()).isMinorCiv())
 								{
-									GET_PLAYER(pOriginCity->getOwner()).ChangeNumHistoricEvents(HISTORIC_EVENT_TRADE_CS, 1);
-									int iTourism = GET_PLAYER(pOriginCity->getOwner()).GetHistoricEventTourism(HISTORIC_EVENT_TRADE_CS);
-									if (iTourism > 0)
+									if (GET_PLAYER(pOriginCity->getOwner()).GetEventTourismCS() > 0)
 									{
-										GET_PLAYER(pOriginCity->getOwner()).GetCulture()->AddTourismAllKnownCivsWithModifiers(iTourism);
-										CvNotifications* pNotification = GET_PLAYER(pOriginCity->getOwner()).GetNotifications();
-										if (pNotification)
+										int iTourism = GET_PLAYER(pOriginCity->getOwner()).GetHistoricEventTourism(HISTORIC_EVENT_TRADE_CS);
+										GET_PLAYER(pOriginCity->getOwner()).ChangeNumHistoricEvents(HISTORIC_EVENT_TRADE_CS, 1);
+										if (iTourism > 0)
 										{
-											Localization::String strSummary;
-											Localization::String strMessage;
-											strMessage = Localization::Lookup("TXT_KEY_TOURISM_EVENT_TRADE_CS_BONUS");
-											strMessage << iTourism;
-											strMessage << GET_PLAYER(pDestCity->getOwner()).getCivilizationShortDescriptionKey();
-											strSummary = Localization::Lookup("TXT_KEY_TOURISM_EVENT_SUMMARY_TRADE_CS");
-											pNotification->Add(NOTIFICATION_GENERIC, strMessage.toUTF8(), strSummary.toUTF8(), pOriginCity->getX(), pOriginCity->getY(), pOriginCity->getOwner());
+											GET_PLAYER(pOriginCity->getOwner()).GetCulture()->AddTourismAllKnownCivsWithModifiers(iTourism);
+											CvNotifications* pNotification = GET_PLAYER(pOriginCity->getOwner()).GetNotifications();
+											if (pNotification)
+											{
+												Localization::String strSummary;
+												Localization::String strMessage;
+												strMessage = Localization::Lookup("TXT_KEY_TOURISM_EVENT_TRADE_CS_BONUS");
+												strMessage << iTourism;
+												strMessage << GET_PLAYER(pDestCity->getOwner()).getCivilizationShortDescriptionKey();
+												strSummary = Localization::Lookup("TXT_KEY_TOURISM_EVENT_SUMMARY_TRADE_CS");
+												pNotification->Add(NOTIFICATION_GENERIC, strMessage.toUTF8(), strSummary.toUTF8(), pOriginCity->getX(), pOriginCity->getY(), pOriginCity->getOwner());
+											}
 										}
 									}
+#if defined(MOD_BALANCE_CORE_DIFFICULTY)
+									else if (MOD_BALANCE_CORE_DIFFICULTY && !GET_PLAYER(pOriginCity->getOwner()).isHuman() && GET_PLAYER(pOriginCity->getOwner()).isMajorCiv() && GET_PLAYER(pOriginCity->getOwner()).getNumCities() > 0)
+									{
+										GET_PLAYER(pOriginCity->getOwner()).DoDifficultyBonus(HISTORIC_EVENT_TRADE_CS);
+									}
+#endif
 								}
 							}
 						}

--- a/CvGameCoreDLL_Expansion2/CvTradeClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTradeClasses.cpp
@@ -2515,6 +2515,7 @@ void CvPlayerTrade::MoveUnits (void)
 								{
 									if (pTradeConnection->m_eDomain == DOMAIN_LAND)
 									{
+										GET_PLAYER(pOriginCity->getOwner()).ChangeNumHistoricEvents(HISTORIC_EVENT_TRADE_LAND, 1);
 										int iTourism = GET_PLAYER(pOriginCity->getOwner()).GetHistoricEventTourism(HISTORIC_EVENT_TRADE_LAND, pOriginCity);
 										if (iTourism > 0)
 										{
@@ -2572,6 +2573,7 @@ void CvPlayerTrade::MoveUnits (void)
 									}
 									else if (pTradeConnection->m_eDomain == DOMAIN_SEA)
 									{
+										GET_PLAYER(pOriginCity->getOwner()).ChangeNumHistoricEvents(HISTORIC_EVENT_TRADE_SEA, 1);
 										int iTourism = GET_PLAYER(pOriginCity->getOwner()).GetHistoricEventTourism(HISTORIC_EVENT_TRADE_SEA, pOriginCity);
 										if (iTourism > 0)
 										{
@@ -2622,8 +2624,8 @@ void CvPlayerTrade::MoveUnits (void)
 								}
 								else if (GET_PLAYER(pDestCity->getOwner()).isMinorCiv() && GET_PLAYER(pOriginCity->getOwner()).GetEventTourismCS() > 0)
 								{
-									int iTourism = GET_PLAYER(pOriginCity->getOwner()).GetHistoricEventTourism(HISTORIC_EVENT_TRADE_CS);
 									GET_PLAYER(pOriginCity->getOwner()).ChangeNumHistoricEvents(HISTORIC_EVENT_TRADE_CS, 1);
+									int iTourism = GET_PLAYER(pOriginCity->getOwner()).GetHistoricEventTourism(HISTORIC_EVENT_TRADE_CS);
 									if (iTourism > 0)
 									{
 										GET_PLAYER(pOriginCity->getOwner()).GetCulture()->AddTourismAllKnownCivsWithModifiers(iTourism);


### PR DESCRIPTION
Some of the events were triggering the difficulty bonus and incrementing ChangeNumHistoricEvents even when the civ didn't get tourism bonuses; some of them weren't. Now they all at least trigger the difficulty bonus, which is consistent for game difficulty.

Fixed land and sea TR historic events not triggering the AI's difficulty bonus.

Slightly more detailed logging for difficulty bonus (DIG/TRADE).