### PR TITLE
Misc 11/02/21

### DIFF
--- a/(6c) 43 Civs CP/EUI/TopPanel.lua
+++ b/(6c) 43 Civs CP/EUI/TopPanel.lua
@@ -2430,6 +2430,100 @@ local function ResourcesToolTip( control )
 					end
 				end
 			end
+			for improvement in GameInfo.Improvements() do
+				local improvementID = improvement.ID
+				local numResource = Game.GetNumResourceRequiredForImprovement(improvementID, resourceID)
+				if numResource > 0 then
+					-- how many improvements are the player responsible for
+					local numExisting = g_activePlayer:GetResponsibleForImprovementCount(improvementID)
+					-- how many improvements is the player currently building
+					local numBuilds = 0
+					for unit in g_activePlayer:Units() do
+						if unit:IsWork() then
+							local improvementBuildingID = unit:GetImprovementBuildType()
+							if improvementBuildingID == improvementID then
+								numBuilds = numBuilds + 1
+							end
+						end
+					end
+					-- can player build this improvement someday ?
+					local canBuildSomeday = true
+					if ( civ5_mode and improvement.ObsoleteTech and g_activeTeamTechs:HasTech( GameInfoTypes[improvement.ObsoleteTech] ) ) then
+						canBuildSomeday = false
+					end
+					if (improvement.CivilizationType and GameInfoTypes[improvement.CivilizationType] ~= g_activeCivilization) then
+						canBuildSomeday = false
+					end
+					if canBuildSomeday or numExisting > 0 or numBuilds > 0 then
+						local totalResource = (numExisting + numBuilds) * numResource
+						local tip = L( improvement.Description )
+						if canBuildSomeday then
+							local tech
+							for build in GameInfo.Builds() do
+								if build.ImprovementType then
+									if improvementID == GameInfoTypes[build.ImprovementType] then
+										if build.PrereqTech then
+											tech = GameInfo.Technologies[ build.PrereqTech ]
+										end
+										break
+									end
+								end
+							end
+							if tech and not g_activeTeamTechs:HasTech( tech.ID ) then
+								tip = S( "%s [COLOR_CYAN]%s[ENDCOLOR]", tip, L(tech.Description) )
+							end
+						end
+						if totalResource > 0 then
+							tipIndex = tipIndex+1
+							tips:insert( tipIndex, "[ICON_BULLET]" .. totalResource .. resource.IconString .. " = " ..  numExisting .. " (+" .. numBuilds .. ") " .. tip )
+						else
+							tips:insert( "[ICON_BULLET] (" .. numResource .. "/" .. tip .. ")" )
+						end
+					end
+				end
+			end
+			for route in GameInfo.Routes() do
+				local routeID = route.ID
+				local numResource = Game.GetNumResourceRequiredForRoute(routeID, resourceID)
+				if numResource > 0 then
+					-- how many routes is the player responsible for
+					local numExisting = g_activePlayer:GetResponsibleForRouteCount(routeID)
+					-- how many improvements is the player currently building
+					local numBuilds = 0
+					for unit in g_activePlayer:Units() do
+						if unit:IsWork() then
+							local routeBuildingID = unit:GetRouteBuildType()
+							if routeBuildingID == routeID then
+								numBuilds = numBuilds + 1
+							end
+						end
+					end
+					if numExisting > 0 or numBuilds > 0 then
+						local totalResource = (numExisting + numBuilds) * numResource
+						local tip = L( route.Description )
+						local tech
+						for build in GameInfo.Builds() do
+							if build.RouteType then
+								if routeID == GameInfoTypes[build.RouteType] then
+									if build.PrereqTech then
+										tech = GameInfo.Technologies[ build.PrereqTech ]
+									end
+									break
+								end
+							end
+						end
+						if tech and not g_activeTeamTechs:HasTech( tech.ID ) then
+							tip = S( "%s [COLOR_CYAN]%s[ENDCOLOR]", tip, L(tech.Description) )
+						end
+						if totalResource > 0 then
+							tipIndex = tipIndex+1
+							tips:insert( tipIndex, "[ICON_BULLET]" .. totalResource .. resource.IconString .. " = " ..  numExisting .. " (+" .. numBuilds .. ") " .. tip )
+						else
+							tips:insert( "[ICON_BULLET] (" .. numResource .. "/" .. tip .. ")" )
+						end
+					end
+				end
+			end
 		end
 	end
 

--- a/(6c) 43 Civs CP/EUI/UnitPanel.lua
+++ b/(6c) 43 Civs CP/EUI/UnitPanel.lua
@@ -1797,6 +1797,22 @@ function ActionToolTipHandler( control )
 
 			end
 
+			-- Insufficient resource count?
+			if improvement or route then
+				for resource in GameInfo.Resources() do
+					local resourceID = resource.ID
+					local numResource = 0
+					if improvement then
+						numResource = Game.GetNumResourceRequiredForImprovement(improvementID, resourceID)
+					elseif route then
+						numResource = Game.GetNumResourceRequiredForRoute(routeID, resourceID)
+					end
+					if numResource > 0 and g_activePlayer:GetNumResourceAvailable( resourceID, true ) <= 0 then
+						disabledTip:insertLocalized( "TXT_KEY_BUILD_BLOCKED_RESOURCE_REQUIRED", numResource, resource.IconString, resource.Description, strImpRouteKey )
+					end
+				end
+			end
+
 		-- Not a Worker build, use normal disabled help from XML
 		else
 

--- a/(6c) 43 Civs CP/No-EUI/UnitPanel.lua
+++ b/(6c) 43 Civs CP/No-EUI/UnitPanel.lua
@@ -1560,6 +1560,23 @@ function TipHandler( control )
 				strDisabledString = strDisabledString .. "[NEWLINE]";
 				strDisabledString = strDisabledString .. Locale.ConvertTextKey("TXT_KEY_BUILD_BLOCKED_BY_FEATURE", pFeatureTech.Description, pFeature.Description);
 			end
+
+			-- Insufficient resource count?
+			if pImprovement or pRoute then
+				for resource in GameInfo.Resources() do
+					local iResource = resource.ID;
+					local iNumResource = 0;
+					if pImprovement then
+						iNumResource = Game.GetNumResourceRequiredForImprovement(iImprovement, iResource);
+					elseif pRoute then
+						iNumResource = Game.GetNumResourceRequiredForRoute(iRoute, iResource);
+					end
+					if iNumResource > 0 and pActivePlayer:GetNumResourceAvailable(iResource, true) <= 0 then
+						strDisabledString = strDisabledString .. "[NEWLINE]";
+						strDisabledString = strDisabledString .. Locale.ConvertTextKey("TXT_KEY_BUILD_BLOCKED_RESOURCE_REQUIRED", iNumResource, resource.IconString, resource.Description, strImpRouteKey);
+					end
+				end
+			end
 			
 		-- Not a Worker build, use normal disabled help from XML
 		else

--- a/Community Balance Patch/LUA/UnitPanel.lua
+++ b/Community Balance Patch/LUA/UnitPanel.lua
@@ -1560,6 +1560,23 @@ function TipHandler( control )
 				strDisabledString = strDisabledString .. "[NEWLINE]";
 				strDisabledString = strDisabledString .. Locale.ConvertTextKey("TXT_KEY_BUILD_BLOCKED_BY_FEATURE", pFeatureTech.Description, pFeature.Description);
 			end
+
+			-- Insufficient resource count?
+			if pImprovement or pRoute then
+				for resource in GameInfo.Resources() do
+					local iResource = resource.ID;
+					local iNumResource = 0;
+					if pImprovement then
+						iNumResource = Game.GetNumResourceRequiredForImprovement(iImprovement, iResource);
+					elseif pRoute then
+						iNumResource = Game.GetNumResourceRequiredForRoute(iRoute, iResource);
+					end
+					if iNumResource > 0 and pActivePlayer:GetNumResourceAvailable(iResource, true) <= 0 then
+						strDisabledString = strDisabledString .. "[NEWLINE]";
+						strDisabledString = strDisabledString .. Locale.ConvertTextKey("TXT_KEY_BUILD_BLOCKED_RESOURCE_REQUIRED", iNumResource, resource.IconString, resource.Description, strImpRouteKey);
+					end
+				end
+			end
 			
 		-- Not a Worker build, use normal disabled help from XML
 		else

--- a/Community Patch/Core Files/Core Tables/CustomModOptions.xml
+++ b/Community Patch/Core Files/Core Tables/CustomModOptions.xml
@@ -208,8 +208,9 @@
 		- Column 'RandResourceChance' in 'Improvements'.
 		- Column 'NewOwner' in 'Improvements'.
 		- Column 'RemoveWhenComplete' in 'Improvements'.
