### PR TITLE
April fixes

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvVotingClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvVotingClasses.cpp
@@ -11594,7 +11594,7 @@ int CvLeagueAI::ScoreVoteChoiceYesNo(CvProposal* pProposal, int iChoice, bool bE
 		{
 			if (bCanGold)
 			{
-				int iOurSeaMight = GetPlayer()->GetMilitarySeaMight();
+				int iOurSeaMight = GetPlayer()->GetMilitaryMight();
 				int iHighestSeaMight = 0;
 				for (int i = 0; i < MAX_MAJOR_CIVS; i++)
 				{
@@ -11602,7 +11602,7 @@ int CvLeagueAI::ScoreVoteChoiceYesNo(CvProposal* pProposal, int iChoice, bool bE
 					if (GET_PLAYER(e).isAlive() && !GET_PLAYER(e).isMinorCiv())
 					{
 						iAliveCivs++;
-						int iSeaMight = GET_PLAYER(e).GetMilitarySeaMight();
+						int iSeaMight = GET_PLAYER(e).GetMilitaryMight();
 						if (iSeaMight > iHighestSeaMight)
 						{
 							iHighestSeaMight = iSeaMight;
@@ -11610,7 +11610,7 @@ int CvLeagueAI::ScoreVoteChoiceYesNo(CvProposal* pProposal, int iChoice, bool bE
 					}
 				}
 				int iSeaMightPercent = (iOurSeaMight * 100) / max(1,iHighestSeaMight);
-				iExtra += (iPercentofWinning * iSeaMightPercent) / 7;
+				iExtra += (iPercentofWinning * iSeaMightPercent) / 8;
 				iExtra += iPercentofWinning * 3;
 			}
 			if (bCanSilver)
@@ -11647,7 +11647,7 @@ int CvLeagueAI::ScoreVoteChoiceYesNo(CvProposal* pProposal, int iChoice, bool bE
 			if (bCanSilver)
 			{
 				iExtra += 100;
-				int iOurMilitaryMight = GetPlayer()->GetMilitarySeaMight();
+				int iOurMilitaryMight = GetPlayer()->GetMilitaryMight();
 				int iHighestMilitaryMight = 0;
 				for (int i = 0; i < MAX_MAJOR_CIVS; i++)
 				{
@@ -11655,7 +11655,7 @@ int CvLeagueAI::ScoreVoteChoiceYesNo(CvProposal* pProposal, int iChoice, bool bE
 					if (GET_PLAYER(e).isAlive() && !GET_PLAYER(e).isMinorCiv())
 					{
 						iAliveCivs++;
-						int iMilitaryMight = GET_PLAYER(e).GetMilitarySeaMight();
+						int iMilitaryMight = GET_PLAYER(e).GetMilitaryMight();
 						if (iMilitaryMight > iHighestMilitaryMight)
 						{
 							iHighestMilitaryMight = iMilitaryMight;

--- a/CvGameCoreDLL_Expansion2/CvVotingClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvVotingClasses.h
@@ -952,7 +952,7 @@ private:
 	void FindBestVoteChoices(CvRepealProposal* pProposal, VoteConsiderationList& considerations);
 	int ScoreVoteChoice(CvEnactProposal* pProposal, int iChoice, bool bConsiderGlobal = false);
 	int ScoreVoteChoice(CvRepealProposal* pProposal, int iChoice, bool bConsiderGlobal = false);
-	int ScoreVoteChoiceYesNo(CvProposal* pProposal, int iChoice, bool bEnact, bool bConsiderGlobal);
+	int ScoreVoteChoiceYesNo(CvProposal* pProposal, int iChoice, bool bEnact, bool bConsiderGlobal, bool bForSelf = true);
 	int ScoreVoteChoicePlayer(CvProposal* pProposal, int iChoice, bool bEnact);
 
 	// Proposing


### PR DESCRIPTION
- Vote trading for Diplo Victory now allowed again. Tbh the whole trading vote system is a bit flawed because it considers choices individually rather than comparing to others. (You wouldn't trade a vote cheaply for something you kinda wanted if you really really wanted something else) This should work for now though.

- Not sure if this was the case before but you can also see how much a civ would want to vote for all the other civs so you can figure out who they are likely to vote for