### PR TITLE
Adding GetOriginalCapitalPlot, ChangeYieldFromTraits

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -193,6 +193,7 @@ CvCity::CvCity() :
 #endif
 	, m_iJONSCulturePerTurnFromPolicies("CvCity::m_iJONSCulturePerTurnFromPolicies", m_syncArchive)
 	, m_iJONSCulturePerTurnFromSpecialists("CvCity::m_iJONSCulturePerTurnFromSpecialists", m_syncArchive)
+	, m_iaAddedYieldPerTurnFromTraits("CvCity::m_iaAddedYieldPerTurnFromTraits", m_syncArchive)
 #if !defined(MOD_API_UNIFIED_YIELDS_CONSOLIDATION)
 	, m_iJONSCulturePerTurnFromReligion("CvCity::m_iJONSCulturePerTurnFromReligion", m_syncArchive)
 #endif
@@ -1378,6 +1379,7 @@ void CvCity::reset(int iID, PlayerTypes eOwner, int iX, int iY, bool bConstructo
 #endif
 	m_iJONSCulturePerTurnFromPolicies = 0;
 	m_iJONSCulturePerTurnFromSpecialists = 0;
+	m_iaAddedYieldPerTurnFromTraits.resize(NUM_YIELD_TYPES);
 #if !defined(MOD_API_UNIFIED_YIELDS_CONSOLIDATION)
 	m_iJONSCulturePerTurnFromReligion = 0;
 #endif
@@ -18603,6 +18605,28 @@ int CvCity::GetJONSCulturePerTurnFromTraits() const
 	VALIDATE_OBJECT
 	return GET_PLAYER(m_eOwner).GetPlayerTraits()->GetCityCultureBonus();
 }
+//	--------------------------------------------------------------------------------
+void CvCity::ChangeYieldFromTraits(YieldTypes eIndex, int iChange)
+{
+	VALIDATE_OBJECT
+		CvAssertMsg(eIndex >= 0, "eIndex expected to be >= 0");
+	CvAssertMsg(eIndex < NUM_YIELD_TYPES, "eIndex expected to be < NUM_YIELD_TYPES");
+
+	if (iChange != 0)
+	{
+		m_iaAddedYieldPerTurnFromTraits.setAt(eIndex, m_iaAddedYieldPerTurnFromTraits[eIndex] + iChange);
+
+		if (getTeam() == GC.getGame().getActiveTeam())
+		{
+			if (isCitySelected())
+			{
+				DLLUI->setDirty(CityScreen_DIRTY_BIT, true);
+				//DLLUI->setDirty(InfoPane_DIRTY_BIT, true );
+			}
+		}
+	}
+}
+
 #if defined(MOD_BALANCE_CORE)
 //	--------------------------------------------------------------------------------
 int CvCity::GetYieldPerTurnFromTraits(YieldTypes eYield) const
@@ -18664,7 +18688,7 @@ int CvCity::GetYieldPerTurnFromTraits(YieldTypes eYield) const
 	}
 #endif
 
-	return iYield;
+	return (iYield + m_iaAddedYieldPerTurnFromTraits[eYield]);
 }
 #endif
 //	--------------------------------------------------------------------------------

--- a/CvGameCoreDLL_Expansion2/CvCity.h
+++ b/CvGameCoreDLL_Expansion2/CvCity.h
@@ -673,6 +673,7 @@ public:
 	int GetJONSCulturePerTurnFromGreatWorks() const;
 
 	int GetJONSCulturePerTurnFromTraits() const;
+	void ChangeYieldFromTraits(YieldTypes eIndex, int iChange);
 #if defined(MOD_BALANCE_CORE)
 	int GetYieldPerTurnFromTraits(YieldTypes eYield) const;
 #endif
@@ -1810,6 +1811,7 @@ protected:
 #endif
 	FAutoVariable<int, CvCity> m_iJONSCulturePerTurnFromPolicies;
 	FAutoVariable<int, CvCity> m_iJONSCulturePerTurnFromSpecialists;