+		- Column 'QuantityRequirement' in 'Improvement_ResourceTypes'.
 	-->
-    <Row Class="4" Name="IMPROVEMENTS_EXTENSIONS" Value="0" DbUpdates="1"/>
+    <Row Class="4" Name="IMPROVEMENTS_EXTENSIONS" Value="0"/>
 	
     <!-- 
 	Various new tables and logics for plots. Currently, this is required to activate:

--- a/Community Patch/Core Files/Text/CoreText_en_US.xml
+++ b/Community Patch/Core Files/Text/CoreText_en_US.xml
@@ -7742,6 +7742,10 @@
 		<Row Tag="TXT_KEY_MONOPOLY_GP_MOD">
 			<Text>[ICON_BULLET] Resource Monopoly Bonus: +{1_num}%</Text>
 		</Row>
+		<!-- Build blocked -->
+		<Row Tag="TXT_KEY_BUILD_BLOCKED_RESOURCE_REQUIRED">
+			<Text>{1_Num} {2_ResourceIcon} {3_ResourceName:textkey} is required to construct {TXT_KEY_GRAMMAR_A_AN &lt;&lt; {@4_ImprovementName:textkey}}.</Text>
+		</Row>
 	</Language_en_US>
 	<PostDefines>
 		<Row Name="PROMOTION_DEEPWATER_EMBARKATION">

--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
@@ -2344,56 +2344,80 @@ int CvBuilderTaskingAI::ScorePlotBuild(CvPlot* pPlot, ImprovementTypes eImprovem
 			switch(eYield)
 			{
 				case YIELD_FOOD:
-					iTempWeight = GC.getBUILDER_TASKING_BASELINE_ADDS_FOOD() * GC.getImprovementInfo(eImprovement)->GetYieldChange(iI);
+					iTempWeight = GC.getBUILDER_TASKING_BASELINE_ADDS_FOOD() * pImprovement->GetYieldChange(iI);
 #if defined(MOD_IMPROVEMENTS_EXTENSIONS)
 					if (MOD_IMPROVEMENTS_EXTENSIONS)
 					{
-						iTempWeight += GC.getBUILDER_TASKING_BASELINE_ADDS_FOOD() * GC.getFeatureInfo(GC.getImprovementInfo(eImprovement)->GetCreatedFeature())->getYieldChange(iI);
+						CvFeatureInfo* pFeature = GC.getFeatureInfo(pImprovement->GetCreatedFeature());
+						if (pFeature)
+						{
+							iTempWeight += GC.getBUILDER_TASKING_BASELINE_ADDS_FOOD() * pFeature->getYieldChange(iI);
+						}
 					}
 #endif
 					break;
 				case YIELD_PRODUCTION:
-					iTempWeight = GC.getBUILDER_TASKING_BASELINE_ADDS_PRODUCTION() * GC.getImprovementInfo(eImprovement)->GetYieldChange(iI);
+					iTempWeight = GC.getBUILDER_TASKING_BASELINE_ADDS_PRODUCTION() * pImprovement->GetYieldChange(iI);
 #if defined(MOD_IMPROVEMENTS_EXTENSIONS)
 					if (MOD_IMPROVEMENTS_EXTENSIONS)
 					{
-						iTempWeight += GC.getBUILDER_TASKING_BASELINE_ADDS_PRODUCTION() * GC.getFeatureInfo(GC.getImprovementInfo(eImprovement)->GetCreatedFeature())->getYieldChange(iI);
+						CvFeatureInfo* pFeature = GC.getFeatureInfo(pImprovement->GetCreatedFeature());
+						if (pFeature)
+						{
+							iTempWeight += GC.getBUILDER_TASKING_BASELINE_ADDS_PRODUCTION() * pFeature->getYieldChange(iI);
+						}
 					}
 #endif
 					break;
 				case YIELD_GOLD:
-					iTempWeight = GC.getBUILDER_TASKING_BASELINE_ADDS_GOLD() * GC.getImprovementInfo(eImprovement)->GetYieldChange(iI);
+					iTempWeight = GC.getBUILDER_TASKING_BASELINE_ADDS_GOLD() * pImprovement->GetYieldChange(iI);
 #if defined(MOD_IMPROVEMENTS_EXTENSIONS)
 					if (MOD_IMPROVEMENTS_EXTENSIONS)
 					{
-						iTempWeight += GC.getBUILDER_TASKING_BASELINE_ADDS_GOLD() * GC.getFeatureInfo(GC.getImprovementInfo(eImprovement)->GetCreatedFeature())->getYieldChange(iI);
+						CvFeatureInfo* pFeature = GC.getFeatureInfo(pImprovement->GetCreatedFeature());
+						if (pFeature)
+						{
+							iTempWeight += GC.getBUILDER_TASKING_BASELINE_ADDS_GOLD() * pFeature->getYieldChange(iI);
+						}
 					}
 #endif
 					break;
 				case YIELD_SCIENCE:
-					iTempWeight = GC.getBUILDER_TASKING_BASELINE_ADDS_SCIENCE() * GC.getImprovementInfo(eImprovement)->GetYieldChange(iI);
+					iTempWeight = GC.getBUILDER_TASKING_BASELINE_ADDS_SCIENCE() * pImprovement->GetYieldChange(iI);
 #if defined(MOD_IMPROVEMENTS_EXTENSIONS)
 					if (MOD_IMPROVEMENTS_EXTENSIONS)
 					{
-						iTempWeight += GC.getBUILDER_TASKING_BASELINE_ADDS_SCIENCE() * GC.getFeatureInfo(GC.getImprovementInfo(eImprovement)->GetCreatedFeature())->getYieldChange(iI);
+						CvFeatureInfo* pFeature = GC.getFeatureInfo(pImprovement->GetCreatedFeature());
+						if (pFeature)
+						{
+							iTempWeight += GC.getBUILDER_TASKING_BASELINE_ADDS_SCIENCE() * pFeature->getYieldChange(iI);
+						}
 					}
 #endif
 					break;
 				case YIELD_CULTURE:
-					iTempWeight = GC.getBUILDER_TASKING_BASELINE_ADDS_CULTURE() * GC.getImprovementInfo(eImprovement)->GetYieldChange(iI);
+					iTempWeight = GC.getBUILDER_TASKING_BASELINE_ADDS_CULTURE() * pImprovement->GetYieldChange(iI);
 #if defined(MOD_IMPROVEMENTS_EXTENSIONS)
 					if (MOD_IMPROVEMENTS_EXTENSIONS)
 					{
-						iTempWeight += GC.getBUILDER_TASKING_BASELINE_ADDS_CULTURE() * GC.getFeatureInfo(GC.getImprovementInfo(eImprovement)->GetCreatedFeature())->getYieldChange(iI);
+						CvFeatureInfo* pFeature = GC.getFeatureInfo(pImprovement->GetCreatedFeature());
+						if (pFeature)
+						{
+							iTempWeight += GC.getBUILDER_TASKING_BASELINE_ADDS_CULTURE() * pFeature->getYieldChange(iI);
+						}
 					}
 #endif
 					break;
 				case YIELD_FAITH:
-					iTempWeight = GC.getBUILDER_TASKING_BASELINE_ADDS_FAITH() * GC.getImprovementInfo(eImprovement)->GetYieldChange(iI);
+					iTempWeight = GC.getBUILDER_TASKING_BASELINE_ADDS_FAITH() * pImprovement->GetYieldChange(iI);
 #if defined(MOD_IMPROVEMENTS_EXTENSIONS)
 					if (MOD_IMPROVEMENTS_EXTENSIONS)
 					{
-						iTempWeight += GC.getBUILDER_TASKING_BASELINE_ADDS_FAITH() * GC.getFeatureInfo(GC.getImprovementInfo(eImprovement)->GetCreatedFeature())->getYieldChange(iI);
+						CvFeatureInfo* pFeature = GC.getFeatureInfo(pImprovement->GetCreatedFeature());
+						if (pFeature)
+						{
+							iTempWeight += GC.getBUILDER_TASKING_BASELINE_ADDS_FAITH() * pFeature->getYieldChange(iI);
+						}
 					}
 #endif
 					break;

--- a/CvGameCoreDLL_Expansion2/CvImprovementClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvImprovementClasses.cpp
@@ -449,7 +449,7 @@ bool CvImprovementEntry::CacheResults(Database::Results& kResults, CvDatabaseUti
 		Database::Results* pResourceTypes = kUtility.GetResults(strResourceTypesKey);
 		if(pResourceTypes == NULL)
 		{
-			pResourceTypes = kUtility.PrepareResults(strResourceTypesKey, "select Resources.ID, ResourceType, ResourceMakesValid, ResourceTrade, DiscoveryRand from Improvement_ResourceTypes inner join Resources on ResourceType = Resources.Type where ImprovementType = ?");
+			pResourceTypes = kUtility.PrepareResults(strResourceTypesKey, "select Resources.ID, ResourceType, ResourceMakesValid, ResourceTrade, DiscoveryRand, QuantityRequirement from Improvement_ResourceTypes inner join Resources on ResourceType = Resources.Type where ImprovementType = ?");
 		}
 
 		std::string strYieldResultsKey = "Improvements - YieldResults";

--- a/CvGameCoreDLL_Expansion2/CvPlayer.h
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.h
@@ -2219,6 +2219,14 @@ public:
 	void changeTotalImprovementsBuilt(ImprovementTypes eIndex, int iChange);
 #endif
 
+#if defined(MOD_IMPROVEMENTS_EXTENSIONS)
+	int getResponsibleForRouteCount(RouteTypes eIndex) const;
+	void changeResponsibleForRouteCount(RouteTypes eIndex, int iChange);
+
+	int getResponsibleForImprovementCount(ImprovementTypes eIndex) const;
+	void changeResponsibleForImprovementCount(ImprovementTypes eIndex, int iChange);
+#endif
+
 	int getGreatPersonImprovementCount();
 
 	int getFreeBuildingCount(BuildingTypes eIndex) const;
@@ -3518,6 +3526,10 @@ protected:
 	FAutoVariable<std::vector<int>, CvPlayer> m_paiImprovementCount;
 #if defined(MOD_BALANCE_CORE)
 	FAutoVariable<std::vector<int>, CvPlayer> m_paiTotalImprovementsBuilt;
+#endif
+#if defined(MOD_IMPROVEMENTS_EXTENSIONS)
+	std::map<RouteTypes, int> m_piResponsibleForRouteCount;
+	std::map<ImprovementTypes, int> m_piResponsibleForImprovementCount;
 #endif
 	FAutoVariable<std::vector<int>, CvPlayer> m_paiFreeBuildingCount;
 	FAutoVariable<std::vector<int>, CvPlayer> m_paiFreePromotionCount;

--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -2510,25 +2510,6 @@ bool CvPlot::canHaveImprovement(ImprovementTypes eImprovement, PlayerTypes ePlay
 		}
 	}
 
-#if defined(MOD_IMPROVEMENTS_EXTENSIONS)
-	if (MOD_IMPROVEMENTS_EXTENSIONS)
-	{
-		// Check resource requirements
-		for (iI = 0; iI < GC.getNumResourceInfos(); iI++)
-		{
-			ResourceTypes eResource = (ResourceTypes)iI;
-			if (eResource != NO_RESOURCE)
-			{
-				int iNumResource = pkImprovementInfo->GetResourceQuantityRequirement(iI);
-				if (iNumResource > 0 && GET_PLAYER(ePlayer).getNumResourceAvailable(eResource) < iNumResource)
-				{
-					return false;
-				}
-			}
-		}
-	}
-#endif
-
 #if defined(MOD_EVENTS_PLOT)
 	if (MOD_EVENTS_PLOT) {
 		if (GAMEEVENTINVOKE_TESTALL(GAMEEVENT_PlotCanImprove, getX(), getY(), eImprovement) == GAMEEVENTRETURN_FALSE) {
@@ -2827,25 +2808,6 @@ bool CvPlot::canBuild(BuildTypes eBuild, PlayerTypes ePlayer, bool bTestVisible,
 						return false;
 					}
 				}
-
-#if defined(MOD_IMPROVEMENTS_EXTENSIONS)
-				if (MOD_IMPROVEMENTS_EXTENSIONS)
-				{
-					// Check resource requirements
-					for (int iI = 0; iI < GC.getNumResourceInfos(); iI++)
-					{
-						ResourceTypes eResource = (ResourceTypes)iI;
-						if (eResource != NO_RESOURCE)
-						{
-							int iNumResource = pkBuildRoute->getResourceQuantityRequirement(iI);
-							if (iNumResource > 0 && GET_PLAYER(ePlayer).getNumResourceAvailable(eResource) < iNumResource)
-							{
-								return false;
-							}
-						}
-					}
-				}
-#endif
 			}
 		}
 
@@ -5974,6 +5936,7 @@ void CvPlot::setOwner(PlayerTypes eNewValue, int iAcquiringCityID, bool bCheckUn
 				}
 			}
 #endif
