### PR TITLE
AssignStartingPlots and Communitu_79a update

### DIFF
--- a/Community Patch/Mapscripts/Communitu_79a.lua
+++ b/Community Patch/Mapscripts/Communitu_79a.lua
@@ -85,12 +85,12 @@ function MapGlobals:New()
 
 
 	--Adjusting these will generate larger or smaller landmasses and features.
-	mglobal.landMinScatter			= 0.05 	--Recommended range:[0.02 to 0.1]
-	mglobal.landMaxScatter			= 0.08	--Recommended range:[0.03 to 0.3]
+	mglobal.landMinScatter			= 0.02 	--Recommended range:[0.02 to 0.1]
+	mglobal.landMaxScatter			= 0.04	--Recommended range:[0.03 to 0.3]
 											--Higher values makes continental divisions and stringy features more likely,
 											--and very high values result in a lot of stringy continents and islands.
 
-	mglobal.coastScatter			= 0.08 	--Recommended range:[0.01 to 0.3]
+	mglobal.coastScatter			= 0.02 	--Recommended range:[0.01 to 0.3]
 											--Higher values result in more islands and variance on landmasses and coastlines.
 
 	mglobal.mountainScatter			= 200 * mapW --Recommended range:[130 to 1000]
@@ -186,25 +186,25 @@ function MapGlobals:New()
 	2 - temperature
 	3 - rainfall
 	4 - sea_level
-	5 - Strategic Resource Density
-	6 - Strategic Deposit Size
-	7 - Strategic Balance
-	8 - Bonus Resource Density
-	9 - Legendary Start
-	10 - Luxury Resource Density
-	11 - Players Start
-	12 - Ocean Rifts
-	13 - Ocean Rift Width
-	14 - Circumnavigation Path
-	15 - Land Scatter
+	5 - Players Starting Locations
+	6 - Ocean Shapes
+	7 - Ocean Rift Width
+	8 - Circumnavigation Path
+	9 - Force Coastal Starts
+	10 - Land Shapes
+	11 - Resources in Starting Locations
+	12 - Strategic Deposit Size
+	13 - Bonus Resource Density
+	14 - Strategic Resource Density
+	15 - Luxury Resource Density
 	16 - Override AssignStartingPlots
-	17 - Force Coastal Starts
+
 
 	--]]
 
 	do
 
-	overrideAssignStartingPlots = (Map.GetCustomOption(16) == 1)
+	overrideAssignStartingPlots = (Map.GetCustomOption(16) == 2)
 
 	local oWorldAge = Map.GetCustomOption(1)
 	if oWorldAge == 1 then
@@ -323,8 +323,8 @@ function MapGlobals:New()
 	print("Land Percent: ", mglobal.landPercent)
 
 
-	local oStarts = Map.GetCustomOption(11)
-	if oStarts == 1 then
+	local oStarts = Map.GetCustomOption(5)
+	if oStarts == 2 then
 		print("Map Starts: Everywhere")
 		mglobal.offsetAtlanticPercent	= 0.48	-- Percent of land to divide at the Atlantic Ocean (50% is usually halfway on the map)
 		mglobal.offshoreCS				= 0.25	-- Percent of city states on uninhabited islands
@@ -338,7 +338,7 @@ function MapGlobals:New()
 	end
 
 
-	local oRiftWidth = Map.GetCustomOption(13)
+	local oRiftWidth = Map.GetCustomOption(7)
 	if oRiftWidth == 4 then oRiftWidth = 1 + Map.Rand(3, "Random Rift Width") end
 	if oRiftWidth == 1 then
 		print("Map Ocean Width: Narrow")
@@ -350,24 +350,24 @@ function MapGlobals:New()
 		mglobal.landPercent = mglobal.landPercent + 0.05
 	end
 
-	local oLandScatter = Map.GetCustomOption(15)
+	local oLandScatter = Map.GetCustomOption(10)
 	local scatterOdds = 1
 	if oLandScatter == 1 then
 		print("Map Land Scatter: Blocky")
-		scatterOdds = 2/3
+		scatterOdds = 1/3
 	elseif oLandScatter == 3 then
 		print("Map Land Scatter: Stringy")
-		scatterOdds = 1.5
+		scatterOdds = 5
 	elseif oLandScatter == 4 then
 		print("Map Land Scatter: Extremely Stringy")
-		scatterOdds = 2
+		scatterOdds = 15
 	elseif oLandScatter == 5 then
 		print("Map Land Scatter: Random")
 		local scatterRand = PWRand()
 		local higher = (1 == Map.Rand(2, "modifyOddsRandom for scatter"))
-		mglobal.landMinScatter = modifyOddsRandom(mglobal.landMinScatter, 0.5, scatterRand, higher)
-		mglobal.landMaxScatter = modifyOddsRandom(mglobal.landMaxScatter, 0.5, scatterRand, higher)
-		mglobal.coastScatter = modifyOddsRandom(mglobal.coastScatter, 0.5, scatterRand, higher)
+		mglobal.landMinScatter = modifyOddsRandom(mglobal.landMinScatter, 10, scatterRand, higher)
+		mglobal.landMaxScatter = modifyOddsRandom(mglobal.landMaxScatter, 10, scatterRand, higher)
+		mglobal.coastScatter = modifyOddsRandom(mglobal.coastScatter, 10, scatterRand, higher)
 	else
 		print("Map Land Scatter: Normal")
 	end
@@ -1181,19 +1181,20 @@ function MapGlobals:New()
 									local quantity = res_quantity[use_this_res_index]
 									-- added by azum4roll: give some variance to strategic amounts
 									local rand = PWRand()
-									if (rand >= 0.8) then
-										quantity = math.floor(quantity * 1.2 + 0.5)
-									elseif (rand < 0.2) then
-										quantity = math.floor(quantity * 0.8 + 0.5)
+									if (rand >= 0.75) then
+										quantity = quantity * 1.2
+									elseif (rand < 0.25) then
+										quantity = quantity * 0.8
 									end
-
+									quantity = math.floor(quantity + 0.5)
+	
 									res_plot:SetResourceType(res_ID[use_this_res_index], quantity);
 									if (Game.GetResourceUsageType(res_ID[use_this_res_index]) == ResourceUsageTypes.RESOURCEUSAGE_LUXURY) then
 										self.totalLuxPlacedSoFar = self.totalLuxPlacedSoFar + 1;
 									end
 									self:PlaceResourceImpact(x, y, impact_table_number, res_min[use_this_res_index] + res_addition);
 									placed_this_res = true;
-									self.amounts_of_resources_placed[res_ID[use_this_res_index] + 1] = self.amounts_of_resources_placed[res_ID[use_this_res_index] + 1] + res_quantity[use_this_res_index];
+									self.amounts_of_resources_placed[res_ID[use_this_res_index] + 1] = self.amounts_of_resources_placed[res_ID[use_this_res_index] + 1] + quantity;
 								end
 							end
 						elseif impact_table_number == 2 then
@@ -1301,7 +1302,7 @@ function MapGlobals:New()
 			-- type will avoid if possible. See ProcessResourceList for impact numbers.
 			--
 			-- Order of placement matters, so changing the order may affect a later dependency.
-
+			
 			-- Adjust amounts, if applicable, based on strategic deposit size setting.
 			local uran_amt, horse_amt, oil_amt, iron_amt, coal_amt, alum_amt = self:GetMajorStrategicResourceQuantityValues()
 			local resources_to_place = {}
@@ -1316,98 +1317,96 @@ function MapGlobals:New()
 				resMultiplier = getRandomMultiplier(0.5);
 			end
 
-			print("self.resDensity = " .. self.resDensity);
-
 			-- Place Strategic resources.
 			print("Map Generation - Placing Strategics");
-
+			
 			-- Revamped by azum4roll: now place most resources one by one for easier balancing
 			resources_to_place = {
 				{self.horse_ID, horse_amt, 100, 1, 2}
 			};
-			self:ProcessResourceList(24 * resMultiplier, 1, self.grass_flat_no_feature, resources_to_place);
-			self:ProcessResourceList(34 * resMultiplier, 1, self.plains_flat_no_feature, resources_to_place);
-
+			self:ProcessResourceList(20 * resMultiplier, 1, self.grass_flat_no_feature, resources_to_place);
+			self:ProcessResourceList(32 * resMultiplier, 1, self.plains_flat_no_feature, resources_to_place);
+			
 			resources_to_place = {
-				{self.horse_ID, horse_amt, 100, 0, 2}
+				{self.horse_ID, horse_amt * 0.7, 100, 2, 3}
 			};
-			self:ProcessResourceList(20 * resMultiplier, 1, self.desert_wheat_list, resources_to_place);
-			self:ProcessResourceList(70 * resMultiplier, 1, self.tundra_flat_no_feature, resources_to_place);
-
+			self:ProcessResourceList(35 * resMultiplier, 1, self.desert_wheat_list, resources_to_place);
+			self:ProcessResourceList(60 * resMultiplier, 1, self.tundra_flat_no_feature, resources_to_place);
+			
 			resources_to_place = {
-				{self.iron_ID, iron_amt, 100, 0, 2}
+				{self.iron_ID, iron_amt, 100, 1, 3}
 			};
-			self:ProcessResourceList(75 * resMultiplier, 1, self.hills_open_list, resources_to_place);
+			self:ProcessResourceList(80 * resMultiplier, 1, self.hills_open_list, resources_to_place);
 			self:ProcessResourceList(180 * resMultiplier, 1, self.flat_open_no_tundra_no_desert, resources_to_place);
-			self:ProcessResourceList(40 * resMultiplier, 1, self.desert_flat_no_feature, resources_to_place);
-
+			self:ProcessResourceList(55 * resMultiplier, 1, self.desert_flat_no_feature, resources_to_place);
+			
 			resources_to_place = {
-				{self.iron_ID, iron_amt, 100, 0, 1}
+				{self.iron_ID, iron_amt, 100, 1, 2}
 			};
-			self:ProcessResourceList(120 * resMultiplier, 1, self.tundra_flat_no_feature, resources_to_place);
-
+			self:ProcessResourceList(90 * resMultiplier, 1, self.tundra_flat_no_feature, resources_to_place);
+			
 			resources_to_place = {
 				{self.coal_ID, coal_amt, 100, 1, 2}
 			};
 			self:ProcessResourceList(65 * resMultiplier, 1, self.hills_open_no_tundra_no_desert, resources_to_place);
 			self:ProcessResourceList(170 * resMultiplier, 1, self.grass_flat_no_feature, resources_to_place);
 			self:ProcessResourceList(120 * resMultiplier, 1, self.plains_flat_no_feature, resources_to_place);
