### PR TITLE
Small updates

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvTechClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTechClasses.cpp
@@ -2679,16 +2679,22 @@ int CvTeamTechs::GetResearchCost(TechTypes eTech) const
 
 	//to avoid overflow, we have to work a bit differently here
 	int iCost = pkTechInfo->GetResearchCost();
-	int iModifier = 0;
+	int iModifier = 100;
 
 	CvHandicapInfo* pkHandicapInfo = GC.getHandicapInfo(m_pTeam->getHandicapType());
 	if(pkHandicapInfo)
-		iModifier += (pkHandicapInfo->getResearchPercent() - 100);
-
-	iModifier += (GC.getMap().getWorldInfo().getResearchPercent() - 100);
-	iModifier += (GC.getGame().getGameSpeedInfo().getResearchPercent() - 100);
-	iModifier += (GC.getGame().getStartEraInfo().getResearchPercent() - 100);
-	iModifier += std::max(0, GC.getTECH_COST_EXTRA_TEAM_MEMBER_MODIFIER() * (m_pTeam->getNumMembers() - 1));
+	{
+		iModifier *= (pkHandicapInfo->getResearchPercent());
+		iModifier /= 100;
+	}
+	iModifier *= (GC.getMap().getWorldInfo().getResearchPercent());
+	iModifier /= 100;
+	iModifier *= (GC.getGame().getGameSpeedInfo().getResearchPercent());
+	iModifier /= 100;
+	iModifier *= (GC.getGame().getStartEraInfo().getResearchPercent());
+	iModifier /= 100;
+	iModifier *= (100 + std::max(0, GC.getTECH_COST_EXTRA_TEAM_MEMBER_MODIFIER() * (m_pTeam->getNumMembers() - 1)));
+	iModifier /= 100;
 
 #if defined(MOD_CIV6_EUREKA)
 	iModifier += (std::max(0, (1000000 - (pkTechInfo->GetEurekaPerMillion() * m_paiEurekaCounter[eTech]) / max(1, m_pTeam->getNumMembers())) / 10000) - 100);
@@ -2696,10 +2702,10 @@ int CvTeamTechs::GetResearchCost(TechTypes eTech) const
 
 	if (iCost<10000)
 		//avoid rounding errors
-		return std::max(1, iCost + (iCost*iModifier)/100);
+		return std::max(1, (iCost*iModifier)/100);
 	else
 		//avoid overflow
-	return std::max(1, iCost + (iCost/100)*iModifier);
+	return std::max(1, (iCost/100)*iModifier);
 }
 
 #if defined(MOD_CIV6_EUREKA)

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -30382,7 +30382,7 @@ int CvUnit::AI_promotionValue(PromotionTypes ePromotion)
 		else
 		{
 			iExtra = iTemp * (2 * iFlavorOffense + iFlavorDefense);
-			iExtra *= 1.5; 		// In order to buff dreadnought slightly
+			iExtra *= 1; 	
 		}
 		iValue += iExtra;
 		