+
 			// Plot was owned by someone else
 			if(isOwned())
 			{
@@ -6115,21 +6078,6 @@ void CvPlot::setOwner(PlayerTypes eNewValue, int iAcquiringCityID, bool bCheckUn
 						setResourceType(NO_RESOURCE, 0);
 					}
 #endif
-					// Maintenance change!
-					if(MustPayMaintenanceHere(getOwner()))
-					{
-						GET_PLAYER(getOwner()).GetTreasury()->ChangeBaseImprovementGoldMaintenance(-GC.getImprovementInfo(getImprovementType())->GetGoldMaintenance());
-					}
-				}
-
-				// Route is here
-				if(getRouteType() != NO_ROUTE && !isCity())
-				{
-					// Maintenance change!
-					if(MustPayMaintenanceHere(getOwner()))
-					{
-						GET_PLAYER(getOwner()).GetTreasury()->ChangeBaseImprovementGoldMaintenance(-GC.getRouteInfo(getRouteType())->GetGoldMaintenance());
-					}
 				}
 
 				// Remove Resource Quantity from total
@@ -6166,28 +6114,6 @@ void CvPlot::setOwner(PlayerTypes eNewValue, int iAcquiringCityID, bool bCheckUn
 					}
 				}
 			}
-			// Plot is unowned
-			else
-			{
-				// Someone paying for this improvement
-				if(GetPlayerResponsibleForImprovement() != NO_PLAYER)
-				{
-					if(MustPayMaintenanceHere(GetPlayerResponsibleForImprovement()))
-					{
-						GET_PLAYER(GetPlayerResponsibleForImprovement()).GetTreasury()->ChangeBaseImprovementGoldMaintenance(-GC.getImprovementInfo(getImprovementType())->GetGoldMaintenance());
-					}
-					SetPlayerResponsibleForImprovement(NO_PLAYER);
-				}
-				// Someone paying for this Route
-				if(GetPlayerResponsibleForRoute() != NO_PLAYER)
-				{
-					if(MustPayMaintenanceHere(GetPlayerResponsibleForRoute()))
-					{
-						GET_PLAYER(GetPlayerResponsibleForRoute()).GetTreasury()->ChangeBaseImprovementGoldMaintenance(-GC.getRouteInfo(getRouteType())->GetGoldMaintenance());
-					}
-					SetPlayerResponsibleForRoute(NO_PLAYER);
-				}
-			}
 
 			// This plot is ABOUT TO BE owned. Pop Goody Huts/remove barb camps, etc. Otherwise it will try to reduce the # of Improvements we have in our borders, and these guys shouldn't apply to that count
 			if(eNewValue != NO_PLAYER)
@@ -6206,6 +6132,31 @@ void CvPlot::setOwner(PlayerTypes eNewValue, int iAcquiringCityID, bool bCheckUn
 					SetPlayerThatClearedBarbCampHere(eNewValue);
 
 					// Don't give gold for Camps cleared by settling
+				}
+
+				// Transfer responsibility of routes and improvements if the plot is now owned by someone else
+				if (getImprovementType() != NO_IMPROVEMENT)
+				{
+					SetPlayerResponsibleForImprovement(eNewValue);
+				}
+				if (getRouteType() != NO_ROUTE && !isCity())
+				{
+					SetPlayerResponsibleForRoute(eNewValue);
+				}
+			}
+			else
+			{
+				// Transfer responsibility of improvements back to the original builder if the plot is now unowned, and the improvement can be built outside of borders
+				// If the improvement is not supposed to function outside borders, then no one is responsible for it
+				// Original builder of route is not stored in memory, so the responsible player remains the previous owner
+				if (getImprovementType() != NO_IMPROVEMENT)
+				{
+					CvImprovementEntry* pkImprovementInfo = GC.getImprovementInfo(getImprovementType());
+					if (pkImprovementInfo && pkImprovementInfo->IsOutsideBorders())
+					{
+						SetPlayerResponsibleForImprovement(GetPlayerThatBuiltImprovement());
+					}
+					SetPlayerResponsibleForImprovement(NO_PLAYER);
 				}
 			}
 