-
+			
 			resources_to_place = {
 				{self.oil_ID, oil_amt, 100, 1, 3}
 			};
 			self:ProcessResourceList(40 * resMultiplier, 1, self.desert_flat_no_feature, resources_to_place);
 			self:ProcessResourceList(75 * resMultiplier, 1, self.tundra_flat_no_feature, resources_to_place);
-
+			
 			resources_to_place = {
 				{self.aluminum_ID, alum_amt, 100, 1, 3}
 			};
 			self:ProcessResourceList(42 * resMultiplier, 1, self.hills_open_no_grass, resources_to_place);
 			self:ProcessResourceList(27 * resMultiplier, 1, self.flat_open_no_grass_no_plains, resources_to_place);
 			self:ProcessResourceList(100 * resMultiplier, 1, self.plains_flat_no_feature, resources_to_place);
-
+			
 			resources_to_place = {
-				{self.uranium_ID, uran_amt, 100, 1, 2}
+				{self.uranium_ID, uran_amt, 100, 2, 4}
 			};
 			self:ProcessResourceList(50 * resMultiplier, 1, self.hills_jungle_list, resources_to_place);
 			self:ProcessResourceList(200 * resMultiplier, 1, self.hills_open_list, resources_to_place);
 			self:ProcessResourceList(90 * resMultiplier, 1, self.tundra_flat_no_feature, resources_to_place);
 			self:ProcessResourceList(150 * resMultiplier, 1, self.desert_flat_no_feature, resources_to_place);
 			self:ProcessResourceList(300 * resMultiplier, 1, self.flat_open_no_tundra_no_desert, resources_to_place);
-
+			
 			resources_to_place = {
-				{self.iron_ID, iron_amt, 90, 0, 2},
+				{self.iron_ID, iron_amt, 90, 1, 3},
 				{self.uranium_ID, uran_amt, 10, 1, 2}
 			};
-			self:ProcessResourceList(45 * resMultiplier, 1, self.hills_forest_list, resources_to_place);
-			self:ProcessResourceList(50 * resMultiplier, 1, self.forest_flat_that_are_not_tundra, resources_to_place);
-			self:ProcessResourceList(60 * resMultiplier, 1, self.tundra_flat_forest, resources_to_place);
-
+			self:ProcessResourceList(65 * resMultiplier, 1, self.hills_forest_list, resources_to_place);
+			self:ProcessResourceList(70 * resMultiplier, 1, self.forest_flat_that_are_not_tundra, resources_to_place);
+			self:ProcessResourceList(75 * resMultiplier, 1, self.tundra_flat_forest, resources_to_place);
+			
 			resources_to_place = {
-				{self.oil_ID, oil_amt, 60, 1, 1},
-				{self.uranium_ID, uran_amt, 40, 1, 1}
+				{self.oil_ID, oil_amt, 60, 1, 3},
+				{self.uranium_ID, uran_amt, 40, 1, 2}
 			};
 			self:ProcessResourceList(15 * resMultiplier, 1, self.marsh_list, resources_to_place);
 			self:ProcessResourceList(60 * resMultiplier, 1, self.jungle_flat_list, resources_to_place);
-
+			
 			resources_to_place = {
 				{self.oil_ID, oil_amt, 40, 1, 2},
 				{self.uranium_ID, uran_amt, 20, 1, 2},
 				{self.iron_ID, iron_amt, 40, 1, 2}
 			};
 			self:ProcessResourceList(7 * resMultiplier, 1, self.snow_flat_list, resources_to_place);
-
+			
 			self:AddModernMinorStrategicsToCityStates();
-
-			self:PlaceSmallQuantitiesOfStrategics(160 * resMultiplier / self.iNumCivs, self.land_list);
-
+			
+			self:PlaceSmallQuantitiesOfStrategics(26 * resMultiplier, self.land_list);
+			
 			self:PlaceOilInTheSea();
 
 			-- Check for low or missing Strategic resources
 			uran_amt, horse_amt, oil_amt, iron_amt, coal_amt, alum_amt = self:GetSmallStrategicResourceQuantityValues();
 			while self.amounts_of_resources_placed[self.iron_ID + 1] < 4 * self.iNumCivs do
-				--print("Map has very low iron, adding another.");
-				local resources_to_place = { {self.iron_ID, iron_amt, 20, 0, 2} };
+				print("Map has very low iron, adding another.");
+				local resources_to_place = { {self.iron_ID, iron_amt, 20, 1, 2} };
 				self:ProcessResourceList(99999, 1, self.desert_flat_no_feature, resources_to_place); -- 99999 means one per that many tiles: a single instance.
 				self:ProcessResourceList(99999, 1, self.hills_forest_list, resources_to_place);
 				self:ProcessResourceList(99999, 1, self.hills_open_list, resources_to_place);
@@ -1415,7 +1414,7 @@ function MapGlobals:New()
 				self:ProcessResourceList(99999, 1, self.tundra_flat_forest, resources_to_place);
 			end
 			while self.amounts_of_resources_placed[self.horse_ID + 1] < 4 * self.iNumCivs do
-				--print("Map has very low horse, adding another.");
+				print("Map has very low horse, adding another.");
 				local resources_to_place = { {self.horse_ID, horse_amt, 25, 1, 2} };
 				self:ProcessResourceList(99999, 1, self.grass_flat_no_feature, resources_to_place);
 				self:ProcessResourceList(99999, 1, self.plains_flat_no_feature, resources_to_place);
@@ -1423,39 +1422,41 @@ function MapGlobals:New()
 				self:ProcessResourceList(99999, 1, self.tundra_flat_no_feature, resources_to_place);
 			end
 			while self.amounts_of_resources_placed[self.coal_ID + 1] < 4 * self.iNumCivs do
-				--print("Map has very low coal, adding another.");
-				local resources_to_place = { {self.coal_ID, coal_amt, 33, 0, 0} };
+				print("Map has very low coal, adding another.");
+				local resources_to_place = { {self.coal_ID, coal_amt, 33, 1, 2} };
 				self:ProcessResourceList(99999, 1, self.hills_open_no_tundra_no_desert, resources_to_place);
 				self:ProcessResourceList(99999, 1, self.grass_flat_no_feature, resources_to_place);
 				self:ProcessResourceList(99999, 1, self.plains_flat_no_feature, resources_to_place);
 			end
 			while self.amounts_of_resources_placed[self.oil_ID + 1] < 4 * self.iNumCivs do
-				--print("Map has very low oil, adding another.");
-				local resources_to_place = { {self.oil_ID, oil_amt, 33, 0, 0} };
+				print("Map has very low oil, adding another.");
+				local resources_to_place = { {self.oil_ID, oil_amt, 33, 1, 2} };
 				self:ProcessResourceList(99999, 1, self.desert_flat_no_feature, resources_to_place);
 				self:ProcessResourceList(99999, 1, self.tundra_flat_no_feature, resources_to_place);
 				self:ProcessResourceList(99999, 1, self.jungle_flat_list, resources_to_place);
 			end
 			while self.amounts_of_resources_placed[self.aluminum_ID + 1] < 5 * self.iNumCivs do
-				--print("Map has very low aluminum, adding another.");
-				local resources_to_place = { {self.aluminum_ID, alum_amt, 33, 0, 0} };
+				print("Map has very low aluminum, adding another.");
+				local resources_to_place = { {self.aluminum_ID, alum_amt, 33, 1, 2} };
 				self:ProcessResourceList(99999, 1, self.hills_open_no_grass, resources_to_place);
 				self:ProcessResourceList(99999, 1, self.flat_open_no_grass_no_plains, resources_to_place);
 				self:ProcessResourceList(99999, 1, self.plains_flat_no_feature, resources_to_place);
 			end
 			while self.amounts_of_resources_placed[self.uranium_ID + 1] < 2 * self.iNumCivs do
-				--print("Map has very low uranium, adding another.");
-				local resources_to_place = { {self.uranium_ID, uran_amt, 100, 0, 0} };
+				print("Map has very low uranium, adding another.");
+				local resources_to_place = { {self.uranium_ID, uran_amt, 100, 2, 4} };
 				self:ProcessResourceList(99999, 1, self.land_list, resources_to_place);
 			end
-
+			
 			self:PlaceBonusResources();
 		end
 		------------------------------------------------------------------------------
 		function AssignStartingPlots:PlaceFish()
 			print("AssignStartingPlots:PlaceFish()")
 			for plotID, plot in Plots(Shuffle) do
-				PlacePossibleFish(plot)
+				if PlacePossibleFish(plot) then
+					self.amounts_of_resources_placed[self.fish_ID + 1] = self.amounts_of_resources_placed[self.fish_ID + 1] + 1;
+				end
 			end
 		end
 		function PlacePossibleFish(plot)
@@ -1491,9 +1492,11 @@ function MapGlobals:New()
 			-- odds = odds / landDistance
 			oddsMultiplier = oddsMultiplier / landDistance
 			odds = modifyOdds(odds, oddsMultiplier)
+			--print("oddsMultiplier:", oddsMultiplier, "odds:", odds)
 
 			if odds >= PWRand() then
 				plot:SetResourceType(fishID, 1)
+				return true
 				--print(string.format( "PlacePossibleFish fertility=%-3s odds=%-3s fishMod=%-3s", Round(sumFertility), Round(odds), Round(fishMod) ))
 			end
 		end
@@ -1507,15 +1510,16 @@ function MapGlobals:New()
 			elseif self.bonusDensity == 4 then -- Random
 				resMultiplier = getRandomMultiplier(0.5);
 			end
-
+			
 			-- Place Bonus Resources
 			print("Map Generation - Placing Bonuses");
-
+			
 			-- modified by azum4roll: PlaceFish only depends on fishTargetFertility now
 			-- self:PlaceFish(8 * resMultiplier, self.coast_list);
 			self:PlaceFish()
 			self:PlaceSexyBonusAtCivStarts()
 			self:AddExtraBonusesToHillsRegions()
+			
 			local resources_to_place = {}
 
 			if IsEvenMoreResourcesActive() == true then
@@ -1527,7 +1531,7 @@ function MapGlobals:New()
 				{self.deer_ID, 1, 100, 0, 2} };
 				self:ProcessResourceList(16 * resMultiplier, 3, self.tundra_flat_no_feature, resources_to_place)
 				-- 12
-
+				
 				resources_to_place = {
 				{self.wheat_ID, 1, 100, 1, 2} };
 				self:ProcessResourceList(20 * resMultiplier, 3, self.desert_wheat_list, resources_to_place)
@@ -1536,22 +1540,22 @@ function MapGlobals:New()
 				{self.wheat_ID, 1, 100, 2, 3} };
 				self:ProcessResourceList(44 * resMultiplier, 3, self.plains_flat_no_feature, resources_to_place)
 				-- 27
