### PR TITLE
RSI 13/01/21

### DIFF
--- a/Community Balance Patch/Balance Changes/Beliefs/Pantheons.sql
+++ b/Community Balance Patch/Balance Changes/Beliefs/Pantheons.sql
@@ -317,10 +317,10 @@ VALUES
 	('BELIEF_ONE_WITH_NATURE', 'YIELD_CULTURE', 2);
 
 INSERT INTO Belief_YieldPerBorderGrowth
-	(BeliefType, YieldType, Yield)
+	(BeliefType, YieldType, Yield, IsEraScaling)
 VALUES
-	('BELIEF_RELIGIOUS_SETTLEMENTS', 'YIELD_FAITH', 20),
-	('BELIEF_RELIGIOUS_SETTLEMENTS', 'YIELD_PRODUCTION', 10);
+	('BELIEF_RELIGIOUS_SETTLEMENTS', 'YIELD_FAITH', 20, 0),
+	('BELIEF_RELIGIOUS_SETTLEMENTS', 'YIELD_PRODUCTION', 10, 0);
 
 INSERT INTO Belief_FeatureYieldChanges
 	(BeliefType, FeatureType, YieldType, Yield)

--- a/Community Balance Patch/Balance Changes/Leaders/GodsKings/GKLeaderChanges.sql
+++ b/Community Balance Patch/Balance Changes/Leaders/GodsKings/GKLeaderChanges.sql
@@ -356,11 +356,11 @@ VALUES
 	('BELIEF_EPONA', 'YIELD_CULTURE_LOCAL', 3);
 
 INSERT INTO Belief_YieldPerBorderGrowth
-	(BeliefType, YieldType, Yield)
+	(BeliefType, YieldType, Yield, IsEraScaling)
 VALUES
-	('BELIEF_EPONA', 'YIELD_SCIENCE', 10),
-	('BELIEF_EPONA', 'YIELD_CULTURE', 10),
-	('BELIEF_EPONA', 'YIELD_FOOD', 10);
+	('BELIEF_EPONA', 'YIELD_SCIENCE', 10, 1),
+	('BELIEF_EPONA', 'YIELD_CULTURE', 10, 1),
+	('BELIEF_EPONA', 'YIELD_FOOD', 10, 1);
 
 INSERT INTO Belief_ImprovementYieldChanges
 	(BeliefType, ImprovementType, YieldType, Yield)

--- a/Community Patch/Core Files/Core Tables/CoreTableAdditions.xml
+++ b/Community Patch/Core Files/Core Tables/CoreTableAdditions.xml
@@ -177,6 +177,7 @@
 		<Column name="BeliefType" type="text" reference="Beliefs(Type)"/>
 		<Column name="YieldType" type="integer" reference="Yields(Type)"/>
 		<Column name="Yield" type="integer" default="0"/>
+		<Column name="IsEraScaling" type="boolean" default="false"/>
 	</Table>
 
 	<!-- PANTHEON: Allows you to define any belief to grant x yield for every use of the faith healer ability, where X is the number below.-->

--- a/Community Patch/Core Files/Core Tables/CoreTableAdditions.xml
+++ b/Community Patch/Core Files/Core Tables/CoreTableAdditions.xml
@@ -473,11 +473,12 @@
 		<Column name="PromotionType" type="integer" reference="UnitPromotions(Type)"/>
 	</Table>
 
-	<!-- BELIEF: Founder only. Grants yields to the holy city when researching technology. Scales with number of followers. Does not scale with era. -->
+	<!-- BELIEF: Founder only. Grants yields to the holy city when researching technology. Scales with number of followers. -->
 	<Table name="Belief_YieldFromTechUnlock">
 		<Column name="BeliefType" type="text" reference="Beliefs(Type)"/>
 		<Column name="YieldType" type="integer" reference="Yields(Type)"/>
 		<Column name="Yield" type="integer" default="0"/>
+		<Column name="IsEraScaling" type="boolean" default="false"/>
 	</Table>
 
 	<!-- BELIEF: Intended as a Pantheon or Follower. Grants yields to the owning city, or capital, when finishing an improvement if religion is the player's majority. Note that roads are not considered improvements. -->