@@ -30421,7 +30421,7 @@ int CvUnit::AI_promotionValue(PromotionTypes ePromotion)
 	{
 		iExtra = getExtraOpenAttackPercent();
 		iExtra = (iTemp + iExtra) * (iFlavorOffense + iFlavorDefense + iFlavorMobile);
-		iExtra *= 0.3;
+		iExtra *= 0.4;
 		if(noDefensiveBonus())
 		{
 			iExtra *= 2;
@@ -30532,9 +30532,9 @@ int CvUnit::AI_promotionValue(PromotionTypes ePromotion)
 		iExtra = getExtraAttackBelowHealthMod();
 		iExtra = ( iTemp + iExtra ) * ( iFlavorDefense + 2 * iFlavorOffense);
 		if (isRanged())
-			iExtra *= 0.5;		// Had to artificially increase this as barrage sucks
+			iExtra *= 0.5;		
 		else
-			iExtra *= 0.4;
+			iExtra *= 0.3;
 		if (noDefensiveBonus())
 			iExtra *= 1.5;
 		iValue += iExtra;
@@ -30636,7 +30636,7 @@ int CvUnit::AI_promotionValue(PromotionTypes ePromotion)
 	if (iTemp != 0)
 	{
 		iExtra = iTemp  * (iFlavorOffense + iFlavorDefense + iFlavorCityDefense);
-		iExtra *= 0.1;
+		iExtra *= 0.08;
 		iValue += iExtra;
 	}
 
@@ -30645,7 +30645,7 @@ int CvUnit::AI_promotionValue(PromotionTypes ePromotion)
 	if (iTemp != 0)
 	{
 		iExtra = (2 * iFlavorOffense + iFlavorDefense);
-		iExtra *= 10;
+		iExtra *= 8;
 		iValue += iExtra;
 	}
 	
@@ -30718,7 +30718,7 @@ int CvUnit::AI_promotionValue(PromotionTypes ePromotion)
 		if (isRanged())
 			{
 			iExtra = iTemp * (iFlavorOffense + iFlavorDefense + iFlavorCityDefense);
-			iExtra *= 70;
+			iExtra *= 80;
 			}
 		else
 			{
@@ -30737,7 +30737,7 @@ int CvUnit::AI_promotionValue(PromotionTypes ePromotion)
 	if(iTemp != 0 && isRanged())
 	{
 		iExtra = iTemp * ( 3 * iFlavorRanged );
-		iExtra *= 100;
+		iExtra *= 120;
 		iExtra /= max(1,GetRange());
 		iValue += iExtra;
 	
@@ -30747,7 +30747,7 @@ int CvUnit::AI_promotionValue(PromotionTypes ePromotion)
 	// R + S: Indirect Fire.
 	{
 		iExtra = (iFlavorRanged * 2 + iFlavorOffense);
-		iExtra *= 10;
+		iExtra *= 30;
 		iExtra *= GetRange();
 		iValue += iExtra;
 	}
@@ -30944,45 +30944,18 @@ int CvUnit::AI_promotionValue(PromotionTypes ePromotion)
 	if(pkPromotionInfo->IsAmphib())     
 	// M: Amphibious.
 	{
-		if((AI_getUnitAIType() == UNITAI_FAST_ATTACK) ||
-				(AI_getUnitAIType() == UNITAI_ATTACK))
-		{
-#if defined(MOD_BALANCE_CORE_MILITARY_PROMOTION_ADVANCED)
-			iValue += iFlavorMobile * 2;
-#else
-			iValue += 40 + iFlavorOffense * 2;
-#endif
-		}
-		else
-		{
-#if defined(MOD_BALANCE_CORE_MILITARY)
-			iValue += iFlavorMobile;
-#else
-			iValue += 10 + iFlavorOffense * 2;
-#endif
-		}
+		iExtra = (iFlavorNaval * 2 + iFlavorOffense);
+		iExtra *= 8;
+		iValue += iExtra;		
 	}
 
 	if(pkPromotionInfo->IsRiver())
 	// M: Amphibious.
 	{
-		if((AI_getUnitAIType() == UNITAI_FAST_ATTACK) ||
-				(AI_getUnitAIType() == UNITAI_ATTACK))
-		{
-#if defined(MOD_BALANCE_CORE_MILITARY)
-			iValue += iFlavorMobile * 2;
-#else
-			iValue += 40 + iFlavorOffense * 2;
-#endif
-		}
-		else
-		{
-#if defined(MOD_BALANCE_CORE_MILITARY)
-			iValue += iFlavorMobile;
-#else
-			iValue += 10 + iFlavorOffense * 2;
-#endif
-		}
+		iExtra = (iFlavorMobile * 2 + iFLavorOffense);
+		iExtra *= 4;
+		iExtra *= maxMoves()
+		iValue += iExtra;	
 	}
 
 

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -30532,9 +30532,9 @@ int CvUnit::AI_promotionValue(PromotionTypes ePromotion)
 		iExtra = getExtraAttackBelowHealthMod();
 		iExtra = ( iTemp + iExtra ) * ( iFlavorDefense + 2 * iFlavorOffense);
 		if (isRanged())
-			iExtra *= 0.5;		
+			iExtra *= 0.3;		
 		else
-			iExtra *= 0.3;
+			iExtra *= 0.4;
 		if (noDefensiveBonus())
 			iExtra *= 1.5;
 		iValue += iExtra;


### PR DESCRIPTION
Tweaks to promotion logic including for barrage change and added values for amphibious.

Vanguard (known as COASTAL_TERROR in xml) says it has 100 damage vs cities in game, but xml has value of 125. Didn't change this as I don't know which is correct.

Base Tech cost formula updated to be multiplicative rather than additive.

There are some other issues with tech cost and particularly overflow which I will mention in a separate issue.