### PR TITLE
Add GiveOnlyOnStartingTurn for promotions

### DIFF
--- a/Community Patch/Core Files/Core Tables/CoreTableEntries.sql
+++ b/Community Patch/Core Files/Core Tables/CoreTableEntries.sql
@@ -941,6 +941,9 @@ ALTER TABLE UnitPromotions ADD COLUMN 'GiveDefenseMod' INTEGER DEFAULT 0;
 -- Unit gives Invisibility to another Unit? Requires IsNearbyPromotion, NearbyRange, and GiveDomain Set on this Promotion.
 ALTER TABLE UnitPromotions ADD COLUMN 'GiveInvisibility' BOOLEAN DEFAULT 0;
 
+-- Unit only gives these effects at the start of the turn (works for GiveExperiencePercent, GiveCombatMod, GiveDefenseMod, GiveInvisibility, GiveOutsideFriendlyLandsModifier, GiveHPHealedIfEnemyKilled, GiveExtraAttacks)
+ALTER TABLE UnitPromotions ADD COLUMN 'GiveOnlyOnStartingTurn' BOOLEAN DEFAULT 0;
+
 -- Unit gains Combat modifier when near cities. Requires IsNearbyPromotion and NearbyRange Set on this Promotion.
 ALTER TABLE UnitPromotions ADD NearbyCityCombatMod INTEGER DEFAULT 0;
 

--- a/CvGameCoreDLL_Expansion2/CvPromotionClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPromotionClasses.cpp
@@ -268,6 +268,7 @@ CvPromotionEntry::CvPromotionEntry():
 	m_iGiveExtraAttacks(0),
 	m_iGiveDefenseMod(0),
 	m_bGiveInvisibility(false),
+	m_bGiveOnlyOnStartingTurn(false),
 	m_iNearbyHealEnemyTerritory(0),
 	m_iNearbyHealNeutralTerritory(0),
 	m_iNearbyHealFriendlyTerritory(0),