--- a/CvGameCoreDLL_Expansion2/CvBeliefClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvBeliefClasses.h
@@ -106,7 +106,7 @@ public:
 	int GetYieldFromConquest(int i) const;
 	int GetYieldFromPolicyUnlock(int i) const;
 	int GetYieldFromEraUnlock(int i) const;
-	int GetYieldFromTechUnlock(YieldTypes eYield) const;
+	int GetYieldFromTechUnlock(YieldTypes eYield, bool bEraScaling = false) const;
 	int GetYieldFromConversion(int i) const;
 	int GetYieldFromConversionExpo(int i) const;
 	int GetYieldFromWLTKD(int i) const;
@@ -355,7 +355,7 @@ protected:
 	int* m_piYieldFromConquest;
 	int* m_piYieldFromPolicyUnlock;
 	int* m_piYieldFromEraUnlock;
-	std::map<int, int> m_piYieldFromTechUnlock;
+	std::map<int, std::map<bool, int>> m_pbiYieldFromTechUnlock;
 	int* m_piYieldFromConversion;
 	int* m_piYieldFromConversionExpo;
 	int* m_piYieldFromWLTKD;
@@ -588,7 +588,7 @@ public:
 	int GetYieldFromConquest(YieldTypes eYieldType , PlayerTypes ePlayer = NO_PLAYER, const CvCity* pCity = NULL, bool bHolyCityOnly = false) const;
 	int GetYieldFromPolicyUnlock(YieldTypes eYieldType , PlayerTypes ePlayer = NO_PLAYER, const CvCity* pCity = NULL, bool bHolyCityOnly = false) const;
 	int GetYieldFromEraUnlock(YieldTypes eYieldType , PlayerTypes ePlayer = NO_PLAYER, const CvCity* pCity = NULL, bool bHolyCityOnly = false) const;
-	int GetYieldFromTechUnlock(YieldTypes eYield, PlayerTypes ePlayer = NO_PLAYER, const CvCity* pCity = NULL, bool bHolyCityOnly = false) const;
+	int GetYieldFromTechUnlock(YieldTypes eYield, bool bEraScaling = false, PlayerTypes ePlayer = NO_PLAYER, const CvCity* pCity = NULL, bool bHolyCityOnly = false) const;
 	int GetYieldFromConversion(YieldTypes eYieldType , PlayerTypes ePlayer = NO_PLAYER, const CvCity* pCity = NULL, bool bHolyCityOnly = false) const;
 	int GetYieldFromConversionExpo(YieldTypes eYieldType, PlayerTypes ePlayer = NO_PLAYER, const CvCity* pCity = NULL, bool bHolyCityOnly = false) const;
 	int GetYieldFromWLTKD(YieldTypes eYieldType, PlayerTypes ePlayer = NO_PLAYER, const CvCity* pCity = NULL, bool bHolyCityOnly = false) const;

--- a/CvGameCoreDLL_Expansion2/CvBeliefClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvBeliefClasses.h
@@ -95,7 +95,7 @@ public:
 	int GetYieldPerPop(int i) const;
 	int GetYieldPerGPT(int i) const;
 	int GetYieldPerLux(int i) const;
-	int GetYieldPerBorderGrowth(int i) const;
+	int GetYieldPerBorderGrowth(YieldTypes eYield, bool bEraScaling = false) const;
 	int GetYieldPerHeal(int i) const;
 	int GetYieldPerBirth(int i) const;
 	int GetYieldPerScience(int i) const;
@@ -344,7 +344,7 @@ protected:
 	int* m_piYieldPerPop;
 	int* m_piYieldPerGPT;
 	int* m_piYieldPerLux;
-	int* m_piYieldPerBorderGrowth;
+	std::map<int, std::map<bool, int>> m_pbiYieldPerBorderGrowth;
 	int* m_piYieldPerHeal;
 	int* m_piYieldPerBirth;
 	int* m_piYieldPerScience;