@@ -6342,11 +6293,6 @@ void CvPlot::setOwner(PlayerTypes eNewValue, int iAcquiringCityID, bool bCheckUn
 						setResourceType(eResourceFromImprovement, iQuantity);
 					}
 #endif
-					// Maintenance change!
-					if(MustPayMaintenanceHere(eNewValue))
-					{
-						GET_PLAYER(eNewValue).GetTreasury()->ChangeBaseImprovementGoldMaintenance(GC.getImprovementInfo(getImprovementType())->GetGoldMaintenance());
-					}
 				}
 
 #if defined(MOD_DIPLOMACY_CITYSTATES)
@@ -6374,15 +6320,6 @@ void CvPlot::setOwner(PlayerTypes eNewValue, int iAcquiringCityID, bool bCheckUn
 					}
 				}
 #endif
-				// Route is here
-				if(getRouteType() != NO_ROUTE && !isCity())
-				{
-					// Maintenance change!
-					if(MustPayMaintenanceHere(eNewValue))
-					{
-						GET_PLAYER(eNewValue).GetTreasury()->ChangeBaseImprovementGoldMaintenance(GC.getRouteInfo(getRouteType())->GetGoldMaintenance());
-					}
-				}
 
 				if(getResourceType() != NO_RESOURCE)
 				{
@@ -7554,12 +7491,6 @@ void CvPlot::setImprovementType(ImprovementTypes eNewValue, PlayerTypes eBuilder
 				CvPlayer& owningPlayer = GET_PLAYER(owningPlayerID);
 				owningPlayer.changeImprovementCount(eOldImprovement, -1);
 
-				// Maintenance change!
-				if(MustPayMaintenanceHere(owningPlayerID))
-				{
-					GET_PLAYER(owningPlayerID).GetTreasury()->ChangeBaseImprovementGoldMaintenance(-GC.getImprovementInfo(getImprovementType())->GetGoldMaintenance());
-				}
-
 				// Siphon resource changes
 				PlayerTypes eOldBuilder = GetPlayerThatBuiltImprovement();
 				if(oldImprovementEntry.GetLuxuryCopiesSiphonedFromMinor() > 0 && eOldBuilder != NO_PLAYER)
@@ -7605,15 +7536,6 @@ void CvPlot::setImprovementType(ImprovementTypes eNewValue, PlayerTypes eBuilder
 				}
 #endif
 
-				// Update the amount of a Resource used up by the previous Improvement that is being removed
-				int iNumResourceInfos= GC.getNumResourceInfos();
-				for(int iResourceLoop = 0; iResourceLoop < iNumResourceInfos; iResourceLoop++)
-				{
-					if(oldImprovementEntry.GetResourceQuantityRequirement(iResourceLoop) > 0)
-					{
-						owningPlayer.changeNumResourceUsed((ResourceTypes) iResourceLoop, -oldImprovementEntry.GetResourceQuantityRequirement(iResourceLoop));
-					}
-				}
 #if defined(MOD_DIPLOMACY_CITYSTATES)
 				// Embassy extra vote in WC mod
 				if(MOD_DIPLOMACY_CITYSTATES && oldImprovementEntry.GetCityStateExtraVote() > 0 && eOldBuilder != NO_PLAYER)
@@ -7636,17 +7558,9 @@ void CvPlot::setImprovementType(ImprovementTypes eNewValue, PlayerTypes eBuilder
 				}
 			}
 #endif
-			// Someone had built something here in an unowned plot, remove effects of the old improvement
-			if(GetPlayerResponsibleForImprovement() != NO_PLAYER)
-			{
-				// Maintenance change!
-				if(MustPayMaintenanceHere(GetPlayerResponsibleForImprovement()))
-				{
-					GET_PLAYER(GetPlayerResponsibleForImprovement()).GetTreasury()->ChangeBaseImprovementGoldMaintenance(-GC.getImprovementInfo(getImprovementType())->GetGoldMaintenance());
-				}
-
-				SetPlayerResponsibleForImprovement(NO_PLAYER);
-			}
+			// Maintenance change!
+			// Remove maintenance of the old improvement while we can still easily fetch the cost
+			SetPlayerResponsibleForImprovement(NO_PLAYER);
 		}
 
 		m_eImprovementType = eNewValue;
@@ -7956,10 +7870,8 @@ void CvPlot::setImprovementType(ImprovementTypes eNewValue, PlayerTypes eBuilder
 				}
 #endif
 				// Maintenance
-				if(MustPayMaintenanceHere(owningPlayerID))
-				{
-					GET_PLAYER(owningPlayerID).GetTreasury()->ChangeBaseImprovementGoldMaintenance(newImprovementEntry.GetGoldMaintenance());
-				}
+				// If plot is owned, the plot owner is responsible for the improvement
+				SetPlayerResponsibleForImprovement(owningPlayerID);
 
 				// Siphon resource changes
 				if(newImprovementEntry.GetLuxuryCopiesSiphonedFromMinor() > 0 && eBuilder != NO_PLAYER)
@@ -8088,6 +8000,13 @@ void CvPlot::setImprovementType(ImprovementTypes eNewValue, PlayerTypes eBuilder
 					setOwner(eBuilder, iBestCityID);
 				}
 #endif
+				// Maintenance
+				// If plot is unowned, and the improvement can be built outside of borders, the builder is responsible for the improvement
+				// If improvement is not usually allowed to be built outside of borders, then no one is responsible
+				if (newImprovementEntry.IsOutsideBorders())
+				{
+					SetPlayerResponsibleForImprovement(eBuilder);
+				}
 			}
 #endif
 #if defined(MOD_BALANCE_CORE)
@@ -8404,20 +8323,6 @@ void CvPlot::setImprovementType(ImprovementTypes eNewValue, PlayerTypes eBuilder
 		}
 #endif
 
-		// Update the amount of a Resource used up by this Improvement
-		if(isOwned() && eNewValue != NO_IMPROVEMENT)
-		{
-			CvPlayer& owningPlayer = GET_PLAYER(owningPlayerID);
-			CvImprovementEntry& newImprovementEntry = *GC.getImprovementInfo(eNewValue);
-			int iNumResourceInfos = GC.getNumResourceInfos();
-			for(int iResourceLoop = 0; iResourceLoop < iNumResourceInfos; iResourceLoop++)
-			{
-				if(newImprovementEntry.GetResourceQuantityRequirement(iResourceLoop) > 0)
-				{
-					owningPlayer.changeNumResourceUsed((ResourceTypes) iResourceLoop, newImprovementEntry.GetResourceQuantityRequirement(iResourceLoop));
-				}
-			}
-		}
 
 		// Update the most recent builder
 		if (GetPlayerThatBuiltImprovement() != eBuilder)
@@ -8713,7 +8618,7 @@ RouteTypes CvPlot::getRouteType() const
 
 
 //	--------------------------------------------------------------------------------
