### PR TITLE
Border expansion fixes

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -2846,16 +2846,19 @@ void CvCity::doTurn()
 		// Following function also looks at WLTKD stuff
 		DoTestResourceDemanded();
 
+		int iBorderGrowth = 0;
+		iBorderGrowth += getJONSCulturePerTurn();
+		iBorderGrowth += getYieldRate(YIELD_CULTURE_LOCAL, false);
 		// Culture accumulation
-		if(getJONSCulturePerTurn() > 0)
+		if(iBorderGrowth > 0)
 		{
-			ChangeJONSCultureStored(getJONSCulturePerTurn());
+			ChangeJONSCultureStored(iBorderGrowth);
 #if defined(MOD_BALANCE_CORE_POLICIES)
-			ChangeJONSCultureStored(getYieldRate(YIELD_CULTURE_LOCAL, false));
-			//Doubles during Golden Age
+			// Doubles during Golden Age ???
+			// Tooltip says just during WLTKD
 			if(GET_PLAYER(getOwner()).IsDoubleBorderGA() && (GET_PLAYER(getOwner()).isGoldenAge() || (GetWeLoveTheKingDayCounter() > 0)))
 			{
-				ChangeJONSCultureStored(getJONSCulturePerTurn());
+				ChangeJONSCultureStored(iBorderGrowth);
 			}
 #endif
 		}
@@ -29135,7 +29138,7 @@ void CvCity::DoUpdateCheapestPlotInfluenceDistance()
 
 	if (!plots.empty())
 	{
-		SetCheapestPlotInfluenceDistance( calculateInfluenceDistance( GC.getMap().plotByIndex(plots.front()), getBuyPlotDistance() ) );
+		SetCheapestPlotInfluenceDistance( calculateInfluenceDistance( GC.getMap().plotByIndex(plots.front()), GC.getMAXIMUM_ACQUIRE_PLOT_DISTANCE()) );
 	}
 	else
 		SetCheapestPlotInfluenceDistance(INT_MAX);


### PR DESCRIPTION
- Extra border Growth now applies to border expansion even if culture per turn in city is 0.
- burghers (fealty) policy now also doubles the extra border growth.
- Fixed a bug where if the next best border growth tile is outside the BuyPlotDistance (3), then cost for purchasing any new tile will increase a lot.
- Left a comment about an issue where Burghers (fealty) policy doubles border growth speed during Golden ages also, though tooltip says only during WLTKD. Will make separate issue about this.