@@ -577,7 +577,7 @@ public:
 	int GetYieldPerPop(YieldTypes eYieldType, PlayerTypes ePlayer = NO_PLAYER, const CvCity* pCity = NULL, bool bHolyCityOnly = false) const;
 	int GetYieldPerGPT(YieldTypes eYieldType , PlayerTypes ePlayer = NO_PLAYER, const CvCity* pCity = NULL, bool bHolyCityOnly = false) const;
 	int GetYieldPerLux(YieldTypes eYieldType , PlayerTypes ePlayer = NO_PLAYER, const CvCity* pCity = NULL, bool bHolyCityOnly = false) const;
-	int GetYieldPerBorderGrowth(YieldTypes eYieldType , PlayerTypes ePlayer = NO_PLAYER, const CvCity* pCity = NULL, bool bHolyCityOnly = false) const;
+	int GetYieldPerBorderGrowth(YieldTypes eYieldType, bool bEraScaling = false, PlayerTypes ePlayer = NO_PLAYER, const CvCity* pCity = NULL, bool bHolyCityOnly = false) const;
 	int GetYieldPerHeal(YieldTypes eYieldType, PlayerTypes ePlayer = NO_PLAYER, const CvCity* pCity = NULL, bool bHolyCityOnly = false) const;
 	int GetYieldPerBirth(YieldTypes eYieldType , PlayerTypes ePlayer = NO_PLAYER, const CvCity* pCity = NULL, bool bHolyCityOnly = false) const;
 	int GetYieldPerScience(YieldTypes eYieldType , PlayerTypes ePlayer = NO_PLAYER, const CvCity* pCity = NULL, bool bHolyCityOnly = false) const;

--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -21323,7 +21323,6 @@ void CvCity::UpdateHappinessFromBuildingClasses()
 
 	// Building Class Mods
 	iSpecialBuildingHappiness = 0;
-	bool bVenice = kPlayer.GetPlayerTraits()->IsNoAnnexing();
 #if defined(MOD_BALANCE_CORE)
 	bool bRome = kPlayer.GetPlayerTraits()->IsKeepConqueredBuildings();
 	if (!MOD_BUILDINGS_THOROUGH_PREREQUISITES && !bRome)

--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -21321,105 +21321,77 @@ void CvCity::UpdateHappinessFromBuildingClasses()
 
 	iTotalHappiness += iSpecialPolicyBuildingHappiness;
 
-	BuildingClassTypes eBuildingClass;
-
 	// Building Class Mods
 	iSpecialBuildingHappiness = 0;
