### PR TITLE
Tribute fixes

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
@@ -15074,13 +15074,6 @@ int CvMinorCivAI::GetBullyGoldAmount(PlayerTypes eBullyPlayer, bool bIgnoreScali
 	iGold *= (100 + GET_PLAYER(eBullyPlayer).GetPlayerTraits()->GetBullyValueModifier());
 	iGold /= 100;
 
-	// Rounding
-	int iVisibleDivisor = /*5*/ GC.getMINOR_CIV_GOLD_GIFT_VISIBLE_DIVISOR(); //antonjs: consider: separate XML
-	iGold /= iVisibleDivisor;
-	iGold *= iVisibleDivisor;
-
-	iGold *= (100 + GET_PLAYER(eBullyPlayer).GetPlayerTraits()->GetBullyValueModifier());
-	iGold /= 100;
 
 	if (!bIgnoreScaling)
 	{
@@ -15089,7 +15082,7 @@ int CvMinorCivAI::GetBullyGoldAmount(PlayerTypes eBullyPlayer, bool bIgnoreScali
 		iGold /= 100;
 	}
 	if (iGold <= 0)
-		iGold = -1;
+		iGold = 0;
 
 	return iGold;
 }
@@ -15147,6 +15140,7 @@ int CvMinorCivAI::CalculateBullyScore(PlayerTypes eBullyPlayer, bool bForUnit, C
 
 	int iMilitaryMightPercent = (100 * GET_PLAYER(eBullyPlayer).GetMilitaryMight(true)) / max(1, iTotalMilitaryMight);
 	int	iGlobalMilitaryScore = (iMilitaryMightPercent * iGlobalMilitaryScoreMax)/100; 
+	iScore += iGlobalMilitaryScore;
 
 	if (sTooltipSink)
 	{
@@ -15656,7 +15650,7 @@ void CvMinorCivAI::DoMajorBullyGold(PlayerTypes eBully, int iGold)
 		CvCity* pCapital = GET_PLAYER(eBully).getCapitalCity();
 		if (pCapital != NULL)
 		{
-			GET_PLAYER(eBully).doInstantYield(INSTANT_YIELD_TYPE_BULLY, true, NO_GREATPERSON, NO_BUILDING, iGold, false, NO_PLAYER, NULL, false, pCapital);
+			GET_PLAYER(eBully).doInstantYield(INSTANT_YIELD_TYPE_BULLY, true, NO_GREATPERSON, NO_BUILDING, iGold, true, NO_PLAYER, NULL, false, pCapital);
 			//do we get a lump some of yields from this?
 			if (GET_PLAYER(eBully).GetPlayerTraits()->GetBullyYieldMultiplierAnnex() != 0)
 			{
@@ -15773,25 +15767,17 @@ int CvMinorCivAI::GetYieldTheftAmount(PlayerTypes eBully, YieldTypes eYield, boo
 	iGold *= (100 + GET_PLAYER(eBully).GetPlayerTraits()->GetBullyValueModifier());
 	iGold /= 100;
 
-	// Rounding
-	int iVisibleDivisor = /*5*/ GC.getMINOR_CIV_GOLD_GIFT_VISIBLE_DIVISOR(); //antonjs: consider: separate XML
-	iGold /= iVisibleDivisor;
-	iGold *= iVisibleDivisor;
-
-	iGold *= (100 + GET_PLAYER(eBully).GetPlayerTraits()->GetBullyValueModifier());
-	iGold /= 100;
 
 	if (!bIgnoreScaling)
 	{
-		int iFactor = CalculateBullyScore(eBully, false);
+		int iFactor = CalculateBullyScore(eBully, true);
 		iGold *= iFactor;
 		iGold /= 100;
 	}
-	if (iGold <= 0)
-		iGold = -1;
 
 	if (iGold <= 0)
-		return 0;
+		iGold = 0;
+
 
 	return iGold;
 }
@@ -16163,7 +16149,7 @@ void CvMinorCivAI::DoMajorBullyUnit(PlayerTypes eBully, UnitTypes eUnitType)
 					iValue = GetYieldTheftAmount(eBully, YIELD_FOOD);
 					if (iValue > 0)
 					{
-						GET_PLAYER(eBully).doInstantYield(INSTANT_YIELD_TYPE_BULLY, true, NO_GREATPERSON, NO_BUILDING, iValue, false, NO_PLAYER, NULL, false, pBullyCapital);
+						GET_PLAYER(eBully).doInstantYield(INSTANT_YIELD_TYPE_BULLY, true, NO_GREATPERSON, NO_BUILDING, iValue, true, NO_PLAYER, NULL, false, pBullyCapital);
 
 						pBullyCapital->changeFood(iValue);
 						if (GC.getGame().getActivePlayer() != NULL)

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -27159,7 +27159,7 @@ void CvPlayer::doInstantYield(InstantYieldType iType, bool bCityFaith, GreatPers
 				//Exclusions
 				if(eYield != YIELD_POPULATION)
 				{
-					if (iType != INSTANT_YIELD_TYPE_TR_MOVEMENT && iType != INSTANT_YIELD_TYPE_PURCHASE && iType != INSTANT_YIELD_TYPE_U_PROD && iType != INSTANT_YIELD_TYPE_MINOR_QUEST_REWARD && iType != INSTANT_YIELD_TYPE_TR_MOVEMENT_IN_FOREIGN)
+					if (iType != INSTANT_YIELD_TYPE_TR_MOVEMENT && iType != INSTANT_YIELD_TYPE_PURCHASE && iType != INSTANT_YIELD_TYPE_U_PROD && iType != INSTANT_YIELD_TYPE_MINOR_QUEST_REWARD && iType != INSTANT_YIELD_TYPE_TR_MOVEMENT_IN_FOREIGN && iType != INSTANT_YIELD_TYPE_BULLY)
 					{
 						if (ePlayer == NO_PLAYER && eYield == YIELD_TOURISM)
 						{


### PR DESCRIPTION
- GetBullyValueModifier no longer applied twice to tribute values
- removed the rounding to the nearest 5 (it wasn't working correctly anyways and is more trouble than it's worth imo)
- Value now shows 0 when you can't tribute
- iGlobalMilitaryScore now actually factored into tribute score
- Heavy tribute now includes the extra negative modifier it should have
- Culture yield from tributing Food and Gold with Tribute policy now scales with era like other yields. Tbh it probably shouldn't for all of them but should be all or none and most already did.
- Culture yield from tribute policy no longer scales with gamespeed (the tribute value already does).

#7295 #7101 done. Pretty sure there is now no more weirdness from tribute values or tooltip. (tested).

Didn't want to change game balance but:
- Gold tribute should probably scale the same as heavy tribute (Heavy tribute currently increases more as game goes on) or at least have lower penalties or noone will ever do it.
- iGlobalMilitaryScore should be based on your military compared to average instead of yours as a percentage of total military so that it is fair with different numbers of civs.
- Actually wouldn't be too hard to include Civs protecting a City State's military into iOurPower so that iLocalPowerRatio was reduced by protective civs in the area.