-void CvPlot::setRouteType(RouteTypes eNewValue)
+void CvPlot::setRouteType(RouteTypes eNewValue, PlayerTypes eBuilder)
 {
 	RouteTypes eOldRoute = getRouteType();
 	int iI;
@@ -8726,74 +8631,26 @@ void CvPlot::setRouteType(RouteTypes eNewValue)
 		// Remove old effects
 		if(eOldRoute != NO_ROUTE && !isCity())
 		{
-			// Owned by someone
-			if(isOwned())
-			{
-				CvRouteInfo& oldRouteInfo = *GC.getRouteInfo(eOldRoute);
-				CvPlayer& owningPlayer = GET_PLAYER(getOwner());
-
-				// Maintenance change!
-				if(MustPayMaintenanceHere(getOwner()))
-				{
-					GET_PLAYER(getOwner()).GetTreasury()->ChangeBaseImprovementGoldMaintenance(-GC.getRouteInfo(getRouteType())->GetGoldMaintenance());
-				}
-
-				// Update the amount of a Resource used up by a Route which was previously here
-				int iNumResourceInfos = GC.getNumResourceInfos();
-				for(int iResourceLoop = 0; iResourceLoop < iNumResourceInfos; iResourceLoop++)
-				{
-					int iRequiredResources = oldRouteInfo.getResourceQuantityRequirement(iResourceLoop);
-					if(iRequiredResources > 0)
-					{
-						owningPlayer.changeNumResourceUsed((ResourceTypes) iResourceLoop, -iRequiredResources);
-					}
-				}
-			}
-
-			// Someone built a route here in an unowned plot, remove the effects of it (since we're changing it to something else)
-			if(GetPlayerResponsibleForRoute() != NO_PLAYER)
-			{
-				// Maintenance change!
-				if(MustPayMaintenanceHere(GetPlayerResponsibleForRoute()))
-				{
-					CvRouteInfo* pkRouteInfo = GC.getRouteInfo(getRouteType());
-					if(pkRouteInfo)
-					{
-						GET_PLAYER(GetPlayerResponsibleForRoute()).GetTreasury()->ChangeBaseImprovementGoldMaintenance(-pkRouteInfo->GetGoldMaintenance());
-					}
-				}
-
-				SetPlayerResponsibleForRoute(NO_PLAYER);
-			}
+			// Maintenance change!
+			// Remove maintenance while we can still easily access the cost
+			SetPlayerResponsibleForRoute(NO_PLAYER);
 		}
 
 		// Route switch here!
 		m_eRouteType = eNewValue;
 
-		// Apply new effects
-		if(isOwned() && eNewValue != NO_ROUTE && !isCity())
+		// Apply new effects (maintenance and resource usage)
+		if(eNewValue != NO_ROUTE && !isCity())
 		{
-			CvRouteInfo* newRouteInfo = GC.getRouteInfo(eNewValue);
-			if(newRouteInfo)
+			if (isOwned())
 			{
-				CvPlayer& owningPlayer = GET_PLAYER(getOwner());
-
-				// Maintenance
-				if(MustPayMaintenanceHere(getOwner()))
-				{
-					GET_PLAYER(getOwner()).GetTreasury()->ChangeBaseImprovementGoldMaintenance(newRouteInfo->GetGoldMaintenance());
-				}
-
-				// Update the amount of a Resource used up by this Route
-				int iNumResourceInfos = GC.getNumResourceInfos();
-				for(int iResourceLoop = 0; iResourceLoop < iNumResourceInfos; iResourceLoop++)
-				{
-					int iRequiredResources = newRouteInfo->getResourceQuantityRequirement(iResourceLoop);
-					if(iRequiredResources > 0)
-					{
-						owningPlayer.changeNumResourceUsed((ResourceTypes) iResourceLoop, iRequiredResources);
-					}
-				}
+				// If plot is owned, the plot owner is responsible for the route maintenance
+				SetPlayerResponsibleForRoute(getOwner());
+			}
+			else
+			{
+				// If plot is unowned, the builder is responsible for the route maintenance
+				SetPlayerResponsibleForRoute(eBuilder);
 			}
 		}
 
@@ -8885,7 +8742,7 @@ void CvPlot::updateCityRoute()
 			eCityRoute = ((RouteTypes)(GC.getINITIAL_CITY_ROUTE_TYPE()));
 		}
 
-		setRouteType(eCityRoute);
+		setRouteType(eCityRoute, getOwner());
 	}
 }
 
@@ -8914,8 +8771,74 @@ PlayerTypes CvPlot::GetPlayerResponsibleForImprovement() const
 /// Who pays maintenance for this Improvement?
 void CvPlot::SetPlayerResponsibleForImprovement(PlayerTypes eNewValue)
 {
-	if(GetPlayerResponsibleForImprovement() != eNewValue)
+	PlayerTypes eOldValue = GetPlayerResponsibleForImprovement();
+	if(eOldValue != eNewValue)
 	{
+		ImprovementTypes eImprovement = getImprovementType();
+		if (eImprovement != NO_IMPROVEMENT)
+		{
+			CvImprovementEntry* pkImprovementInfo = GC.getImprovementInfo(eImprovement);
+
+			if (pkImprovementInfo)
+			{
+				if (eOldValue != NO_PLAYER)
+				{
+					// Old owner no longer needs to pay maintenance
+					if (MustPayMaintenanceHere(eOldValue))
+					{
+						GET_PLAYER(eOldValue).GetTreasury()->ChangeBaseImprovementGoldMaintenance(-pkImprovementInfo->GetGoldMaintenance());
+					}
+
+#if defined(MOD_IMPROVEMENTS_EXTENSIONS)
+					if (MOD_IMPROVEMENTS_EXTENSIONS)
+					{
+						// Remember how many improvements we are responsible for (for UI)
+						GET_PLAYER(eOldValue).changeResponsibleForImprovementCount(eImprovement, -1);
+					}
+#endif
+				}
+
+				if (eNewValue != NO_PLAYER)
+				{
+					// New owner needs to pay maintenance
+					if (MustPayMaintenanceHere(eNewValue))
+					{
+						GET_PLAYER(eNewValue).GetTreasury()->ChangeBaseImprovementGoldMaintenance(pkImprovementInfo->GetGoldMaintenance());
+					}
+
+#if defined(MOD_IMPROVEMENTS_EXTENSIONS)
+					if (MOD_IMPROVEMENTS_EXTENSIONS)
+					{
+						// Remember how many improvements we are responsible for (for UI)
+						GET_PLAYER(eNewValue).changeResponsibleForImprovementCount(eImprovement, 1);
+					}
+#endif
+				}
+
+				if (MOD_IMPROVEMENTS_EXTENSIONS)
+				{
+					// Change resource quantity used
+					for (int iResourceLoop = 0; iResourceLoop < GC.getNumResourceInfos(); iResourceLoop++)
+					{
+						int iNumResource = pkImprovementInfo->GetResourceQuantityRequirement(iResourceLoop);;
+
+						if (iNumResource > 0)
+						{
+							if (eOldValue != NO_PLAYER)
+							{
+								GET_PLAYER(eOldValue).changeNumResourceUsed((ResourceTypes)iResourceLoop, -iNumResource);
+							}
+							if (eNewValue != NO_PLAYER)
+							{
+								GET_PLAYER(eNewValue).changeNumResourceUsed((ResourceTypes)iResourceLoop, iNumResource);
+							}
+						}
+					}
+				}
+			}
+		}
+
+		// Transfer responsibility
 		m_ePlayerResponsibleForImprovement = eNewValue;
 	}
 }
@@ -8931,8 +8854,74 @@ PlayerTypes CvPlot::GetPlayerResponsibleForRoute() const
 /// Who pays maintenance for this Route?
 void CvPlot::SetPlayerResponsibleForRoute(PlayerTypes eNewValue)
 {
-	if(GetPlayerResponsibleForRoute() != eNewValue)
+	PlayerTypes eOldValue = GetPlayerResponsibleForRoute();
+	if (eOldValue != eNewValue)
 	{
+		RouteTypes eRoute = getRouteType();
+		if (eRoute != NO_ROUTE)
+		{
+			CvRouteInfo* pkRouteInfo = GC.getRouteInfo(eRoute);
+
+			if (pkRouteInfo)
+			{
+				if (eOldValue != NO_PLAYER)
+				{
+					// Old owner no longer needs to pay maintenance
+					if (MustPayMaintenanceHere(eOldValue))
+					{
+						GET_PLAYER(eOldValue).GetTreasury()->ChangeBaseImprovementGoldMaintenance(-pkRouteInfo->GetGoldMaintenance());
+					}
+
+#if defined(MOD_IMPROVEMENTS_EXTENSIONS)
+					if (MOD_IMPROVEMENTS_EXTENSIONS)
+					{
+						// Remember how many routes we are responsible for (for UI)
+						GET_PLAYER(eOldValue).changeResponsibleForRouteCount(eRoute, -1);
+					}
+#endif
+				}
+
+				if (eNewValue != NO_PLAYER)
+				{
+					// New owner needs to pay maintenance
+					if (MustPayMaintenanceHere(eNewValue))
+					{
+						GET_PLAYER(eNewValue).GetTreasury()->ChangeBaseImprovementGoldMaintenance(pkRouteInfo->GetGoldMaintenance());
+					}
+
+#if defined(MOD_IMPROVEMENTS_EXTENSIONS)
+					if (MOD_IMPROVEMENTS_EXTENSIONS)
+					{
+						// Remember how many routes we are responsible for (for UI)
+						GET_PLAYER(eNewValue).changeResponsibleForRouteCount(eRoute, 1);
+					}
+#endif
+				}
+
+				if (MOD_IMPROVEMENTS_EXTENSIONS)
+				{
+					// Change resource quantity used
+					for (int iResourceLoop = 0; iResourceLoop < GC.getNumResourceInfos(); iResourceLoop++)
+					{
+						int iNumResource = pkRouteInfo->getResourceQuantityRequirement(iResourceLoop);;
+
+						if (iNumResource > 0)
+						{
+							if (eOldValue != NO_PLAYER)
+							{
+								GET_PLAYER(eOldValue).changeNumResourceUsed((ResourceTypes)iResourceLoop, -iNumResource);
+							}
+							if (eNewValue != NO_PLAYER)
+							{
+								GET_PLAYER(eNewValue).changeNumResourceUsed((ResourceTypes)iResourceLoop, iNumResource);
+							}
+						}
+					}
+				}
+			}
+		}
+
+		// Transfer responsibility
 		m_ePlayerResponsibleForRoute = eNewValue;
 	}
 }
