### PR TITLE
goody hut cleanliness and fixes

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -13630,7 +13630,7 @@ void CvPlayer::receiveGoody(CvPlot* pPlot, GoodyTypes eGoody, CvUnit* pUnit)
 	}
 
 	// Population
-	int iPop = MOD_BALANCE_CORE ? kGoodyInfo.getPopulation() : 0;
+	int iPop = kGoodyInfo.getPopulation();
 	if (kGoodyInfo.getPopulation() > 0)
 	{
 		CvCity* pBestCity = bestCityFinder(*this, *pPlot);

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -13543,22 +13543,26 @@ void CvPlayer::receiveGoody(CvPlot* pPlot, GoodyTypes eGoody, CvUnit* pUnit)
 	{
 		CvCity* operator()(CvPlayer& kPlayer, const CvPlot& kPlot)
 		{
-			int iBestCityDistance = -1;
+			int iBestCityDistance = 0;
+			bool bBestCityIsProductive = false;
 			CvCity* pBestCity = NULL;
 
 			int iLoop;
 			for (CvCity* pLoopCity = kPlayer.firstCity(&iLoop); pLoopCity != NULL; pLoopCity = kPlayer.nextCity(&iLoop))
 			{
-				// Ignore cities that produce nothing
-				if (pLoopCity->IsResistance() || pLoopCity->IsRazing())
+				bool bCityIsProductive = !(pLoopCity->IsResistance() || pLoopCity->IsRazing());
+
+				// Only select unproductive cities if we also have no productive cities
+				if (bBestCityIsProductive && !bCityIsProductive)
 					continue;
 
 				// Prefer cities nearest the plot
 				int iDistance = plotDistance(kPlot.getX(), kPlot.getY(), pLoopCity->getX(), pLoopCity->getY());
 
-				if (iBestCityDistance == -1 || iDistance < iBestCityDistance)
+				if (pBestCity == NULL || iDistance < iBestCityDistance)
 				{
 					iBestCityDistance = iDistance;
+					bBestCityIsProductive = bCityIsProductive;
 					pBestCity = pLoopCity;
 				}
 			}

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -13109,20 +13109,6 @@ bool CvPlayer::canReceiveGoody(CvPlot* pPlot, GoodyTypes eGoody, CvUnit* pUnit) 
 		// Don't give more Population if we're already unhappy
 		if (IsEmpireUnhappy())
 			return false;
-
-		int iLoop;
-		bool bGood = false;
-		for (const CvCity* pLoopCity = firstCity(&iLoop); pLoopCity != NULL; pLoopCity = nextCity(&iLoop))
-		{
-			if (pLoopCity->IsResistance() || pLoopCity->IsRazing())
-				continue;
-			
-			bGood = true;
-			break;
-		}
-
-		if (!bGood)
-			return false;
 	}
 
 	// Production
@@ -13132,20 +13118,6 @@ bool CvPlayer::canReceiveGoody(CvPlot* pPlot, GoodyTypes eGoody, CvUnit* pUnit) 
 			return false;
 
 		if (getNumCities() == 0)
-			return false;
-
-		int iLoop;
-		bool bGood = false;
-		for (const CvCity* pLoopCity = firstCity(&iLoop); pLoopCity != NULL; pLoopCity = nextCity(&iLoop))
-		{
-			if (pLoopCity->IsResistance() || pLoopCity->IsRazing())
-				continue;
-			
-			bGood = true;
-			break;
-		}
-
-		if (!bGood)
 			return false;
 	}
 
@@ -13172,20 +13144,6 @@ bool CvPlayer::canReceiveGoody(CvPlot* pPlot, GoodyTypes eGoody, CvUnit* pUnit) 
 			return false;
 
 		if (getNumCities() == 0)
-			return false;
-
-		int iLoop;
-		bool bGood = false;
-		for (const CvCity* pLoopCity = firstCity(&iLoop); pLoopCity != NULL; pLoopCity = nextCity(&iLoop))
-		{
-			if (pLoopCity->IsResistance() || pLoopCity->IsRazing())
-				continue;
-			
-			bGood = true;
-			break;
-		}
-
-		if (!bGood)
 			return false;
 	}
 

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -13621,7 +13621,7 @@ void CvPlayer::receiveGoody(CvPlot* pPlot, GoodyTypes eGoody, CvUnit* pUnit)
 
 		if (iGold != 0)
 		{
-			goodyValueModifier(iGold, -1, true, true);
+			goodyValueModifier(iGold, GC.getGame().getGameSpeedInfo().getGoldPercent(), true, true);
 			GetTreasury()->ChangeGold(iGold);
 			changeInstantYieldValue(YIELD_GOLD, iGold);
 			strBuffer += " ";
@@ -13670,7 +13670,7 @@ void CvPlayer::receiveGoody(CvPlot* pPlot, GoodyTypes eGoody, CvUnit* pUnit)
 	int iGoldenAge = MOD_BALANCE_CORE ? kGoodyInfo.getGoldenAge() : 0;
 	if (iGoldenAge > 0 && GetNumGoldenAges() <= 0)
 	{
-		goodyValueModifier(iGoldenAge, GC.getGame().getGameSpeedInfo().getCulturePercent(), true, true);
+		goodyValueModifier(iGoldenAge, GC.getGame().getGameSpeedInfo().getGoldenAgePercent(), true, true);
 		ChangeGoldenAgeProgressMeter(iGoldenAge);
 		changeInstantYieldValue(YIELD_GOLDEN_AGE_POINTS, iGoldenAge);
 	}

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -13674,7 +13674,7 @@ void CvPlayer::receiveGoody(CvPlot* pPlot, GoodyTypes eGoody, CvUnit* pUnit)
 	}
 
 	// Free Tiles
-	int iFreeTiles = kGoodyInfo.getFreeTiles();
+	int iFreeTiles = MOD_BALANCE_CORE ? kGoodyInfo.getFreeTiles() : 0;
 	if(iFreeTiles > 0)
 	{
 		CvCity* pBestCity = bestCityFinder(*this, *pPlot);

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -13656,8 +13656,6 @@ void CvPlayer::receiveGoody(CvPlot* pPlot, GoodyTypes eGoody, CvUnit* pUnit)
 			goodyValueModifier(iProduction, GC.getGame().getGameSpeedInfo().getInstantYieldPercent(), true, true);
 			pBestCity->changeProduction(iProduction);
 			changeInstantYieldValue(YIELD_PRODUCTION, iProduction);
-			strBuffer += " ";
-			strBuffer += GetLocalizedText("TXT_KEY_GOODY_PRODUCTION");
 		}
 		else
 		{


### PR DESCRIPTION
### code only
- Consolidates find best city routine
- Consolidates value modification routine

### impacts gameplay
- Gold rewards now scale with speed by gold percent (previously not scaled at all)
- Golden Age Point rewards now scale with speed by golden age percent (previously scaled by culture percent)
- Apply MOD_BALANCE_CORE check for all MOD_BALANCE_CORE rewards consistently (is this actually desired?)
- Fix TXT_KEY_GOODY_PRODUCTION being displayed twice in the reward message.
- Goody Hut rewards may be given to unproductive cities in the event that no cities are actually productive.