-	for (int iI = 0; iI < GC.getNumBuildingClassInfos(); iI++)
+	bool bVenice = kPlayer.GetPlayerTraits()->IsNoAnnexing();
+#if defined(MOD_BALANCE_CORE)
+	bool bRome = kPlayer.GetPlayerTraits()->IsKeepConqueredBuildings();
+	if (!MOD_BUILDINGS_THOROUGH_PREREQUISITES && !bRome)
+#else
+	if (!MOD_BUILDINGS_THOROUGH_PREREQUISITES)
+#endif
 	{
-		eBuildingClass = (BuildingClassTypes)iI;
-
-		CvBuildingClassInfo* pkBuildingClassInfo = GC.getBuildingClassInfo(eBuildingClass);
-		if (!pkBuildingClassInfo)
+		for (int iI = 0; iI < GC.getNumBuildingClassInfos(); iI++)
 		{
-			continue;
-		}
-
-		BuildingTypes eBuilding = NO_BUILDING;
-		int iNumTotal = 0;
-		bool bVenice = kPlayer.GetPlayerTraits()->IsNoAnnexing();
-#if defined(MOD_BALANCE_CORE)
-		bool bRome = kPlayer.GetPlayerTraits()->IsKeepConqueredBuildings();
-		if (!MOD_BUILDINGS_THOROUGH_PREREQUISITES && !bRome)
-#else
-		if (!MOD_BUILDINGS_THOROUGH_PREREQUISITES)
-#endif
-		{
-			eBuilding = (BuildingTypes)getCivilizationInfo().getCivilizationBuildings(eBuildingClass);
-			iNumTotal = kPlayer.countNumBuildings(eBuilding) - (MOD_BALANCE_CORE_PUPPET_CHANGES && !bVenice ? kPlayer.countNumBuildingsInPuppets(eBuilding) : 0);
-		}
-
-#if defined(MOD_BALANCE_CORE)
-		if ((eBuilding != NO_BUILDING && iNumTotal > 0) || MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome)
-#else
-		if ((eBuilding != NO_BUILDING && iNumTotal > 0) || MOD_BUILDINGS_THOROUGH_PREREQUISITES)
-#endif
-		{
-			CvBuildingEntry* pkBuilding = NULL;
-#if defined(MOD_BALANCE_CORE)
-			//if (!MOD_BUILDINGS_THOROUGH_PREREQUISITES && !bRome)
-#else
-			//if (!MOD_BUILDINGS_THOROUGH_PREREQUISITES)
-#endif
+			BuildingClassTypes eBuildingClass = (BuildingClassTypes)iI;
+			CvBuildingClassInfo* pkBuildingClassInfo = GC.getBuildingClassInfo(eBuildingClass);
+			if (!pkBuildingClassInfo)
 			{
-				pkBuilding = GC.getBuildingInfo(eBuilding);
+				continue;
 			}
-#if defined(MOD_BALANCE_CORE)
-			if (pkBuilding)// || MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome)
-#else
-			if (pkBuilding)// || MOD_BUILDINGS_THOROUGH_PREREQUISITES)
-#endif
+
+			BuildingTypes eBuilding = (BuildingTypes)getCivilizationInfo().getCivilizationBuildings(eBuildingClass);
+			bool bVenice = kPlayer.GetPlayerTraits()->IsNoAnnexing();
+			int iNumTotal = kPlayer.countNumBuildings(eBuilding) - (MOD_BALANCE_CORE_PUPPET_CHANGES && !bVenice ? kPlayer.countNumBuildingsInPuppets(eBuilding) : 0);
+		
+			if (eBuilding != NO_BUILDING && iNumTotal > 0)
 			{
-				for (int jJ = 0; jJ < GC.getNumBuildingClassInfos(); jJ++)
+				CvBuildingEntry* pkBuilding = GC.getBuildingInfo(eBuilding);
+				if (pkBuilding)
 				{
-					BuildingClassTypes eBuildingClassThatGivesHappiness = (BuildingClassTypes)jJ;
-					int iHappinessPerBuilding = 0;
-#if defined(MOD_BALANCE_CORE)
-					//if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome)
-#else
-					if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
-#endif
-					//{
-					//	int iLoop;
-					//	for (const CvCity* pLoopCity = kPlayer.firstCity(&iLoop); pLoopCity != NULL; pLoopCity = kPlayer.nextCity(&iLoop))
-					//	{
-					//		if (MOD_BALANCE_CORE_PUPPET_CHANGES && !bVenice && pLoopCity->IsPuppet())
-					//		{
-					//			continue;
-					//		}
-					//		eBuilding = pLoopCity->GetCityBuildings()->GetBuildingTypeFromClass(eBuildingClass);
-					//		if (eBuilding != NO_BUILDING && pLoopCity->GetCityBuildings()->GetNumBuilding(eBuilding) > 0)
-					//		{
-					//			pkBuilding = GC.getBuildingInfo(eBuilding);
-					//			if (pkBuilding)
-					//			{
-					//				iHappinessPerBuilding += pkBuilding->GetBuildingClassHappiness(eBuildingClassThatGivesHappiness);
-					//			}
-					//		}
-					//	}
-					//}
-					//else
+					for (int jJ = 0; jJ < GC.getNumBuildingClassInfos(); jJ++)
 					{
-						iHappinessPerBuilding = pkBuilding->GetBuildingClassHappiness(eBuildingClassThatGivesHappiness) * kPlayer.getNumBuildings(eBuilding);
+						BuildingClassTypes eBuildingClassThatGivesHappiness = (BuildingClassTypes)jJ;
+						int iHappinessPerBuilding = pkBuilding->GetBuildingClassHappiness(eBuildingClassThatGivesHappiness) * iNumTotal;
+						if (iHappinessPerBuilding > 0)
+						{
+							BuildingTypes eBuildingThatGivesHappiness = (BuildingTypes)getCivilizationInfo().getCivilizationBuildings(eBuildingClassThatGivesHappiness);
+							if (eBuildingThatGivesHappiness != NO_BUILDING)
+							{
+								int iNumTotal2 = GetCityBuildings()->GetNumBuilding(eBuildingThatGivesHappiness);
+
+								iSpecialBuildingHappiness += iHappinessPerBuilding * iNumTotal2;
+							}
+						}
 					}
-					if (iHappinessPerBuilding > 0)
+				}
+			}
+		}
+	}
+	else
+	{
+		for (int iI = 0; iI < GC.getNumBuildingInfos(); iI++)
+		{
+			BuildingTypes eBuilding = (BuildingTypes)iI;
+			if (eBuilding == NO_BUILDING)
+			{
+				continue;
+			}
+			bool bVenice = kPlayer.GetPlayerTraits()->IsNoAnnexing();
+			int iNumTotal = kPlayer.countNumBuildings(eBuilding) - (MOD_BALANCE_CORE_PUPPET_CHANGES && !bVenice ? kPlayer.countNumBuildingsInPuppets(eBuilding) : 0);
+
+			if (iNumTotal > 0)
+			{
+				CvBuildingEntry* pkBuilding = GC.getBuildingInfo(eBuilding);
+				if (pkBuilding)
+				{
+					for (int jJ = 0; jJ < GC.getNumBuildingClassInfos(); jJ++)
 					{
-						BuildingTypes eBuildingThatGivesHappiness = NO_BUILDING;
-#if defined(MOD_BALANCE_CORE)
-						if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || kPlayer.GetPlayerTraits()->IsKeepConqueredBuildings())
-#else
-						if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
-#endif
+						BuildingClassTypes eBuildingClassThatGivesHappiness = (BuildingClassTypes)jJ;
+						int iHappinessPerBuilding = pkBuilding->GetBuildingClassHappiness(eBuildingClassThatGivesHappiness) * iNumTotal;
+						if (iHappinessPerBuilding > 0)
 						{
-							eBuildingThatGivesHappiness = GetCityBuildings()->GetBuildingTypeFromClass(eBuildingClassThatGivesHappiness);
-						}
-						else
-						{
-							eBuildingThatGivesHappiness = (BuildingTypes)getCivilizationInfo().getCivilizationBuildings(eBuildingClassThatGivesHappiness);
-						}
-						if (eBuildingThatGivesHappiness != NO_BUILDING)
-						{
-							int iNumTotal2 = GetCityBuildings()->GetNumBuilding(eBuildingThatGivesHappiness);
+							int iNumTotal2 = GetCityBuildings()->GetNumBuildingClass(eBuildingClassThatGivesHappiness);
 
 							iSpecialBuildingHappiness += iHappinessPerBuilding * iNumTotal2;
 						}

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -26632,7 +26632,11 @@ void CvPlayer::doInstantYield(InstantYieldType iType, bool bCityFaith, GreatPers
 
 					if(pReligion)
 					{
-						iValue += pReligion->m_Beliefs.GetYieldPerBorderGrowth(eYield, GetID(), pLoopCity);
+						iScaleValue = pReligion->m_Beliefs.GetYieldPerBorderGrowth(eYield, true, GetID(), pLoopCity);
+						iScaleValue *= iEra;
+						iValue += iScaleValue;
+
+						iValue += pReligion->m_Beliefs.GetYieldPerBorderGrowth(eYield, false, GetID(), pLoopCity);
 					}
 					for(int iI = 0; iI < GC.getNumTerrainInfos(); iI++)
 					{

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -26556,16 +26556,20 @@ void CvPlayer::doInstantYield(InstantYieldType iType, bool bCityFaith, GreatPers
 				}
 				case INSTANT_YIELD_TYPE_TECH:
 				{
-					iValue +=  pLoopCity->GetYieldFromTech(eYield);
-					if(pLoopCity->isCapital())
+					// the following instant yield sources have no non era scaling options
+					if (bEraScale)
 					{
-						iValue += getYieldFromTech(eYield);
+						iValue += pLoopCity->GetYieldFromTech(eYield);
+						if (pLoopCity->isCapital())
+						{
+							iValue += getYieldFromTech(eYield);
+						}
 					}
 
 #if defined(MOD_BALANCE_CORE_BELIEFS)
 					if (pReligion)
 					{
-						iValue += pReligion->m_Beliefs.GetYieldFromTechUnlock(eYield, GetID(), pLoopCity, true) * pReligion->m_Beliefs.GetFollowerScalerLimiter(iNumFollowers);
+						iValue += pReligion->m_Beliefs.GetYieldFromTechUnlock(eYield, bEraScale, GetID(), pLoopCity, true) * pReligion->m_Beliefs.GetFollowerScalerLimiter(iNumFollowers);
 					}
 #endif
 					break;

--- a/CvGameCoreDLL_Expansion2/CvReligionClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvReligionClasses.cpp
@@ -8780,9 +8780,9 @@ int CvReligionAI::ScoreBeliefAtCity(CvBeliefEntry* pEntry, CvCity* pCity)
 
 			iTempValue += (pEntry->GetYieldPerLux(iI) * max(1, iNumLuxuries)) * ModifierValue;
 		}
-		if (pEntry->GetYieldPerBorderGrowth(iI) > 0)
+		if (pEntry->GetYieldPerBorderGrowth((YieldTypes)iI) > 0)
 		{
-			int iVal = ((pEntry->GetYieldPerBorderGrowth(iI) * iCulture) / max(4, pCity->GetJONSCultureLevel() * 4));
+			int iVal = ((pEntry->GetYieldPerBorderGrowth((YieldTypes)iI) * iCulture) / max(4, pCity->GetJONSCultureLevel() * 4));
 			if (m_pPlayer->GetPlayerTraits()->IsExpansionist())
 			{
 				iVal *= 2;

--- a/CvGameCoreDLL_Expansion2/CvTeam.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTeam.cpp
@@ -8041,7 +8041,9 @@ void CvTeam::processTech(TechTypes eTech, int iChange)
 #if defined(MOD_BALANCE_CORE_POLICIES)
 			if(!bNoBonus)
 			{
-				kPlayer.doInstantYield(INSTANT_YIELD_TYPE_TECH);
+				// call one for era scaling, another for no era scaliing
+				kPlayer.doInstantYield(INSTANT_YIELD_TYPE_TECH, false, NO_GREATPERSON, NO_BUILDING, 0, true);
+				kPlayer.doInstantYield(INSTANT_YIELD_TYPE_TECH, false, NO_GREATPERSON, NO_BUILDING, 0, false);
 			}
 #endif
 #if defined(MOD_BALANCE_CORE)

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -13310,56 +13310,57 @@ bool CvUnit::blastTourism()
 	}
 
 	int iTourismBlast = getBlastTourism();
+	int iTourismBlastPercentOthers = m_pUnitInfo->GetOneShotTourismPercentOthers();
+	PlayerTypes eOwner = pPlot->getOwner();
+	CvPlayer &kUnitOwner = GET_PLAYER(getOwner());
+
+	// Apply to target, then save what is the amount we actually applied
+	int iTourismBlastAfterModifier = kUnitOwner.GetCulture()->ChangeInfluenceOn(eOwner, iTourismBlast, true, true);
 
 #if defined(MOD_BALANCE_CORE_NEW_GP_ATTRIBUTES)
 	//Let's make the GM a little more flexible.
-	if(MOD_BALANCE_CORE_NEW_GP_ATTRIBUTES)
+	if (MOD_BALANCE_CORE_NEW_GP_ATTRIBUTES)
 	{
 		PlayerTypes eOwner = pPlot->getOwner();
 
+		// Give happiness to Musician owner
 		int iCap = GC.getBALANCE_CORE_MUSICIAN_BLAST_HAPPINESS();
 
-		if(GET_PLAYER(getOwner()).getCapitalCity() != NULL)
+		if (GET_PLAYER(getOwner()).getCapitalCity() != NULL)
 		{
 			GET_PLAYER(getOwner()).getCapitalCity()->ChangeUnmoddedHappinessFromBuildings(iCap);
 		}
 
+		// Send notifications
 		CvNotifications* pNotifications = GET_PLAYER(getOwner()).GetNotifications();
-		if (pNotifications) 
+		if (pNotifications)
 		{
 			Localization::String localizedText = Localization::Lookup("TXT_KEY_NOTIFICATION_GREAT_MUSICIAN_FAMILIAR_TOUR");
 			localizedText << GET_PLAYER(eOwner).getCivilizationAdjectiveKey();
-			localizedText << iTourismBlast;
+			localizedText << iTourismBlastAfterModifier;
 			localizedText << iCap;
 			Localization::String localizedSummary = Localization::Lookup("TXT_KEY_NOTIFICATION_GREAT_MUSICIAN_FAMILIAR_TOUR_S");
 			localizedSummary << GET_PLAYER(eOwner).getCivilizationAdjectiveKey();
 			pNotifications->Add(NOTIFICATION_GREAT_PERSON_ACTIVE_PLAYER, localizedText.toUTF8(), localizedSummary.toUTF8(), getX(), getY(), getUnitType());
 		}
 		CvNotifications* pNotifications2 = GET_PLAYER(eOwner).GetNotifications();
-		if (pNotifications2) 
+		if (pNotifications2)
 		{
 			Localization::String localizedText = Localization::Lookup("TXT_KEY_NOTIFICATION_GREAT_MUSICIAN_FAMILIAR_TOUR_TARGET");
 			localizedText << GET_PLAYER(getOwner()).getCivilizationAdjectiveKey();
-			localizedText << iTourismBlast;
+			localizedText << iTourismBlastAfterModifier;
 			Localization::String localizedSummary = Localization::Lookup("TXT_KEY_NOTIFICATION_GREAT_MUSICIAN_FAMILIAR_TOUR_TARGET_S");
 			localizedSummary << GET_PLAYER(getOwner()).getCivilizationAdjectiveKey();
 			pNotifications2->Add(NOTIFICATION_CULTURE_VICTORY_SOMEONE_INFLUENTIAL, localizedText.toUTF8(), localizedSummary.toUTF8(), getX(), getY(), eOwner);
 		}
-		if(GC.getLogging() && GC.getAILogging())
+		if (GC.getLogging() && GC.getAILogging())
 		{
 			CvString strLogString;
-			strLogString.Format("Foreign Tour, Familiar. Tourism gained: %d. Happiness they gained: %d", iTourismBlast, iCap);
+			strLogString.Format("Foreign Tour, Familiar. Tourism gained: %d. Happiness they gained: %d", iTourismBlastAfterModifier, iCap);
 			GET_PLAYER(getOwner()).GetHomelandAI()->LogHomelandMessage(strLogString);
 		}
 	}
 #endif
-
-	int iTourismBlastPercentOthers = m_pUnitInfo->GetOneShotTourismPercentOthers();
-	PlayerTypes eOwner = pPlot->getOwner();
-	CvPlayer &kUnitOwner = GET_PLAYER(getOwner());
-
-	// Apply to target
-	kUnitOwner.GetCulture()->ChangeInfluenceOn(eOwner, iTourismBlast, true, true);
 
 	//store off this data
 	GET_PLAYER(getOwner()).changeInstantTourismValue(eOwner, iTourismBlast);
@@ -13414,7 +13415,7 @@ bool CvUnit::blastTourism()
 			strInfluenceText = GetLocalizedText( "TXT_KEY_CO_DOMINANT");
 
 		char text[256] = {0};
-		sprintf_s(text, "[COLOR_WHITE]+%d [ICON_TOURISM][ENDCOLOR]   %s", iTourismBlast, strInfluenceText.c_str());
+		sprintf_s(text, "[COLOR_WHITE]+%d [ICON_TOURISM][ENDCOLOR]   %s", iTourismBlastAfterModifier, strInfluenceText.c_str());
 		SHOW_PLOT_POPUP(pPlot, getOwner(), text);
 	}
 


### PR DESCRIPTION
- Refactored CvCity::UpdateHappinessFromBuildingClasses() for MOD_BUILDINGS_THOROUGH_PREREQUISITES. Should not freeze the game when conquering cities now.
- Added IsEraScaling column to Belief_YieldFromTechUnlock.
- Added IsEraScaling column to Belief_YieldPerBorderGrowth.
- Celt's Epona pantheon now scales with era as described in tooltip.
- Fixed Lua method unit:GetBlastTourism(). Now correctly shows the tourism the unit would grant if it was to perform a concert tour with the player whose plot it is on.
- Tooltip when performing concert tours now correctly show the actual amount of tourism after modifiers gained with the player.

Save game compatible.