@@ -9125,10 +9114,7 @@ void CvPlot::setPlotCity(CvCity* pNewValue)
 			if(getRouteType() != NO_ROUTE && getPlotCity()->getOwner() == getOwner())
 			{
 				// Maintenance change!
-				if(MustPayMaintenanceHere(getOwner()))
-				{
-					GET_PLAYER(getOwner()).GetTreasury()->ChangeBaseImprovementGoldMaintenance(GC.getRouteInfo(getRouteType())->GetGoldMaintenance());
-				}
+				SetPlayerResponsibleForRoute(getOwner());
 			}
 
 
@@ -9181,14 +9167,11 @@ void CvPlot::setPlotCity(CvCity* pNewValue)
 				setImprovementType(eMachuPichu);
 			}
 #endif
-			// Is a route is here?  If we already owned this plot, then we were paying maintenance, now we don't have to.
+			// Is a route is here?  If we already own this plot, then we were paying maintenance, now we don't have to.
 			if(getRouteType() != NO_ROUTE && getPlotCity()->getOwner() == getOwner())
 			{
 				// Maintenance change!
-				if(MustPayMaintenanceHere(getOwner()))
-				{
-					GET_PLAYER(getOwner()).GetTreasury()->ChangeBaseImprovementGoldMaintenance(-GC.getRouteInfo(getRouteType())->GetGoldMaintenance());
-				}
+				SetPlayerResponsibleForRoute(NO_PLAYER);
 			}
 
 		}
@@ -11915,20 +11898,6 @@ bool CvPlot::changeBuildProgress(BuildTypes eBuild, int iChange, PlayerTypes ePl
 #endif
 				}
 
-				// Unowned plot, someone has to foot the bill
-#if defined(MOD_IMPROVEMENTS_EXTENSIONS)
-				if(getOwner() == NO_PLAYER && !(MOD_IMPROVEMENTS_EXTENSIONS && GC.getImprovementInfo(eImprovement)->IsRemovesSelf()))
-#else
-				if(getOwner() == NO_PLAYER)
-#endif
-				{
-					if(MustPayMaintenanceHere(ePlayer))
-					{
-						kPlayer.GetTreasury()->ChangeBaseImprovementGoldMaintenance(GC.getImprovementInfo(eImprovement)->GetGoldMaintenance());
-					}
-					SetPlayerResponsibleForImprovement(ePlayer);
-				}
-
 				CvImprovementEntry& newImprovementEntry = *GC.getImprovementInfo(eImprovement);
 
 				// If this improvement removes the underlying resource, do that
@@ -12015,17 +11984,7 @@ bool CvPlot::changeBuildProgress(BuildTypes eBuild, int iChange, PlayerTypes ePl
 				CvRouteInfo* pkRouteInfo = GC.getRouteInfo(eRoute);
 				if(pkRouteInfo)
 				{
-					setRouteType(eRoute);
-
-					// Unowned plot, someone has to foot the bill
-					if(getOwner() == NO_PLAYER)
-					{
-						if(MustPayMaintenanceHere(ePlayer))
-						{
-							kPlayer.GetTreasury()->ChangeBaseImprovementGoldMaintenance(pkRouteInfo->GetGoldMaintenance());
-						}
-						SetPlayerResponsibleForRoute(ePlayer);
-					}
+					setRouteType(eRoute, ePlayer);
 				}
 			}
 
@@ -12067,7 +12026,7 @@ bool CvPlot::changeBuildProgress(BuildTypes eBuild, int iChange, PlayerTypes ePl
 
 			if(pkBuildInfo->IsRemoveRoute())
 			{
-				setRouteType(NO_ROUTE);
+				setRouteType(NO_ROUTE, ePlayer);
 			}
 
 			bFinished = true;

--- a/CvGameCoreDLL_Expansion2/CvPlot.h
+++ b/CvGameCoreDLL_Expansion2/CvPlot.h
@@ -610,7 +610,7 @@ public:
 	void SetWorldAnchor(GenericWorldAnchorTypes eAnchor, int iData1 = -1);
 
 	RouteTypes getRouteType() const;
-	void setRouteType(RouteTypes eNewValue);
+	void setRouteType(RouteTypes eNewValue, PlayerTypes eBuilder = NO_PLAYER);
 	void updateCityRoute();
 
 	bool IsRoutePillaged() const;

--- a/CvGameCoreDLL_Expansion2/CvTradeClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTradeClasses.cpp
@@ -2033,12 +2033,7 @@ bool CvGameTrade::StepUnit (int iIndex)
 					CvRouteInfo* pkRouteInfo = GC.getRouteInfo(autoBuildRoadType);
 					if (pkRouteInfo)
 					{
-						pPlot->setRouteType(autoBuildRoadType);
-						// Unowned plot, someone has to foot the bill
-						if (pPlot->getOwner() == NO_PLAYER)
-						{
-							pPlot->SetPlayerResponsibleForRoute(kTradeConnection.m_eOriginOwner);
-						}
+						pPlot->setRouteType(autoBuildRoadType, kTradeConnection.m_eOriginOwner);
 					}
 				}
 			}

--- a/CvGameCoreDLL_Expansion2/CvWorldBuilderMapLoader.cpp
+++ b/CvGameCoreDLL_Expansion2/CvWorldBuilderMapLoader.cpp
@@ -1209,22 +1209,6 @@ bool CvWorldBuilderMapLoader::InitMap()
 				eRoute = ROUTE_RAILROAD;
 
 			pkPlot->setRouteType(eRoute);
-
-			const PlayerTypes eOwner = GetPlayerType(kPlotData.m_byRouteOwner);
-			if(eOwner != NO_PLAYER && !pkPlot->isOwned())
-			{
-				// Mark the player as responsible for this route and update the treasury
-				CvTreasury* pkTreasury = GET_PLAYER(eOwner).GetTreasury();
-				const CvRouteInfo* pkRouteInfo = GC.getRouteInfo(eRoute);
-				if(pkTreasury != NULL && pkRouteInfo != NULL)
-				{
-					if(pkPlot->MustPayMaintenanceHere(eOwner))
-					{
-						pkTreasury->ChangeBaseImprovementGoldMaintenance(pkRouteInfo->GetGoldMaintenance());
-					}
-					pkPlot->SetPlayerResponsibleForRoute(eOwner);
-				}
-			}
 		}
 
 		const CvWorldBuilderMap::City* pkCity = sg_kSave.m_kCities[kPlotData.m_hCity];

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaGame.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaGame.cpp
@@ -303,6 +303,11 @@ void CvLuaGame::RegisterMembers(lua_State* L)
 	Method(GetNumResourceRequiredForUnit);
 	Method(GetNumResourceRequiredForBuilding);
 
+#if defined(MOD_IMPROVEMENTS_EXTENSIONS)
+	Method(GetNumResourceRequiredForImprovement);
+	Method(GetNumResourceRequiredForRoute);
+#endif
+
 	Method(IsCombatWarned);
 	Method(SetCombatWarned);
 
@@ -2082,6 +2087,45 @@ int CvLuaGame::lGetNumResourceRequiredForBuilding(lua_State* L)
 	lua_pushinteger(L, iNumNeeded);
 	return 1;
 }