-
+				
 				resources_to_place = {
 				{self.banana_ID, 1, 100, 0, 1} };
 				self:ProcessResourceList(30 * resMultiplier, 3, self.banana_list, resources_to_place)
 				-- 14
-
+				
 				resources_to_place = {
 				{self.banana_ID, 1, 100, 0, 1} };
 				self:ProcessResourceList(40 * resMultiplier, 3, self.marsh_list, resources_to_place)
 				-- none
-
+				
 				resources_to_place = {
 				{self.cow_ID, 1, 100, 0, 2} };
 				self:ProcessResourceList(30 * resMultiplier, 3, self.grass_flat_no_feature, resources_to_place)
 				-- 18
-
+				
 			-- CBP
 				resources_to_place = {
 				{self.bison_ID, 1, 100, 0, 2} };
@@ -1567,32 +1571,32 @@ function MapGlobals:New()
 				{self.stone_ID, 1, 100, 1, 1} };
 				self:ProcessResourceList(40 * resMultiplier, 3, self.dry_grass_flat_no_feature, resources_to_place)
 				-- 20
-
+				
 				resources_to_place = {
 				{self.stone_ID, 1, 100, 1, 1} };
 				self:ProcessResourceList(40 * resMultiplier, 3, self.dry_plains_flat_no_feature, resources_to_place)
 				-- none
-
+				
 				resources_to_place = {
 				{self.stone_ID, 1, 100, 1, 2} };
 				self:ProcessResourceList(30 * resMultiplier, 3, self.tundra_flat_no_feature, resources_to_place)
 				-- 15
-
+				
 				resources_to_place = {
 				{self.stone_ID, 1, 100, 0, 2} };
 				self:ProcessResourceList(16 * resMultiplier, 3, self.desert_flat_no_feature, resources_to_place)
 				-- 19
-
+				
 				resources_to_place = {
 				{self.stone_ID, 1, 100, 1, 2} };
 				self:ProcessResourceList(36 * resMultiplier, 3, self.hills_open_list, resources_to_place)
 				-- none
-
+				
 				resources_to_place = {
 				{self.stone_ID, 1, 100, 0, 2} };
 				self:ProcessResourceList(10 * resMultiplier, 3, self.snow_flat_list, resources_to_place)
 				-- none
-
+				
 				resources_to_place = {
 				{self.deer_ID, 1, 100, 3, 4} };
 				self:ProcessResourceList(50 * resMultiplier, 3, self.forest_flat_that_are_not_tundra, resources_to_place)
@@ -1697,7 +1701,7 @@ function MapGlobals:New()
 				{self.deer_ID, 1, 100, 0, 2} };
 				self:ProcessResourceList(8 * resMultiplier, 3, self.tundra_flat_no_feature, resources_to_place)
 				-- 12
-
+				
 				resources_to_place = {
 				{self.wheat_ID, 1, 100, 1, 2} };
 				self:ProcessResourceList(10 * resMultiplier, 3, self.desert_wheat_list, resources_to_place)
@@ -1706,63 +1710,63 @@ function MapGlobals:New()
 				{self.wheat_ID, 1, 100, 2, 3} };
 				self:ProcessResourceList(22 * resMultiplier, 3, self.plains_flat_no_feature, resources_to_place)
 				-- 27
-
+				
 				resources_to_place = {
 				{self.banana_ID, 1, 100, 0, 1} };
-				self:ProcessResourceList(15 * resMultiplier, 3, self.banana_list, resources_to_place)
+				self:ProcessResourceList(12 * resMultiplier, 3, self.banana_list, resources_to_place)
 				-- 14
-
+				
 				resources_to_place = {
 				{self.banana_ID, 1, 100, 0, 1} };
-				self:ProcessResourceList(20 * resMultiplier, 3, self.marsh_list, resources_to_place)
+				self:ProcessResourceList(16 * resMultiplier, 3, self.marsh_list, resources_to_place)
 				-- none
-
+				
 				resources_to_place = {
 				{self.cow_ID, 1, 100, 0, 2} };
-				self:ProcessResourceList(15 * resMultiplier, 3, self.grass_flat_no_feature, resources_to_place)
+				self:ProcessResourceList(14 * resMultiplier, 3, self.grass_flat_no_feature, resources_to_place)
 				-- 18
-
+				
 			-- CBP
 				resources_to_place = {
 				{self.bison_ID, 1, 100, 0, 2} };
-				self:ProcessResourceList(12 * resMultiplier, 3, self.flat_open_no_tundra_no_desert, resources_to_place)
+				self:ProcessResourceList(18 * resMultiplier, 3, self.flat_open_no_tundra_no_desert, resources_to_place)
 			-- END
 
 				resources_to_place = {
 				{self.sheep_ID, 1, 100, 0, 2} };
-				self:ProcessResourceList(22 * resMultiplier, 3, self.hills_open_list, resources_to_place)
+				self:ProcessResourceList(18 * resMultiplier, 3, self.hills_open_list, resources_to_place)
 				-- 13
 
 				resources_to_place = {
 				{self.stone_ID, 1, 100, 1, 1} };
-				self:ProcessResourceList(20 * resMultiplier, 3, self.dry_grass_flat_no_feature, resources_to_place)
+				self:ProcessResourceList(30 * resMultiplier, 3, self.dry_grass_flat_no_feature, resources_to_place)
 				-- 20
-
+				
 				resources_to_place = {
 				{self.stone_ID, 1, 100, 1, 1} };
-				self:ProcessResourceList(20 * resMultiplier, 3, self.dry_plains_flat_no_feature, resources_to_place)
+				self:ProcessResourceList(60 * resMultiplier, 3, self.dry_plains_flat_no_feature, resources_to_place)
 				-- none
-
+				
 				resources_to_place = {
 				{self.stone_ID, 1, 100, 1, 2} };
-				self:ProcessResourceList(15 * resMultiplier, 3, self.tundra_flat_no_feature, resources_to_place)
+				self:ProcessResourceList(60 * resMultiplier, 3, self.tundra_flat_no_feature, resources_to_place)
 				-- 15
-
+				
 				resources_to_place = {
 				{self.stone_ID, 1, 100, 0, 2} };
-				self:ProcessResourceList(8 * resMultiplier, 3, self.desert_flat_no_feature, resources_to_place)
+				self:ProcessResourceList(14 * resMultiplier, 3, self.desert_flat_no_feature, resources_to_place)
 				-- 19
-
+				
 				resources_to_place = {
 				{self.stone_ID, 1, 100, 1, 2} };
-				self:ProcessResourceList(18 * resMultiplier, 3, self.hills_open_list, resources_to_place)
+				self:ProcessResourceList(60 * resMultiplier, 3, self.hills_open_list, resources_to_place)
 				-- none
-
+				
 				resources_to_place = {
 				{self.stone_ID, 1, 100, 0, 2} };
-				self:ProcessResourceList(5 * resMultiplier, 3, self.snow_flat_list, resources_to_place)
+				self:ProcessResourceList(8 * resMultiplier, 3, self.snow_flat_list, resources_to_place)
 				-- none
-
+				
 				resources_to_place = {
 				{self.deer_ID, 1, 100, 3, 4} };
 				self:ProcessResourceList(25 * resMultiplier, 3, self.forest_flat_that_are_not_tundra, resources_to_place)
@@ -1816,7 +1820,7 @@ function MapGlobals:New()
 			self:AdjustTiles()
 
 			local largestLand = Map.FindBiggestArea(false)
-			if Map.GetCustomOption(11) == 2 then
+			if Map.GetCustomOption(5) == 1 then
 				-- Biggest continent placement
 				if largestLand:GetNumTiles() < 0.25 * Map.GetLandPlots() then
 					print("AI Map Strategy - Offshore expansion with navy bias")
@@ -1854,7 +1858,7 @@ end
 function GetMapScriptInfo()
 	local world_age, temperature, rainfall, sea_level = GetCoreMapOptions()
 	return {
-		Name = "Communitu_79a v2.0.0",
+		Name = "Communitu_79a v2.1.0",
 		Description = "Communitas mapscript for Vox Populi",
 		IsAdvancedMap = false,
 		SupportsMultiplayer = true,
@@ -1866,16 +1870,86 @@ function GetMapScriptInfo()
 			rainfall,
 			sea_level,
 			{
-                Name = "Strategic Resource Density",
-				Description = "Controls the amount of strategic resource deposits appearing on the map",
+                Name = "Players Start In",
                 Values = {
-                    "Sparse",
-                    "Normal",
-					"Abundant",
-					"Random",
+                    "Terra - Largest Continent",
+                    "Continents - Everywhere",
                 },
                 DefaultValue = 2,
                 SortPriority = 1,
+            },
+			{
+                Name = "Ocean Shapes",
+				Description = "Vertical ocean rifts separating continents",
+                Values = {
+                    "2 Atlantic",
+                    "Pacific and Atlantic",
+                    "2 Pacific",
+                    "2 Random",
+                    "1 Random",
+                    "None",
+					"Random",
+                },
+                DefaultValue = 2,
+                SortPriority = 2,
+            },
+			{
+                Name = "Rift Width",
+				Description = "Impassable ocean width",
+                Values = {
+                    "Narrow",
+                    "Normal",
+                    "Wide",
+					"Random",
+                },
+                DefaultValue = 2,
+                SortPriority = 3,
+            },
+			{
+                Name = "Circumnavigation",
+				Description = "Guarantees horizontal water path around the world",
+                Values = {
+                    "On",
+                    "Off",
+                },
+                DefaultValue = 2,
+                SortPriority = 4,
+            },
+			{
+				Name = "Force Coastal Start",
+				Description = "Every major civ starts on the coast",
+				Values = {
+					"Yes",
+					"No",
+					"Random",
+				},
+				DefaultValue = 2,
+                SortPriority = 5,
+            },
+			{
+				Name = "Land Shapes",
+				Description = "Controls continent and island shapes",
+				Values = {
+					"Blocky",
+					"Normal",
+					"Stringy",
+					"Extremely Stringy",
+					"Random",
+				},
+				DefaultValue = 2,
+                SortPriority = 6,
+            },
+			{
+                Name = "Starting Resources",
+				Description = "Adds strategics and/or extra resources to starting position",
+                Values = {
+					"Add both",
+					"Normal",
+					"Add some strategics",
+					"Add some extra bonus",
+                },
+				DefaultValue = 2,
+                SortPriority = 7,
             },
 			{
                 Name = "Strategic Deposit Size",
@@ -1887,17 +1961,7 @@ function GetMapScriptInfo()
 					"Random",
                 },
                 DefaultValue = 2,
-                SortPriority = 2,
-            },
-			{
-                Name = "Strategic Balance",
-				Description = "Provides a minor deposit of Iron and Horses 4-6 tiles from starting position",
-                Values = {
-					"On",
-					"Off",
-                },
-                DefaultValue = 2,
-                SortPriority = 3,
+                SortPriority = 8,
             },
 			{
                 Name = "Bonus Resource Density",
@@ -1909,17 +1973,19 @@ function GetMapScriptInfo()
 					"Random",
                 },
                 DefaultValue = 2,
