### PR TITLE
City state unit spawn changes

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
@@ -14330,7 +14330,7 @@ void CvMinorCivAI::DoSpawnUnit(PlayerTypes eMajor)
 				else
 				{
 #if defined(MOD_GLOBAL_CS_GIFT_SHIPS)
-					eUnit = GC.getGame().GetCompetitiveSpawnUnitType(eMajor, /*bIncludeUUs*/ false, /*bIncludeRanged*/true, pSpawnCity->plot()->isCoastalLand(GC.getMIN_WATER_SIZE_FOR_OCEAN()) && MOD_GLOBAL_CS_GIFT_SHIPS);
+					eUnit = GC.getGame().GetCompetitiveSpawnUnitType(eMajor, /*bIncludeUUs*/ false, /*bIncludeRanged*/true, pMinorCapital->plot()->isCoastalLand(GC.getMIN_WATER_SIZE_FOR_OCEAN()) && MOD_GLOBAL_CS_GIFT_SHIPS);
 #else
 					eUnit = GC.getGame().GetCompetitiveSpawnUnitType(eMajor, /*bIncludeUUs*/ false, /*bIncludeRanged*/true);
 #endif

--- a/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
@@ -14330,7 +14330,7 @@ void CvMinorCivAI::DoSpawnUnit(PlayerTypes eMajor)
 				else
 				{
 #if defined(MOD_GLOBAL_CS_GIFT_SHIPS)
-					eUnit = GC.getGame().GetCompetitiveSpawnUnitType(eMajor, /*bIncludeUUs*/ false, /*bIncludeRanged*/true, MOD_GLOBAL_CS_GIFT_SHIPS);
+					eUnit = GC.getGame().GetCompetitiveSpawnUnitType(eMajor, /*bIncludeUUs*/ false, /*bIncludeRanged*/true, pSpawnCity->plot()->isCoastalLand(GC.getMIN_WATER_SIZE_FOR_OCEAN()) && MOD_GLOBAL_CS_GIFT_SHIPS);
 #else
 					eUnit = GC.getGame().GetCompetitiveSpawnUnitType(eMajor, /*bIncludeUUs*/ false, /*bIncludeRanged*/true);
 #endif


### PR DESCRIPTION
- Stop spawning units option now freezes the counter
- Naval unit gifts from minors will now spawn near the minor capital instead of nearest major's city if major's city is not coastal. (Minors should only offer naval units if their capital is coastal)
Maybe someone else could make this cleaner but I have tested it and it does the job.