### PR TITLE
Fixed bug where global event buildings were not being added properly

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -8955,6 +8955,7 @@ void CvPlayer::DoEventChoice(EventChoiceTypes eEventChoice, EventTypes eEvent, b
 			//Let's see if it even happens.
 			if(pkEventChoiceInfo->getEventChance() > 0)
 			{
+
 				int iRandom = GC.getGame().getJonRandNum(100, "Random Event Chance");
 				int iLimit = pkEventChoiceInfo->getEventChance();
 				if(iRandom > iLimit)
@@ -9014,6 +9015,7 @@ void CvPlayer::DoEventChoice(EventChoiceTypes eEventChoice, EventTypes eEvent, b
 			}
 			if(pkEventChoiceInfo->getEventBuilding() != -1)
 			{
+
 				BuildingClassTypes eBuildingClass = (BuildingClassTypes)pkEventChoiceInfo->getEventBuilding();
 				if(eBuildingClass != NO_BUILDINGCLASS)
 				{
@@ -9025,6 +9027,7 @@ void CvPlayer::DoEventChoice(EventChoiceTypes eEventChoice, EventTypes eEvent, b
 		
 						if (pCivilizationInfo != NULL)
 						{
+
 							BuildingTypes eBuildingType = NO_BUILDING;
 							bool bRome = GetPlayerTraits()->IsKeepConqueredBuildings();
 							if (!MOD_BUILDINGS_THOROUGH_PREREQUISITES && !bRome)
@@ -9037,6 +9040,7 @@ void CvPlayer::DoEventChoice(EventChoiceTypes eEventChoice, EventTypes eEvent, b
 								int iLoop;
 								for (CvCity* pLoopCity = firstCity(&iLoop); pLoopCity != NULL; pLoopCity = nextCity(&iLoop))
 								{
+
 									if (pkEventChoiceInfo->isCoastalOnly() && !pLoopCity->isCoastal())
 									{
 										continue;
@@ -9049,7 +9053,7 @@ void CvPlayer::DoEventChoice(EventChoiceTypes eEventChoice, EventTypes eEvent, b
 
 									if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome)
 									{
-										eBuildingType = pLoopCity->GetCityBuildings()->GetBuildingTypeFromClass(eBuildingClass);
+										eBuildingType = (BuildingTypes)pCivilizationInfo->getCivilizationBuildings(eBuildingClass);
 										if (eBuildingType == NO_BUILDING)
 										{
 											continue;


### PR DESCRIPTION
I encountered an issue with the civ specific events from engisneer, apparently the dummy buildings were not being built at all after making a choice.

Let me picture exactly how I encountered the bug:

While playing Celts, there's a civ specific choice that lets you get a promotion on melee units and also +33% great musician rate in all cities. The first part was working, but the second half wasn't. After messing around with possible culprits, I came to the conclusion that the dummy building that boosts the great musician rate by +33% was not being built when selecting that choice.
Upon inspecting the cpp files of the dll and doing some trial and error, I found out that the reason why this happened was because the type of the building that was being passed was 'NO_BUILDING' because the function that was getting the building type, was trying to do it under the assumption that a building from the same class was already present in the city, which is not the case for most dummy buildings in the E&D core.

This should at the very least fix all the civ-specific events that create dummy buildings in cities to boost stuff/yields