-                SortPriority = 4,
+                SortPriority = 9,
             },
 			{
-                Name = "Legendary Start",
-				Description = "Provides extra bonus resources around starting position",
+                Name = "Strategic Resource Density",
+				Description = "Controls the amount of strategic resource deposits appearing on the map",
                 Values = {
-					"On",
-					"Off",
+                    "Sparse",
+                    "Normal",
+					"Abundant",
+					"Random",
                 },
                 DefaultValue = 2,
-                SortPriority = 5,
+                SortPriority = 10,
             },
 			{
                 Name = "Luxury Resource Density",
@@ -1931,86 +1997,17 @@ function GetMapScriptInfo()
 					"Random",
                 },
                 DefaultValue = 2,
-                SortPriority = 6,
-            },
-			{
-                Name = "Players Start",
-                Values = {
-                    "Continents - Everywhere",
-                    "Terra - Largest Continent",
-                },
-                DefaultValue = 1,
-                SortPriority = 7,
-            },
-			{
-                Name = "Ocean Rifts",
-				Description = "Vertical ocean rifts separating continents",
-                Values = {
-                    "Pacific and Atlantic",
-                    "2 Atlantic",
-                    "2 Pacific",
-                    "2 Random",
-                    "1 Random",
-                    "None",
-					"Random",
-                },
-                DefaultValue = 1,
-                SortPriority = 8,
-            },
-			{
-                Name = "Rift Width",
-                Values = {
-                    "Narrow",
-                    "Normal",
-                    "Wide",
-					"Random",
-                },
-                DefaultValue = 2,
-                SortPriority = 9,
-            },
-			{
-                Name = "Circumnavigation Path",
-				Description = "Guarantees horizontal water path around the world",
-                Values = {
-                    "On",
-                    "Off",
-                },
-                DefaultValue = 1,
-                SortPriority = 10,
-            },
-			{
-				Name = "Land Scatter",
-				Description = "Controls continent and island shape",
-				Values = {
-					"Blocky",
-					"Normal",
-					"Stringy",
-					"Extremely Stringy",
-					"Random",
-				},
-				DefaultValue = 2,
 				SortPriority = 11,
 			},
 			{
 				Name = "Override AssignStartingPlots",
 				Description = "Extra map-specific optimizations when turned on. Turn off for standard VP performance.",
 				Values = {
-					"Yes",
 					"No",
-				},
-				DefaultValue = 1,
-				SortPriority = 12,
-			},
-			{
-				Name = "Force Coastal Starts",
-				Description = "Every major civ starts on the coast",
-				Values = {
 					"Yes",
-					"No",
-					"Random",
 				},
 				DefaultValue = 2,
-				SortPriority = 13,
+				SortPriority = 12,
 			},
 		},
 	}
@@ -2027,7 +2024,7 @@ function GetMapInitData(worldSize)
 		[GameInfo.Worlds.WORLDSIZE_HUGE.ID] = {97, 66}
 		}
 
-	if Map.GetCustomOption(11) == 2 then
+	if Map.GetCustomOption(5) == 1 then
 		-- Enlarge terra-style maps 30% to create expansion room on the new world
 		worldsizes = {
 		[GameInfo.Worlds.WORLDSIZE_DUEL.ID] = {44, 31},
@@ -2402,16 +2399,16 @@ log:SetLevel("INFO")
 
 function StartPlotSystem()
 	-- Get Resources setting input by user.
-	local resDensity = Map.GetCustomOption(5) or 2;
-	local resSize = Map.GetCustomOption(6) or 2;
-	local resBalance = (Map.GetCustomOption(7) == 1);
-	local bonusDensity = Map.GetCustomOption(8) or 2;
-	local legStart = (Map.GetCustomOption(9) == 1);
-	local luxuryDensity = Map.GetCustomOption(10) or 2;
+	local resDensity = Map.GetCustomOption(14) or 2;
+	local resSize = Map.GetCustomOption(12) or 2;
+	local resBalance = (Map.GetCustomOption(11) == 1 or Map.GetCustomOption(11) == 3);
+	local bonusDensity = Map.GetCustomOption(13) or 2;
+	local legStart = (Map.GetCustomOption(11) == 1 or Map.GetCustomOption(11) == 4);
+	local luxuryDensity = Map.GetCustomOption(15) or 2;
 
 	if resSize == 4 then resSize = 1 + Map.Rand(3, "Random Strategic Deposit Size") end
 
-	if Map.GetCustomOption(16) ~= 1 then
+	if Map.GetCustomOption(16) ~= 2 then
 		-- Legendary Balance, Strategic Balance and Resource Density are one option only
 		if resBalance then
 			resDensity = 5;
@@ -2422,9 +2419,9 @@ function StartPlotSystem()
 		end
 	end
 
-	local oStarts = Map.GetCustomOption(11);
+	local oStarts = Map.GetCustomOption(5);
 	local divMethod = nil;
-	if oStarts == 1 then
+	if oStarts == 2 then
 		-- Continents
 		divMethod = 2;
 	else
@@ -2445,11 +2442,12 @@ function StartPlotSystem()
 		bonus = bonusDensity,
 		legendary = legStart,
 		lux = luxuryDensity,
+		comm = true,
 	};
 	start_plot_database:GenerateRegions(args);
 
 	-- Do we need to force starts along the ocean?
-	local coastalStarts = Map.GetCustomOption(17);
+	local coastalStarts = Map.GetCustomOption(9);
 	if coastalStarts == 3 then
 		coastalStarts = 1 + Map.Rand(2, "Random Coastal Starts");
 	end
@@ -2640,7 +2638,7 @@ function ConnectPolarSeasToOceans()
 end
 
 function ConnectTerraContinents()
-	if Map.GetCustomOption(11) == 1 then
+	if Map.GetCustomOption(5) == 2 then
 		-- Continents-style formation
 		return
 	end
@@ -3873,7 +3871,7 @@ function CreateArcticOceans()
 end
 
 function CreateVerticalOceans()
-	local oOceanRifts = Map.GetCustomOption(12)
+	local oOceanRifts = Map.GetCustomOption(6)
 	if oOceanRifts == 7 then oOceanRifts = 1 + Map.Rand(6, "Random Ocean Rifts") end
 	local mapW, mapH = Map.GetGridSize()
 	if oOceanRifts == 6 then
@@ -3932,11 +3930,11 @@ function CreateVerticalOceans()
 		log:Debug("CreateVerticalOceans: Creating Atlantic at x=%s", startX)
 		CreateAtlantic(startX)
 		return
-	elseif oOceanRifts == 1 or oOceanRifts == 3 then
+	elseif oOceanRifts == 2 or oOceanRifts == 3 then
 		-- PA or PP
 		log:Debug("CreateVerticalOceans: Creating Pacific  at x=%s", startX)
 		CreatePacific(startX)
-	elseif oOceanRifts == 2 then
+	elseif oOceanRifts == 1 then
 		-- AA
 		log:Debug("CreateVerticalOceans: Creating Atlantic at x=%s", startX)
 		CreateAtlantic(startX)
@@ -4232,7 +4230,7 @@ end
 -- Creates an horizontal passage (by tu_79)
 function CreateMagallanes()
 	-- Don't do this for Terra maps or if the option is turned off
-	if Map.GetCustomOption(11) == 2 or Map.GetCustomOption(14) == 2 then
+	if Map.GetCustomOption(5) == 1 or Map.GetCustomOption(8) == 2 then
 		return
 	end
 

--- a/EUI Compatibility Files/EUI Compatibility Files/LUA/AssignStartingPlots.lua
+++ b/EUI Compatibility Files/EUI Compatibility Files/LUA/AssignStartingPlots.lua
@@ -135,7 +135,7 @@ function AssignStartingPlots.Create()
 		AttemptToPlaceSmallStrategicAtPlot = AssignStartingPlots.AttemptToPlaceSmallStrategicAtPlot,
 		FindFallbackForUnmatchedRegionPriority = AssignStartingPlots.FindFallbackForUnmatchedRegionPriority,
 		AddStrategicBalanceResources = AssignStartingPlots.AddStrategicBalanceResources,
-		AttemptToPlaceStoneAtGrassPlot = AssignStartingPlots.AttemptToPlaceStoneAtGrassPlot,
+		AttemptToPlaceForestAtGrassPlot = AssignStartingPlots.AttemptToPlaceForestAtGrassPlot,
 		NormalizeStartLocation = AssignStartingPlots.NormalizeStartLocation,
 		NormalizeTeamLocations = AssignStartingPlots.NormalizeTeamLocations,
 		
@@ -206,7 +206,7 @@ function AssignStartingPlots.Create()
 		resSize = 2,
 		legStart = false,
 		resBalance = false,
-		bonusDensiy = 2,
+		bonusDensity = 2,
 		luxuryDensity = 2,
 		
 		-- Civ start position variables
@@ -1617,6 +1617,14 @@ function AssignStartingPlots:GenerateRegions(args)
 	end
 	self.legStart = args.legend or (args.resources == 4);		-- Legendary Start setting
 	self.resBalance = args.balance or (args.resources == 5);	-- Strategic Balance setting
+
+	print("-"); print("Resource settings");
+	print("Strategic Density = ", self.resDensity);
+	print("Strategic Size = ", self.resSize);
+	print("Bonus Density = ", self.bonusDensity);
+	print("Luxury Density = ", self.luxuryDensity);
+	print("Legendary Start = ", self.legStart);
+	print("Strategic Balance = ", self.resBalance);
 
 	-- Determine number of civilizations and city states present in this game.
 	self.iNumCivs, self.iNumCityStates, self.player_ID_list, self.bTeamGame, self.teams_with_major_civs, self.number_civs_per_team = GetPlayerAndTeamInfo()