+
+#if defined(MOD_IMPROVEMENTS_EXTENSIONS)
+//------------------------------------------------------------------------------
+int CvLuaGame::lGetNumResourceRequiredForImprovement(lua_State* L)
+{
+	const ImprovementTypes eImprovement = (ImprovementTypes)luaL_checkint(L, 1);
+	const ResourceTypes eResource = (ResourceTypes)luaL_checkint(L, 2);
+
+	CvImprovementEntry* pkImprovementInfo = GC.getImprovementInfo(eImprovement);
+	CvResourceInfo* pkResourceInfo = GC.getResourceInfo(eResource);
+
+	int iNumNeeded = 0;
+	if (pkImprovementInfo && pkResourceInfo)
+	{
+		iNumNeeded = pkImprovementInfo->GetResourceQuantityRequirement((int)eResource);
+	}
+
+	lua_pushinteger(L, iNumNeeded);
+	return 1;
+}
+//------------------------------------------------------------------------------
+int CvLuaGame::lGetNumResourceRequiredForRoute(lua_State* L)
+{
+	const RouteTypes eRoute = (RouteTypes)luaL_checkint(L, 1);
+	const ResourceTypes eResource = (ResourceTypes)luaL_checkint(L, 2);
+
+	CvRouteInfo* pkRouteInfo = GC.getRouteInfo(eRoute);
+	CvResourceInfo* pkResourceInfo = GC.getResourceInfo(eResource);
+
+	int iNumNeeded = 0;
+	if (pkRouteInfo && pkResourceInfo)
+	{
+		iNumNeeded = pkRouteInfo->getResourceQuantityRequirement((int)eResource);
+	}
+
+	lua_pushinteger(L, iNumNeeded);
+	return 1;
+}
+#endif
 
 //------------------------------------------------------------------------------
 int CvLuaGame::lIsCombatWarned(lua_State* L)

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaGame.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaGame.h
@@ -290,6 +290,11 @@ protected:
 	static int lGetNumResourceRequiredForUnit(lua_State* L);
 	static int lGetNumResourceRequiredForBuilding(lua_State* L);
 
+#if defined(MOD_IMPROVEMENTS_EXTENSIONS)
+	static int lGetNumResourceRequiredForImprovement(lua_State* L);
+	static int lGetNumResourceRequiredForRoute(lua_State* L);
+#endif
+
 	static int lIsCombatWarned(lua_State* L);
 	static int lSetCombatWarned(lua_State* L);
 

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
@@ -1477,6 +1477,10 @@ void CvLuaPlayer::PushMethods(lua_State* L, int t)
 	Method(CountAllTerrain);
 	Method(CountAllWorkedTerrain);
 #endif
+#if defined(MOD_IMPROVEMENTS_EXTENSIONS)
+	Method(GetResponsibleForRouteCount);
+	Method(GetResponsibleForImprovementCount);
+#endif
 #if defined(MOD_BALANCE_CORE)
 	Method(DoInstantYield);
 	Method(GetInstantYieldHistoryTooltip);
@@ -15839,6 +15843,26 @@ LUAAPIIMPL(Player, CountAllResource)
 LUAAPIIMPL(Player, CountAllWorkedResource)
 LUAAPIIMPL(Player, CountAllTerrain)
 LUAAPIIMPL(Player, CountAllWorkedTerrain)
+#endif
+#if defined(MOD_IMPROVEMENTS_EXTENSIONS)
+//-------------------------------------------------------------------------
+int CvLuaPlayer::lGetResponsibleForRouteCount(lua_State* L)
+{
+	CvPlayerAI* pkPlayer = GetInstance(L);
+	const RouteTypes eRoute = (RouteTypes)lua_tointeger(L, 2);
+	const int iResult = pkPlayer->getResponsibleForRouteCount(eRoute);
+	lua_pushinteger(L, iResult);
+	return 1;
+}
+//-------------------------------------------------------------------------
+int CvLuaPlayer::lGetResponsibleForImprovementCount(lua_State* L)
+{
+	CvPlayerAI* pkPlayer = GetInstance(L);
+	const ImprovementTypes eImprovement = (ImprovementTypes)lua_tointeger(L, 2);
+	const int iResult = pkPlayer->getResponsibleForImprovementCount(eImprovement);
+	lua_pushinteger(L, iResult);
+	return 1;
+}
 #endif
 #if defined(MOD_BALANCE_CORE)
 //-------------------------------------------------------------------------

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.h
@@ -1472,6 +1472,10 @@ protected:
 	LUAAPIEXTN(CountAllTerrain, int, iTerrainType);
 	LUAAPIEXTN(CountAllWorkedTerrain, int, iTerrainType);
 #endif
+#if defined(MOD_IMPROVEMENTS_EXTENSIONS)
+	static int lGetResponsibleForRouteCount(lua_State* L);
+	static int lGetResponsibleForImprovementCount(lua_State* L);
+#endif
 #if defined(MOD_BALANCE_CORE)
 	static int lDoInstantYield(lua_State* L);
 	static int lGetInstantYieldHistoryTooltip(lua_State* L);

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.cpp
@@ -203,6 +203,11 @@ void CvLuaUnit::PushMethods(lua_State* L, int t)
 	Method(CanBuildRoute);
 	Method(GetBuildType);
 	Method(WorkRate);
+
+#if defined(MOD_API_LUA_EXTENSIONS)
+	Method(GetImprovementBuildType);
+	Method(GetRouteBuildType);
+#endif
 #if defined(MOD_CIV6_WORKER)
 	Method(GetBuilderStrength);
 #endif
@@ -2419,6 +2424,40 @@ int CvLuaUnit::lWorkRate(lua_State* L)
 	lua_pushinteger(L, iResult);
 	return 1;
 }
+#if defined(MOD_API_LUA_EXTENSIONS)
+//------------------------------------------------------------------------------
+int CvLuaUnit::lGetImprovementBuildType(lua_State* L)
+{
+	CvUnit* pkUnit = GetInstance(L);
+	const BuildTypes eBuild = pkUnit->getBuildType();
+	const CvBuildInfo* pBuild = GC.getBuildInfo(eBuild);
+	int iImprovement = (int)NO_IMPROVEMENT;
+	if (pBuild)
+	{
+		iImprovement = pBuild->getImprovement();
+	}
+
+
+	lua_pushinteger(L, iImprovement);
+	return 1;
+}
+//------------------------------------------------------------------------------
+int CvLuaUnit::lGetRouteBuildType(lua_State* L)
+{
+	CvUnit* pkUnit = GetInstance(L);
+	const BuildTypes eBuild = pkUnit->getBuildType();
+	const CvBuildInfo* pBuild = GC.getBuildInfo(eBuild);
+	int iRoute = (int)NO_ROUTE;
+	if (pBuild)
+	{
+		iRoute = pBuild->getRoute();
+	}
+
+
+	lua_pushinteger(L, iRoute);
+	return 1;
+}
+#endif
 #if defined(MOD_CIV6_WORKER)
 //------------------------------------------------------------------------------
 //int getBuilderStrength();

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.h
@@ -208,6 +208,11 @@ protected:
 	static int lGetBuildType(lua_State* L);
 	static int lWorkRate(lua_State* L);
 
+#if defined(MOD_API_LUA_EXTENSIONS)
+	static int lGetImprovementBuildType(lua_State* L);
+	static int lGetRouteBuildType(lua_State* L);
+#endif
+
 #if defined(MOD_CIV6_WORKER)
 	static int lGetBuilderStrength(lua_State* L);
 #endif

--- a/EUI Compatibility Files/EUI Compatibility Files/LUA/TopPanel.lua
+++ b/EUI Compatibility Files/EUI Compatibility Files/LUA/TopPanel.lua
@@ -2430,6 +2430,100 @@ local function ResourcesToolTip( control )
 					end
 				end
 			end