@@ -540,6 +541,7 @@ bool CvPromotionEntry::CacheResults(Database::Results& kResults, CvDatabaseUtili
 	m_iGiveExtraAttacks = kResults.GetInt("GiveExtraAttacks");
 	m_iGiveDefenseMod = kResults.GetInt("GiveDefenseMod");
 	m_bGiveInvisibility = kResults.GetBool("GiveInvisibility");
+	m_bGiveOnlyOnStartingTurn = kResults.GetBool("GiveOnlyOnStartingTurn");
 	m_iNearbyHealEnemyTerritory = kResults.GetInt("NearbyHealEnemyTerritory");
 	m_iNearbyHealNeutralTerritory = kResults.GetInt("NearbyHealNeutralTerritory");
 	m_iNearbyHealFriendlyTerritory = kResults.GetInt("NearbyHealFriendlyTerritory");
@@ -2494,6 +2496,10 @@ int CvPromotionEntry::GetGiveDefenseMod() const
 bool CvPromotionEntry::IsGiveInvisibility() const
 {
 	return m_bGiveInvisibility;
+}
+bool CvPromotionEntry::IsGiveOnlyOnStartingTurn() const
+{
+	return m_bGiveOnlyOnStartingTurn;
 }
 int CvPromotionEntry::GetNearbyHealEnemyTerritory() const
 {

--- a/CvGameCoreDLL_Expansion2/CvPromotionClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvPromotionClasses.h
@@ -293,6 +293,7 @@ public:
 	int GetGiveExtraAttacks() const;
 	int GetGiveDefenseMod() const;
 	bool IsGiveInvisibility() const;
+	bool IsGiveOnlyOnStartingTurn() const;
 	int GetNearbyHealEnemyTerritory() const;
 	int GetNearbyHealNeutralTerritory() const;
 	int GetNearbyHealFriendlyTerritory() const;
@@ -613,6 +614,7 @@ protected:
 	int m_iGiveExtraAttacks;
 	int m_iGiveDefenseMod;
 	bool m_bGiveInvisibility;
+	bool m_bGiveOnlyOnStartingTurn;
 	int m_iNearbyHealEnemyTerritory;
 	int m_iNearbyHealNeutralTerritory;
 	int m_iNearbyHealFriendlyTerritory;

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -443,6 +443,7 @@ CvUnit::CvUnit() :
 	, m_iGiveExtraAttacks("CvUnit::m_iGiveExtraAttacks", m_syncArchive)
 	, m_iGiveDefenseMod("CvUnit::m_iGiveDefenseMod", m_syncArchive)
 	, m_bGiveInvisibility("CvUnit::m_bGiveInvisibility", m_syncArchive)
+	, m_bGiveOnlyOnStartingTurn("CvUnit::m_bGiveOnlyOnStartingTurn", m_syncArchive)
 	, m_bConvertUnit("CvUnit::m_bConvertUnit", m_syncArchive)
 	, m_eConvertDomain("CvUnit::m_eConvertDomain", m_syncArchive)
 	, m_eConvertDomainUnit("CvUnit::m_eConvertDomainUnit", m_syncArchive)
@@ -1551,6 +1552,7 @@ void CvUnit::reset(int iID, UnitTypes eUnit, PlayerTypes eOwner, bool bConstruct
 	m_iGiveExtraAttacks = 0;
 	m_iGiveDefenseMod = 0;
 	m_bGiveInvisibility = false;
+	m_bGiveOnlyOnStartingTurn = false;
 	m_bConvertUnit = false;
 	m_eConvertDomainUnit = NO_UNIT;
 	m_eConvertDomain = NO_DOMAIN;
@@ -17814,6 +17816,16 @@ bool CvUnit::isGiveInvisibility() const
 	VALIDATE_OBJECT
 	return GetIsGiveInvisibility() > 0;
 }
+bool CvUnit::isGiveOnlyOnStartingTurn() const
+{
+	VALIDATE_OBJECT
+	return m_bGiveOnlyOnStartingTurn;
+}
+void CvUnit::SetIsGiveOnlyOnStartingTurn(bool bNewValue)
+{
+	VALIDATE_OBJECT
+	m_bGiveOnlyOnStartingTurn = bNewValue;
+}
 void CvUnit::ChangeIsConvertUnit(int iValue)
 {
 	VALIDATE_OBJECT
@@ -22866,7 +22878,10 @@ int CvUnit::GetGiveExperiencePercentToUnit() const
 			{
 				if (pUnit->getGiveDomain() != NO_DOMAIN && (pUnit->getGiveDomain() == getDomainType()))
 				{
-					iExperience = pUnit->getGiveExperiencePercent();
+					if (!pUnit->isGiveOnlyOnStartingTurn() || (pUnit->getMoves() >= pUnit->maxMoves()))
+					{
+						iExperience = pUnit->getGiveExperiencePercent();
+					}
 				}
 			}
 		}
@@ -22901,7 +22916,10 @@ int CvUnit::GetGiveCombatModToUnit(const CvPlot* pAtPlot) const
 			{
 				if (pUnit->getGiveDomain() != NO_DOMAIN && (pUnit->getGiveDomain() == getDomainType()))
 				{
-					iMod = pUnit->getGiveCombatMod();
+					if (!pUnit->isGiveOnlyOnStartingTurn() || (pUnit->getMoves() >= pUnit->maxMoves()))
+					{
+						iMod = pUnit->getGiveCombatMod();
+					}
 				}
 			}
 		}
@@ -22934,7 +22952,10 @@ int CvUnit::GetGiveDefenseModToUnit() const
 			{
 				if (pUnit->getGiveDomain() != NO_DOMAIN && (pUnit->getGiveDomain() == getDomainType()))
 				{
-					iMod = pUnit->getGiveDefenseMod();
+					if (!pUnit->isGiveOnlyOnStartingTurn() || (pUnit->getMoves() >= pUnit->maxMoves()))
+					{
+						iMod = pUnit->getGiveDefenseMod();
+					}
 				}
 			}
 		}
@@ -23069,7 +23090,10 @@ bool CvUnit::IsHiddenByNearbyUnit(const CvPlot* pAtPlot) const
 			{
 				if (pUnit->getGiveDomain() != NO_DOMAIN && (pUnit->getGiveDomain() == getDomainType()) && (pUnit->getTeam() == getTeam()))
 				{
-					return true;
+					if (!pUnit->isGiveOnlyOnStartingTurn() || (pUnit->getMoves() >= pUnit->maxMoves()))
+					{
+						return true;
+					}
 				}
 			}
 		}
