### PR TITLE
fix incorrect passing of CvPlayerAI instance in place of PlayerTypes index

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -6071,7 +6071,7 @@ bool CvUnit::canGift(bool bTestVisible, bool bTestTransport) const
 
 	if (MOD_EVENTS_MINORS_INTERACTION)
 	{
-		if (GAMEEVENTINVOKE_TESTALL(GAMEEVENT_PlayerCanGiftUnit, getOwner(), GET_PLAYER(pPlot->getOwner()), GetID()) == GAMEEVENTRETURN_FALSE)
+		if (GAMEEVENTINVOKE_TESTALL(GAMEEVENT_PlayerCanGiftUnit, getOwner(), pPlot->getOwner(), GetID()) == GAMEEVENTRETURN_FALSE)
 		{
 			return false;
 		}


### PR DESCRIPTION
GAMEEVENT_PlayerCanGiftUnit expects 3 int sized arguments but is being passed a CvPlayerAI object instance as the second argument.