@@ -3729,7 +3737,7 @@ function AssignStartingPlots:AttemptToPlaceBonusResourceAtPlot(x, y, bAllowOasis
 		return false
 	end
 	local plotType = plot:GetPlotType()
-	--
+	-- Randomize resource selected instead -- September 2020, azum4roll
 	if featureType == FeatureTypes.FEATURE_JUNGLE then -- Place Banana
 		plot:SetResourceType(self.banana_ID, 1);
 		--print("Placed Banana.");
@@ -3747,15 +3755,31 @@ function AssignStartingPlots:AttemptToPlaceBonusResourceAtPlot(x, y, bAllowOasis
 		return true, false
 	elseif plotType == PlotTypes.PLOT_LAND then
 		if featureType == FeatureTypes.NO_FEATURE then
-			if terrainType == TerrainTypes.TERRAIN_GRASS then -- Place Cows
-				plot:SetResourceType(self.cow_ID, 1);
-				--print("Placed Cow.");
-				self.amounts_of_resources_placed[self.cow_ID + 1] = self.amounts_of_resources_placed[self.cow_ID + 1] + 1;
+			if terrainType == TerrainTypes.TERRAIN_GRASS then -- Place Cows or Bison
+				local diceroll = Map.Rand(3, "Selection of Bonus Resource type - Start Normalization LUA");
+				local resourceType;
+				if diceroll < 2 then
+					resourceType = self.cow_ID;
+					--print("Placed Cows.");
+				else
+					resourceType = self.bison_ID;
+					--print("Placed Bison.");
+				end
+				plot:SetResourceType(resourceType, 1);
+				self.amounts_of_resources_placed[resourceType + 1] = self.amounts_of_resources_placed[resourceType + 1] + 1;
 				return true, false
-			elseif terrainType == TerrainTypes.TERRAIN_PLAINS then -- Place Wheat
-				plot:SetResourceType(self.wheat_ID, 1);
-				--print("Placed Wheat.");
-				self.amounts_of_resources_placed[self.wheat_ID + 1] = self.amounts_of_resources_placed[self.wheat_ID + 1] + 1;
+			elseif terrainType == TerrainTypes.TERRAIN_PLAINS then -- Place Wheat or Bison
+				local diceroll = Map.Rand(3, "Selection of Bonus Resource type - Start Normalization LUA");
+				local resourceType;
+				if diceroll < 2 then
+					resourceType = self.wheat_ID;
+					--print("Placed Wheat.");
+				else
+					resourceType = self.bison_ID;
+					--print("Placed Bison.");
+				end
+				plot:SetResourceType(resourceType, 1);
+				self.amounts_of_resources_placed[resourceType + 1] = self.amounts_of_resources_placed[resourceType + 1] + 1;
 				return true, false
 			elseif terrainType == TerrainTypes.TERRAIN_TUNDRA then -- Place Deer
 				plot:SetResourceType(self.deer_ID, 1);
@@ -3986,10 +4010,11 @@ function AssignStartingPlots:AddStrategicBalanceResources(region_number)
 	end
 end
 ------------------------------------------------------------------------------
-function AssignStartingPlots:AttemptToPlaceStoneAtGrassPlot(x, y)
+function AssignStartingPlots:AttemptToPlaceForestAtGrassPlot(x, y)
 	-- Function modified May 2011 to boost production at heavy grass starts. - BT
 	-- Now placing Stone instead of Cows. Returns true if Stone is placed.
-	--print("-"); print("Attempting to place Stone at: ", x, y);
+	-- Now placing Forest instead of Stone. -- September 2020, azum4roll
+	--print("-"); print("Attempting to place Forest at: ", x, y);
 	local plot = Map.GetPlot(x, y);
 	if plot == nil then
 		--print("Placement failed, plot was nil.");
@@ -4004,10 +4029,9 @@ function AssignStartingPlots:AttemptToPlaceStoneAtGrassPlot(x, y)
 		local featureType = plot:GetFeatureType()
 		if featureType == FeatureTypes.NO_FEATURE then
 			local terrainType = plot:GetTerrainType()
-			if terrainType == TerrainTypes.TERRAIN_GRASS then -- Place Stone
-				plot:SetResourceType(self.stone_ID, 1);
-				--print("Placed Stone.");
-				self.amounts_of_resources_placed[self.stone_ID + 1] = self.amounts_of_resources_placed[self.stone_ID + 1] + 1;
+			if terrainType == TerrainTypes.TERRAIN_GRASS then -- Place Forest
+				plot:SetFeatureType(FeatureTypes.FEATURE_FOREST, -1);
+				--print("Placed Forest.");
 				return true
 			end
 		end
@@ -4134,10 +4158,10 @@ function AssignStartingPlots:NormalizeStartLocation(region_number)
 						innerCanHaveBonus = innerCanHaveBonus + 1;
 					elseif featureType == FeatureTypes.FEATURE_FOREST then
 						innerCanHaveBonus = innerCanHaveBonus + 1;
-					elseif terrainType == TerrainTypes.TERRAIN_GRASS then
-						iNumGrass = iNumGrass + 1;
-					elseif terrainType == TerrainTypes.TERRAIN_PLAINS then
-						iNumPlains = iNumPlains + 1;
+--					elseif terrainType == TerrainTypes.TERRAIN_GRASS then
+--						iNumGrass = iNumGrass + 1;
+--					elseif terrainType == TerrainTypes.TERRAIN_PLAINS then
+--						iNumPlains = iNumPlains + 1;
 					end
 				elseif featureType == FeatureTypes.FEATURE_OASIS then
 					innerThreeFood = innerThreeFood + 1;
@@ -4277,10 +4301,10 @@ function AssignStartingPlots:NormalizeStartLocation(region_number)
 						outerCanHaveBonus = outerCanHaveBonus + 1;
 					elseif featureType == FeatureTypes.FEATURE_FOREST then
 						outerCanHaveBonus = outerCanHaveBonus + 1;
-					elseif terrainType == TerrainTypes.TERRAIN_GRASS then
-						iNumGrass = iNumGrass + 1;
-					elseif terrainType == TerrainTypes.TERRAIN_PLAINS then
-						iNumPlains = iNumPlains + 1;
+--					elseif terrainType == TerrainTypes.TERRAIN_GRASS then
+--						iNumGrass = iNumGrass + 1;
+--					elseif terrainType == TerrainTypes.TERRAIN_PLAINS then
+--						iNumPlains = iNumPlains + 1;
 					end
 				elseif featureType == FeatureTypes.FEATURE_OASIS then
 					innerThreeFood = innerThreeFood + 1;
@@ -4381,10 +4405,10 @@ function AssignStartingPlots:NormalizeStartLocation(region_number)
 			local placedHill = self:AttemptToPlaceHillsAtPlot(searchX, searchY);
 			if placedHill == true then
 				innerHammerScore = innerHammerScore + 4;
-				--print("Added hills next to hammer-poor start plot at ", x, y);
+				print("Added hills next to hammer-poor start plot at ", x, y);
 				break
 			elseif attempt == 6 then
-				--print("FAILED to add hills next to hammer-poor start plot at ", x, y);
+				print("FAILED to add hills next to hammer-poor start plot at ", x, y);
 			end
 		end
 	end
@@ -4395,7 +4419,8 @@ function AssignStartingPlots:NormalizeStartLocation(region_number)
 	end
 	
 	-- If early hammers will be too short, attempt to add a small Horse or Iron to second ring.
-	if innerHammerScore < 3 and earlyHammerScore < 6 then -- Add a small Horse or Iron to second ring.
+	-- Add a forest instead -- September 2020, azum4roll
+	if innerHammerScore < 3 and earlyHammerScore < 6 then -- Add a forest to second ring.
 		if isEvenY then
 			randomized_second_ring_adjustments = GetShuffledCopyOfTable(self.secondRingYIsEven);
 		else
@@ -4404,12 +4429,23 @@ function AssignStartingPlots:NormalizeStartLocation(region_number)
 		for attempt = 1, 12 do
 			local plot_adjustments = randomized_second_ring_adjustments[attempt];
 			local searchX, searchY = self:ApplyHexAdjustment(x, y, plot_adjustments)
-			-- Attempt to place a Hill at the currently chosen plot.
-			local placedStrategic = self:AttemptToPlaceSmallStrategicAtPlot(searchX, searchY);
-			if placedStrategic == true then
-				break
-			elseif attempt == 12 then
-				--print("FAILED to add small strategic resource near hammer-poor start plot at ", x, y);
+			-- Attempt to place a Forest at the currently chosen plot.
+			local plot = Map.GetPlot(searchX, searchY);
+			if plot:GetResourceType(-1) == -1 then -- No resource here, safe to proceed.
+				local plotType = plot:GetPlotType();
+				local terrainType = plot:GetTerrainType();
+				local featureType = plot:GetFeatureType();
+				if plotType == PlotTypes.PLOT_LAND then
+					if terrainType ~= TerrainTypes.TERRAIN_DESERT and terrainType ~= TerrainTypes.TERRAIN_SNOW then
+						if featureType == FeatureTypes.NO_FEATURE then
+							plot:SetFeatureType(FeatureTypes.FEATURE_FOREST, -1);
+							break;
+						end
+					end
+				end
+			end
+			if attempt == 12 then
+				print("FAILED to add forest near hammer-poor start plot at ", x, y);
 			end
 		end
 	end
@@ -4501,7 +4537,7 @@ function AssignStartingPlots:NormalizeStartLocation(region_number)
 		if iNumConversionCandidates == 0 then
 			iNumFoodBonusNeeded = 3;
 		else
-			--print("-"); print("*** START HAD NO 2-FOOD TILES, YET ONLY QUALIFIED FOR 2 BONUS; CONVERTING A PLAINS TO GRASS! ***"); print("-");
+			print("-"); print("*** START HAD NO 2-FOOD TILES, YET ONLY QUALIFIED FOR 2 BONUS; CONVERTING A PLAINS TO GRASS! ***"); print("-");
 			local diceroll = 1 + Map.Rand(iNumConversionCandidates, "Choosing plot to convert to Grass near food-poor Plains start - LUA");
 			local conversionPlotIndex = plot_list[diceroll];
 			local conv_x = (conversionPlotIndex - 1) % iW;
@@ -4515,9 +4551,9 @@ function AssignStartingPlots:NormalizeStartLocation(region_number)
 	if iNumFoodBonusNeeded > 0 then
 		local maxBonusesPossible = innerCanHaveBonus + outerCanHaveBonus;
 
-		--print("-");
-		--print("Food-Poor start ", x, y, " needs ", iNumFoodBonusNeeded, " Bonus, with ", maxBonusesPossible, " eligible plots.");
-		--print("-");
+		print("-");
+		print("Food-Poor start ", x, y, " needs ", iNumFoodBonusNeeded, " Bonus, with ", maxBonusesPossible, " eligible plots.");
+		print("-");
 
 		local innerPlaced, outerPlaced = 0, 0;
 		local randomized_first_ring_adjustments, randomized_second_ring_adjustments, randomized_third_ring_adjustments;
@@ -4548,7 +4584,7 @@ function AssignStartingPlots:NormalizeStartLocation(region_number)
 						if allow_oasis == true and placedOasis == true then -- First oasis was placed on this pass, so change permission.
 							allow_oasis = false;
 						end
-						--print("Placed a Bonus in first ring at ", searchX, searchY);
+						print("Placed a Bonus in first ring at ", searchX, searchY);
 						innerPlaced = innerPlaced + 1;
 						innerCanHaveBonus = innerCanHaveBonus - 1;
 						iNumFoodBonusNeeded = iNumFoodBonusNeeded - 1;
@@ -4570,7 +4606,7 @@ function AssignStartingPlots:NormalizeStartLocation(region_number)
 						if allow_oasis == true and placedOasis == true then -- First oasis was placed on this pass, so change permission.
 							allow_oasis = false;
 						end
-						--print("Placed a Bonus in second ring at ", searchX, searchY);
+						print("Placed a Bonus in second ring at ", searchX, searchY);
 						outerPlaced = outerPlaced + 1;
 						outerCanHaveBonus = outerCanHaveBonus - 1;
 						iNumFoodBonusNeeded = iNumFoodBonusNeeded - 1;
@@ -4591,7 +4627,7 @@ function AssignStartingPlots:NormalizeStartLocation(region_number)
 						if allow_oasis == true and placedOasis == true then -- First oasis was placed on this pass, so change permission.
 							allow_oasis = false;
 						end
-						--print("Placed a Bonus in third ring at ", searchX, searchY);
+						print("Placed a Bonus in third ring at ", searchX, searchY);
 						iNumFoodBonusNeeded = iNumFoodBonusNeeded - 1;
 						break
 					elseif attempt == 18 then
@@ -4606,13 +4642,14 @@ function AssignStartingPlots:NormalizeStartLocation(region_number)
 	end
 
 	-- Check for heavy grass and light plains. Adding Stone if grass count is high and plains count is low. - May 2011, BT
+	-- Changed to check for only FLAT grass/plains and add forests instead. - September 2020, azum4roll
 	local iNumStoneNeeded = 0;
 	if iNumGrass >= 9 and iNumPlains == 0 then
 		iNumStoneNeeded = 2;
 	elseif iNumGrass >= 6 and iNumPlains <= 4 then
 		iNumStoneNeeded = 1;
 	end
-	if iNumStoneNeeded > 0 then -- Add Stone to this grass start.
+	if iNumStoneNeeded > 0 then -- Add Forest to this grass start.
 		local stonePlaced, innerPlaced = 0, 0;
 		local randomized_first_ring_adjustments, randomized_second_ring_adjustments;
 		if isEvenY then
@@ -4630,10 +4667,10 @@ function AssignStartingPlots:NormalizeStartLocation(region_number)
 				for attempt = 1, 6 do
 					local plot_adjustments = randomized_first_ring_adjustments[attempt];
 					local searchX, searchY = self:ApplyHexAdjustment(x, y, plot_adjustments)
-					-- Attempt to place Cows at the currently chosen plot.
-					local placedBonus = self:AttemptToPlaceStoneAtGrassPlot(searchX, searchY);
+					-- Attempt to place Forest at the currently chosen plot.
+					local placedBonus = self:AttemptToPlaceForestAtGrassPlot(searchX, searchY);
 					if placedBonus == true then
-						--print("Placed Stone in first ring at ", searchX, searchY);
+						print("Placed Forest in first ring at ", searchX, searchY);
 						innerPlaced = innerPlaced + 1;
 						iNumStoneNeeded = iNumStoneNeeded - 1;
 						break
@@ -4647,10 +4684,10 @@ function AssignStartingPlots:NormalizeStartLocation(region_number)
 				for attempt = 1, 12 do
 					local plot_adjustments = randomized_second_ring_adjustments[attempt];
 					local searchX, searchY = self:ApplyHexAdjustment(x, y, plot_adjustments)
-					-- Attempt to place Stone at the currently chosen plot.
-					local placedBonus = self:AttemptToPlaceStoneAtGrassPlot(searchX, searchY);
+					-- Attempt to place Forest at the currently chosen plot.
+					local placedBonus = self:AttemptToPlaceForestAtGrassPlot(searchX, searchY);
 					if placedBonus == true then
-						--print("Placed Stone in second ring at ", searchX, searchY);
+						print("Placed Forest in second ring at ", searchX, searchY);
 						iNumStoneNeeded = iNumStoneNeeded - 1;
 						break
 					elseif attempt == 12 then
@@ -4659,7 +4696,7 @@ function AssignStartingPlots:NormalizeStartLocation(region_number)
 				end
 
 			else -- Tried everywhere, have to give up.
-				break				
+				break
 			end
 		end
 	end
@@ -7339,6 +7376,7 @@ function AssignStartingPlots:GenerateGlobalResourcePlotLists()
 	local temp_flat_covered_no_grass, temp_flat_covered_no_tundra, temp_flat_covered_no_grass_no_tundra = {}, {}, {};	-- MOD.Barathor: New
 	local temp_flat_open, temp_flat_open_no_grass_no_plains, temp_flat_open_no_tundra_no_desert = {}, {}, {};			-- MOD.Barathor: New
 	local temp_flat_open_no_desert, temp_flat_desert_including_flood, temp_hills_open_no_grass_no_plains = {}, {}, {};	-- MOD.Barathor: New
+	local temp_tropical_marsh_list = {};
 	--
 	-- local iW, iH = Map.GetGridSize();	-- MOD.Barathor: Disabled -- already initialized above, though, not a big deal
 	local temp_hills_list, temp_coast_list, temp_grass_flat_no_feature = {}, {}, {};
@@ -7436,6 +7474,27 @@ function AssignStartingPlots:GenerateGlobalResourcePlotLists()
 					end
 				elseif featureType == FeatureTypes.FEATURE_MARSH then
 					table.insert(temp_marsh_list, i);
+					local lat = 0
+					if (y >= (iH/2)) then
+						lat = math.abs((iH/2) - y)/(iH/2)
+					else
+						lat = math.abs((iH/2) - (y + 1))/(iH/2)
+					end
+					local AvgJungleRange = 0
+					local rain = Map.GetCustomOption(2)
+					if rain == 1 then
+						-- Arid
+						AvgJungleRange = 0.08
+					elseif rain == 3 then
+						-- Wet
+						AvgJungleRange = 0.25
+					else
+						-- Normal or Random (Note: I'm currently not sure how to retrieve random, so we'll just use normal for now.)
+						AvgJungleRange = 0.10
+					end
+					if lat <= AvgJungleRange then
+						table.insert(temp_tropical_marsh_list, i);
+					end
 				elseif featureType == FeatureTypes.FEATURE_FLOOD_PLAINS then
 					table.insert(temp_flood_plains_list, i);
 					table.insert(temp_desert_wheat_list, i);
@@ -7576,6 +7635,7 @@ function AssignStartingPlots:GenerateGlobalResourcePlotLists()
 	self.extra_deer_list = GetShuffledCopyOfTable(temp_deer_list)
 	self.desert_wheat_list = GetShuffledCopyOfTable(temp_desert_wheat_list)
 	self.banana_list = GetShuffledCopyOfTable(temp_banana_list)
+	self.tropical_marsh_list = GetShuffledCopyOfTable(temp_tropical_marsh_list)
 	--
 	-- Set up the Global Luxury Plot Lists matrix, with indices synched to GetIndicesForLuxuryType()
 	self.global_luxury_plot_lists = {
@@ -7618,6 +7678,7 @@ function AssignStartingPlots:GenerateGlobalResourcePlotLists()
 	self.flat_open_no_tundra_no_desert,			-- 37	-- MOD.Barathor: New
 	self.flat_open_no_desert,					-- 38	-- MOD.Barathor: New
 	self.flat_desert_including_flood,			-- 39	-- MOD.Barathor: New
+	self.tropical_marsh_list,					-- 40
 	};
 
 end
@@ -7848,11 +7909,12 @@ function AssignStartingPlots:ProcessResourceList(frequency, impact_table_number,
 							local quantity = res_quantity[use_this_res_index]
 							-- added by azum4roll: give some variance to strategic amounts
 							local rand = Map.Rand(10000, "ProcessResourceList - Lua") / 10000
-							if (rand >= 0.8) then
-								quantity = math.floor(quantity * 1.2 + 0.5)
-							elseif (rand < 0.2) then
-								quantity = math.floor(quantity * 0.8 + 0.5)
+							if (rand >= 0.75) then
+								quantity = quantity * 1.2
+							elseif (rand < 0.25) then
+								quantity = quantity * 0.8
 							end
+							quantity = math.floor(quantity + 0.5)
 							--
 							res_plot:SetResourceType(res_ID[use_this_res_index], quantity);
 							if (Game.GetResourceUsageType(res_ID[use_this_res_index]) == ResourceUsageTypes.RESOURCEUSAGE_LUXURY) then
@@ -7860,7 +7922,7 @@ function AssignStartingPlots:ProcessResourceList(frequency, impact_table_number,
 							end
 							self:PlaceResourceImpact(x, y, impact_table_number, res_min[use_this_res_index] + res_addition);
 							placed_this_res = true;
-							self.amounts_of_resources_placed[res_ID[use_this_res_index] + 1] = self.amounts_of_resources_placed[res_ID[use_this_res_index] + 1] + res_quantity[use_this_res_index];
+							self.amounts_of_resources_placed[res_ID[use_this_res_index] + 1] = self.amounts_of_resources_placed[res_ID[use_this_res_index] + 1] + quantity;
 						end
 					end
 				elseif impact_table_number == 2 then
@@ -9888,7 +9950,7 @@ function AssignStartingPlots:PlaceSmallQuantitiesOfStrategics(frequency, plot_li
 									if diceroll < 1 then
 										selected_ID = self.uranium_ID;
 										selected_quantity = uran_amt;
-									elseif diceroll < 7 then
+									elseif diceroll < 6 then
 										selected_ID = self.iron_ID;
 										selected_quantity = iron_amt;
 									else
@@ -9900,10 +9962,10 @@ function AssignStartingPlots:PlaceSmallQuantitiesOfStrategics(frequency, plot_li
 									if diceroll < 1 then
 										selected_ID = self.uranium_ID;
 										selected_quantity = uran_amt;
-									elseif diceroll < 5 then
+									elseif diceroll < 4 then
 										selected_ID = self.iron_ID;
 										selected_quantity = iron_amt;
-									elseif diceroll < 8 then
+									elseif diceroll < 7 then
 										selected_ID = self.coal_ID;
 										selected_quantity = coal_amt;
 									else
@@ -9915,7 +9977,7 @@ function AssignStartingPlots:PlaceSmallQuantitiesOfStrategics(frequency, plot_li
 									if diceroll < 1 then
 										selected_ID = self.uranium_ID;
 										selected_quantity = uran_amt;
-									elseif diceroll < 7 then
+									elseif diceroll < 5 then
 										selected_ID = self.iron_ID;
 										selected_quantity = iron_amt;
 									else
@@ -9925,14 +9987,23 @@ function AssignStartingPlots:PlaceSmallQuantitiesOfStrategics(frequency, plot_li
 								end
 							elseif terrainType == TerrainTypes.TERRAIN_GRASS then
 								if res_plot:IsFreshWater() then
-									selected_ID = self.horse_ID;
-									selected_quantity = horse_amt;
-								else
 									local diceroll = Map.Rand(10, "Resource selection - Place Small Quantities LUA");
 									if diceroll < 1 then
 										selected_ID = self.uranium_ID;
 										selected_quantity = uran_amt;
 									elseif diceroll < 3 then
+										selected_ID = self.iron_ID;
+										selected_quantity = iron_amt;
+									else
+										selected_ID = self.horse_ID;
+										selected_quantity = horse_amt;
+									end
+								else
+									local diceroll = Map.Rand(10, "Resource selection - Place Small Quantities LUA");
+									if diceroll < 1 then
+										selected_ID = self.uranium_ID;
+										selected_quantity = uran_amt;
+									elseif diceroll < 4 then
 										selected_ID = self.iron_ID;
 										selected_quantity = iron_amt;
 									elseif diceroll < 6 then
@@ -9954,7 +10025,7 @@ function AssignStartingPlots:PlaceSmallQuantitiesOfStrategics(frequency, plot_li
 								elseif diceroll < 5 then
 									selected_ID = self.coal_ID;
 									selected_quantity = coal_amt;
-								elseif diceroll < 8 then
+								elseif diceroll < 7 then
 									selected_ID = self.horse_ID;
 									selected_quantity = horse_amt;
 								else
@@ -10322,7 +10393,7 @@ function AssignStartingPlots:AddExtraBonusesToHillsRegions()
 		if table.maxn(dry_hills) > 0 then
 			local resources_to_place = {
 			{self.sheep_ID, 1, 100, 0, 1} };
-			self:ProcessResourceList(9 / infertility_quotient, 3, dry_hills, resources_to_place)
+			self:ProcessResourceList(16 / infertility_quotient, 3, dry_hills, resources_to_place)
 		end
 		if table.maxn(jungles) > 0 then
 			local resources_to_place = {
@@ -10337,12 +10408,12 @@ function AssignStartingPlots:AddExtraBonusesToHillsRegions()
 		if table.maxn(flat_plains) > 0 then
 			local resources_to_place = {
 			{self.wheat_ID, 1, 100, 0, 2} };
-			self:ProcessResourceList(18 / infertility_quotient, 3, flat_plains, resources_to_place)
+			self:ProcessResourceList(16 / infertility_quotient, 3, flat_plains, resources_to_place)
 		end
 		if table.maxn(flat_grass) > 0 then
 			local resources_to_place = {
 			{self.cow_ID, 1, 100, 0, 2} };
-			self:ProcessResourceList(20 / infertility_quotient, 3, flat_grass, resources_to_place)
+			self:ProcessResourceList(14 / infertility_quotient, 3, flat_grass, resources_to_place)
 		end
 		if table.maxn(forests) > 0 then
 			local resources_to_place = {
@@ -10351,7 +10422,7 @@ function AssignStartingPlots:AddExtraBonusesToHillsRegions()
 		end
 		
 		--
-		--print("-"); print("Added extra Bonus resources to Hills Region#", region_number);
+		print("-"); print("Added extra Bonus resources to Hills Region#", region_number);
 		--
 	end
 end
@@ -10548,7 +10619,7 @@ function AssignStartingPlots:AdjustTiles()
 				if res_ID == self.ivory_ID then
 					-- Always want it flat.  Other types are fine on hills.
 					plot:SetPlotType(PlotTypes.PLOT_LAND, false, true)
-				end				
+				end
 				
 				-- Don't remove flood plains if present for the few that are placed on it, only remove other features, like marsh or any trees.				
 				if (featureType ~= FeatureTypes.FEATURE_FLOOD_PLAINS) then	
@@ -10660,10 +10731,10 @@ end
 function AssignStartingPlots:GetMajorStrategicResourceQuantityValues()
 	-- This function determines quantity per tile for each strategic resource's major deposit size.
 	-- Note: scripts that cannot place Oil in the sea need to increase amounts on land to compensate.
-	local uran_amt, horse_amt, oil_amt, iron_amt, coal_amt, alum_amt = 2, 4, 6, 4, 7, 7;
+	local uran_amt, horse_amt, oil_amt, iron_amt, coal_amt, alum_amt = 2, 3, 6, 3, 7, 7;
 	-- Check the strategic deposit size setting.
 	if self.resSize == 1 then -- Small
-		uran_amt, horse_amt, oil_amt, iron_amt, coal_amt, alum_amt = 2, 3, 3, 2, 3, 3;
+		uran_amt, horse_amt, oil_amt, iron_amt, coal_amt, alum_amt = 2, 2, 3, 2, 3, 3;
 	elseif self.resSize == 3 then -- Large
 		uran_amt, horse_amt, oil_amt, iron_amt, coal_amt, alum_amt = 4, 6, 9, 6, 10, 10;
 	end
@@ -10672,12 +10743,12 @@ end
 ------------------------------------------------------------------------------
 function AssignStartingPlots:GetSmallStrategicResourceQuantityValues()
 	-- This function determines quantity per tile for each strategic resource's small deposit size.
-	local uran_amt, horse_amt, oil_amt, iron_amt, coal_amt, alum_amt = 1, 2, 2, 2, 2, 2;
+	local uran_amt, horse_amt, oil_amt, iron_amt, coal_amt, alum_amt = 1, 2, 2, 2, 2, 3;
 	-- Check the strategic deposit size setting.
 	if self.resSize == 1 then -- Small
-		uran_amt, horse_amt, oil_amt, iron_amt, coal_amt, alum_amt = 1, 1, 1, 1, 1, 1;
+		uran_amt, horse_amt, oil_amt, iron_amt, coal_amt, alum_amt = 1, 1, 1, 1, 1, 2;
 	elseif self.resSize == 3 then -- Large
-		uran_amt, horse_amt, oil_amt, iron_amt, coal_amt, alum_amt = 2, 2, 2, 2, 2, 2;
+		uran_amt, horse_amt, oil_amt, iron_amt, coal_amt, alum_amt = 2, 2, 2, 2, 2, 3;
 	end
 	return uran_amt, horse_amt, oil_amt, iron_amt, coal_amt, alum_amt
 end
@@ -10712,26 +10783,26 @@ function AssignStartingPlots:PlaceStrategicAndBonusResources()
 	resources_to_place = {
 		{self.horse_ID, horse_amt, 100, 1, 2}
 	};
-	self:ProcessResourceList(24 * resMultiplier, 1, self.grass_flat_no_feature, resources_to_place);
-	self:ProcessResourceList(34 * resMultiplier, 1, self.plains_flat_no_feature, resources_to_place);
+	self:ProcessResourceList(20 * resMultiplier, 1, self.grass_flat_no_feature, resources_to_place);
+	self:ProcessResourceList(32 * resMultiplier, 1, self.plains_flat_no_feature, resources_to_place);
 	
 	resources_to_place = {
-		{self.horse_ID, horse_amt, 100, 0, 2}
+		{self.horse_ID, horse_amt * 0.7, 100, 2, 3}
 	};
-	self:ProcessResourceList(20 * resMultiplier, 1, self.desert_wheat_list, resources_to_place);
-	self:ProcessResourceList(70 * resMultiplier, 1, self.tundra_flat_no_feature, resources_to_place);
+	self:ProcessResourceList(40 * resMultiplier, 1, self.desert_wheat_list, resources_to_place);
+	self:ProcessResourceList(60 * resMultiplier, 1, self.tundra_flat_no_feature, resources_to_place);
 	
 	resources_to_place = {
-		{self.iron_ID, iron_amt, 100, 0, 2}
+		{self.iron_ID, iron_amt, 100, 1, 3}
 	};
-	self:ProcessResourceList(75 * resMultiplier, 1, self.hills_open_list, resources_to_place);
-	self:ProcessResourceList(180 * resMultiplier, 1, self.flat_open_no_tundra_no_desert, resources_to_place);
-	self:ProcessResourceList(40 * resMultiplier, 1, self.desert_flat_no_feature, resources_to_place);
+	self:ProcessResourceList(80 * resMultiplier, 1, self.hills_open_list, resources_to_place);
+	self:ProcessResourceList(100 * resMultiplier, 1, self.flat_open_no_tundra_no_desert, resources_to_place);
+	self:ProcessResourceList(55 * resMultiplier, 1, self.desert_flat_no_feature, resources_to_place);
 	
 	resources_to_place = {
-		{self.iron_ID, iron_amt, 100, 0, 1}
+		{self.iron_ID, iron_amt, 100, 1, 2}
 	};
-	self:ProcessResourceList(120 * resMultiplier, 1, self.tundra_flat_no_feature, resources_to_place);
+	self:ProcessResourceList(90 * resMultiplier, 1, self.tundra_flat_no_feature, resources_to_place);
 	
 	resources_to_place = {
 		{self.coal_ID, coal_amt, 100, 1, 2}
@@ -10743,18 +10814,18 @@ function AssignStartingPlots:PlaceStrategicAndBonusResources()
 	resources_to_place = {
 		{self.oil_ID, oil_amt, 100, 1, 3}
 	};
-	self:ProcessResourceList(40 * resMultiplier, 1, self.desert_flat_no_feature, resources_to_place);
+	self:ProcessResourceList(35 * resMultiplier, 1, self.desert_flat_no_feature, resources_to_place);
 	self:ProcessResourceList(75 * resMultiplier, 1, self.tundra_flat_no_feature, resources_to_place);
 	
 	resources_to_place = {
 		{self.aluminum_ID, alum_amt, 100, 1, 3}
 	};
-	self:ProcessResourceList(42 * resMultiplier, 1, self.hills_open_no_grass, resources_to_place);
-	self:ProcessResourceList(27 * resMultiplier, 1, self.flat_open_no_grass_no_plains, resources_to_place);
-	self:ProcessResourceList(100 * resMultiplier, 1, self.plains_flat_no_feature, resources_to_place);
+	self:ProcessResourceList(38 * resMultiplier, 1, self.hills_open_no_grass, resources_to_place);
+	self:ProcessResourceList(25 * resMultiplier, 1, self.flat_open_no_grass_no_plains, resources_to_place);
+	self:ProcessResourceList(50 * resMultiplier, 1, self.plains_flat_no_feature, resources_to_place);
 	
 	resources_to_place = {
-		{self.uranium_ID, uran_amt, 100, 1, 2}
+		{self.uranium_ID, uran_amt, 100, 2, 4}
 	};
 	self:ProcessResourceList(50 * resMultiplier, 1, self.hills_jungle_list, resources_to_place);
 	self:ProcessResourceList(200 * resMultiplier, 1, self.hills_open_list, resources_to_place);
@@ -10763,16 +10834,16 @@ function AssignStartingPlots:PlaceStrategicAndBonusResources()
 	self:ProcessResourceList(300 * resMultiplier, 1, self.flat_open_no_tundra_no_desert, resources_to_place);
 	
 	resources_to_place = {
-		{self.iron_ID, iron_amt, 90, 0, 2},
+		{self.iron_ID, iron_amt, 90, 1, 3},
 		{self.uranium_ID, uran_amt, 10, 1, 2}
 	};
-	self:ProcessResourceList(45 * resMultiplier, 1, self.hills_forest_list, resources_to_place);
-	self:ProcessResourceList(50 * resMultiplier, 1, self.forest_flat_that_are_not_tundra, resources_to_place);
-	self:ProcessResourceList(60 * resMultiplier, 1, self.tundra_flat_forest, resources_to_place);
+	self:ProcessResourceList(50 * resMultiplier, 1, self.hills_forest_list, resources_to_place);
+	self:ProcessResourceList(55 * resMultiplier, 1, self.forest_flat_that_are_not_tundra, resources_to_place);
+	self:ProcessResourceList(65 * resMultiplier, 1, self.tundra_flat_forest, resources_to_place);
 	
 	resources_to_place = {
-		{self.oil_ID, oil_amt, 60, 1, 1},
-		{self.uranium_ID, uran_amt, 40, 1, 1}
+		{self.oil_ID, oil_amt, 60, 1, 3},
+		{self.uranium_ID, uran_amt, 40, 1, 2}
 	};
 	self:ProcessResourceList(15 * resMultiplier, 1, self.marsh_list, resources_to_place);
 	self:ProcessResourceList(60 * resMultiplier, 1, self.jungle_flat_list, resources_to_place);
@@ -10786,7 +10857,7 @@ function AssignStartingPlots:PlaceStrategicAndBonusResources()
 	
 	self:AddModernMinorStrategicsToCityStates();
 	
-	self:PlaceSmallQuantitiesOfStrategics(160 * resMultiplier / self.iNumCivs, self.land_list);
+	self:PlaceSmallQuantitiesOfStrategics(20 * resMultiplier, self.land_list);
 	
 	self:PlaceOilInTheSea();
 
@@ -10794,7 +10865,7 @@ function AssignStartingPlots:PlaceStrategicAndBonusResources()
 	uran_amt, horse_amt, oil_amt, iron_amt, coal_amt, alum_amt = self:GetSmallStrategicResourceQuantityValues();
 	while self.amounts_of_resources_placed[self.iron_ID + 1] < 4 * self.iNumCivs do
 		print("Map has very low iron, adding another.");
-		local resources_to_place = { {self.iron_ID, iron_amt, 20, 0, 2} };
+		local resources_to_place = { {self.iron_ID, iron_amt, 20, 1, 2} };
 		self:ProcessResourceList(99999, 1, self.desert_flat_no_feature, resources_to_place); -- 99999 means one per that many tiles: a single instance.
 		self:ProcessResourceList(99999, 1, self.hills_forest_list, resources_to_place);
 		self:ProcessResourceList(99999, 1, self.hills_open_list, resources_to_place);
@@ -10811,28 +10882,28 @@ function AssignStartingPlots:PlaceStrategicAndBonusResources()
 	end
 	while self.amounts_of_resources_placed[self.coal_ID + 1] < 4 * self.iNumCivs do
 		print("Map has very low coal, adding another.");
-		local resources_to_place = { {self.coal_ID, coal_amt, 33, 0, 0} };
+		local resources_to_place = { {self.coal_ID, coal_amt, 33, 1, 2} };
 		self:ProcessResourceList(99999, 1, self.hills_open_no_tundra_no_desert, resources_to_place);
 		self:ProcessResourceList(99999, 1, self.grass_flat_no_feature, resources_to_place);
 		self:ProcessResourceList(99999, 1, self.plains_flat_no_feature, resources_to_place);
 	end
 	while self.amounts_of_resources_placed[self.oil_ID + 1] < 4 * self.iNumCivs do
 		print("Map has very low oil, adding another.");
-		local resources_to_place = { {self.oil_ID, oil_amt, 33, 0, 0} };
+		local resources_to_place = { {self.oil_ID, oil_amt, 33, 1, 2} };
 		self:ProcessResourceList(99999, 1, self.desert_flat_no_feature, resources_to_place);
 		self:ProcessResourceList(99999, 1, self.tundra_flat_no_feature, resources_to_place);
 		self:ProcessResourceList(99999, 1, self.jungle_flat_list, resources_to_place);
 	end
 	while self.amounts_of_resources_placed[self.aluminum_ID + 1] < 5 * self.iNumCivs do
 		print("Map has very low aluminum, adding another.");
-		local resources_to_place = { {self.aluminum_ID, alum_amt, 33, 0, 0} };
+		local resources_to_place = { {self.aluminum_ID, alum_amt, 33, 1, 2} };
 		self:ProcessResourceList(99999, 1, self.hills_open_no_grass, resources_to_place);
 		self:ProcessResourceList(99999, 1, self.flat_open_no_grass_no_plains, resources_to_place);
 		self:ProcessResourceList(99999, 1, self.plains_flat_no_feature, resources_to_place);
 	end
 	while self.amounts_of_resources_placed[self.uranium_ID + 1] < 2 * self.iNumCivs do
 		print("Map has very low uranium, adding another.");
-		local resources_to_place = { {self.uranium_ID, uran_amt, 100, 0, 0} };
+		local resources_to_place = { {self.uranium_ID, uran_amt, 100, 2, 4} };
 		self:ProcessResourceList(99999, 1, self.land_list, resources_to_place);
 	end
 	
@@ -10884,7 +10955,7 @@ function AssignStartingPlots:PlaceBonusResources()
 		
 		resources_to_place = {
 		{self.banana_ID, 1, 100, 0, 1} };
-		self:ProcessResourceList(40 * resMultiplier, 3, self.marsh_list, resources_to_place)
+		self:ProcessResourceList(40 * resMultiplier, 3, self.tropical_marsh_list, resources_to_place)
 		-- none
 		
 		resources_to_place = {
@@ -11054,7 +11125,7 @@ function AssignStartingPlots:PlaceBonusResources()
 		
 		resources_to_place = {
 		{self.banana_ID, 1, 100, 0, 1} };
-		self:ProcessResourceList(20 * resMultiplier, 3, self.marsh_list, resources_to_place)
+		self:ProcessResourceList(20 * resMultiplier, 3, self.tropical_marsh_list, resources_to_place)
 		-- none
 		
 		resources_to_place = {
@@ -11065,42 +11136,42 @@ function AssignStartingPlots:PlaceBonusResources()
 	-- CBP
 		resources_to_place = {
 		{self.bison_ID, 1, 100, 0, 2} };
-		self:ProcessResourceList(12 * resMultiplier, 3, self.flat_open_no_tundra_no_desert, resources_to_place)
+		self:ProcessResourceList(18 * resMultiplier, 3, self.flat_open_no_tundra_no_desert, resources_to_place)
 	-- END
 
 		resources_to_place = {
 		{self.sheep_ID, 1, 100, 0, 2} };
-		self:ProcessResourceList(22 * resMultiplier, 3, self.hills_open_list, resources_to_place)
+		self:ProcessResourceList(18 * resMultiplier, 3, self.hills_open_list, resources_to_place)
 		-- 13
 
 		resources_to_place = {
 		{self.stone_ID, 1, 100, 1, 1} };
-		self:ProcessResourceList(20 * resMultiplier, 3, self.dry_grass_flat_no_feature, resources_to_place)
+		self:ProcessResourceList(30 * resMultiplier, 3, self.dry_grass_flat_no_feature, resources_to_place)
 		-- 20
 		
 		resources_to_place = {
 		{self.stone_ID, 1, 100, 1, 1} };
-		self:ProcessResourceList(20 * resMultiplier, 3, self.dry_plains_flat_no_feature, resources_to_place)
+		self:ProcessResourceList(60 * resMultiplier, 3, self.dry_plains_flat_no_feature, resources_to_place)
 		-- none
 		
 		resources_to_place = {
 		{self.stone_ID, 1, 100, 1, 2} };
-		self:ProcessResourceList(15 * resMultiplier, 3, self.tundra_flat_no_feature, resources_to_place)
+		self:ProcessResourceList(60 * resMultiplier, 3, self.tundra_flat_no_feature, resources_to_place)
 		-- 15
 		
 		resources_to_place = {
 		{self.stone_ID, 1, 100, 0, 2} };
-		self:ProcessResourceList(8 * resMultiplier, 3, self.desert_flat_no_feature, resources_to_place)
+		self:ProcessResourceList(13 * resMultiplier, 3, self.desert_flat_no_feature, resources_to_place)
 		-- 19
 		
 		resources_to_place = {
 		{self.stone_ID, 1, 100, 1, 2} };
-		self:ProcessResourceList(18 * resMultiplier, 3, self.hills_open_list, resources_to_place)
+		self:ProcessResourceList(60 * resMultiplier, 3, self.hills_open_list, resources_to_place)
 		-- none
 		
 		resources_to_place = {
 		{self.stone_ID, 1, 100, 0, 2} };
-		self:ProcessResourceList(5 * resMultiplier, 3, self.snow_flat_list, resources_to_place)
+		self:ProcessResourceList(8 * resMultiplier, 3, self.snow_flat_list, resources_to_place)
 		-- none
 		
 		resources_to_place = {


### PR DESCRIPTION
AssignStartingPlots changes:
- Less bonus resources overall
- Even less stone
- Bananas are in tropical areas only
- Less iron and horses, and each major deposit is 2-4 instead of 3-5
- Tundra/desert major horses are 2-3
- Bison can spawn 3 tiles around start positions

Communitu_79a changes:
- Map options shuffled to put resource options at the bottom
- Land Shapes option effect much more apparent (Extremely Stringy is REALLY stringy)
- Strategic Balance and Legendary Start options merged into one (Starting Resources)
- Resource amount based on AssignStartingPlots but slightly lowered to compensate more land