### PR TITLE
Misc 14/05/21

### DIFF
--- a/Community Patch/Core Files/Core Tables/CoreTableEntries.sql
+++ b/Community Patch/Core Files/Core Tables/CoreTableEntries.sql
@@ -158,7 +158,7 @@ ALTER TABLE Traits ADD COLUMN 'IsNoReligiousStrife' BOOLEAN DEFAULT 0;
 
 ALTER TABLE Traits ADD COLUMN 'WonderProductionModGA' INTEGER DEFAULT 0;
 
--- TRAIT: Changes the food consumed by each non-specialist citizen. --
+-- TRAIT: Changes the food (times 100) consumed by each non-specialist citizen. --
 ALTER TABLE Traits ADD COLUMN 'NonSpecialistFoodChange' INTEGER DEFAULT 0;
 
 -- Abnormal scaler. Works for:

--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -2785,7 +2785,7 @@ void CvCity::doTurn()
 		bool bAllowNoProduction = !doCheckProduction();
 #if defined(MOD_BALANCE_CORE)
 		bool bWeGrew = false;
-		int iDifference = (getYieldRateTimes100(YIELD_FOOD, false) - foodConsumption() * 100);
+		int iDifference = (getYieldRateTimes100(YIELD_FOOD, false) - foodConsumptionTimes100());
 		if(isFoodProduction() || getFood() <= 5 || iDifference <= 0)
 		{
 			doGrowth();
@@ -7585,7 +7585,7 @@ void CvCity::updateEconomicValue()
 	//- economic value is in gold, so use a rough conversion factor for the others
 	//- for food and gold only surplus is interesting, rest is converted to other yields already
 	//- ignore trade, as the city might the change owner
-	iYieldValue += (getYieldRateTimes100(YIELD_FOOD, true) - foodConsumption() * 100) * 3;
+	iYieldValue += (getYieldRateTimes100(YIELD_FOOD, true) - foodConsumptionTimes100()) * 3;
 	iYieldValue += getYieldRateTimes100(YIELD_PRODUCTION, true) * 4;
 	iYieldValue += getYieldRateTimes100(YIELD_SCIENCE, true) * 3;
 	iYieldValue += (getYieldRateTimes100(YIELD_GOLD, true) - GetCityBuildings()->GetTotalBaseBuildingMaintenance() * 100) * 1;
@@ -8584,7 +8584,7 @@ bool CvCity::canTrain(UnitTypes eUnit, bool bContinue, bool bTestVisible, bool b
 {
 	VALIDATE_OBJECT
 	//no units in puppets except venice
-	if(eUnit == NO_UNIT || CityStrategyAIHelpers::IsTestCityStrategy_IsPuppetAndAnnexable(this))
+	if(eUnit == NO_UNIT)
 	{
 		return false;
 	}
@@ -8878,29 +8878,6 @@ bool CvCity::canConstruct(BuildingTypes eBuilding, bool bContinue, bool bTestVis
 	{
 		return false;
 	}
-
-#if defined(MOD_BALANCE_CORE_PUPPETS_LIMITED_BUILDINGS)
-	//puppets will only build very few buildings
-	if (CityStrategyAIHelpers::IsTestCityStrategy_IsPuppetAndAnnexable(this))
-	{
-		//too new? not ok
-		if (pkBuildingInfo->GetEra() > GET_PLAYER(getOwner()).GetCurrentEra() - 1)
-			return false;
-
-		//no defensive value? not ok
-		if (pkBuildingInfo->GetDefenseModifier() == 0)
-		{
-			/*
-			//option: disallow everything that costs maintenance if we are running a deficit
-			static EconomicAIStrategyTypes eStrategyLosingMoney = (EconomicAIStrategyTypes)GC.getInfoTypeForString("ECONOMICAISTRATEGY_LOSING_MONEY", true);
-			if (pkBuildingInfo->GetGoldMaintenance() > 0 && GET_PLAYER(m_eOwner).GetEconomicAI()->IsUsingStrategy(eStrategyLosingMoney))
-				return false;
-			*/
-
-			return false;
-		}
-	}
-#endif
 
 #if defined(MOD_BALANCE_CORE_BELIEFS)
 	// Religion-enabled national wonder
@@ -13552,7 +13529,11 @@ int CvCity::getProductionDifference(int /*iProductionNeeded*/, int /*iProduction
 		return 0;
 	}
 
+#if defined(MOD_BALANCE_CORE)
+	int iFoodProduction = ((bFoodProduction) ? (GetFoodProductionTimes100(getYieldRateTimes100(YIELD_FOOD, false) - foodConsumptionTimes100(true))) / 100 : 0);
+#else
 	int iFoodProduction = ((bFoodProduction) ? (GetFoodProduction(getYieldRate(YIELD_FOOD, false) - foodConsumption(true))) : 0);
+#endif
 
 	int iOverflow = ((bOverflow) ? (getOverflowProduction() + getFeatureProduction()) : 0);
 
@@ -13605,7 +13586,11 @@ int CvCity::getProductionDifferenceTimes100(int /*iProductionNeeded*/, int /*iPr
 		return 0;
 	}
 
+#if defined(MOD_BALANCE_CORE)
+	int iFoodProduction = ((bFoodProduction) ? (GetFoodProductionTimes100(getYieldRateTimes100(YIELD_FOOD, false) - foodConsumptionTimes100(true))) / 100 : 0);
+#else
 	int iFoodProduction = ((bFoodProduction) ? GetFoodProduction(getYieldRate(YIELD_FOOD, false) - foodConsumption(true)) : 0);
+#endif
 	iFoodProduction *= 100;
 
 	int iOverflow = ((bOverflow) ? (getOverflowProductionTimes100() + getFeatureProduction() * 100) : 0);
@@ -13685,17 +13670,20 @@ int CvCity::getExtraProductionDifference(int iExtra, int iModifier) const
 /// Convert extra food to production if building a unit built partially from food
 int CvCity::GetFoodProduction(int iExcessFood) const
 {
+#if defined(MOD_BALANCE_CORE)
+	return GetFoodProductionTimes100(iExcessFood * 100);
+#else
 	int iRtnValue;
 
-	if(iExcessFood <= 0)
+	if (iExcessFood <= 0)
 	{
 		iRtnValue = 0;
 	}
-	else if(iExcessFood <= 2)
+	else if (iExcessFood <= 2)
 	{
 		iRtnValue = iExcessFood * 100;
 	}
-	else if(iExcessFood > 2 && iExcessFood <= 4)
+	else if (iExcessFood > 2 && iExcessFood <= 4)
 	{
 		iRtnValue = 200 + (iExcessFood - 2) * 50;
 	}
@@ -13705,7 +13693,36 @@ int CvCity::GetFoodProduction(int iExcessFood) const
 	}
 
 	return (iRtnValue / 100);
+#endif
 }
+
+#if defined(MOD_BALANCE_CORE)
+//	--------------------------------------------------------------------------------
+/// Convert extra food to production if building a unit built partially from food
+int CvCity::GetFoodProductionTimes100(int iExcessFoodTimes100) const
+{
+	int iRtnValue;
+
+	if (iExcessFoodTimes100 <= 0)
+	{
+		iRtnValue = 0;
+	}
+	else if (iExcessFoodTimes100 <= 200)
+	{
+		iRtnValue = iExcessFoodTimes100;
+	}
+	else if (iExcessFoodTimes100 > 200 && iExcessFoodTimes100 <= 400)
+	{
+		iRtnValue = 200 + (iExcessFoodTimes100 - 200) * 50 / 100;
+	}
+	else
+	{
+		iRtnValue = 300 + (iExcessFoodTimes100 - 400) * 25 / 100;
+	}
+
+	return (iRtnValue);
+}
+#endif
 
 //	--------------------------------------------------------------------------------
 bool CvCity::canHurry(HurryTypes eHurry, bool bTestVisible) const
@@ -17156,9 +17173,16 @@ int CvCity::foodConsumptionSpecialistTimes100() const
 }
 #endif
 
-//	--------------------------------------------------------------------------------
-int CvCity::foodConsumption(bool /*bNoAngry*/, int iExtra) const
+// --------------------------------------------------------------------------------
+int CvCity::foodConsumption(bool bNoAngry, int iExtra) const
 {
+#if defined(MOD_BALANCE_CORE)
+	return foodConsumptionTimes100(bNoAngry, iExtra * 100) / 100;
+}
+//	--------------------------------------------------------------------------------
+int CvCity::foodConsumptionTimes100(bool /*bNoAngry*/, int iExtra) const
+{
+#endif
 	VALIDATE_OBJECT
 #if defined(MOD_BALANCE_YIELD_SCALE_ERA)
 	if(MOD_BALANCE_YIELD_SCALE_ERA)
@@ -17167,25 +17191,32 @@ int CvCity::foodConsumption(bool /*bNoAngry*/, int iExtra) const
 
 		int iPopulation = max(0,(getPopulation() - iSpecialists)); //guard against stupidity
 
-		int iFoodPerPop = /*2*/ GC.getFOOD_CONSUMPTION_PER_POPULATION();
+		int iFoodPerPop = /*2*/ GC.getFOOD_CONSUMPTION_PER_POPULATION() * 100;
 #if defined(MOD_BALANCE_CORE)
-		iFoodPerPop += GetAdditionalFood();
+		iFoodPerPop += GetAdditionalFood() * 100;
 		iFoodPerPop += GET_PLAYER(getOwner()).GetPlayerTraits()->GetNonSpecialistFoodChange();
-		iFoodPerPop = max(1, iFoodPerPop); //cannot reduce food per citizen to less than 1
+		iFoodPerPop = max(100, iFoodPerPop); //cannot reduce food per citizen to less than 1
 #endif
 
 		int iNormalFood = iPopulation * iFoodPerPop;
-		int iSpecialistFood = (foodConsumptionSpecialistTimes100() * iSpecialists) / 100;	
+#if defined(MOD_BALANCE_CORE)
+		int iSpecialistFood = (foodConsumptionSpecialistTimes100() * iSpecialists);	
+		return max(iNormalFood + iSpecialistFood, 100);
+#else
+		int iSpecialistFood = (foodConsumptionSpecialistTimes100() * iSpecialists) / 100;
 		return iNormalFood + iSpecialistFood;
+#endif
 	}
 	else
 	{
 #endif
 	int iPopulation = getPopulation() + iExtra;
 
-	int iFoodPerPop = /*2*/ GC.getFOOD_CONSUMPTION_PER_POPULATION();
 #if defined(MOD_BALANCE_CORE)
-	iFoodPerPop += GetAdditionalFood();
+	int iFoodPerPop = /*2*/ GC.getFOOD_CONSUMPTION_PER_POPULATION() * 100;
+	iFoodPerPop += GetAdditionalFood() * 100;
+#else
+	int iFoodPerPop = /*2*/ GC.getFOOD_CONSUMPTION_PER_POPULATION();
 #endif
 	int iNum = iPopulation * iFoodPerPop;
 	// Specialists eat less food? (Policies, etc.)
@@ -17205,14 +17236,18 @@ int CvCity::foodConsumption(bool /*bNoAngry*/, int iExtra) const
 	if (GET_PLAYER(getOwner()).GetPlayerTraits()->GetNonSpecialistFoodChange() != 0)
 	{
 		int iFoodChangePerPop = GET_PLAYER(getOwner()).GetPlayerTraits()->GetNonSpecialistFoodChange();
-		if (GC.getFOOD_CONSUMPTION_PER_POPULATION() - iFoodChangePerPop < 1)
+		if (GC.getFOOD_CONSUMPTION_PER_POPULATION() + iFoodChangePerPop < 100)
 		{
-			iFoodChangePerPop = GC.getFOOD_CONSUMPTION_PER_POPULATION() - 1; //can't reduce food consumption per citizen to less than 1
+			iFoodChangePerPop = GC.getFOOD_CONSUMPTION_PER_POPULATION() - 100; 
 		}
-		iNum += max(0, (getPopulation() - GetCityCitizens()->GetTotalSpecialistCount())) * iFoodChangePerPop;
+		iNum += max(0, (getPopulation() - GetCityCitizens()->GetTotalSpecialistCount())) * iFoodChangePerPop; //can't reduce food consumption per citizen to less than 1
 	}
 #endif
+#if defined(MOD_BALANCE_CORE)
+	return max(iNum, 100);
+#else
 	return iNum;
+#endif
 #if defined(MOD_BALANCE_YIELD_SCALE_ERA)
 	}
 #endif
@@ -17234,11 +17269,19 @@ int CvCity::foodDifferenceTimes100(bool bBottom, bool bJustCheckingStarve, int i
 
 	if(isFoodProduction())
 	{
+#if defined(MOD_BALANCE_CORE)
+		iDifference = std::min(0, GetFoodProductionTimes100(getYieldRateTimes100(YIELD_FOOD, false) - foodConsumptionTimes100()));
+#else
 		iDifference = std::min(0, GetFoodProduction(getYieldRate(YIELD_FOOD, false) - foodConsumption()) * 100);
+#endif
 	}
 	else
 	{
+#if defined(MOD_BALANCE_CORE)
+		iDifference = (getYieldRateTimes100(YIELD_FOOD, false) - foodConsumptionTimes100());
+#else
 		iDifference = (getYieldRateTimes100(YIELD_FOOD, false) - foodConsumption() * 100);
+#endif
 	}
 
 	if(bBottom)

--- a/CvGameCoreDLL_Expansion2/CvCity.h
+++ b/CvGameCoreDLL_Expansion2/CvCity.h
@@ -439,6 +439,9 @@ public:
 	int getRawProductionDifferenceTimes100(bool bIgnoreFood, bool bOverflow) const;
 	int getExtraProductionDifference(int iExtra) const;
 	int GetFoodProduction(int iExcessFood) const;
+#if defined(MOD_BALANCE_CORE)
+	int GetFoodProductionTimes100(int iExcessFoodTimes100) const;
+#endif
 
 	bool canHurry(HurryTypes eHurry, bool bTestVisible = false) const;
 	void hurry(HurryTypes eHurry);
@@ -526,6 +529,9 @@ public:
 	int foodConsumptionSpecialistTimes100() const;
 #endif
 	int foodConsumption(bool bNoAngry = false, int iExtra = 0) const;
+#if defined(MOD_BALANCE_CORE)
+	int foodConsumptionTimes100(bool bNoAngry = false, int iExtra = 0) const;
+#endif
 	int foodDifference(bool bBottom = true, bool bJustCheckingStarve = false) const;
 	int foodDifferenceTimes100(bool bBottom = true, bool bJustCheckingStarve = false, int iCorpMod = -1, CvString* toolTipSink = NULL) const;
 	int growthThreshold() const;

--- a/CvGameCoreDLL_Expansion2/CvCityCitizens.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCityCitizens.cpp
@@ -781,9 +781,15 @@ bool CvCityCitizens::IsAIWantSpecialistRightNow()
 		iWeight /= 2;
 	}
 
+#if defined(MOD_BALANCE_CORE)
+	int iFoodPerTurn = m_pCity->getYieldRateTimes100(YIELD_FOOD, false);
+	int iFoodEatenPerTurn = m_pCity->foodConsumptionTimes100();
+	int iSurplusFood = (iFoodPerTurn - iFoodEatenPerTurn) / 100;
+#else
 	int iFoodPerTurn = m_pCity->getYieldRate(YIELD_FOOD, false);
 	int iFoodEatenPerTurn = m_pCity->foodConsumption();
 	int iSurplusFood = iFoodPerTurn - iFoodEatenPerTurn;
+#endif
 
 	CityAIFocusTypes eFocusType = GetFocusType();
 	// Don't want specialists until we've met our food needs
@@ -1664,7 +1670,11 @@ bool CvCityCitizens::DoAddBestCitizenFromUnassigned(bool bLogging, bool bUpdateN
 	if (GetNumUnassignedCitizens() == 0)
 		return false;
 
+#if defined(MOD_BALANCE_CORE)
+	int iNetFood100 = m_pCity->getYieldRateTimes100(YIELD_FOOD, false) - m_pCity->foodConsumptionTimes100();
+#else
 	int iNetFood100 = m_pCity->getYieldRateTimes100(YIELD_FOOD, false) - m_pCity->foodConsumption() * 100;
+#endif
 	bool bCanAffordSpecialist = (iNetFood100 >= m_pCity->foodConsumptionSpecialistTimes100());
 	bool bSpecialistForbidden = GET_PLAYER(GetOwner()).isHuman() && IsNoAutoAssignSpecialists();
 	FILogFile* pLog = bLogging && GC.getLogging() ? LOGFILEMGR.GetLog("CityTileScorer.csv", FILogFile::kDontTimeStamp) : NULL;
@@ -1685,7 +1695,11 @@ bool CvCityCitizens::DoAddBestCitizenFromUnassigned(bool bLogging, bool bUpdateN
 
 		if (pLog)
 		{
+#if defined(MOD_BALANCE_CORE)
+			int iExcessFoodTimes100 = m_pCity->getYieldRateTimes100(YIELD_FOOD, false) - (m_pCity->foodConsumptionTimes100());
+#else
 			int iExcessFoodTimes100 = m_pCity->getYieldRateTimes100(YIELD_FOOD, false) - (m_pCity->foodConsumption() * 100);
+#endif
 			CvString strOutBuf;
 			strOutBuf.Format("now working plot %d:%d, current net food %d", pBestPlot->getX(), pBestPlot->getY(), iExcessFoodTimes100);
 			pLog->Msg(strOutBuf);
@@ -1700,7 +1714,11 @@ bool CvCityCitizens::DoAddBestCitizenFromUnassigned(bool bLogging, bool bUpdateN
 
 		if (pLog)
 		{
+#if defined(MOD_BALANCE_CORE)
+			int iExcessFoodTimes100 = m_pCity->getYieldRateTimes100(YIELD_FOOD, false) - (m_pCity->foodConsumptionTimes100());
+#else
 			int iExcessFoodTimes100 = m_pCity->getYieldRateTimes100(YIELD_FOOD, false) - (m_pCity->foodConsumption() * 100);
+#endif
 			CvString strOutBuf;
 			strOutBuf.Format("now working building %d, current net food %d", eBestSpecialistBuilding, iExcessFoodTimes100);
 			pLog->Msg(strOutBuf);
@@ -1886,7 +1904,11 @@ void CvCityCitizens::OptimizeWorkedPlots(bool bLogging)
 	int iCount = 0;
 	FILogFile* pLog = bLogging && GC.getLogging() ? LOGFILEMGR.GetLog("CityTileScorer.csv", FILogFile::kDontTimeStamp) : NULL;
 
+#if defined(MOD_BALANCE_CORE)
+	int iNetFood100 = m_pCity->getYieldRateTimes100(YIELD_FOOD, false) - m_pCity->foodConsumptionTimes100();
+#else
 	int iNetFood100 = m_pCity->getYieldRateTimes100(YIELD_FOOD, false) - m_pCity->foodConsumption() * 100;
+#endif
 	bool bCanAffordSpecialist = (iNetFood100 >= m_pCity->foodConsumptionSpecialistTimes100());
 	bool bSpecialistForbidden = GET_PLAYER(GetOwner()).isHuman() && IsNoAutoAssignSpecialists();
 
@@ -1921,7 +1943,11 @@ void CvCityCitizens::OptimizeWorkedPlots(bool bLogging)
 			{
 				if (pLog)
 				{
+#if defined(MOD_BALANCE_CORE)
+					int iExcessFoodTimes100 = m_pCity->getYieldRateTimes100(YIELD_FOOD, false) - (m_pCity->foodConsumptionTimes100());
+#else
 					int iExcessFoodTimes100 = m_pCity->getYieldRateTimes100(YIELD_FOOD, false) - (m_pCity->foodConsumption() * 100);
+#endif
 					CvString strOutBuf;
 					strOutBuf.Format("nothing to optimize, current net food %d", iExcessFoodTimes100);
 					pLog->Msg(strOutBuf);
@@ -1931,7 +1957,11 @@ void CvCityCitizens::OptimizeWorkedPlots(bool bLogging)
 
 			if (pLog)
 			{
+#if defined(MOD_BALANCE_CORE)
+				int iExcessFoodTimes100 = m_pCity->getYieldRateTimes100(YIELD_FOOD, false) - (m_pCity->foodConsumptionTimes100());
+#else
 				int iExcessFoodTimes100 = m_pCity->getYieldRateTimes100(YIELD_FOOD, false) - (m_pCity->foodConsumption() * 100);
+#endif
 				CvString strOutBuf;
 				strOutBuf.Format("switched plot %d:%d (score %d) to plot %d:%d (score %d), current net food %d", 
 					pWorstWorkedPlot->getX(), pWorstWorkedPlot->getY(), iWorstWorkedPlotValue, pBestFreePlot->getX(), pBestFreePlot->getY(), iBestFreePlotValue, iExcessFoodTimes100);
@@ -1948,7 +1978,11 @@ void CvCityCitizens::OptimizeWorkedPlots(bool bLogging)
 				if (pLog)
 				{
 					CvBuildingEntry* pBuilding = GC.getBuildingInfo(eBestSpecialistBuilding);
+#if defined(MOD_BALANCE_CORE)
+					int iExcessFoodTimes100 = m_pCity->getYieldRateTimes100(YIELD_FOOD, false) - (m_pCity->foodConsumptionTimes100());
+#else
 					int iExcessFoodTimes100 = m_pCity->getYieldRateTimes100(YIELD_FOOD, false) - (m_pCity->foodConsumption() * 100);
+#endif
 
 					CvString strOutBuf;
 					strOutBuf.Format("switched plot %d:%d (score %d) to specialist in %s (score %d), current net food %d", 
@@ -3866,6 +3900,10 @@ SPrecomputedExpensiveNumbers::SPrecomputedExpensiveNumbers(CvCity * pCity)
 	iUnhappinessFromReligion = pCity->getUnhappinessFromReligion();
 	iUnhappinessFromDistress = max(pCity->getUnhappinessFromDefense(),pCity->getUnhappinessFromStarving());
 
+#if defined(MOD_BALANCE_CORE)
+	iExcessFoodTimes100 = pCity->getYieldRateTimes100(YIELD_FOOD, false) - (pCity->foodConsumptionTimes100());
+#else
 	iExcessFoodTimes100 = pCity->getYieldRateTimes100(YIELD_FOOD, false) - (pCity->foodConsumption() * 100);
+#endif
 	iFoodCorpMod = pCity->GetTradeRouteCityMod(YIELD_FOOD);
 }

--- a/CvGameCoreDLL_Expansion2/CvProcessProductionAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvProcessProductionAI.cpp
@@ -288,7 +288,11 @@ int CvProcessProductionAI::CheckProcessBuildSanity(ProcessTypes eProcess, int iT
 					if(m_pCity->GetCityCitizens()->IsForcedAvoidGrowth())
 						return 0;
 
+#if defined(MOD_BALANCE_CORE)
+					int iExcessFoodTimes100 = m_pCity->getYieldRateTimes100(YIELD_FOOD, false) - (m_pCity->foodConsumptionTimes100());
+#else
 					int iExcessFoodTimes100 = m_pCity->getYieldRateTimes100(YIELD_FOOD, false) - (m_pCity->foodConsumption() * 100);
+#endif
 					if (iExcessFoodTimes100 < 0)
 					{
 						iModifier += 30;


### PR DESCRIPTION
- Moved puppet logic to ignore most buildings into CvCityStrategyAI (previous method broke the puppet faith purchase mod).
- NonSpecialistFoodChange column in traits now works in times 100 (eg -100 for -1 food cost).
- Changed citizen food consumption logic to be times 100 for the above (internal change).