### PR TITLE
Fix double XP scaler

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -1067,8 +1067,6 @@ void CvUnit::initWithNameOffset(int iID, UnitTypes eUnit, int iNameOffset, UnitA
 
 	// free XP from handicap?
 	int iXP = GC.getGame().getHandicapInfo().getAIFreeXP();
-	iXP *= GC.getGame().getGameSpeedInfo().getTrainPercent();
-	iXP /= 100;
 	if (iXP && !kPlayer.isHuman() && canAcquirePromotionAny())
 	{
 #if defined(MOD_UNITS_XP_TIMES_100)


### PR DESCRIPTION
My bad on this - I did not notice that non-combat XP was already given a gamespeed scaler in CvUnit::changeExperienceTimes100. The change in this version can therefore be reverted.