### PR TITLE
tag resources as strategic if they are referenced in Building_ResourceQuantityRequirements

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvDllDatabaseUtility.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDllDatabaseUtility.cpp
@@ -239,11 +239,11 @@ bool CvDllDatabaseUtility::PerformDatabasePostProcessing()
 	}
 
 	// ** Modify ResourceUsage of Resources table **
-	// Set ResourceUsage to 1 if it's referenced in Unit_ResourceQuantityRequirements
+	// Set ResourceUsage to 1 if it's referenced in Unit_ResourceQuantityRequirements or Building_ResourceQuantityRequirements
 	// NOTE: This query could be simplified using the IN operator but when analyzed this
 	//			statement generates faster operations.
 	const char* szStrategicResource
-	    = "UPDATE Resources SET ResourceUsage = 1 WHERE EXISTS (SELECT * FROM Unit_ResourceQuantityRequirements WHERE ResourceType = Type)";
+	    = "UPDATE Resources SET ResourceUsage = 1 WHERE EXISTS (SELECT * FROM Unit_ResourceQuantityRequirements WHERE ResourceType = Type) OR EXISTS (SELECT * FROM Building_ResourceQuantityRequirements WHERE ResourceType = Type)";
 	db->Execute(szStrategicResource);
 
 	// Set ResourceUsage to 2 if the Resource has a happiness value greater than 0


### PR DESCRIPTION
Rationale - In vanilla Civ5 all strategic resources are required to build at least one unit, thus checking if a resource is referenced in Unit_ResourceQuantityRequirements is sufficient to find all strategic resources. However in the CBO, coal is not required to build any units (only buildings).

The result of this is that coal ends up being classified as a bonus resource instead of a strategic resource which prevents it from showing up in the top panel and prevents it from being traded between nations.

Fixes #7266