+	FAutoVariable<std::vector<int>, CvCity> m_iaAddedYieldPerTurnFromTraits;
 #if !defined(MOD_API_UNIFIED_YIELDS_CONSOLIDATION)
 	FAutoVariable<int, CvCity> m_iJONSCulturePerTurnFromReligion;
 #endif

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaCity.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaCity.cpp
@@ -275,6 +275,7 @@ void CvLuaCity::PushMethods(lua_State* L, int t)
 	Method(ChangeJONSCulturePerTurnFromSpecialists);
 	Method(GetJONSCulturePerTurnFromGreatWorks);
 	Method(GetJONSCulturePerTurnFromTraits);
+	Method(ChangeYieldFromTraits);
 #if defined(MOD_BALANCE_CORE)
 	Method(GetYieldPerTurnFromTraits);
 	Method(GetYieldFromUnitsInCity);
@@ -3098,6 +3099,11 @@ int CvLuaCity::lGetJONSCulturePerTurnFromGreatWorks(lua_State* L)
 int CvLuaCity::lGetJONSCulturePerTurnFromTraits(lua_State* L)
 {
 	return BasicLuaMethod(L, &CvCity::GetJONSCulturePerTurnFromTraits);
+}
+//void ChangeYieldFromTraits(YieldTypes eIndex, int iChange);
+int CvLuaCity::lChangeYieldFromTraits(lua_State* L)
+{
+	return BasicLuaMethod(L, &CvCity::ChangeYieldFromTraits);
 }
 #if defined(MOD_BALANCE_CORE)
 //------------------------------------------------------------------------------

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaCity.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaCity.h
@@ -269,6 +269,7 @@ protected:
 	static int lChangeJONSCulturePerTurnFromSpecialists(lua_State* L);
 	static int lGetJONSCulturePerTurnFromGreatWorks(lua_State* L);
 	static int lGetJONSCulturePerTurnFromTraits(lua_State* L);
+	static int lChangeYieldFromTraits(lua_State* L);
 #if defined(MOD_BALANCE_CORE)
 	static int lGetYieldPerTurnFromTraits(lua_State* L);
 	static int lGetYieldFromUnitsInCity(lua_State* L);

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
@@ -281,6 +281,7 @@ void CvLuaPlayer::PushMethods(lua_State* L, int t)
 	Method(SetCapitalCity);
 	Method(SetOriginalCapitalXY);
 	Method(GetNumWonders);
+	Method(GetOriginalCapitalPlot);
 #endif
 #if defined(MOD_API_LUA_EXTENSIONS) && defined(MOD_BALANCE_CORE_POLICIES)
 	Method(GetNoUnhappinessExpansion);
@@ -3182,6 +3183,15 @@ int CvLuaPlayer::lGetNumWonders(lua_State* L)
 	
 	const int iResult = pkPlayer->GetNumWonders();
 	lua_pushinteger(L, iResult);
+	return 1;
+}
+//------------------------------------------------------------------------------
+int CvLuaPlayer::lGetOriginalCapitalPlot(lua_State* L)
+{
+	CvPlayerAI* pkPlayer = GetInstance(L);
+
+	CvPlot *pOriginalCapitalPlot = GC.getMap().plot(pkPlayer->GetOriginalCapitalX(), pkPlayer->GetOriginalCapitalY());
+	CvLuaPlot::Push(L, pOriginalCapitalPlot);
 	return 1;
 }
 #endif

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.h
@@ -266,6 +266,7 @@ protected:
 	LUAAPIEXTN(SetCapitalCity, void);
 	LUAAPIEXTN(SetOriginalCapitalXY, void);
 	LUAAPIEXTN(GetNumWonders, int);
+	LUAAPIEXTN(GetOriginalCapitalPlot, int);
 #endif
 #if defined(MOD_API_LUA_EXTENSIONS) && defined(MOD_BALANCE_CORE_POLICIES)
 	LUAAPIEXTN(GetNoUnhappinessExpansion, int);


### PR DESCRIPTION
I've made a function `city:ChangeYieldFromTraits(eYield, iChange)`, both for lua and DLL.
Like the name says, it gives the yield but it shows as up as coming from the trait.

I've made a lua function `player:GetOriginalCapitalPlot()`
Obviously returns the plot of the player's original capital.

Tested both and it looks like they work.