@@ -23103,7 +23127,10 @@ int CvUnit::GetGiveOutsideFriendlyLandsModifierToUnit() const
 				// Only Giving it out to a specific domain?
 				if (pUnit->getGiveDomain() != NO_DOMAIN && (pUnit->getGiveDomain() == getDomainType()))
 				{
-					iMod = pUnit->getGiveOutsideFriendlyLandsModifier();
+					if (!pUnit->isGiveOnlyOnStartingTurn() || (pUnit->getMoves() >= pUnit->maxMoves()))
+					{
+						iMod = pUnit->getGiveOutsideFriendlyLandsModifier();
+					}
 				}
 			}
 		}
@@ -23137,7 +23164,10 @@ int CvUnit::GetGiveExtraAttacksToUnit() const
 				// Only Giving it out to a specific domain?
 				if (pUnit->getGiveDomain() != NO_DOMAIN && (pUnit->getGiveDomain() == getDomainType()))
 				{
-					iExtraAttacks = pUnit->getGiveExtraAttacks();
+					if (!pUnit->isGiveOnlyOnStartingTurn() || (pUnit->getMoves() >= pUnit->maxMoves()))
+					{
+						iExtraAttacks = pUnit->getGiveExtraAttacks();
+					}
 				}
 			}
 		}
@@ -23170,7 +23200,10 @@ int CvUnit::GetGiveHPIfEnemyKilledToUnit() const
 			{
 				if (pUnit->getGiveDomain() != NO_DOMAIN && (pUnit->getGiveDomain() == getDomainType()) && !IsCanAttackRanged())
 				{
-					iHP = pUnit->getGiveHPIfEnemyKilled();
+					if (!pUnit->isGiveOnlyOnStartingTurn() || (pUnit->getMoves() >= pUnit->maxMoves()))
+					{
+						iHP = pUnit->getGiveHPIfEnemyKilled();
+					}
 				}
 			}
 		}
@@ -26558,6 +26591,7 @@ void CvUnit::setHasPromotion(PromotionTypes eIndex, bool bNewValue)
 		ChangeNearbyHealEnemyTerritory(thisPromotion.GetNearbyHealEnemyTerritory() * iChange);
 		ChangeNearbyHealNeutralTerritory(thisPromotion.GetNearbyHealNeutralTerritory() * iChange);
 		ChangeNearbyHealFriendlyTerritory(thisPromotion.GetNearbyHealFriendlyTerritory() * iChange);
+		SetIsGiveOnlyOnStartingTurn(thisPromotion.IsGiveOnlyOnStartingTurn() ? iChange : 0);
 		ChangeIsConvertUnit((thisPromotion.IsConvertUnit()) ? iChange : 0);
 		ChangeIsConvertEnemyUnitToBarbarian((thisPromotion.IsConvertEnemyUnitToBarbarian()) ? iChange : 0);
 		ChangeIsConvertOnFullHP((thisPromotion.IsConvertOnFullHP()) ? iChange : 0);

--- a/CvGameCoreDLL_Expansion2/CvUnit.h
+++ b/CvGameCoreDLL_Expansion2/CvUnit.h
@@ -736,6 +736,8 @@ public:
 	void ChangeIsGiveInvisibility(int iValue);
 	int GetIsGiveInvisibility() const;
 	bool isGiveInvisibility() const;
+	bool isGiveOnlyOnStartingTurn() const;
+	void SetIsGiveOnlyOnStartingTurn(bool bNewValue);
 	void ChangeIsConvertUnit(int iValue);
 	int getIsConvertUnit() const;
 	bool isConvertUnit() const;
@@ -2093,6 +2095,7 @@ protected:
 	FAutoVariable<int, CvUnit> m_iGiveExtraAttacks;
 	FAutoVariable<int, CvUnit> m_iGiveDefenseMod;
 	FAutoVariable<int, CvUnit> m_bGiveInvisibility;
+	FAutoVariable<int, CvUnit> m_bGiveOnlyOnStartingTurn;
 	FAutoVariable<int, CvUnit> m_bConvertUnit;
 	FAutoVariable<int, CvUnit> m_eConvertDomain;
 	FAutoVariable<UnitTypes, CvUnit> m_eConvertDomainUnit;


### PR DESCRIPTION
Unit only gives these effects at the start of the turn (works for GiveExperiencePercent, GiveCombatMod, GiveDefenseMod, GiveInvisibility, GiveOutsideFriendlyLandsModifier, GiveHPHealedIfEnemyKilled, GiveExtraAttacks)