### PR TITLE
RSI 14/01/21

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvTraitClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTraitClasses.cpp
@@ -5710,7 +5710,7 @@ void CvPlayerTraits::UpdateYieldChangeImprovementTypes()
 			if (m_ppaaiYieldChangePerImprovementBuilt[iImprovement][iYield] != 0)
 			{
 				m_vYieldChangeImprovementTypes.push_back((ImprovementTypes)iImprovement);
-				continue;
+				break;
 			}
 		}
 	}


### PR DESCRIPTION
- Fixed Trait_YieldChangesPerImprovementBuilt triggering more than once when there are multiple yield types define for one improvement type.