+			for improvement in GameInfo.Improvements() do
+				local improvementID = improvement.ID
+				local numResource = Game.GetNumResourceRequiredForImprovement(improvementID, resourceID)
+				if numResource > 0 then
+					-- how many improvements are the player responsible for
+					local numExisting = g_activePlayer:GetResponsibleForImprovementCount(improvementID)
+					-- how many improvements is the player currently building
+					local numBuilds = 0
+					for unit in g_activePlayer:Units() do
+						if unit:IsWork() then
+							local improvementBuildingID = unit:GetImprovementBuildType()
+							if improvementBuildingID == improvementID then
+								numBuilds = numBuilds + 1
+							end
+						end
+					end
+					-- can player build this improvement someday ?
+					local canBuildSomeday = true
+					if ( civ5_mode and improvement.ObsoleteTech and g_activeTeamTechs:HasTech( GameInfoTypes[improvement.ObsoleteTech] ) ) then
+						canBuildSomeday = false
+					end
+					if (improvement.CivilizationType and GameInfoTypes[improvement.CivilizationType] ~= g_activeCivilization) then
+						canBuildSomeday = false
+					end
+					if canBuildSomeday or numExisting > 0 or numBuilds > 0 then
+						local totalResource = (numExisting + numBuilds) * numResource
+						local tip = L( improvement.Description )
+						if canBuildSomeday then
+							local tech
+							for build in GameInfo.Builds() do
+								if build.ImprovementType then
+									if improvementID == GameInfoTypes[build.ImprovementType] then
+										if build.PrereqTech then
+											tech = GameInfo.Technologies[ build.PrereqTech ]
+										end
+										break
+									end
+								end
+							end
+							if tech and not g_activeTeamTechs:HasTech( tech.ID ) then
+								tip = S( "%s [COLOR_CYAN]%s[ENDCOLOR]", tip, L(tech.Description) )
+							end
+						end
+						if totalResource > 0 then
+							tipIndex = tipIndex+1
+							tips:insert( tipIndex, "[ICON_BULLET]" .. totalResource .. resource.IconString .. " = " ..  numExisting .. " (+" .. numBuilds .. ") " .. tip )
+						else
+							tips:insert( "[ICON_BULLET] (" .. numResource .. "/" .. tip .. ")" )
+						end
+					end
+				end
+			end
+			for route in GameInfo.Routes() do
+				local routeID = route.ID
+				local numResource = Game.GetNumResourceRequiredForRoute(routeID, resourceID)
+				if numResource > 0 then
+					-- how many routes is the player responsible for
+					local numExisting = g_activePlayer:GetResponsibleForRouteCount(routeID)
+					-- how many improvements is the player currently building
+					local numBuilds = 0
+					for unit in g_activePlayer:Units() do
+						if unit:IsWork() then
+							local routeBuildingID = unit:GetRouteBuildType()
+							if routeBuildingID == routeID then
+								numBuilds = numBuilds + 1
+							end
+						end
+					end
+					if numExisting > 0 or numBuilds > 0 then
+						local totalResource = (numExisting + numBuilds) * numResource
+						local tip = L( route.Description )
+						local tech
+						for build in GameInfo.Builds() do
+							if build.RouteType then
+								if routeID == GameInfoTypes[build.RouteType] then
+									if build.PrereqTech then
+										tech = GameInfo.Technologies[ build.PrereqTech ]
+									end
+									break
+								end
+							end
+						end
+						if tech and not g_activeTeamTechs:HasTech( tech.ID ) then
+							tip = S( "%s [COLOR_CYAN]%s[ENDCOLOR]", tip, L(tech.Description) )
+						end
+						if totalResource > 0 then
+							tipIndex = tipIndex+1
+							tips:insert( tipIndex, "[ICON_BULLET]" .. totalResource .. resource.IconString .. " = " ..  numExisting .. " (+" .. numBuilds .. ") " .. tip )
+						else
+							tips:insert( "[ICON_BULLET] (" .. numResource .. "/" .. tip .. ")" )
+						end
+					end
+				end
+			end
 		end
 	end
 

--- a/EUI Compatibility Files/EUI Compatibility Files/LUA/UnitPanel.lua
+++ b/EUI Compatibility Files/EUI Compatibility Files/LUA/UnitPanel.lua
@@ -579,11 +579,30 @@ local function UnitToolTip( unit, ... )
 		for row in GameInfo.Unit_Builds( thisUnitType ) do
 			local build = row.BuildType and GameInfo.Builds[row.BuildType]
 			if build then
+				local isAvailable = true
 				local buildImprovement = build.ImprovementType and GameInfo.Improvements[ build.ImprovementType ]
+				local buildRoute = build.RouteType and GameInfo.Routes[ build.RouteType ]
 				local requiredCivilizationType = buildImprovement and buildImprovement.CivilizationType
 				if not requiredCivilizationType or GameInfoTypes[ requiredCivilizationType ] == g_activePlayer:GetCivilizationType() then
+					-- technology check
 					local prereqTech = build.PrereqTech and GameInfo.Technologies[build.PrereqTech]
-					tips:insertIf( (not prereqTech or g_activeTechs:HasTech( prereqTech.ID or -1 ) ) and "[ICON_BULLET]" .. L(build.Description) )
+					if prereqTech and not g_activeTechs:HasTech(prereqTech.ID) then
+						isAvailable = false
+					end
+					-- resource check
+					if buildImprovement or buildRoute then
+						for resource in GameInfo.Resources() do
+							local resourceID = resource.ID
+							if buildImprovement and Game.GetNumResourceRequiredForImprovement(GameInfoTypes[buildImprovement], resourceID) > 0 and g_activePlayer:GetNumResourceAvailable( resourceID, true ) <= 0 then
+								isAvailable = false
+							elseif buildRoute and Game.GetNumResourceRequiredForRoute(GameInfoTypes[buildRoute], resourceID) and g_activePlayer:GetNumResourceAvailable( resourceID, true ) <= 0 then
+								isAvailable = false
+							end
+						end
+					end
+					if isAvailable then
+						tips:insert( "[ICON_BULLET]" .. L(build.Description) )
+					end
 				end
 			end
 		end
@@ -1505,6 +1524,7 @@ function ActionToolTipHandler( control )
 
 	-- Route data
 	local route = build and build.RouteType and build.RouteType ~= "NONE" and GameInfo.Routes[build.RouteType]
+	local routeID = route and route.ID or -1
 
 	local strBuildTurnsString = ""
 	local toolTip = table()
@@ -1794,6 +1814,22 @@ function ActionToolTipHandler( control )
 					disabledTip:insertLocalized( "TXT_KEY_BUILD_BLOCKED_BY_FEATURE", pFeatureTech.Description, feature.Description )
 				end
 
+			end
+
+			-- Insufficient resource count?
+			if improvement or route then
+				for resource in GameInfo.Resources() do
+					local resourceID = resource.ID
+					local numResource = 0
+					if improvement then
+						numResource = Game.GetNumResourceRequiredForImprovement(improvementID, resourceID)
+					elseif route then
+						numResource = Game.GetNumResourceRequiredForRoute(routeID, resourceID)
+					end
+					if numResource > 0 and g_activePlayer:GetNumResourceAvailable( resourceID, true ) <= 0 then
+						disabledTip:insertLocalized( "TXT_KEY_BUILD_BLOCKED_RESOURCE_REQUIRED", numResource, resource.IconString, resource.Description, strImpRouteKey )
+					end
+				end
 			end
 
 		-- Not a Worker build, use normal disabled help from XML

--- a/NoEUI Compatibility Files/Mod Template1/LUA/UnitPanel.lua
+++ b/NoEUI Compatibility Files/Mod Template1/LUA/UnitPanel.lua
@@ -1560,6 +1560,23 @@ function TipHandler( control )
 				strDisabledString = strDisabledString .. "[NEWLINE]";
 				strDisabledString = strDisabledString .. Locale.ConvertTextKey("TXT_KEY_BUILD_BLOCKED_BY_FEATURE", pFeatureTech.Description, pFeature.Description);
 			end
+
+			-- Insufficient resource count?
+			if pImprovement or pRoute then
+				for resource in GameInfo.Resources() do
+					local iResource = resource.ID;
+					local iNumResource = 0;
+					if pImprovement then
+						iNumResource = Game.GetNumResourceRequiredForImprovement(iImprovement, iResource);
+					elseif pRoute then
+						iNumResource = Game.GetNumResourceRequiredForRoute(iRoute, iResource);
+					end
+					if iNumResource > 0 and pActivePlayer:GetNumResourceAvailable(iResource, true) <= 0 then
+						strDisabledString = strDisabledString .. "[NEWLINE]";
+						strDisabledString = strDisabledString .. Locale.ConvertTextKey("TXT_KEY_BUILD_BLOCKED_RESOURCE_REQUIRED", iNumResource, resource.IconString, resource.Description, strImpRouteKey);
+					end
+				end
+			end
 			
 		-- Not a Worker build, use normal disabled help from XML
 		else


### PR DESCRIPTION
NOT save game compatible.

- Fixed IMPROVEMENTS_EXTENSIONS in CustomModOptions not working.
- Fixed Route_QuantityRequirements and QuantityRequirement column in Improvement_ResourceTypes not fully working (did not change resource count correctly in every case, did not check if player had enough resource before building). Requires IMPROVEMENTS_EXTENSIONS.
- Moved all route/improvement maintenance checks/changes into CvPlot::SetPlayerResponsibleForImprovement and CvPlot::SetPlayerResponsibleForPlot.
- The responsible player is now always set, instead of just when the route/improvement is built in neutral territory (memory already allocated, let's just use it).
- Total number of improvement/route a player is responsible for now cached, and can be accessed via Lua (disabled if IMPROVEMENTS_EXTENSIONS not enabled).
- Necessary UI changes to display improvement/route resource requirements.