### PR TITLE
Overhaul sync to favor singleplayer performance

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -187,7 +187,7 @@ CvCity::CvCity() :
 	, m_iNumGreatPeople()
 	, m_iBaseGreatPeopleRate()
 	, m_iGreatPeopleRateModifier()
-	, m_iJONSCultureStored(true)
+	, m_iJONSCultureStored()
 	, m_iJONSCultureLevel()
 #if !defined(MOD_API_UNIFIED_YIELDS_CONSOLIDATION)
 	, m_iJONSCulturePerTurnFromBuildings()

--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -71,14 +71,15 @@ void SyncCities()
 		std::vector<CvCity*>::const_iterator i;
 		for(i = citiesToCheck.begin(); i != citiesToCheck.end(); ++i)
 		{
-			const CvCity* city = *i;
+			CvCity* city = *i;
 
 			if(city)
 			{
 				const CvPlayer& player = GET_PLAYER(city->getOwner());
 				if(city->getOwner() == authoritativePlayer || (gDLL->IsHost() && !player.isHuman() && player.isAlive()))
 				{
-					const FAutoArchive& archive = city->getSyncArchive();
+					CvSyncArchive<CvCity>& archive = city->getSyncArchive();
+					archive.collectDeltas();
 					if(archive.hasDeltas())
 					{
 						FMemoryStream memoryStream;
@@ -161,178 +162,178 @@ int ModifierLookup(const vector<pair<T, int>>& container, T key)
 //	--------------------------------------------------------------------------------
 // Public Functions...
 CvCity::CvCity() :
-	m_syncArchive(*this)
-	, m_eOwner("CvCity::m_eOwner", m_syncArchive, NO_PLAYER)
-	, m_iX("CvCity::m_iX", m_syncArchive)
-	, m_iY("CvCity::m_iY", m_syncArchive)
-	, m_iID("CvCity::m_iID", m_syncArchive)
-	, m_iRallyX("CvCity::m_iRallyX", m_syncArchive)
-	, m_iRallyY("CvCity::m_iRallyY", m_syncArchive)
-	, m_iGameTurnFounded("CvCity::m_iGameTurnFounded", m_syncArchive)
-	, m_iGameTurnAcquired("CvCity::m_iGameTurnAcquired", m_syncArchive)
-	, m_iGameTurnLastExpanded("CvCity::m_iGameTurnLastExpanded", m_syncArchive)
+	m_syncArchive()
+	, m_eOwner(NO_PLAYER)
+	, m_iX()
+	, m_iY()
+	, m_iID()
+	, m_iRallyX()
+	, m_iRallyY()
+	, m_iGameTurnFounded()
+	, m_iGameTurnAcquired()
+	, m_iGameTurnLastExpanded()
 #if defined(MOD_BALANCE_CORE)
-	, m_iAdditionalFood("CvCity::m_iAdditionalFood", m_syncArchive)
-	, m_iCityBuildingBombardRange("CvCity::m_iCityBuildingBombardRange", m_syncArchive)
-	, m_iCityIndirectFire("CvCity::m_iCityIndirectFire", m_syncArchive)
-	, m_iCityBuildingRangeStrikeModifier("CvCity::m_iCityBuildingRangeStrikeModifier", m_syncArchive)
+	, m_iAdditionalFood()
+	, m_iCityBuildingBombardRange()
+	, m_iCityIndirectFire()
+	, m_iCityBuildingRangeStrikeModifier()
 #endif
-	, m_iPopulation("CvCity::m_iPopulation", m_syncArchive)
+	, m_iPopulation()
 #if defined(MOD_GLOBAL_CITY_AUTOMATON_WORKERS)
 	, m_iAutomatons(0)
 #endif
-	, m_iHighestPopulation("CvCity::m_iHighestPopulation", m_syncArchive)
-	, m_iExtraHitPoints("CvCity::m_iExtraHitPoints", m_syncArchive)
-	, m_iNumGreatPeople("CvCity::m_iNumGreatPeople", m_syncArchive)
-	, m_iBaseGreatPeopleRate("CvCity::m_iBaseGreatPeopleRate", m_syncArchive)
-	, m_iGreatPeopleRateModifier("CvCity::m_iGreatPeopleRateModifier", m_syncArchive)
-	, m_iJONSCultureStored("CvCity::m_iJONSCultureStored", m_syncArchive, true)
-	, m_iJONSCultureLevel("CvCity::m_iJONSCultureLevel", m_syncArchive)
+	, m_iHighestPopulation()
+	, m_iExtraHitPoints()
+	, m_iNumGreatPeople()
+	, m_iBaseGreatPeopleRate()
+	, m_iGreatPeopleRateModifier()
+	, m_iJONSCultureStored(true)
+	, m_iJONSCultureLevel()
 #if !defined(MOD_API_UNIFIED_YIELDS_CONSOLIDATION)
-	, m_iJONSCulturePerTurnFromBuildings("CvCity::m_iJONSCulturePerTurnFromBuildings", m_syncArchive)
+	, m_iJONSCulturePerTurnFromBuildings()
 #endif
-	, m_iJONSCulturePerTurnFromPolicies("CvCity::m_iJONSCulturePerTurnFromPolicies", m_syncArchive)
-	, m_iJONSCulturePerTurnFromSpecialists("CvCity::m_iJONSCulturePerTurnFromSpecialists", m_syncArchive)
-	, m_iaAddedYieldPerTurnFromTraits("CvCity::m_iaAddedYieldPerTurnFromTraits", m_syncArchive)
+	, m_iJONSCulturePerTurnFromPolicies()
+	, m_iJONSCulturePerTurnFromSpecialists()
+	, m_iaAddedYieldPerTurnFromTraits()
 #if !defined(MOD_API_UNIFIED_YIELDS_CONSOLIDATION)
-	, m_iJONSCulturePerTurnFromReligion("CvCity::m_iJONSCulturePerTurnFromReligion", m_syncArchive)
+	, m_iJONSCulturePerTurnFromReligion()
 #endif
 #if !defined(MOD_API_UNIFIED_YIELDS_CONSOLIDATION)
-	, m_iFaithPerTurnFromBuildings("CvCity::m_iFaithPerTurnFromBuildings", m_syncArchive)
+	, m_iFaithPerTurnFromBuildings()
 #endif
-	, m_iFaithPerTurnFromPolicies("CvCity::m_iFaithPerTurnFromPolicies", m_syncArchive)
+	, m_iFaithPerTurnFromPolicies()
 #if !defined(MOD_API_UNIFIED_YIELDS_CONSOLIDATION)
-	, m_iFaithPerTurnFromReligion("CvCity::m_iFaithPerTurnFromReligion", m_syncArchive)
+	, m_iFaithPerTurnFromReligion()
 #endif
-	, m_iCultureRateModifier("CvCity::m_iCultureRateModifier", m_syncArchive)
-	, m_iNumWorldWonders("CvCity::m_iNumWorldWonders", m_syncArchive)
-	, m_iNumTeamWonders("CvCity::m_iNumTeamWonders", m_syncArchive)
-	, m_iNumNationalWonders("CvCity::m_iNumNationalWonders", m_syncArchive)
-	, m_iWonderProductionModifier("CvCity::m_iWonderProductionModifier", m_syncArchive)
-	, m_iCapturePlunderModifier("CvCity::m_iCapturePlunderModifier", m_syncArchive)
-	, m_iPlotCultureCostModifier("CvCity::m_iPlotCultureCostModifier", m_syncArchive)
-	, m_iPlotBuyCostModifier("CvCity::m_iPlotBuyCostModifier", m_syncArchive)
-	, m_iMaintenance("CvCity::m_iMaintenance", m_syncArchive)
-	, m_iHealRate("CvCity::m_iHealRate", m_syncArchive)
-	, m_iNoOccupiedUnhappinessCount("CvCity::m_iNoOccupiedUnhappinessCount", m_syncArchive)
+	, m_iCultureRateModifier()
+	, m_iNumWorldWonders()
+	, m_iNumTeamWonders()
+	, m_iNumNationalWonders()
+	, m_iWonderProductionModifier()
+	, m_iCapturePlunderModifier()
+	, m_iPlotCultureCostModifier()
+	, m_iPlotBuyCostModifier()
+	, m_iMaintenance()
+	, m_iHealRate()
+	, m_iNoOccupiedUnhappinessCount()
 #if defined(HH_MOD_BUILDINGS_FRUITLESS_PILLAGE)
-	, m_iLocalGainlessPillageCount("CvCity::m_iLocalGainlessPillageCount", m_syncArchive)
+	, m_iLocalGainlessPillageCount()
 #endif
-	, m_iFood("CvCity::m_iFood", m_syncArchive)
-	, m_iFoodKept("CvCity::m_iFoodKept", m_syncArchive)
-	, m_iMaxFoodKeptPercent("CvCity::m_iMaxFoodKeptPercent", m_syncArchive)
-	, m_iOverflowProduction("CvCity::m_iOverflowProduction", m_syncArchive)
-	, m_iFeatureProduction("CvCity::m_iFeatureProduction", m_syncArchive)
-	, m_iMilitaryProductionModifier("CvCity::m_iMilitaryProductionModifier", m_syncArchive)
-	, m_iSpaceProductionModifier("CvCity::m_iSpaceProductionModifier", m_syncArchive)
-	, m_iFreeExperience("CvCity::m_iFreeExperience", m_syncArchive)
-	, m_iCurrAirlift("CvCity::m_iCurrAirlift", m_syncArchive) // unused
-	, m_iMaxAirUnits("CvCity::m_iMaxAirUnits", m_syncArchive)
-	, m_iAirModifier("CvCity::m_iAirModifier", m_syncArchive) // unused
-	, m_iNukeModifier("CvCity::m_iNukeModifier", m_syncArchive)
-	, m_iCultureUpdateTimer("CvCity::m_iCultureUpdateTimer", m_syncArchive)	// unused
-	, m_iCitySizeBoost("CvCity::m_iCitySizeBoost", m_syncArchive)
-	, m_iSpecialistFreeExperience("CvCity::m_iSpecialistFreeExperience", m_syncArchive)
-	, m_iStrengthValue("CvCity::m_iStrengthValue", m_syncArchive, true)
-	, m_iDamage("CvCity::m_iDamage", m_syncArchive)
-	, m_iThreatValue("CvCity::m_iThreatValue", m_syncArchive, true)
-	, m_hGarrison("CvCity::m_hGarrison", m_syncArchive)
-	, m_iResourceDemanded("CvCity::m_iResourceDemanded", m_syncArchive)
-	, m_iWeLoveTheKingDayCounter("CvCity::m_iWeLoveTheKingDayCounter", m_syncArchive)
-	, m_iLastTurnGarrisonAssigned("CvCity::m_iLastTurnGarrisonAssigned", m_syncArchive)
-	, m_iThingsProduced("CvCity::m_iThingsProduced", m_syncArchive)
-	, m_iDemandResourceCounter("CvCity::m_iDemandResourceCounter", m_syncArchive, true)
-	, m_iResistanceTurns("CvCity::m_iResistanceTurns", m_syncArchive)
-	, m_iRazingTurns("CvCity::m_iRazingTurns", m_syncArchive)
-	, m_iLowestRazingPop("CvCity::m_iLowestRazingPop", m_syncArchive)
-	, m_iCountExtraLuxuries("CvCity::m_iCountExtraLuxuries", m_syncArchive)
-	, m_iCheapestPlotInfluenceDistance("CvCity::m_iCheapestPlotInfluenceDistance", m_syncArchive)
-	, m_iEspionageModifier("CvCity::m_iEspionageModifier", m_syncArchive)
-	, m_iTradeRouteRecipientBonus("CvCity::m_iTradeRouteRecipientBonus", m_syncArchive)
-	, m_iTradeRouteSeaGoldBonus("CvCity::m_iTradeRouteSeaGoldBonus", m_syncArchive)
-	, m_iTradeRouteLandGoldBonus("CvCity::m_iTradeRouteLandGoldBonus", m_syncArchive)
-	, m_iTradeRouteTargetBonus("CvCity::m_iTradeRouteTargetBonus", m_syncArchive)
-	, m_iNumTradeRouteBonus("CvCity::m_iNumTradeRouteBonus", m_syncArchive)
-	, m_iCityConnectionTradeRouteGoldModifier("CvCity::m_iCityConnectionTradeRouteGoldModifier", m_syncArchive)
+	, m_iFood()
+	, m_iFoodKept()
+	, m_iMaxFoodKeptPercent()
+	, m_iOverflowProduction()
+	, m_iFeatureProduction()
+	, m_iMilitaryProductionModifier()
+	, m_iSpaceProductionModifier()
+	, m_iFreeExperience()
+	, m_iCurrAirlift() // unused
+	, m_iMaxAirUnits()
+	, m_iAirModifier() // unused
+	, m_iNukeModifier()
+	, m_iCultureUpdateTimer()	// unused
+	, m_iCitySizeBoost()
+	, m_iSpecialistFreeExperience()
+	, m_iStrengthValue()
+	, m_iDamage()
+	, m_iThreatValue()
+	, m_hGarrison()
+	, m_iResourceDemanded()
+	, m_iWeLoveTheKingDayCounter()
+	, m_iLastTurnGarrisonAssigned()
+	, m_iThingsProduced()
+	, m_iDemandResourceCounter()
+	, m_iResistanceTurns()
+	, m_iRazingTurns()
+	, m_iLowestRazingPop()
+	, m_iCountExtraLuxuries()
+	, m_iCheapestPlotInfluenceDistance()
+	, m_iEspionageModifier()
+	, m_iTradeRouteRecipientBonus()
+	, m_iTradeRouteSeaGoldBonus()
+	, m_iTradeRouteLandGoldBonus()
+	, m_iTradeRouteTargetBonus()
+	, m_iNumTradeRouteBonus()
+	, m_iCityConnectionTradeRouteGoldModifier()
 	, m_unitBeingBuiltForOperation()
-	, m_bNeverLost("CvCity::m_bNeverLost", m_syncArchive)
-	, m_bDrafted("CvCity::m_bDrafted", m_syncArchive)
-	, m_bAirliftTargeted("CvCity::m_bAirliftTargeted", m_syncArchive)   // unused
-	, m_bProductionAutomated("CvCity::m_bProductionAutomated", m_syncArchive)
-	, m_bLayoutDirty("CvCity::m_bLayoutDirty", m_syncArchive)
-	, m_bMadeAttack("CvCity::m_bMadeAttack", m_syncArchive)
-	, m_bOccupied("CvCity::m_bOccupied", m_syncArchive)
-	, m_bPuppet("CvCity::m_bPuppet", m_syncArchive)
-	, m_bIgnoreCityForHappiness("CvCity::m_bIgnoreCityForHappiness", m_syncArchive)
-	, m_bIndustrialRouteToCapital("CvCity::m_bIndustrialRouteToCapital", m_syncArchive)
-	, m_iTerrainImprovementNeed("CvCity::m_iTerrainImprovementNeed", m_syncArchive)
-	, m_ePreviousOwner("CvCity::m_ePreviousOwner", m_syncArchive)
-	, m_eOriginalOwner("CvCity::m_eOriginalOwner", m_syncArchive)
-	, m_ePlayersReligion("CvCity::m_ePlayersReligion", m_syncArchive)
-	, m_aiSeaPlotYield("CvCity::m_aiSeaPlotYield", m_syncArchive)
-	, m_aiRiverPlotYield("CvCity::m_aiRiverPlotYield", m_syncArchive)
-	, m_aiLakePlotYield("CvCity::m_aiLakePlotYield", m_syncArchive)
-	, m_aiSeaResourceYield("CvCity::m_aiSeaResourceYield", m_syncArchive)
-	, m_aiBaseYieldRateFromTerrain("CvCity::m_aiBaseYieldRateFromTerrain", m_syncArchive, true)
-	, m_aiBaseYieldRateFromBuildings("CvCity::m_aiBaseYieldRateFromBuildings", m_syncArchive)
-	, m_aiBaseYieldRateFromSpecialists("CvCity::m_aiBaseYieldRateFromSpecialists", m_syncArchive)
-	, m_aiBaseYieldRateFromMisc("CvCity::m_aiBaseYieldRateFromMisc", m_syncArchive)
-	, m_aiBaseYieldRateFromReligion("CvCity::m_aiBaseYieldRateFromReligion", m_syncArchive)
-	, m_aiYieldRateModifier("CvCity::m_aiYieldRateModifier", m_syncArchive)
-	, m_aiYieldPerPop("CvCity::m_aiYieldPerPop", m_syncArchive)
+	, m_bNeverLost()
+	, m_bDrafted()
+	, m_bAirliftTargeted()   // unused
+	, m_bProductionAutomated()
+	, m_bLayoutDirty()
+	, m_bMadeAttack()
+	, m_bOccupied()
+	, m_bPuppet()
+	, m_bIgnoreCityForHappiness()
+	, m_bIndustrialRouteToCapital()
+	, m_iTerrainImprovementNeed()
+	, m_ePreviousOwner()
+	, m_eOriginalOwner()
+	, m_ePlayersReligion()
+	, m_aiSeaPlotYield()
+	, m_aiRiverPlotYield()
+	, m_aiLakePlotYield()
+	, m_aiSeaResourceYield()
+	, m_aiBaseYieldRateFromTerrain()
+	, m_aiBaseYieldRateFromBuildings()
+	, m_aiBaseYieldRateFromSpecialists()
+	, m_aiBaseYieldRateFromMisc()
+	, m_aiBaseYieldRateFromReligion()
+	, m_aiYieldRateModifier()
+	, m_aiYieldPerPop()
 #if defined(MOD_BALANCE_CORE)
 	, m_aiYieldPerPopInEmpire()
 #endif
-	, m_aiYieldPerReligion("CvCity::m_aiYieldPerReligion", m_syncArchive)
-	, m_aiPowerYieldRateModifier("CvCity::m_aiPowerYieldRateModifier", m_syncArchive)
-	, m_aiResourceYieldRateModifier("CvCity::m_aiResourceYieldRateModifier", m_syncArchive)
-	, m_aiExtraSpecialistYield("CvCity::m_aiExtraSpecialistYield", m_syncArchive)
-	, m_aiProductionToYieldModifier("CvCity::m_aiProductionToYieldModifier", m_syncArchive)
-	, m_aiDomainFreeExperience("CvCity::m_aiDomainFreeExperience", m_syncArchive)
-	, m_aiDomainProductionModifier("CvCity::m_aiDomainProductionModifier", m_syncArchive)
+	, m_aiYieldPerReligion()
+	, m_aiPowerYieldRateModifier()
+	, m_aiResourceYieldRateModifier()
+	, m_aiExtraSpecialistYield()
+	, m_aiProductionToYieldModifier()
+	, m_aiDomainFreeExperience()
+	, m_aiDomainProductionModifier()
 #if defined(MOD_BALANCE_CORE_EVENTS)
-	, m_aiGreatWorkYieldChange("CvCity::m_aiGreatWorkYieldChange", m_syncArchive)
-	, m_aiEconomicValue("CvCity::m_aiEconomicValue", m_syncArchive)
-	, m_aiEventChoiceDuration("CvCity::m_aiEventChoiceDuration", m_syncArchive)
-	, m_aiEventIncrement("CvCity::m_aiEventIncrement", m_syncArchive)
-	, m_abEventActive("CvCity::m_abEventActive", m_syncArchive)
-	, m_abEventChoiceActive("CvCity::m_abEventChoiceActive", m_syncArchive)
-	, m_abEventChoiceFired("CvCity::m_abEventChoiceFired", m_syncArchive)
-	, m_abEventFired("CvCity::m_abEventFired", m_syncArchive)
-	, m_aiEventCooldown("CvCity::m_aiEventCooldown", m_syncArchive)
-	, m_aiEventCityYield("CvCity::m_aiEventCityYield", m_syncArchive)
-	, m_iEventHappiness("CvCity::m_iEventHappiness", m_syncArchive)
-	, m_iCityEventCooldown("CvCity::m_iCityEventCooldown", m_syncArchive)
-	, m_iHappinessDelta("CvCity::m_iHappinessDelta", m_syncArchive)
-	, m_iPillagedPlots("CvCity::m_iPillagedPlots", m_syncArchive)
-	, m_iGrowthFromTourism("CvCity::m_iGrowthFromTourism", m_syncArchive)
-	, m_iGrowthEvent("CvCity::m_iGrowthEvent", m_syncArchive)
-	, m_iBuildingClassHappiness("CvCity::m_iBuildingClassHappiness", m_syncArchive)
-	, m_iReligionHappiness("CvCity::m_iReligionHappiness", m_syncArchive)
+	, m_aiGreatWorkYieldChange()
+	, m_aiEconomicValue()
+	, m_aiEventChoiceDuration()
+	, m_aiEventIncrement()
+	, m_abEventActive()
+	, m_abEventChoiceActive()
+	, m_abEventChoiceFired()
+	, m_abEventFired()
+	, m_aiEventCooldown()
+	, m_aiEventCityYield()
+	, m_iEventHappiness()
+	, m_iCityEventCooldown()
+	, m_iHappinessDelta()
+	, m_iPillagedPlots()
+	, m_iGrowthFromTourism()
+	, m_iGrowthEvent()
+	, m_iBuildingClassHappiness()
+	, m_iReligionHappiness()
 #endif
-	, m_abEverOwned("CvCity::m_abEverOwned", m_syncArchive)
-	, m_strScriptData("CvCity::m_strScriptData", m_syncArchive)
-	, m_paiNoResource("CvCity::m_paiNoResource", m_syncArchive)
-	, m_paiFreeResource("CvCity::m_paiFreeResource", m_syncArchive)
-	, m_paiNumResourcesLocal("CvCity::m_paiNumResourcesLocal", m_syncArchive)
-	, m_paiNumUnimprovedResourcesLocal("CvCity::m_paiNumUnimprovedResourcesLocal", m_syncArchive)
-	, m_paiProjectProduction("CvCity::m_paiProjectProduction", m_syncArchive)
-	, m_paiSpecialistProduction("CvCity::m_paiSpecialistProduction", m_syncArchive)
-	, m_paiUnitProduction("CvCity::m_paiUnitProduction", m_syncArchive)
-	, m_paiUnitProductionTime("CvCity::m_paiUnitProductionTime", m_syncArchive)
-	, m_paiSpecialistCount("CvCity::m_paiSpecialistCount", m_syncArchive)
-	, m_paiMaxSpecialistCount("CvCity::m_paiMaxSpecialistCount", m_syncArchive)
-	, m_paiForceSpecialistCount("CvCity::m_paiForceSpecialistCount", m_syncArchive)
-	, m_paiFreeSpecialistCount("CvCity::m_paiFreeSpecialistCount", m_syncArchive)
-	, m_paiImprovementFreeSpecialists("CvCity::m_paiImprovementFreeSpecialists", m_syncArchive)
-	, m_paiUnitCombatFreeExperience("CvCity::m_paiUnitCombatFreeExperience", m_syncArchive)
-	, m_paiUnitCombatProductionModifier("CvCity::m_paiUnitCombatProductionModifier", m_syncArchive)
-	, m_paiFreePromotionCount("CvCity::m_paiFreePromotionCount", m_syncArchive)
-	, m_iBaseHappinessFromBuildings("CvCity::m_iBaseHappinessFromBuildings", m_syncArchive)
-	, m_iUnmoddedHappinessFromBuildings("CvCity::m_iUnmoddedHappinessFromBuildings", m_syncArchive)
-	, m_bRouteToCapitalConnectedLastTurn("CvCity::m_bRouteToCapitalConnectedLastTurn", m_syncArchive)
-	, m_bRouteToCapitalConnectedThisTurn("CvCity::m_bRouteToCapitalConnectedThisTurn", m_syncArchive)
-	, m_strName("CvCity::m_strName", m_syncArchive)
+	, m_abEverOwned()
+	, m_strScriptData()
+	, m_paiNoResource()
+	, m_paiFreeResource()
+	, m_paiNumResourcesLocal()
+	, m_paiNumUnimprovedResourcesLocal()
+	, m_paiProjectProduction()
+	, m_paiSpecialistProduction()
+	, m_paiUnitProduction()
+	, m_paiUnitProductionTime()
+	, m_paiSpecialistCount()
+	, m_paiMaxSpecialistCount()
+	, m_paiForceSpecialistCount()
+	, m_paiFreeSpecialistCount()
+	, m_paiImprovementFreeSpecialists()
+	, m_paiUnitCombatFreeExperience()
+	, m_paiUnitCombatProductionModifier()
+	, m_paiFreePromotionCount()
+	, m_iBaseHappinessFromBuildings()
+	, m_iUnmoddedHappinessFromBuildings()
+	, m_bRouteToCapitalConnectedLastTurn()
+	, m_bRouteToCapitalConnectedThisTurn()
+	, m_strName()
 	, m_orderQueue()
 	, m_pCityBuildings(FNEW(CvCityBuildings, c_eCiv5GameplayDLL, 0))
 	, m_pCityStrategyAI(FNEW(CvCityStrategyAI, c_eCiv5GameplayDLL, 0))
@@ -342,182 +343,187 @@ CvCity::CvCity() :
 	, m_pCityEspionage(FNEW(CvCityEspionage, c_eCiv5GameplayDLL, 0))
 	, m_pCityCulture(FNEW(CvCityCulture, c_eCiv5GameplayDLL, 0))
 	, m_bombardCheckTurn(0)
-	, m_iPopulationRank("CvCity::m_iPopulationRank", m_syncArchive)
-	, m_bPopulationRankValid("CvCity::m_bPopulationRankValid", m_syncArchive)
-	, m_aiBaseYieldRank("CvCity::m_aiBaseYieldRank", m_syncArchive)
-	, m_abBaseYieldRankValid("CvCity::m_abBaseYieldRankValid", m_syncArchive)
-	, m_aiYieldRank("CvCity::m_aiYieldRank", m_syncArchive)
-	, m_abYieldRankValid("CvCity::m_abYieldRankValid", m_syncArchive)
-	, m_bOwedCultureBuilding("CvCity::m_bOwedCultureBuilding", m_syncArchive)
+	, m_iPopulationRank()
+	, m_bPopulationRankValid()
+	, m_aiBaseYieldRank()
+	, m_abBaseYieldRankValid()
+	, m_aiYieldRank()
+	, m_abYieldRankValid()
+	, m_bOwedCultureBuilding()
 #if defined(MOD_BUILDINGS_CITY_WORKING)
-	, m_iCityWorkingChange("CvCity::m_iCityWorkingChange", m_syncArchive)
-	, m_iCitySupplyModifier("CvCity::m_iCitySupplyModifier", m_syncArchive)
-	, m_iCitySupplyFlat("CvCity::m_iCitySupplyFlat", m_syncArchive)
-	, m_bAllowsProductionTradeRoutes("CvCity::m_bAllowsProductionTradeRoutes", m_syncArchive)
-	, m_bAllowsFoodTradeRoutes("CvCity::m_bAllowsFoodTradeRoutes", m_syncArchive)
-	, m_bAllowPuppetPurchase("CvCity::m_bAllowPuppetPurchase", m_syncArchive)
-	, m_iStaticTechDeviation("CvCity::m_iStaticTechDeviation", m_syncArchive)
-	, m_iHappinessFromEmpire("CvCity::m_iHappinessFromEmpire", m_syncArchive)
-	, m_iHappinessFromLuxuries("CvCity::m_iHappinessFromLuxuries", m_syncArchive)
-	, m_iUnhappinessFromEmpire("CvCity::m_iUnhappinessFromEmpire", m_syncArchive)
+	, m_iCityWorkingChange()
+	, m_iCitySupplyModifier()
+	, m_iCitySupplyFlat()
+	, m_bAllowsProductionTradeRoutes()
+	, m_bAllowsFoodTradeRoutes()
+	, m_bAllowPuppetPurchase()
+	, m_iStaticTechDeviation()
+	, m_iHappinessFromEmpire()
+	, m_iHappinessFromLuxuries()
+	, m_iUnhappinessFromEmpire()
 #endif
 #if defined(MOD_BUILDINGS_CITY_AUTOMATON_WORKERS)
-	, m_iCityAutomatonWorkersChange("CvCity::m_iCityAutomatonWorkersChange", m_syncArchive)
+	, m_iCityAutomatonWorkersChange()
 #endif
 #if defined(MOD_RELIGION_CONVERSION_MODIFIERS)
-	, m_iConversionModifier("CvCity::m_iConversionModifier", m_syncArchive)
+	, m_iConversionModifier()
 #endif
 #if defined(MOD_DIPLOMACY_CITYSTATES)
-	, m_aiBaseYieldRateFromLeague("CvCity::m_aiBaseYieldRateFromLeague", m_syncArchive)
-	, m_iTotalScienceyAid("CvCity::m_iTotalScienceyAid", m_syncArchive)
-	, m_iTotalArtsyAid("CvCity::m_iTotalArtsyAid", m_syncArchive)
-	, m_iTotalGreatWorkAid("CvCity::m_iTotalGreatWorkAid", m_syncArchive)
+	, m_aiBaseYieldRateFromLeague()
+	, m_iTotalScienceyAid()
+	, m_iTotalArtsyAid()
+	, m_iTotalGreatWorkAid()
 #endif
 #if defined(MOD_BALANCE_CORE_HAPPINESS_MODIFIERS)
-	, m_iEmpireNeedsModifier("CvCity::m_iEmpireNeedsModifier", m_syncArchive)
-	, m_iChangePovertyUnhappiness("CvCity::m_iChangePovertyUnhappiness", m_syncArchive)
-	, m_iChangeDefenseUnhappiness("CvCity::m_iChangeDefenseUnhappiness", m_syncArchive)
-	, m_iChangeUnculturedUnhappiness("CvCity::m_iChangeUnculturedUnhappiness", m_syncArchive)
-	, m_iChangeIlliteracyUnhappiness("CvCity::m_iChangeIlliteracyUnhappiness", m_syncArchive)
-	, m_iChangeMinorityUnhappiness("CvCity::m_iChangeMinorityUnhappiness", m_syncArchive)
+	, m_iEmpireNeedsModifier()
+	, m_iChangePovertyUnhappiness()
+	, m_iChangeDefenseUnhappiness()
+	, m_iChangeUnculturedUnhappiness()
+	, m_iChangeIlliteracyUnhappiness()
+	, m_iChangeMinorityUnhappiness()
 #endif
 #if defined(MOD_DIPLOMACY_CITYSTATES) || defined(MOD_BALANCE_CORE)
-	, m_aiChangeGrowthExtraYield("CvCity::m_aiChangeGrowthExtraYield", m_syncArchive)
+	, m_aiChangeGrowthExtraYield()
 #endif
 #if defined(MOD_BALANCE_CORE)
-	, m_iNukeInterceptionChance("CvCity::m_iNukeInterceptionChance", m_syncArchive)
-	, m_iTradeRouteSeaDistanceModifier("CvCity::m_iTradeRouteSeaDistanceModifier", m_syncArchive)
-	, m_iTradeRouteLandDistanceModifier("CvCity::m_iTradeRouteLandDistanceModifier", m_syncArchive)
-	, m_iTradePriorityLand("CvCity::m_iTradePriorityLand", m_syncArchive)
-	, m_iTradePrioritySea("CvCity::m_iTradePrioritySea", m_syncArchive)
-	, m_iUnitPurchaseCooldown("CvCity::m_iUnitPurchaseCooldown", m_syncArchive)
-	, m_iUnitPurchaseCooldownCivilian("CvCity::m_iUnitPurchaseCooldownCivilian", m_syncArchive)
-	, m_iUnitFaithPurchaseCooldown("CvCity::m_iUnitFaithPurchaseCooldown", m_syncArchive)
-	, m_iUnitFaithPurchaseCooldownCivilian("CvCity::m_iUnitFaithPurchaseCooldownCivilian", m_syncArchive)
-	, m_iBuildingPurchaseCooldown("CvCity::m_iBuildingPurchaseCooldown", m_syncArchive)
-	, m_iReligiousTradeModifier("CvCity::m_iReligiousTradeModifier", m_syncArchive)
-	, m_iCityAirStrikeDefense("CvCity::m_iCityAirStrikeDefense", m_syncArchive)
-	, m_iFreeBuildingTradeTargetCity("CvCity::m_iFreeBuildingTradeTargetCity", m_syncArchive)
-	, m_iBaseTourism("CvCity::m_iBaseTourism", m_syncArchive)
-	, m_iBaseTourismBeforeModifiers("CvCity::m_iBaseTourismBeforeModifiers", m_syncArchive)
-	, m_aiYieldFromVictory("CvCity::m_aiYieldFromVictory", m_syncArchive)
-	, m_aiYieldFromVictoryGlobal("CvCity::m_aiYieldFromVictoryGlobal", m_syncArchive)
-	, m_aiYieldFromPillage("CvCity::m_aiYieldFromPillage", m_syncArchive)
-	, m_aiYieldFromPillageGlobal("CvCity::m_aiYieldFromPillageGlobal", m_syncArchive)
-	, m_aiNumTimesAttackedThisTurn("CvCity::m_aiNumTimesAttackedThisTurn", m_syncArchive)
-	, m_aiLongestPotentialTradeRoute("CvCity::m_aiLongestPotentialTradeRoute", m_syncArchive)
-	, m_aiNumProjects("CvCity::m_aiNumProjects", m_syncArchive)
-	, m_aiNumUnitsBuilt("CvCity::m_aiNumUnitsBuilt", m_syncArchive)
-	, m_aiStaticGlobalYield("CvCity::m_aiStaticGlobalYield", m_syncArchive)
-	, m_aiStaticNeedAdditives("CvCity::m_aiStaticNeedAdditives", m_syncArchive)
-	, m_aiYieldFromKnownPantheons("CvCity::m_aiYieldFromKnownPantheons", m_syncArchive)
-	, m_aiGoldenAgeYieldMod("CvCity::m_aiGoldenAgeYieldMod", m_syncArchive)
-	, m_aiYieldFromWLTKD("CvCity::m_aiYieldFromWLTKD", m_syncArchive)
-	, m_aiYieldFromConstruction("CvCity::m_aiYieldFromConstruction", m_syncArchive)
-	, m_aiYieldFromTech("CvCity::m_aiYieldFromTech", m_syncArchive)
-	, m_aiYieldFromUnitProduction("CvCity::m_aiYieldFromUnitProduction", m_syncArchive)
-	, m_aiYieldFromBirth("CvCity::m_aiYieldFromBirth", m_syncArchive)
-	, m_aiYieldFromBorderGrowth("CvCity::m_aiYieldFromBorderGrowth", m_syncArchive)
-	, m_aiYieldFromPolicyUnlock("CvCity::m_aiYieldFromPolicyUnlock", m_syncArchive)
-	, m_aiYieldFromPurchase("CvCity::m_aiYieldFromPurchase", m_syncArchive)
-	, m_aiYieldFromFaithPurchase("CvCity::m_aiYieldFromFaithPurchase", m_syncArchive)
-	, m_aiYieldFromUnitLevelUp("CvCity::m_aiYieldFromUnitLevelUp", m_syncArchive)
-	, m_aiYieldPerAlly("CvCity::m_aiYieldPerAlly", m_syncArchive)
-	, m_aiYieldPerFriend("CvCity::m_aiYieldPerFriend", m_syncArchive)
-	, m_aiYieldFromInternalTREnd("CvCity::m_aiYieldFromInternalTREnd", m_syncArchive)
-	, m_aiYieldFromInternalTR("CvCity::m_aiYieldFromInternalTR", m_syncArchive)
-	, m_aiYieldFromProcessModifier("CvCity::m_aiYieldFromProcessModifier", m_syncArchive)
-	, m_aiSpecialistRateModifier("CvCity::m_aiSpecialistRateModifier", m_syncArchive)
-	, m_aiNumTimesOwned("CvCity::m_aiNumTimesOwned", m_syncArchive)
-	, m_aiStaticCityYield("CvCity::m_aiStaticCityYield", m_syncArchive)
-	, m_aiThemingYieldBonus("CvCity::m_aiThemingYieldBonus", m_syncArchive)
-	, m_aiYieldFromSpyAttack("CvCity::m_aiYieldFromSpyAttack", m_syncArchive)
-	, m_aiYieldFromSpyDefense("CvCity::m_aiYieldFromSpyDefense", m_syncArchive)
-	, m_aiBaseYieldRateFromCSAlliance("CvCity::m_aiBaseYieldRateFromCSAlliance", m_syncArchive)
-	, m_aiBaseYieldRateFromCSFriendship("CvCity::m_aiBaseYieldRateFromCSFriendship", m_syncArchive)
-	, m_aiYieldFromMinors("CvCity::m_aiYieldFromMinors", m_syncArchive)
-	, m_aiResourceQuantityPerXFranchises("CvCity::m_aiResourceQuantityPerXFranchises", m_syncArchive)
-	, m_aiYieldChangeFromCorporationFranchises("CvCity::m_aiYieldChangeFromCorporationFranchises", m_syncArchive)
-	, m_aiNeedsFlatReduction("CvCity::m_aiNeedsFlatReduction", m_syncArchive)
-	, m_iLandTourismBonus("CvCity::m_iLandTourismBonus", m_syncArchive)
-	, m_iSeaTourismBonus("CvCity::m_iSeaTourismBonus", m_syncArchive)
-	, m_iAlwaysHeal("CvCity::m_iAlwaysHeal", m_syncArchive)
-	, m_iResourceDiversityModifier("CvCity::m_iResourceDiversityModifier", m_syncArchive)
-	, m_iNoUnhappfromXSpecialists("CvCity::m_iNoUnhappfromXSpecialists", m_syncArchive)
-	, m_aiStaticNeedsUpdateTurn("CvCity::m_aiStaticNeedsUpdateTurn", m_syncArchive)
-	, m_bNoWarmonger("CvCity::m_bNoWarmonger", m_syncArchive)
+	, m_iNukeInterceptionChance()
+	, m_iTradeRouteSeaDistanceModifier()
+	, m_iTradeRouteLandDistanceModifier()
+	, m_iTradePriorityLand()
+	, m_iTradePrioritySea()
+	, m_iUnitPurchaseCooldown()
+	, m_iUnitPurchaseCooldownCivilian()
+	, m_iUnitFaithPurchaseCooldown()
+	, m_iUnitFaithPurchaseCooldownCivilian()
+	, m_iBuildingPurchaseCooldown()
+	, m_iReligiousTradeModifier()
+	, m_iCityAirStrikeDefense()
+	, m_iFreeBuildingTradeTargetCity()
+	, m_iBaseTourism()
+	, m_iBaseTourismBeforeModifiers()
+	, m_aiYieldFromVictory()
+	, m_aiYieldFromVictoryGlobal()
+	, m_aiYieldFromPillage()
+	, m_aiYieldFromPillageGlobal()
+	, m_aiNumTimesAttackedThisTurn()
+	, m_aiLongestPotentialTradeRoute()
+	, m_aiNumProjects()
+	, m_aiNumUnitsBuilt()
+	, m_aiStaticGlobalYield()
+	, m_aiStaticNeedAdditives()
+	, m_aiYieldFromKnownPantheons()
+	, m_aiGoldenAgeYieldMod()
+	, m_aiYieldFromWLTKD()
+	, m_aiYieldFromConstruction()
+	, m_aiYieldFromTech()
+	, m_aiYieldFromUnitProduction()
+	, m_aiYieldFromBirth()
+	, m_aiYieldFromBorderGrowth()
+	, m_aiYieldFromPolicyUnlock()
+	, m_aiYieldFromPurchase()
+	, m_aiYieldFromFaithPurchase()
+	, m_aiYieldFromUnitLevelUp()
+	, m_aiYieldPerAlly()
+	, m_aiYieldPerFriend()
+	, m_aiYieldFromInternalTREnd()
+	, m_aiYieldFromInternalTR()
+	, m_aiYieldFromProcessModifier()
+	, m_aiSpecialistRateModifier()
+	, m_aiNumTimesOwned()
+	, m_aiStaticCityYield()
+	, m_aiThemingYieldBonus()
+	, m_aiYieldFromSpyAttack()
+	, m_aiYieldFromSpyDefense()
+	, m_aiBaseYieldRateFromCSAlliance()
+	, m_aiBaseYieldRateFromCSFriendship()
+	, m_aiYieldFromMinors()
+	, m_aiResourceQuantityPerXFranchises()
+	, m_aiYieldChangeFromCorporationFranchises()
+	, m_aiNeedsFlatReduction()
+	, m_iLandTourismBonus()
+	, m_iSeaTourismBonus()
+	, m_iAlwaysHeal()
+	, m_iResourceDiversityModifier()
+	, m_iNoUnhappfromXSpecialists()
+	, m_aiStaticNeedsUpdateTurn()
+	, m_bNoWarmonger()
 #endif
 #if defined(MOD_BALANCE_CORE_SPIES)
-	, m_iCitySpyRank("CvCity::m_iCitySpyRank", m_syncArchive)
-	, m_iTurnsSinceRankAnnouncement("CvCity::m_iTurnsSinceRankAnnouncement", m_syncArchive)
+	, m_iCitySpyRank()
+	, m_iTurnsSinceRankAnnouncement()
 #endif
 #if defined(MOD_BALANCE_CORE)
-	, m_abIsBestForWonder("CvCity::m_abIsBestForWonder", m_syncArchive)
-	, m_abIsPurchased("CvCity::m_abIsPurchased", m_syncArchive)
-	, m_abTraded("CvCity::m_abTraded", m_syncArchive)
-	, m_abPaidAdoptionBonus("CvCity::m_abPaidAdoptionBonus", m_syncArchive)
-	, m_aiReligiousPressureModifier("CvCity::m_aiReligiousPressureModifier", m_syncArchive)
-	, m_iExtraBuildingMaintenance("CvCity::m_iExtraBuildingMaintenance", m_syncArchive)
-	, m_paiNumTerrainWorked("CvCity::m_paiNumTerrainWorked", m_syncArchive)
-	, m_paiNumFeaturelessTerrainWorked("CvCity::m_paiNumFeaturelessTerrainWorked", m_syncArchive)
-	, m_paiNumFeatureWorked("CvCity::m_paiNumFeatureWorked", m_syncArchive)
-	, m_paiNumResourceWorked("CvCity::m_paiNumResourceWorked", m_syncArchive)
-	, m_paiNumImprovementWorked("CvCity::m_paiNumImprovementWorked", m_syncArchive)
+	, m_abIsBestForWonder()
+	, m_abIsPurchased()
+	, m_abTraded()
+	, m_abPaidAdoptionBonus()
+	, m_aiReligiousPressureModifier()
+	, m_iExtraBuildingMaintenance()
+	, m_paiNumTerrainWorked()
+	, m_paiNumFeaturelessTerrainWorked()
+	, m_paiNumFeatureWorked()
+	, m_paiNumResourceWorked()
+	, m_paiNumImprovementWorked()
 #endif
 #if defined(MOD_BALANCE_CORE_POLICIES)
-	, m_paiBuildingClassCulture("CvCity::m_paiBuildingClassCulture", m_syncArchive)
-	, m_paiHurryModifier("CvCity::m_paiHurryModifier", m_syncArchive)
+	, m_paiBuildingClassCulture()
+	, m_paiHurryModifier()
 #endif
 #if defined(MOD_BALANCE_CORE)
-	, m_vClosestNeighbors("CvCity::m_vClosestNeighbors", m_syncArchive)
+	, m_vClosestNeighbors()
 #endif
-	, m_yieldChanges( NUM_YIELD_TYPES )
-	, m_eventYields ( NUM_YIELD_TYPES )
+	, m_yieldChanges(NUM_YIELD_TYPES)
+	, m_eventYields(NUM_YIELD_TYPES)
 #if defined(MOD_API_UNIFIED_YIELDS) && defined(MOD_API_PLOT_YIELDS)
 	, m_ppiGreatPersonProgressFromConstruction()
 #endif
 #if defined(MOD_BALANCE_CORE)
-	, m_abOwedChosenBuilding("CvCity::m_abOwedChosenBuilding", m_syncArchive)
-	, m_abBuildingInvestment("CvCity::m_abBuildingInvestment", m_syncArchive)
-	, m_abUnitInvestment("CvCity::m_abUnitInvestment", m_syncArchive)
-	, m_abBuildingConstructed("CvCity::m_abBuildingConstructed", m_syncArchive)
-	, m_iBorderObstacleCity("CvCity::m_iBorderObstacleCity", m_syncArchive)
-	, m_iBorderObstacleWater("CvCity::m_iBorderObstacleWater", m_syncArchive)
-	, m_iDeepWaterTileDamage("CvCity::m_iDeepWaterTileDamage", m_syncArchive)
-	, m_iNumNearbyMountains("CvCity::m_iNumNearbyMountains", m_syncArchive)
-	, m_iLocalUnhappinessMod("CvCity::m_iLocalUnhappinessMod", m_syncArchive)
+	, m_abOwedChosenBuilding()
+	, m_abBuildingInvestment()
+	, m_abUnitInvestment()
+	, m_abBuildingConstructed()
+	, m_iBorderObstacleCity()
+	, m_iBorderObstacleWater()
+	, m_iDeepWaterTileDamage()
+	, m_iNumNearbyMountains()
+	, m_iLocalUnhappinessMod()
 #endif
-	, m_bOwedFoodBuilding("CvCity::m_bOwedFoodBuilding", m_syncArchive)
+	, m_bOwedFoodBuilding()
 #if defined(MOD_CORE_PER_TURN_DAMAGE)
-	, m_iDamageTakenThisTurn("CvCity::m_iDamageTakenThisTurn", m_syncArchive)
-	, m_iDamageTakenLastTurn("CvCity::m_iDamageTakenLastTurn", m_syncArchive)
+	, m_iDamageTakenThisTurn()
+	, m_iDamageTakenLastTurn()
 #endif
 #if defined(MOD_BALANCE_CORE)
-	, m_bIsColony("CvCity::m_bIsColony", m_syncArchive)
-	, m_iProvinceLevel("CvCity::m_iProvinceLevel", m_syncArchive)
-	, m_iOrganizedCrime("CvCity::m_iOrganizedCrime", m_syncArchive)
-	, m_iResistanceCounter("CvCity::m_iResistanceCounter", m_syncArchive)
-	, m_iPlagueCounter("CvCity::m_iPlagueCounter", m_syncArchive)
-	, m_iPlagueTurns("CvCity::m_iPlagueTurns", m_syncArchive)
-	, m_iSappedTurns("CvCity::m_iSappedTurns", m_syncArchive)
-	, m_iPlagueType("CvCity::m_iPlagueType", m_syncArchive)
-	, m_iLoyaltyCounter("CvCity::m_iLoyaltyCounter", m_syncArchive)
-	, m_iDisloyaltyCounter("CvCity::m_iDisloyaltyCounter", m_syncArchive)
-	, m_iLoyaltyStateType("CvCity::m_iLoyaltyStateType", m_syncArchive)
-	, m_aiYieldModifierFromHappiness("CvCity::m_aiYieldModifierFromHappiness", m_syncArchive)
-	, m_aiYieldModifierFromHealth("CvCity::m_aiYieldModifierFromHealth", m_syncArchive)
-	, m_aiYieldModifierFromCrime("CvCity::m_aiYieldModifierFromCrime", m_syncArchive)
-	, m_aiYieldModifierFromDevelopment("CvCity::m_aiYieldModifierFromDevelopment", m_syncArchive)
-	, m_aiYieldFromHappiness("CvCity::m_aiYieldFromHappiness", m_syncArchive)
-	, m_aiYieldFromHealth("CvCity::m_aiYieldFromHealth", m_syncArchive)
-	, m_aiYieldFromCrime("CvCity::m_aiYieldFromCrime", m_syncArchive)
-	, m_aiYieldFromDevelopment("CvCity::m_aiYieldFromDevelopment", m_syncArchive)
+	, m_bIsColony()
+	, m_iProvinceLevel()
+	, m_iOrganizedCrime()
+	, m_iResistanceCounter()
+	, m_iPlagueCounter()
+	, m_iPlagueTurns()
+	, m_iSappedTurns()
+	, m_iPlagueType()
+	, m_iLoyaltyCounter()
+	, m_iDisloyaltyCounter()
+	, m_iLoyaltyStateType()
+	, m_aiYieldModifierFromHappiness()
+	, m_aiYieldModifierFromHealth()
+	, m_aiYieldModifierFromCrime()
+	, m_aiYieldModifierFromDevelopment()
+	, m_aiYieldFromHappiness()
+	, m_aiYieldFromHealth()
+	, m_aiYieldFromCrime()
+	, m_aiYieldFromDevelopment()
 #endif
 {
 	OBJECT_ALLOCATED
 	FSerialization::citiesToCheck.push_back(this);
 
 	reset(0, NO_PLAYER, 0, 0, true);
+
+	if (GC.getGame().isNetworkMultiPlayer())
+	{
+		m_syncArchive.initSyncVars(*FNEW(CvSyncArchive<CvCity>::SyncVars(*this), c_eCiv5GameplayDLL, 0));
+	}
 }
 
 //	--------------------------------------------------------------------------------
@@ -1583,16 +1589,16 @@ void CvCity::reset(int iID, PlayerTypes eOwner, int iX, int iY, bool bConstructo
 	m_aiEconomicValue.resize(MAX_CIV_PLAYERS);
 	for (iI = 0; iI < MAX_CIV_PLAYERS; iI++)
 	{
-		m_aiEconomicValue.setAt(iI, 0);
+		m_aiEconomicValue[iI] = 0;
 		
 	}
 	for (iI = 0; iI < REALLY_MAX_PLAYERS; iI++)
 	{
-		m_aiNumTimesAttackedThisTurn.setAt(iI, 0);
+		m_aiNumTimesAttackedThisTurn[iI] = 0;
 	}
 	for (iI = 0; iI < NUM_DOMAIN_TYPES; iI++)
 	{
-		m_aiLongestPotentialTradeRoute.setAt(iI, 0);
+		m_aiLongestPotentialTradeRoute[iI] = 0;
 	}
 #endif
 	m_aiBaseYieldRateFromReligion.resize(NUM_YIELD_TYPES);
@@ -1616,64 +1622,64 @@ void CvCity::reset(int iID, PlayerTypes eOwner, int iX, int iY, bool bConstructo
 	m_aiStaticNeedsUpdateTurn = GC.getGame().getGameTurn();
 	for(iI = 0; iI < NUM_YIELD_TYPES; iI++)
 	{
-		m_aiStaticGlobalYield.setAt(iI, 0);
-		m_aiStaticNeedAdditives.setAt(iI, 0);
-		m_aiSeaPlotYield.setAt(iI, 0);
-		m_aiRiverPlotYield.setAt(iI, 0);
-		m_aiLakePlotYield.setAt(iI, 0);
-		m_aiSeaResourceYield.setAt(iI, 0);
-		m_aiBaseYieldRateFromTerrain.setAt(iI, 0);
-		m_aiBaseYieldRateFromBuildings.setAt(iI, 0);
-		m_aiBaseYieldRateFromSpecialists.setAt(iI, 0);
-		m_aiBaseYieldRateFromMisc.setAt(iI, 0);
+		m_aiStaticGlobalYield[iI] = 0;
+		m_aiStaticNeedAdditives[iI] = 0;
+		m_aiSeaPlotYield[iI] = 0;
+		m_aiRiverPlotYield[iI] = 0;
+		m_aiLakePlotYield[iI] = 0;
+		m_aiSeaResourceYield[iI] = 0;
+		m_aiBaseYieldRateFromTerrain[iI] = 0;
+		m_aiBaseYieldRateFromBuildings[iI] = 0;
+		m_aiBaseYieldRateFromSpecialists[iI] = 0;
+		m_aiBaseYieldRateFromMisc[iI] = 0;
 #if defined(MOD_DIPLOMACY_CITYSTATES)
-		m_aiBaseYieldRateFromLeague.setAt(iI, 0);
+		m_aiBaseYieldRateFromLeague[iI] = 0;
 #endif
 #if defined(MOD_DIPLOMACY_CITYSTATES) || defined(MOD_BALANCE_CORE)
-		m_aiChangeGrowthExtraYield.setAt(iI, 0);
+		m_aiChangeGrowthExtraYield[iI] = 0;
 #endif
 #if defined(MOD_BALANCE_CORE)
-		m_aiGreatWorkYieldChange.setAt(iI, 0);
-		m_aiYieldFromKnownPantheons.setAt(iI, 0);
-		m_aiYieldFromVictory.setAt(iI, 0);
-		m_aiYieldFromVictoryGlobal.setAt(iI, 0);
-		m_aiYieldFromPillage.setAt(iI, 0);
-		m_aiYieldFromPillageGlobal.setAt(iI, 0);
-		m_aiGoldenAgeYieldMod.setAt(iI, 0);
-		m_aiYieldFromWLTKD.setAt(iI, 0);
-		m_aiYieldFromConstruction.setAt(iI, 0);
-		m_aiYieldFromTech.setAt(iI, 0);
-		m_aiYieldFromBirth.setAt(iI, 0);
-		m_aiYieldFromUnitProduction.setAt(iI, 0);
-		m_aiYieldFromBorderGrowth.setAt(iI, 0);
-		m_aiYieldFromPolicyUnlock.setAt(iI, 0);
-		m_aiYieldFromPurchase.setAt(iI, 0);
-		m_aiYieldFromFaithPurchase.setAt(iI, 0);
-		m_aiYieldFromUnitLevelUp.setAt(iI, 0);
-		m_aiYieldPerAlly.setAt(iI, 0);
-		m_aiYieldPerFriend.setAt(iI, 0);
-		m_aiYieldFromInternalTREnd.setAt(iI, 0);
-		m_aiYieldFromInternalTR.setAt(iI, 0);
-		m_aiYieldFromProcessModifier.setAt(iI, 0);
-		m_aiThemingYieldBonus.setAt(iI, 0);
-		m_aiYieldFromSpyAttack.setAt(iI, 0);
-		m_aiYieldFromSpyDefense.setAt(iI, 0);
-		m_aiEventCityYield.setAt(iI, 0);
+		m_aiGreatWorkYieldChange[iI] = 0;
+		m_aiYieldFromKnownPantheons[iI] = 0;
+		m_aiYieldFromVictory[iI] = 0;
+		m_aiYieldFromVictoryGlobal[iI] = 0;
+		m_aiYieldFromPillage[iI] = 0;
+		m_aiYieldFromPillageGlobal[iI] = 0;
+		m_aiGoldenAgeYieldMod[iI] = 0;
+		m_aiYieldFromWLTKD[iI] = 0;
+		m_aiYieldFromConstruction[iI] = 0;
+		m_aiYieldFromTech[iI] = 0;
+		m_aiYieldFromBirth[iI] = 0;
+		m_aiYieldFromUnitProduction[iI] = 0;
+		m_aiYieldFromBorderGrowth[iI] = 0;
+		m_aiYieldFromPolicyUnlock[iI] = 0;
+		m_aiYieldFromPurchase[iI] = 0;
+		m_aiYieldFromFaithPurchase[iI] = 0;
+		m_aiYieldFromUnitLevelUp[iI] = 0;
+		m_aiYieldPerAlly[iI] = 0;
+		m_aiYieldPerFriend[iI] = 0;
+		m_aiYieldFromInternalTREnd[iI] = 0;
+		m_aiYieldFromInternalTR[iI] = 0;
+		m_aiYieldFromProcessModifier[iI] = 0;
+		m_aiThemingYieldBonus[iI] = 0;
+		m_aiYieldFromSpyAttack[iI] = 0;
+		m_aiYieldFromSpyDefense[iI] = 0;
+		m_aiEventCityYield[iI] = 0;
 #endif
-		m_aiBaseYieldRateFromReligion.setAt(iI, 0);
+		m_aiBaseYieldRateFromReligion[iI] = 0;
 #if defined(MOD_BALANCE_CORE)
-		m_aiYieldFromMinors.setAt(iI, 0);
-		m_aiBaseYieldRateFromCSFriendship.setAt(iI, 0);
-		m_aiBaseYieldRateFromCSAlliance.setAt(iI, 0);
-		m_aiStaticCityYield.setAt(iI, 0);
+		m_aiYieldFromMinors[iI] = 0;
+		m_aiBaseYieldRateFromCSFriendship[iI] = 0;
+		m_aiBaseYieldRateFromCSAlliance[iI] = 0;
+		m_aiStaticCityYield[iI] = 0;
 #endif
-		m_aiYieldPerPop.setAt(iI, 0);
-		m_aiYieldPerReligion.setAt(iI, 0);
-		m_aiYieldRateModifier.setAt(iI, 0);
-		m_aiPowerYieldRateModifier.setAt(iI, 0);
-		m_aiResourceYieldRateModifier.setAt(iI, 0);
-		m_aiExtraSpecialistYield.setAt(iI, 0);
-		m_aiProductionToYieldModifier.setAt(iI, 0);
+		m_aiYieldPerPop[iI] = 0;
+		m_aiYieldPerReligion[iI] = 0;
+		m_aiYieldRateModifier[iI] = 0;
+		m_aiPowerYieldRateModifier[iI] = 0;
+		m_aiResourceYieldRateModifier[iI] = 0;
+		m_aiExtraSpecialistYield[iI] = 0;
+		m_aiProductionToYieldModifier[iI] = 0;
 	}
 #if defined(MOD_BALANCE_CORE_EVENTS)
 	m_abEventChoiceFired.resize(GC.getNumCityEventChoiceInfos());
@@ -1681,9 +1687,9 @@ void CvCity::reset(int iID, PlayerTypes eOwner, int iX, int iY, bool bConstructo
 	m_abEventChoiceActive.resize(GC.getNumCityEventChoiceInfos());
 	for(iI = 0; iI < GC.getNumCityEventChoiceInfos(); iI++)
 	{
-		m_aiEventChoiceDuration.setAt(iI, 0);
-		m_abEventChoiceFired.setAt(iI, false);
-		m_abEventChoiceActive.setAt(iI, false);
+		m_aiEventChoiceDuration[iI] = 0;
+		m_abEventChoiceFired[iI] = false;
+		m_abEventChoiceActive[iI] = false;
 	}
 	m_abEventFired.resize(GC.getNumCityEventInfos());
 	m_abEventActive.resize(GC.getNumCityEventInfos());
@@ -1691,18 +1697,18 @@ void CvCity::reset(int iID, PlayerTypes eOwner, int iX, int iY, bool bConstructo
 	m_aiEventCooldown.resize(GC.getNumCityEventInfos());
 	for(iI = 0; iI < GC.getNumCityEventInfos(); iI++)
 	{
-		m_abEventFired.setAt(iI, false);
-		m_abEventActive.setAt(iI, false);
-		m_aiEventIncrement.setAt(iI, 0);
-		m_aiEventCooldown.setAt(iI, 0);
+		m_abEventFired[iI] = false;
+		m_abEventActive[iI] = false;
+		m_aiEventIncrement[iI] = 0;
+		m_aiEventCooldown[iI] = 0;
 	}
 #endif
 	m_aiDomainFreeExperience.resize(NUM_DOMAIN_TYPES);
 	m_aiDomainProductionModifier.resize(NUM_DOMAIN_TYPES);
 	for(iI = 0; iI < NUM_DOMAIN_TYPES; iI++)
 	{
-		m_aiDomainFreeExperience.setAt(iI, 0);
-		m_aiDomainProductionModifier.setAt(iI, 0);
+		m_aiDomainFreeExperience[iI] = 0;
+		m_aiDomainProductionModifier[iI] = 0;
 	}
 
 	m_abEverOwned.resize(REALLY_MAX_PLAYERS);
@@ -1711,40 +1717,40 @@ void CvCity::reset(int iID, PlayerTypes eOwner, int iX, int iY, bool bConstructo
 	m_abIsPurchased.resize(GC.getNumBuildingClassInfos());
 	for(iI = 0; iI < GC.getNumBuildingClassInfos(); iI++)
 	{
-		m_abIsPurchased.setAt(iI, false);
-		m_abIsBestForWonder.setAt(iI, false);
+		m_abIsPurchased[iI] = false;
+		m_abIsBestForWonder[iI] = false;
 	}
 
 	for(iI = 0; iI < GC.getNumProjectInfos(); iI++)
 	{
-		m_aiNumProjects.setAt(iI, 0);
+		m_aiNumProjects[iI] = 0;
 	}
 
 	for (iI = 0; iI < GC.getNumUnitInfos(); iI++)
 	{
-		m_aiNumUnitsBuilt.setAt(iI, 0);
+		m_aiNumUnitsBuilt[iI] = 0;
 	}
 
 	m_abTraded.resize(REALLY_MAX_PLAYERS);
 #endif
 	for(iI = 0; iI < REALLY_MAX_PLAYERS; iI++)
 	{
-		m_abEverOwned.setAt(iI, false);
+		m_abEverOwned[iI] = false;
 #if defined(MOD_BALANCE_CORE)
-		m_abTraded.setAt(iI, false);
-		m_aiNumTimesOwned.setAt(iI, false);
+		m_abTraded[iI] = false;
+		m_aiNumTimesOwned[iI] = false;
 #endif
 	}
 #if defined(MOD_BALANCE_CORE)
 	m_abPaidAdoptionBonus.resize(GC.getNumReligionInfos());
 	for(iI = 0; iI < GC.getNumReligionInfos(); iI++)
 	{
-		m_abPaidAdoptionBonus.setAt(iI, false);
+		m_abPaidAdoptionBonus[iI] = false;
 	}
 	m_aiReligiousPressureModifier.resize(GC.getNumReligionInfos());
 	for (iI = 0; iI < GC.getNumReligionInfos(); iI++)
 	{
-		m_aiReligiousPressureModifier.setAt(iI, 0);
+		m_aiReligiousPressureModifier[iI] = 0;
 	}
 #endif
 
@@ -1782,21 +1788,21 @@ void CvCity::reset(int iID, PlayerTypes eOwner, int iX, int iY, bool bConstructo
 #endif
 	for(iI = 0; iI < NUM_YIELD_TYPES; iI++)
 	{
-		m_abBaseYieldRankValid.setAt(iI, false);
-		m_abYieldRankValid.setAt(iI, false);
-		m_aiBaseYieldRank.setAt(iI, -1);
-		m_aiYieldRank.setAt(iI, -1);
+		m_abBaseYieldRankValid[iI] = false;
+		m_abYieldRankValid[iI] = false;
+		m_aiBaseYieldRank[iI] = -1;
+		m_aiYieldRank[iI] = -1;
 #if defined(MOD_BALANCE_CORE)
-		m_aiNeedsFlatReduction.setAt(iI, 0);
-		m_aiYieldChangeFromCorporationFranchises.setAt(iI, 0);
-		m_aiYieldModifierFromHappiness.setAt(iI, 0);
-		m_aiYieldModifierFromHealth.setAt(iI, 0);
-		m_aiYieldModifierFromCrime.setAt(iI, 0);
-		m_aiYieldModifierFromDevelopment.setAt(iI, 0);
-		m_aiYieldFromHappiness.setAt(iI, 0);
-		m_aiYieldFromHealth.setAt(iI, 0);
-		m_aiYieldFromCrime.setAt(iI, 0);
-		m_aiYieldFromDevelopment.setAt(iI, 0);
+		m_aiNeedsFlatReduction[iI] = 0;
+		m_aiYieldChangeFromCorporationFranchises[iI] = 0;
+		m_aiYieldModifierFromHappiness[iI] = 0;
+		m_aiYieldModifierFromHealth[iI] = 0;
+		m_aiYieldModifierFromCrime[iI] = 0;
+		m_aiYieldModifierFromDevelopment[iI] = 0;
+		m_aiYieldFromHappiness[iI] = 0;
+		m_aiYieldFromHealth[iI] = 0;
+		m_aiYieldFromCrime[iI] = 0;
+		m_aiYieldFromDevelopment[iI] = 0;
 #endif
 	}
 #if defined(MOD_BALANCE_CORE)
@@ -1806,13 +1812,13 @@ void CvCity::reset(int iID, PlayerTypes eOwner, int iX, int iY, bool bConstructo
 	m_abBuildingConstructed.resize(GC.getNumBuildingClassInfos());
 	for(int iI = 0; iI < GC.getNumBuildingClassInfos(); iI++)
 	{
-		m_abOwedChosenBuilding.setAt(iI, false);
-		m_abBuildingInvestment.setAt(iI, false);
-		m_abBuildingConstructed.setAt(iI, false);
+		m_abOwedChosenBuilding[iI] = false;
+		m_abBuildingInvestment[iI] = false;
+		m_abBuildingConstructed[iI] = false;
 	}
 	for(int iI = 0; iI < GC.getNumUnitClassInfos(); iI++)
 	{
-		m_abUnitInvestment.setAt(iI, false);
+		m_abUnitInvestment[iI] = false;
 	}
 #endif
 #if defined(MOD_BALANCE_CORE_JFD)
@@ -1847,12 +1853,12 @@ void CvCity::reset(int iID, PlayerTypes eOwner, int iX, int iY, bool bConstructo
 #endif
 		for(iI = 0; iI < iNumResources; iI++)
 		{
-			m_paiNoResource.setAt(iI, 0);
-			m_paiFreeResource.setAt(iI, 0);
-			m_paiNumResourcesLocal.setAt(iI, 0);
-			m_paiNumUnimprovedResourcesLocal.setAt(iI, 0);
+			m_paiNoResource[iI] = 0;
+			m_paiFreeResource[iI] = 0;
+			m_paiNumResourcesLocal[iI] = 0;
+			m_paiNumUnimprovedResourcesLocal[iI] = 0;
 #if defined(MOD_BALANCE_CORE)
-			m_aiResourceQuantityPerXFranchises.setAt(iI, 0);
+			m_aiResourceQuantityPerXFranchises[iI] = 0;
 #endif
 		}
 
@@ -1861,7 +1867,7 @@ void CvCity::reset(int iID, PlayerTypes eOwner, int iX, int iY, bool bConstructo
 		m_paiProjectProduction.resize(iNumProjectInfos);
 		for(iI = 0; iI < iNumProjectInfos; iI++)
 		{
-			m_paiProjectProduction.setAt(iI, 0);
+			m_paiProjectProduction[iI] = 0;
 		}
 
 		int iNumSpecialistInfos = GC.getNumSpecialistInfos();
@@ -1869,9 +1875,9 @@ void CvCity::reset(int iID, PlayerTypes eOwner, int iX, int iY, bool bConstructo
 		m_paiSpecialistProduction.resize(iNumSpecialistInfos);
 		for(iI = 0; iI < GC.getNumSpecialistInfos(); iI++)
 		{
-			m_paiSpecialistProduction.setAt(iI, 0);
+			m_paiSpecialistProduction[iI] = 0;
 #if defined(MOD_BALANCE_CORE)
-			m_aiSpecialistRateModifier.setAt(iI, 0);
+			m_aiSpecialistRateModifier[iI] = 0;
 #endif
 		}
 
@@ -1885,8 +1891,8 @@ void CvCity::reset(int iID, PlayerTypes eOwner, int iX, int iY, bool bConstructo
 		m_paiUnitProductionTime.resize(iNumUnitInfos);
 		for(iI = 0; iI < iNumUnitInfos; iI++)
 		{
-			m_paiUnitProduction.setAt(iI, 0);
-			m_paiUnitProductionTime.setAt(iI, 0);
+			m_paiUnitProduction[iI] = 0;
+			m_paiUnitProductionTime[iI] = 0;
 		}
 
 		CvAssertMsg((0 < iNumSpecialistInfos),  "GC.getNumSpecialistInfos() is not greater than zero but an array is being allocated in CvCity::reset");
@@ -1901,10 +1907,10 @@ void CvCity::reset(int iID, PlayerTypes eOwner, int iX, int iY, bool bConstructo
 
 		for(iI = 0; iI < iNumSpecialistInfos; iI++)
 		{
-			m_paiSpecialistCount.setAt(iI, 0);
-			m_paiMaxSpecialistCount.setAt(iI, 0);
-			m_paiForceSpecialistCount.setAt(iI, 0);
-			m_paiFreeSpecialistCount.setAt(iI, 0);
+			m_paiSpecialistCount[iI] = 0;
+			m_paiMaxSpecialistCount[iI] = 0;
+			m_paiForceSpecialistCount[iI] = 0;
+			m_paiFreeSpecialistCount[iI] = 0;
 		}
 
 		int iNumImprovementInfos = GC.getNumImprovementInfos();
@@ -1913,7 +1919,7 @@ void CvCity::reset(int iID, PlayerTypes eOwner, int iX, int iY, bool bConstructo
 		m_paiImprovementFreeSpecialists.resize(iNumImprovementInfos);
 		for(iI = 0; iI < iNumImprovementInfos; iI++)
 		{
-			m_paiImprovementFreeSpecialists.setAt(iI, 0);
+			m_paiImprovementFreeSpecialists[iI] = 0;
 		}
 
 		int iNumUnitCombatClassInfos = GC.getNumUnitCombatClassInfos();
@@ -1924,11 +1930,11 @@ void CvCity::reset(int iID, PlayerTypes eOwner, int iX, int iY, bool bConstructo
 		m_paiUnitCombatProductionModifier.resize(iNumUnitCombatClassInfos);
 		for(iI = 0; iI < iNumUnitCombatClassInfos; iI++)
 		{
-			m_paiUnitCombatFreeExperience.setAt(iI, 0);
-			m_paiUnitCombatProductionModifier.setAt(iI, 0);
+			m_paiUnitCombatFreeExperience[iI] = 0;
+			m_paiUnitCombatProductionModifier[iI] = 0;
 		}
 
-		m_paiFreePromotionCount.dirtyGet().clear();
+		m_paiFreePromotionCount.clear();
 
 #if defined(MOD_BALANCE_CORE_POLICIES)
 		int iNumBuildingClassInfos = GC.getNumBuildingClassInfos();
@@ -1937,7 +1943,7 @@ void CvCity::reset(int iID, PlayerTypes eOwner, int iX, int iY, bool bConstructo
 		m_paiBuildingClassCulture.resize(iNumBuildingClassInfos);
 		for(iI = 0; iI < iNumBuildingClassInfos; iI++)
 		{
-			m_paiBuildingClassCulture.setAt(iI, 0);
+			m_paiBuildingClassCulture[iI] = 0;
 		}
 		
 		int iNumHurryInfos = GC.getNumHurryInfos();
@@ -1946,7 +1952,7 @@ void CvCity::reset(int iID, PlayerTypes eOwner, int iX, int iY, bool bConstructo
 		m_paiHurryModifier.resize(iNumHurryInfos);
 		for(iI = 0; iI < iNumHurryInfos; iI++)
 		{
-			m_paiHurryModifier.setAt(iI, 0);
+			m_paiHurryModifier[iI] = 0;
 		}
 #endif
 
@@ -1961,29 +1967,29 @@ void CvCity::reset(int iID, PlayerTypes eOwner, int iX, int iY, bool bConstructo
 		m_paiNumTerrainWorked.resize(iNumTerrainInfos);
 		for(iI = 0; iI < iNumTerrainInfos; iI++)
 		{
-			m_paiNumTerrainWorked.setAt(iI, 0);
-			m_paiNumFeaturelessTerrainWorked.setAt(iI, 0);
+			m_paiNumTerrainWorked[iI] = 0;
+			m_paiNumFeaturelessTerrainWorked[iI] = 0;
 		}
 
 		m_paiNumFeatureWorked.clear();
 		m_paiNumFeatureWorked.resize(iNumFeatureInfos);
 		for(iI = 0; iI < iNumFeatureInfos; iI++)
 		{
-			m_paiNumFeatureWorked.setAt(iI, 0);
+			m_paiNumFeatureWorked[iI] = 0;
 		}
 
 		m_paiNumResourceWorked.clear();
 		m_paiNumResourceWorked.resize(iNumResourceInfos);
 		for(iI = 0; iI < iNumResourceInfos; iI++)
 		{
-			m_paiNumResourceWorked.setAt(iI, 0);
+			m_paiNumResourceWorked[iI] = 0;
 		}
 
 		m_paiNumImprovementWorked.clear();
 		m_paiNumImprovementWorked.resize(iNumImprovementInfos);
 		for(iI = 0; iI < iNumImprovementInfos; iI++)
 		{
-			m_paiNumImprovementWorked.setAt(iI, 0);
+			m_paiNumImprovementWorked[iI] = 0;
 		}
 #endif
 	}
@@ -3102,7 +3108,7 @@ void CvCity::SetStaticYield(YieldTypes eYield, int iValue)
 {
 	CvAssertMsg(eYield >= 0, "eIndex expected to be >= 0");
 	CvAssertMsg(eYield < NUM_YIELD_TYPES, "eIndex expected to be < NUM_YIELD_TYPES");
-	m_aiStaticCityYield.setAt(eYield, iValue);
+	m_aiStaticCityYield[eYield] = iValue;
 }
 
 int CvCity::GetStaticYield(YieldTypes eYield) const
@@ -3175,7 +3181,7 @@ void CvCity::SetLongestPotentialTradeRoute(int iValue, DomainTypes eDomain)
 	VALIDATE_OBJECT
 	CvAssertMsg(eDomain >= 0, "eIndex1 is expected to be non-negative (invalid Index)");
 	CvAssertMsg(eDomain < NUM_DOMAIN_TYPES, "eIndex1 is expected to be within maximum bounds (invalid Index)");
-	return m_aiLongestPotentialTradeRoute.setAt(eDomain, iValue);
+	m_aiLongestPotentialTradeRoute[eDomain] = iValue;
 }
 
 bool CvCity::AreOurBordersTouching(PlayerTypes ePlayer)
@@ -3224,7 +3230,7 @@ void CvCity::SetGlobalStaticYield(YieldTypes eYield, int iValue)
 	CvAssertMsg(eYield >= 0, "eIndex expected to be >= 0");
 	CvAssertMsg(eYield < NUM_YIELD_TYPES, "eIndex expected to be < NUM_YIELD_TYPES");
 
-	m_aiStaticGlobalYield.setAt(eYield, iValue);
+	m_aiStaticGlobalYield[eYield] = iValue;
 }
 int CvCity::GetGlobalStaticYield(YieldTypes eYield) const
 {
@@ -3237,7 +3243,7 @@ void CvCity::SetStaticNeedAdditives(YieldTypes eYield, int iValue)
 	CvAssertMsg(eYield >= 0, "eIndex expected to be >= 0");
 	CvAssertMsg(eYield < NUM_YIELD_TYPES, "eIndex expected to be < NUM_YIELD_TYPES");
 
-	m_aiStaticNeedAdditives.setAt(eYield, iValue);
+	m_aiStaticNeedAdditives[eYield] = iValue;
 }
 int CvCity::GetStaticNeedAdditives(YieldTypes eYield) const
 {
@@ -3347,7 +3353,7 @@ void CvCity::ChangeEventChoiceDuration(CityEventChoiceTypes eEventChoice,int iVa
 	CvAssertMsg(eEventChoice < GC.getNumCityEventChoiceInfos(), "eEvent is expected to be within maximum bounds (invalid Index)");
 	if(iValue != 0)
 	{
-		m_aiEventChoiceDuration.setAt(eEventChoice, m_aiEventChoiceDuration[eEventChoice] + iValue);
+		m_aiEventChoiceDuration[eEventChoice] = m_aiEventChoiceDuration[eEventChoice] + iValue;
 	}
 }
 void CvCity::SetEventChoiceDuration(CityEventChoiceTypes eEventChoice,int iValue)
@@ -3355,7 +3361,7 @@ void CvCity::SetEventChoiceDuration(CityEventChoiceTypes eEventChoice,int iValue
 	VALIDATE_OBJECT
 	CvAssertMsg(eEventChoice >= 0, "eEvent is expected to be non-negative (invalid Index)");
 	CvAssertMsg(eEventChoice < GC.getNumCityEventChoiceInfos(), "eEvent is expected to be within maximum bounds (invalid Index)");
-	m_aiEventChoiceDuration.setAt(eEventChoice, iValue);
+	m_aiEventChoiceDuration[eEventChoice] = iValue;
 }
 int CvCity::GetEventIncrement(CityEventTypes eEvent) const
 {
@@ -3371,7 +3377,7 @@ void CvCity::IncrementEvent(CityEventTypes eEvent, int iValue)
 	CvAssertMsg(eEvent < GC.getNumCityEventInfos(), "eEvent is expected to be within maximum bounds (invalid Index)");
 	if(iValue != 0)
 	{
-		m_aiEventIncrement.setAt(eEvent, m_aiEventIncrement[eEvent] + iValue);
+		m_aiEventIncrement[eEvent] = m_aiEventIncrement[eEvent] + iValue;
 	}
 }
 int CvCity::GetCityEventCooldown() const
@@ -3394,7 +3400,7 @@ void CvCity::ChangeEventCityYield(YieldTypes eYield, int iValue)
 	CvAssertMsg(eYield < NUM_YIELD_TYPES, "eYield is expected to be within maximum bounds (invalid Index)");
 	if(iValue != 0)
 	{
-		m_aiEventCityYield.setAt(eYield, m_aiEventCityYield[eYield] + iValue);
+		m_aiEventCityYield[eYield] = m_aiEventCityYield[eYield] + iValue;
 		updateYield(false);
 	}
 }
@@ -7307,7 +7313,7 @@ void CvCity::SetEventActive(CityEventTypes eEvent, bool bValue)
 	CvAssertMsg(eEvent >= 0, "eEvent is expected to be non-negative (invalid Index)");
 	CvAssertMsg(eEvent < GC.getNumCityEventInfos(), "eEvent is expected to be within maximum bounds (invalid Index)");
 
-	m_abEventActive.setAt(eEvent, bValue);
+	m_abEventActive[eEvent] = bValue;
 }
 bool CvCity::IsEventActive(CityEventTypes eEvent) const
 {
@@ -7323,7 +7329,7 @@ void CvCity::SetEventChoiceActive(CityEventChoiceTypes eEventChoice, bool bValue
 	CvAssertMsg(eEventChoice >= 0, "eEventChoice is expected to be non-negative (invalid Index)");
 	CvAssertMsg(eEventChoice < GC.getNumCityEventChoiceInfos(), "eEventChoice is expected to be within maximum bounds (invalid Index)");
 
-	m_abEventChoiceActive.setAt(eEventChoice, bValue);
+	m_abEventChoiceActive[eEventChoice] = bValue;
 }
 bool CvCity::IsEventChoiceActive(CityEventChoiceTypes eEventChoice) const
 {
@@ -7340,7 +7346,7 @@ void CvCity::SetEventChoiceFired(CityEventChoiceTypes eEvent, bool bValue)
 	CvAssertMsg(eEvent >= 0, "eEvent is expected to be non-negative (invalid Index)");
 	CvAssertMsg(eEvent < GC.getNumCityEventChoiceInfos(), "eEvent is expected to be within maximum bounds (invalid Index)");
 
-	m_abEventChoiceFired.setAt(eEvent, bValue);
+	m_abEventChoiceFired[eEvent] = bValue;
 }
 bool CvCity::IsEventChoiceFired(CityEventChoiceTypes eEvent) const
 {
@@ -7356,7 +7362,7 @@ void CvCity::SetEventFired(CityEventTypes eEvent, bool bValue)
 	CvAssertMsg(eEvent >= 0, "eEvent is expected to be non-negative (invalid Index)");
 	CvAssertMsg(eEvent < GC.getNumCityEventInfos(), "eEvent is expected to be within maximum bounds (invalid Index)");
 
-	m_abEventFired.setAt(eEvent, bValue);
+	m_abEventFired[eEvent] = bValue;
 }
 bool CvCity::IsEventFired(CityEventTypes eEvent) const
 {
@@ -7380,7 +7386,7 @@ void CvCity::ChangeEventCooldown(CityEventTypes eEvent,int iValue)
 	CvAssertMsg(eEvent < GC.getNumCityEventInfos(), "eEvent is expected to be within maximum bounds (invalid Index)");
 	if(iValue != 0)
 	{
-		m_aiEventCooldown.setAt(eEvent, m_aiEventCooldown[eEvent] + iValue);
+		m_aiEventCooldown[eEvent] = m_aiEventCooldown[eEvent] + iValue;
 	}
 }
 void CvCity::SetEventCooldown(CityEventTypes eEvent,int iValue)
@@ -7388,7 +7394,7 @@ void CvCity::SetEventCooldown(CityEventTypes eEvent,int iValue)
 	VALIDATE_OBJECT
 	CvAssertMsg(eEvent >= 0, "eEvent is expected to be non-negative (invalid Index)");
 	CvAssertMsg(eEvent < GC.getNumCityEventInfos(), "eEvent is expected to be within maximum bounds (invalid Index)");
-	m_aiEventCooldown.setAt(eEvent, iValue);
+	m_aiEventCooldown[eEvent] = iValue;
 }
 int CvCity::GetEventHappiness() const
 {
@@ -7695,7 +7701,7 @@ void CvCity::updateEconomicValue()
 	for (int iPlayerLoop = 0; iPlayerLoop < MAX_CIV_PLAYERS; iPlayerLoop++)
 	{
 		PlayerTypes ePossibleOwner = (PlayerTypes)iPlayerLoop;
-		m_aiEconomicValue.setAt(iPlayerLoop, 0); //everybody gets a new value
+		m_aiEconomicValue[iPlayerLoop] = 0; //everybody gets a new value
 
 		if (ePossibleOwner != NO_PLAYER && GET_PLAYER(ePossibleOwner).isAlive())
 		{
@@ -7752,7 +7758,7 @@ void CvCity::updateEconomicValue()
 				}
 			}
 
-			m_aiEconomicValue.setAt(ePossibleOwner, iYieldValue + iResourceValue);
+			m_aiEconomicValue[ePossibleOwner] = iYieldValue + iResourceValue;
 		}
 	}
 }
@@ -8238,8 +8244,8 @@ int CvCity::findBaseYieldRateRank(YieldTypes eYield)
 			}
 		}
 
-		m_abBaseYieldRankValid.setAt(eYield, true);
-		m_aiBaseYieldRank.setAt(eYield, iRank);
+		m_abBaseYieldRankValid[eYield] = true;
+		m_aiBaseYieldRank[eYield] = iRank;
 	}
 
 	return m_aiBaseYieldRank[eYield];
@@ -8266,8 +8272,8 @@ int CvCity::findYieldRateRank(YieldTypes eYield)
 			}
 		}
 
-		m_abYieldRankValid.setAt(eYield, true);
-		m_aiYieldRank.setAt(eYield, iRank);
+		m_abYieldRankValid[eYield] = true;
+		m_aiYieldRank[eYield] = iRank;
 	}
 
 	return m_aiYieldRank[eYield];
@@ -9616,11 +9622,11 @@ void CvCity::ChangeNumResourceLocal(ResourceTypes eResource, int iChange, bool b
 		//unimproved is just here for the cache.
 		if (bUnimproved)
 		{
-			m_paiNumUnimprovedResourcesLocal.setAt(eResource, max(0, m_paiNumUnimprovedResourcesLocal[eResource] + iChange));
+			m_paiNumUnimprovedResourcesLocal[eResource] = max(0, m_paiNumUnimprovedResourcesLocal[eResource] + iChange);
 			return;
 		}
 		else
-			m_paiNumResourcesLocal.setAt(eResource, max(0, m_paiNumResourcesLocal[eResource] + iChange));
+			m_paiNumResourcesLocal[eResource] = max(0, m_paiNumResourcesLocal[eResource] + iChange);
 
 		if(bOldHasResource != IsHasResourceLocal(eResource, /*bTestVisible*/ false))
 		{
@@ -10102,7 +10108,7 @@ bool CvCity::IsBuildingFeatureValid(BuildingTypes eBuilding, CvString* toolTipSi
 ResourceTypes CvCity::GetResourceDemanded(bool bHideUnknown) const
 {
 	VALIDATE_OBJECT
-	ResourceTypes eResourceDemanded = static_cast<ResourceTypes>(m_iResourceDemanded.get());
+	ResourceTypes eResourceDemanded = static_cast<ResourceTypes>(m_iResourceDemanded);
 
 	// If we're not hiding the result then don't bother with looking at tech
 	if(!bHideUnknown)
@@ -11740,7 +11746,7 @@ void CvCity::SetBuildingInvestment(BuildingClassTypes eBuildingClass, bool bNewV
 		GAMEEVENTINVOKE_HOOK(GAMEEVENT_CityInvestedBuilding, getOwner(), GetID(), eBuildingClass, bNewValue);
 	}
 
-	m_abBuildingInvestment.setAt(eBuildingClass, bNewValue);
+	m_abBuildingInvestment[eBuildingClass] = bNewValue;
 }
 
 //	--------------------------------------------------------------------------------
@@ -11762,7 +11768,7 @@ void CvCity::SetUnitInvestment(UnitClassTypes eUnitClass, bool bNewValue)
 		GAMEEVENTINVOKE_HOOK(GAMEEVENT_CityInvestedUnit, getOwner(), GetID(), eUnitClass, bNewValue);
 	}
 
-	m_abUnitInvestment.setAt(eUnitClass, bNewValue);
+	m_abUnitInvestment[eUnitClass] = bNewValue;
 }
 
 //	--------------------------------------------------------------------------------
@@ -11779,7 +11785,7 @@ void CvCity::SetBuildingConstructed(BuildingClassTypes eBuildingClass, bool bNew
 	FAssert(eBuildingClass >= 0);
 	FAssert(eBuildingClass < GC.getNumBuildingClassInfos());
 
-	m_abBuildingConstructed.setAt(eBuildingClass, bNewValue);
+	m_abBuildingConstructed[eBuildingClass] = bNewValue;
 }	
 #endif
 //	--------------------------------------------------------------------------------
@@ -16319,7 +16325,7 @@ void CvCity::UpdateReligion(ReligionTypes eNewMajority, bool bRecalcPlotYields)
 #endif
 	for(int iYield = 0; iYield < NUM_YIELD_TYPES; iYield++)
 	{
-		m_aiBaseYieldRateFromReligion.setAt(iYield, 0);
+		m_aiBaseYieldRateFromReligion[iYield] = 0;
 	}
 
 	for(int iYield = 0; iYield < NUM_YIELD_TYPES; iYield++)
@@ -16670,7 +16676,7 @@ void CvCity::SetPaidAdoptionBonus(ReligionTypes eReligion, bool bNewValue)
 	VALIDATE_OBJECT
 	CvAssertMsg(eReligion >= 0, "eReligion expected to be >= 0");
 	CvAssertMsg(eReligion < GC.getNumReligionInfos(), "eReligion expected to be < getNumReligionInfos");
-	m_abPaidAdoptionBonus.setAt(eReligion, bNewValue);
+	m_abPaidAdoptionBonus[eReligion] = bNewValue;
 }
 
 int CvCity::GetReligiousPressureModifier(ReligionTypes eReligion) const
@@ -16685,7 +16691,7 @@ void CvCity::SetReligiousPressureModifier(ReligionTypes eReligion, int iNewValue
 	VALIDATE_OBJECT
 	CvAssertMsg(eReligion >= 0, "eReligion expected to be >= 0");
 	CvAssertMsg(eReligion < GC.getNumReligionInfos(), "eReligion expected to be < getNumReligionInfos");
-	m_aiReligiousPressureModifier.setAt(eReligion, iNewValue);
+	m_aiReligiousPressureModifier[eReligion] = iNewValue;
 }
 void CvCity::ChangeReligiousPressureModifier(ReligionTypes eReligion, int iNewValue)
 {
@@ -17016,7 +17022,7 @@ void CvCity::SetTraded(PlayerTypes ePlayer, bool bValue)
 	VALIDATE_OBJECT
 	CvAssertMsg(ePlayer >= 0, "eIndex expected to be >= 0");
 	CvAssertMsg(ePlayer < MAX_PLAYERS, "eIndex expected to be < MAX_PLAYERS");
-	m_abTraded.setAt(ePlayer, bValue);
+	m_abTraded[ePlayer] = bValue;
 }
 bool CvCity::IsTraded(PlayerTypes ePlayer)
 {
@@ -18429,7 +18435,7 @@ bool CvCity::HasGarrison() const
 	{
 		if (m_hGarrison>-1 && GetGarrisonedUnit()==NULL)
 		{
-			OutputDebugString(CvString::format("error! invalid garrison %d is set in %s!\n",m_hGarrison.get(),getName().c_str()).c_str());
+			OutputDebugString(CvString::format("error! invalid garrison %d is set in %s!\n",m_hGarrison,getName().c_str()).c_str());
 			(const_cast<CvCity*>(this))->m_hGarrison = -1;
 			return false;
 		}
@@ -18956,7 +18962,7 @@ void CvCity::SetJONSCultureStored(int iValue)
 
 	if (GetID() == g_iCityToTrace)
 	{
-		OutputDebugString(CvString::format("Turn %d, culture %d, delta %d\n",GC.getGame().getGameTurn(),m_iJONSCultureStored.get(),iValue-m_iJONSCultureStored.get()).c_str());
+		OutputDebugString(CvString::format("Turn %d, culture %d, delta %d\n",GC.getGame().getGameTurn(),m_iJONSCultureStored,iValue-m_iJONSCultureStored).c_str());
 	}
 		
 	m_iJONSCultureStored = iValue;
@@ -19503,7 +19509,7 @@ void CvCity::ChangeYieldFromTraits(YieldTypes eIndex, int iChange)
 
 	if (iChange != 0)
 	{
-		m_iaAddedYieldPerTurnFromTraits.setAt(eIndex, m_iaAddedYieldPerTurnFromTraits[eIndex] + iChange);
+		m_iaAddedYieldPerTurnFromTraits[eIndex] = m_iaAddedYieldPerTurnFromTraits[eIndex] + iChange;
 
 		if (getTeam() == GC.getGame().getActiveTeam())
 		{
@@ -20012,7 +20018,7 @@ void CvCity::ChangeNumTerrainWorked(TerrainTypes eTerrain, int iChange)
 {
 	CvAssertMsg(eTerrain >= 0, "eTerrain is expected to be non-negative (invalid Index)");
 	CvAssertMsg(eTerrain < GC.getNumTerrainInfos(), "eTerrain is expected to be within maximum bounds (invalid Index)");
-	m_paiNumTerrainWorked.setAt(eTerrain, m_paiNumTerrainWorked[eTerrain] + iChange);
+	m_paiNumTerrainWorked[eTerrain] = m_paiNumTerrainWorked[eTerrain] + iChange;
 	CvAssert(GetNumTerrainWorked(eTerrain) >= 0);
 
 	//Update yields
@@ -20038,7 +20044,7 @@ void CvCity::ChangeNumFeaturelessTerrainWorked(TerrainTypes eTerrain, int iChang
 {
 	CvAssertMsg(eTerrain >= 0, "eTerrain is expected to be non-negative (invalid Index)");
 	CvAssertMsg(eTerrain < GC.getNumTerrainInfos(), "eTerrain is expected to be within maximum bounds (invalid Index)");
-	m_paiNumFeaturelessTerrainWorked.setAt(eTerrain, m_paiNumFeaturelessTerrainWorked[eTerrain] + iChange);
+	m_paiNumFeaturelessTerrainWorked[eTerrain] = m_paiNumFeaturelessTerrainWorked[eTerrain] + iChange;
 	CvAssert(GetNumFeaturelessTerrainWorked(eTerrain) >= 0);
 
 	//Update yields
@@ -20064,7 +20070,7 @@ void CvCity::ChangeNumFeatureWorked(FeatureTypes eFeature, int iChange)
 {
 	CvAssertMsg(eFeature >= 0, "eFeature is expected to be non-negative (invalid Index)");
 	CvAssertMsg(eFeature < GC.getNumFeatureInfos(), "eFeature is expected to be within maximum bounds (invalid Index)");
-	m_paiNumFeatureWorked.setAt(eFeature, m_paiNumFeatureWorked[eFeature] + iChange);
+	m_paiNumFeatureWorked[eFeature] = m_paiNumFeatureWorked[eFeature] + iChange;
 	CvAssert(GetNumFeatureWorked(eFeature) >= 0);
 	
 	//Update yields
@@ -20089,7 +20095,7 @@ void CvCity::ChangeNumResourceWorked(ResourceTypes eResource, int iChange)
 {
 	CvAssertMsg(eResource >= 0, "eResource is expected to be non-negative (invalid Index)");
 	CvAssertMsg(eResource < GC.getNumResourceInfos(), "eResource is expected to be within maximum bounds (invalid Index)");
-	m_paiNumResourceWorked.setAt(eResource, m_paiNumResourceWorked[eResource] + iChange);
+	m_paiNumResourceWorked[eResource] = m_paiNumResourceWorked[eResource] + iChange;
 	CvAssert(GetNumResourceWorked(eResource) >= 0);
 }
 //	--------------------------------------------------------------------------------
@@ -20104,7 +20110,7 @@ void CvCity::ChangeNumImprovementWorked(ImprovementTypes eImprovement, int iChan
 {
 	CvAssertMsg(eImprovement >= 0, "eImprovement is expected to be non-negative (invalid Index)");
 	CvAssertMsg(eImprovement < GC.getNumImprovementInfos(), "eImprovement is expected to be within maximum bounds (invalid Index)");
-	m_paiNumImprovementWorked.setAt(eImprovement, m_paiNumImprovementWorked[eImprovement] + iChange);
+	m_paiNumImprovementWorked[eImprovement] = m_paiNumImprovementWorked[eImprovement] + iChange;
 	CvAssert(GetNumImprovementWorked(eImprovement) >= 0);
 }
 
@@ -20629,7 +20635,7 @@ void CvCity::changeHurryModifier(HurryTypes eIndex, int iChange)
 	{
 		CvAssertMsg(eIndex >= 0, "eIndex is expected to be non-negative (invalid Index)");
 		CvAssertMsg(eIndex < GC.getNumHurryInfos(), "eIndex is expected to be within maximum bounds (invalid Index)");
-		m_paiHurryModifier.setAt(eIndex, m_paiHurryModifier[eIndex] + iChange);
+		m_paiHurryModifier[eIndex] = m_paiHurryModifier[eIndex] + iChange;
 	}
 }
 
@@ -20711,7 +20717,7 @@ void CvCity::changeBuildingClassCultureChange(BuildingClassTypes eIndex, int iCh
 {
 	CvAssertMsg(eIndex >= 0, "eIndex is expected to be non-negative (invalid Index)");
 	CvAssertMsg(eIndex < GC.getNumBuildingClassInfos(), "eIndex is expected to be within maximum bounds (invalid Index)");
-	m_paiBuildingClassCulture.setAt(eIndex, m_paiBuildingClassCulture[eIndex] + iChange);
+	m_paiBuildingClassCulture[eIndex] = m_paiBuildingClassCulture[eIndex] + iChange;
 	CvAssert(getBuildingClassCultureChange(eIndex) >= 0);
 }
 #endif
@@ -24430,7 +24436,7 @@ void CvCity::SetOwedChosenBuilding(BuildingClassTypes eBuildingClass, bool bNewV
 	FAssert(eBuildingClass >= 0);
 	FAssert(eBuildingClass < GC.getNumBuildingClassInfos());
 
-	m_abOwedChosenBuilding.setAt(eBuildingClass, bNewValue);
+	m_abOwedChosenBuilding[eBuildingClass] = bNewValue;
 }
 #endif
 
@@ -24643,7 +24649,7 @@ void CvCity::SetNumTimesOwned(PlayerTypes ePlayer, int iValue)
 {
 	CvAssertMsg(ePlayer >= 0, "eIndex expected to be >= 0");
 	CvAssertMsg(ePlayer < MAX_PLAYERS, "eIndex expected to be < MAX_PLAYERS");
-	m_aiNumTimesOwned.setAt(ePlayer, iValue);
+	m_aiNumTimesOwned[ePlayer] = iValue;
 }
 void CvCity::ChangeNumTimesOwned(PlayerTypes ePlayer, int iValue)
 {
@@ -24684,7 +24690,7 @@ void CvCity::changeSeaPlotYield(YieldTypes eIndex, int iChange)
 
 	if(iChange != 0)
 	{
-		m_aiSeaPlotYield.setAt(eIndex, m_aiSeaPlotYield[eIndex] + iChange);
+		m_aiSeaPlotYield[eIndex] = m_aiSeaPlotYield[eIndex] + iChange;
 		CvAssert(getSeaPlotYield(eIndex) >= 0);
 
 		updateYield();
@@ -24709,7 +24715,7 @@ void CvCity::changeRiverPlotYield(YieldTypes eIndex, int iChange)
 
 	if(iChange != 0)
 	{
-		m_aiRiverPlotYield.setAt(eIndex, m_aiRiverPlotYield[eIndex] + iChange);
+		m_aiRiverPlotYield[eIndex] = m_aiRiverPlotYield[eIndex] + iChange;
 		CvAssert(getRiverPlotYield(eIndex) >= 0);
 
 		updateYield();
@@ -24735,7 +24741,7 @@ void CvCity::changeLakePlotYield(YieldTypes eIndex, int iChange)
 
 	if(iChange != 0)
 	{
-		m_aiLakePlotYield.setAt(eIndex, m_aiLakePlotYield[eIndex] + iChange);
+		m_aiLakePlotYield[eIndex] = m_aiLakePlotYield[eIndex] + iChange;
 		CvAssert(getLakePlotYield(eIndex) >= 0);
 
 		updateYield();
@@ -24761,7 +24767,7 @@ void CvCity::changeSeaResourceYield(YieldTypes eIndex, int iChange)
 
 	if(iChange != 0)
 	{
-		m_aiSeaResourceYield.setAt(eIndex, m_aiSeaResourceYield[eIndex] + iChange);
+		m_aiSeaResourceYield[eIndex] = m_aiSeaResourceYield[eIndex] + iChange;
 		CvAssert(getSeaResourceYield(eIndex) >= 0);
 
 		updateYield();
@@ -24971,7 +24977,7 @@ void CvCity::SetSpecialReligionYields(YieldTypes eIndex, int iChange)
 
 	if (iChange != m_aiYieldFromKnownPantheons[eIndex])
 	{
-		m_aiYieldFromKnownPantheons.setAt(eIndex, iChange);
+		m_aiYieldFromKnownPantheons[eIndex] = iChange;
 		CvAssert(GetSpecialReligionYields(eIndex) >= 0);
 	}
 }
@@ -25720,7 +25726,7 @@ void CvCity::ChangeBaseYieldRateFromTerrain(YieldTypes eIndex, int iChange)
 			OutputDebugString("houston, we have a problem!\n");
 		}
 
-		m_aiBaseYieldRateFromTerrain.setAt(eIndex, m_aiBaseYieldRateFromTerrain[eIndex] + iChange);
+		m_aiBaseYieldRateFromTerrain[eIndex] = m_aiBaseYieldRateFromTerrain[eIndex] + iChange;
 
 		if(getTeam() == GC.getGame().getActiveTeam())
 		{
@@ -25741,7 +25747,7 @@ void CvCity::SetBaseYieldRateFromTerrain(YieldTypes eIndex, int iValue)
 
 	if (iValue != m_aiBaseYieldRateFromTerrain[eIndex])
 	{
-		m_aiBaseYieldRateFromTerrain.setAt(eIndex, iValue);
+		m_aiBaseYieldRateFromTerrain[eIndex] = iValue;
 
 		if (getTeam() == GC.getGame().getActiveTeam())
 		{
@@ -25773,7 +25779,7 @@ void CvCity::ChangeBaseYieldRateFromBuildings(YieldTypes eIndex, int iChange)
 
 	if(iChange != 0)
 	{
-		m_aiBaseYieldRateFromBuildings.setAt(eIndex, m_aiBaseYieldRateFromBuildings[eIndex] + iChange);
+		m_aiBaseYieldRateFromBuildings[eIndex] = m_aiBaseYieldRateFromBuildings[eIndex] + iChange;
 
 		if(getTeam() == GC.getGame().getActiveTeam())
 		{
@@ -25807,7 +25813,7 @@ void CvCity::ChangeBaseYieldRateFromSpecialists(YieldTypes eIndex, int iChange)
 
 	if(iChange != 0)
 	{
-		m_aiBaseYieldRateFromSpecialists.setAt(eIndex, m_aiBaseYieldRateFromSpecialists[eIndex] + iChange);
+		m_aiBaseYieldRateFromSpecialists[eIndex] = m_aiBaseYieldRateFromSpecialists[eIndex] + iChange;
 
 		if(getTeam() == GC.getGame().getActiveTeam())
 		{
@@ -25840,7 +25846,7 @@ void CvCity::ChangeBaseYieldRateFromMisc(YieldTypes eIndex, int iChange)
 
 	if(iChange != 0)
 	{
-		m_aiBaseYieldRateFromMisc.setAt(eIndex, m_aiBaseYieldRateFromMisc[eIndex] + iChange);
+		m_aiBaseYieldRateFromMisc[eIndex] = m_aiBaseYieldRateFromMisc[eIndex] + iChange;
 
 		if(getTeam() == GC.getGame().getActiveTeam())
 		{
@@ -25884,7 +25890,7 @@ void CvCity::ChangeBaseYieldRateFromLeague(YieldTypes eIndex, int iChange)
 
 	if(iChange != 0)
 	{
-		m_aiBaseYieldRateFromLeague.setAt(eIndex, m_aiBaseYieldRateFromLeague[eIndex] + iChange);
+		m_aiBaseYieldRateFromLeague[eIndex] = m_aiBaseYieldRateFromLeague[eIndex] + iChange;
 
 		if(getTeam() == GC.getGame().getActiveTeam())
 		{
@@ -25967,7 +25973,7 @@ void CvCity::ChangeGrowthExtraYield(YieldTypes eIndex, int iChange)
 
 	if(iChange != 0)
 	{
-		m_aiChangeGrowthExtraYield.setAt(eIndex, m_aiChangeGrowthExtraYield[eIndex] + iChange);
+		m_aiChangeGrowthExtraYield[eIndex] = m_aiChangeGrowthExtraYield[eIndex] + iChange;
 		CvAssert(GetGrowthExtraYield(eIndex) >= 0);
 	}
 }
@@ -25993,7 +25999,7 @@ void CvCity::ChangeYieldFromVictory(YieldTypes eIndex, int iChange)
 
 	if(iChange != 0)
 	{
-		m_aiYieldFromVictory.setAt(eIndex, m_aiYieldFromVictory[eIndex] + iChange);
+		m_aiYieldFromVictory[eIndex] = m_aiYieldFromVictory[eIndex] + iChange;
 		CvAssert(GetYieldFromVictory(eIndex) >= 0);
 	}
 }
@@ -26017,7 +26023,7 @@ void CvCity::ChangeYieldFromVictoryGlobal(YieldTypes eIndex, int iChange)
 
 	if (iChange != 0)
 	{
-		m_aiYieldFromVictoryGlobal.setAt(eIndex, m_aiYieldFromVictoryGlobal[eIndex] + iChange);
+		m_aiYieldFromVictoryGlobal[eIndex] = m_aiYieldFromVictoryGlobal[eIndex] + iChange;
 		CvAssert(GetYieldFromVictoryGlobal(eIndex) >= 0);
 	}
 }
@@ -26042,7 +26048,7 @@ void CvCity::ChangeYieldFromPillage(YieldTypes eIndex, int iChange)
 
 	if (iChange != 0)
 	{
-		m_aiYieldFromPillage.setAt(eIndex, m_aiYieldFromPillage[eIndex] + iChange);
+		m_aiYieldFromPillage[eIndex] = m_aiYieldFromPillage[eIndex] + iChange;
 		CvAssert(GetYieldFromPillage(eIndex) >= 0);
 	}
 }
@@ -26065,7 +26071,7 @@ void CvCity::ChangeYieldFromPillageGlobal(YieldTypes eIndex, int iChange)
 
 	if (iChange != 0)
 	{
-		m_aiYieldFromPillageGlobal.setAt(eIndex, m_aiYieldFromPillageGlobal[eIndex] + iChange);
+		m_aiYieldFromPillageGlobal[eIndex] = m_aiYieldFromPillageGlobal[eIndex] + iChange;
 		CvAssert(GetYieldFromPillageGlobal(eIndex) >= 0);
 	}
 }
@@ -26090,7 +26096,7 @@ void CvCity::ChangeGoldenAgeYieldMod(YieldTypes eIndex, int iChange)
 
 	if(iChange != 0)
 	{
-		m_aiGoldenAgeYieldMod.setAt(eIndex, m_aiGoldenAgeYieldMod[eIndex] + iChange);
+		m_aiGoldenAgeYieldMod[eIndex] = m_aiGoldenAgeYieldMod[eIndex] + iChange;
 		CvAssert(GetGoldenAgeYieldMod(eIndex) >= 0);
 	}
 }
@@ -26116,7 +26122,7 @@ void CvCity::ChangeYieldFromWLTKD(YieldTypes eIndex, int iChange)
 
 	if(iChange != 0)
 	{
-		m_aiYieldFromWLTKD.setAt(eIndex, m_aiYieldFromWLTKD[eIndex] + iChange);
+		m_aiYieldFromWLTKD[eIndex] = m_aiYieldFromWLTKD[eIndex] + iChange;
 		CvAssert(GetYieldFromWLTKD(eIndex) >= 0);
 	}
 }
@@ -26140,7 +26146,7 @@ void CvCity::ChangeYieldFromConstruction(YieldTypes eIndex, int iChange)
 
 	if(iChange != 0)
 	{
-		m_aiYieldFromConstruction.setAt(eIndex, m_aiYieldFromConstruction[eIndex] + iChange);
+		m_aiYieldFromConstruction[eIndex] = m_aiYieldFromConstruction[eIndex] + iChange;
 		CvAssert(GetYieldFromConstruction(eIndex) >= 0);
 	}
 }
@@ -26164,7 +26170,7 @@ void CvCity::ChangeYieldFromTech(YieldTypes eIndex, int iChange)
 
 	if(iChange != 0)
 	{
-		m_aiYieldFromTech.setAt(eIndex, m_aiYieldFromTech[eIndex] + iChange);
+		m_aiYieldFromTech[eIndex] = m_aiYieldFromTech[eIndex] + iChange;
 		CvAssert(GetYieldFromTech(eIndex) >= 0);
 	}
 }
@@ -26189,7 +26195,7 @@ void CvCity::ChangeYieldFromBirth(YieldTypes eIndex, int iChange)
 
 	if(iChange != 0)
 	{
-		m_aiYieldFromBirth.setAt(eIndex, m_aiYieldFromBirth[eIndex] + iChange);
+		m_aiYieldFromBirth[eIndex] = m_aiYieldFromBirth[eIndex] + iChange;
 		CvAssert(GetYieldFromBirth(eIndex) >= 0);
 	}
 }
@@ -26213,7 +26219,7 @@ void CvCity::ChangeYieldFromUnitProduction(YieldTypes eIndex, int iChange)
 
 	if(iChange != 0)
 	{
-		m_aiYieldFromUnitProduction.setAt(eIndex, m_aiYieldFromUnitProduction[eIndex] + iChange);
+		m_aiYieldFromUnitProduction[eIndex] = m_aiYieldFromUnitProduction[eIndex] + iChange;
 		CvAssert(GetYieldFromUnitProduction(eIndex) >= 0);
 	}
 }
@@ -26238,7 +26244,7 @@ void CvCity::ChangeYieldFromBorderGrowth(YieldTypes eIndex, int iChange)
 
 	if(iChange != 0)
 	{
-		m_aiYieldFromBorderGrowth.setAt(eIndex, m_aiYieldFromBorderGrowth[eIndex] + iChange);
+		m_aiYieldFromBorderGrowth[eIndex] = m_aiYieldFromBorderGrowth[eIndex] + iChange;
 		CvAssert(GetYieldFromBorderGrowth(eIndex) >= 0);
 	}
 }
@@ -26262,7 +26268,7 @@ void CvCity::ChangeYieldFromPolicyUnlock(YieldTypes eIndex, int iChange)
 
 	if(iChange != 0)
 	{
-		m_aiYieldFromPolicyUnlock.setAt(eIndex, m_aiYieldFromPolicyUnlock[eIndex] + iChange);
+		m_aiYieldFromPolicyUnlock[eIndex] = m_aiYieldFromPolicyUnlock[eIndex] + iChange;
 		CvAssert(GetYieldFromPolicyUnlock(eIndex) >= 0);
 	}
 }
@@ -26286,7 +26292,7 @@ void CvCity::ChangeYieldFromPurchase(YieldTypes eIndex, int iChange)
 
 	if(iChange != 0)
 	{
-		m_aiYieldFromPurchase.setAt(eIndex, m_aiYieldFromPurchase[eIndex] + iChange);
+		m_aiYieldFromPurchase[eIndex] = m_aiYieldFromPurchase[eIndex] + iChange;
 		CvAssert(GetYieldFromPurchase(eIndex) >= 0);
 	}
 }
@@ -26311,7 +26317,7 @@ void CvCity::ChangeYieldFromFaithPurchase(YieldTypes eIndex, int iChange)
 
 	if (iChange != 0)
 	{
-		m_aiYieldFromFaithPurchase.setAt(eIndex, m_aiYieldFromFaithPurchase[eIndex] + iChange);
+		m_aiYieldFromFaithPurchase[eIndex] = m_aiYieldFromFaithPurchase[eIndex] + iChange;
 		CvAssert(GetYieldFromFaithPurchase(eIndex) >= 0);
 	}
 }
@@ -26335,7 +26341,7 @@ void CvCity::ChangeYieldFromUnitLevelUp(YieldTypes eIndex, int iChange)
 
 	if(iChange != 0)
 	{
-		m_aiYieldFromUnitLevelUp.setAt(eIndex, m_aiYieldFromUnitLevelUp[eIndex] + iChange);
+		m_aiYieldFromUnitLevelUp[eIndex] = m_aiYieldFromUnitLevelUp[eIndex] + iChange;
 		CvAssert(GetYieldFromUnitLevelUp(eIndex) >= 0);
 	}
 }
@@ -26360,7 +26366,7 @@ void CvCity::ChangeYieldPerAlly(YieldTypes eIndex, int iChange)
 
 	if (iChange != 0)
 	{
-		m_aiYieldPerAlly.setAt(eIndex, m_aiYieldPerAlly[eIndex] + iChange);
+		m_aiYieldPerAlly[eIndex] = m_aiYieldPerAlly[eIndex] + iChange;
 		CvAssert(GetYieldPerAlly(eIndex) >= 0);
 	}
 }
@@ -26384,7 +26390,7 @@ void CvCity::ChangeYieldPerFriend(YieldTypes eIndex, int iChange)
 
 	if (iChange != 0)
 	{
-		m_aiYieldPerFriend.setAt(eIndex, m_aiYieldPerFriend[eIndex] + iChange);
+		m_aiYieldPerFriend[eIndex] = m_aiYieldPerFriend[eIndex] + iChange;
 		CvAssert(GetYieldPerFriend(eIndex) >= 0);
 	}
 }
@@ -26460,7 +26466,7 @@ void CvCity::ChangeYieldFromInternalTREnd(YieldTypes eIndex1, int iChange)
 	CvAssertMsg(eIndex1 < NUM_YIELD_TYPES, "eIndex expected to be < NUM_YIELD_TYPES");
 	if (iChange != 0)
 	{
-		m_aiYieldFromInternalTREnd.setAt(eIndex1, m_aiYieldFromInternalTREnd[eIndex1] + iChange);
+		m_aiYieldFromInternalTREnd[eIndex1] = m_aiYieldFromInternalTREnd[eIndex1] + iChange;
 		CvAssert(GetYieldFromInternalTREnd(eIndex1) >= 0);
 	}
 }
@@ -26485,7 +26491,7 @@ void CvCity::ChangeYieldFromInternalTR(YieldTypes eIndex1, int iChange)
 	CvAssertMsg(eIndex1 < NUM_YIELD_TYPES, "eIndex expected to be < NUM_YIELD_TYPES");
 	if (iChange != 0)
 	{
-		m_aiYieldFromInternalTR.setAt(eIndex1, m_aiYieldFromInternalTR[eIndex1] + iChange);
+		m_aiYieldFromInternalTR[eIndex1] = m_aiYieldFromInternalTR[eIndex1] + iChange;
 		CvAssert(GetYieldFromInternalTR(eIndex1) >= 0);
 	}
 }
@@ -26511,7 +26517,7 @@ void CvCity::ChangeYieldFromProcessModifier(YieldTypes eIndex1, int iChange)
 	CvAssertMsg(eIndex1 < NUM_YIELD_TYPES, "eIndex expected to be < NUM_YIELD_TYPES");
 	if (iChange != 0)
 	{
-		m_aiYieldFromProcessModifier.setAt(eIndex1, m_aiYieldFromProcessModifier[eIndex1] + iChange);
+		m_aiYieldFromProcessModifier[eIndex1] = m_aiYieldFromProcessModifier[eIndex1] + iChange;
 		CvAssert(GetYieldFromProcessModifier(eIndex1) >= 0);
 	}
 }
@@ -26535,7 +26541,7 @@ void CvCity::ChangeSpecialistRateModifier(SpecialistTypes eSpecialist, int iChan
 
 	if(iChange != 0)
 	{
-		m_aiSpecialistRateModifier.setAt(eSpecialist, m_aiSpecialistRateModifier[eSpecialist] + iChange);
+		m_aiSpecialistRateModifier[eSpecialist] = m_aiSpecialistRateModifier[eSpecialist] + iChange;
 		CvAssert(GetSpecialistRateModifier(eSpecialist) >= 0);
 	}
 }
@@ -26559,7 +26565,7 @@ void CvCity::ChangeThemingYieldBonus(YieldTypes eIndex, int iChange)
 
 	if(iChange != 0)
 	{
-		m_aiThemingYieldBonus.setAt(eIndex, m_aiThemingYieldBonus[eIndex] + iChange);
+		m_aiThemingYieldBonus[eIndex] = m_aiThemingYieldBonus[eIndex] + iChange;
 		CvAssert(GetThemingYieldBonus(eIndex) >= 0);
 	}
 }
@@ -26584,7 +26590,7 @@ void CvCity::ChangeYieldFromSpyAttack(YieldTypes eIndex, int iChange)
 
 	if (iChange != 0)
 	{
-		m_aiYieldFromSpyAttack.setAt(eIndex, m_aiYieldFromSpyAttack[eIndex] + iChange);
+		m_aiYieldFromSpyAttack[eIndex] = m_aiYieldFromSpyAttack[eIndex] + iChange;
 		CvAssert(GetYieldFromSpyAttack(eIndex) >= 0);
 	}
 }
@@ -26609,7 +26615,7 @@ void CvCity::ChangeYieldFromSpyDefense(YieldTypes eIndex, int iChange)
 
 	if (iChange != 0)
 	{
-		m_aiYieldFromSpyDefense.setAt(eIndex, m_aiYieldFromSpyDefense[eIndex] + iChange);
+		m_aiYieldFromSpyDefense[eIndex] = m_aiYieldFromSpyDefense[eIndex] + iChange;
 		CvAssert(GetYieldFromSpyDefense(eIndex) >= 0);
 	}
 }
@@ -26692,7 +26698,7 @@ void CvCity::ChangeFlatNeedsReduction(YieldTypes eYield, int iValue)
 {
 	if (iValue != 0)
 	{
-		m_aiNeedsFlatReduction.setAt(eYield, GetFlatNeedsReduction(eYield) + iValue);
+		m_aiNeedsFlatReduction[eYield] = GetFlatNeedsReduction(eYield) + iValue;
 	}	
 }
 
@@ -26807,7 +26813,7 @@ void CvCity::ChangeBaseYieldRateFromReligion(YieldTypes eIndex, int iChange)
 
 	if(iChange != 0)
 	{
-		m_aiBaseYieldRateFromReligion.setAt(eIndex, m_aiBaseYieldRateFromReligion[eIndex] + iChange);
+		m_aiBaseYieldRateFromReligion[eIndex] = m_aiBaseYieldRateFromReligion[eIndex] + iChange;
 
 		if(getTeam() == GC.getGame().getActiveTeam())
 		{
@@ -26843,7 +26849,7 @@ void CvCity::ChangeBaseYieldRateFromCSAlliance(YieldTypes eIndex, int iChange)
 
 	if(iChange != 0)
 	{
-		m_aiBaseYieldRateFromCSAlliance.setAt(eIndex, m_aiBaseYieldRateFromCSAlliance[eIndex] + iChange);
+		m_aiBaseYieldRateFromCSAlliance[eIndex] = m_aiBaseYieldRateFromCSAlliance[eIndex] + iChange;
 		CvAssert(GetBaseYieldRateFromCSAlliance(eIndex) >= 0); 
 	}
 }
@@ -26851,7 +26857,7 @@ void CvCity::SetBaseYieldRateFromCSAlliance(YieldTypes eIndex, int iValue)
 {
 	if(GetBaseYieldRateFromCSAlliance(eIndex) != iValue)
 	{
-		m_aiBaseYieldRateFromCSAlliance.setAt(eIndex, iValue);
+		m_aiBaseYieldRateFromCSAlliance[eIndex] = iValue;
 	}
 }
 //	--------------------------------------------------------------------------------
@@ -26877,7 +26883,7 @@ void CvCity::ChangeBaseYieldRateFromCSFriendship(YieldTypes eIndex, int iChange)
 
 	if(iChange != 0)
 	{
-		m_aiBaseYieldRateFromCSFriendship.setAt(eIndex, m_aiBaseYieldRateFromCSFriendship[eIndex] + iChange);
+		m_aiBaseYieldRateFromCSFriendship[eIndex] = m_aiBaseYieldRateFromCSFriendship[eIndex] + iChange;
 		CvAssert(GetBaseYieldRateFromCSFriendship(eIndex) >= 0); 
 	}
 }
@@ -26885,13 +26891,13 @@ void CvCity::SetBaseYieldRateFromCSFriendship(YieldTypes eIndex, int iValue)
 {
 	if(GetBaseYieldRateFromCSFriendship(eIndex) != iValue)
 	{
-		m_aiBaseYieldRateFromCSFriendship.setAt(eIndex, iValue);
+		m_aiBaseYieldRateFromCSFriendship[eIndex] = iValue;
 	}
 }
 
 void CvCity::SetYieldFromMinors(YieldTypes eYield, int iValue)
 {
-	m_aiYieldFromMinors.setAt(eYield, iValue);
+	m_aiYieldFromMinors[eYield] = iValue;
 }
 int CvCity::GetYieldFromMinors(YieldTypes eYield) const
 {
@@ -27148,7 +27154,7 @@ void CvCity::SetYieldChangeFromCorporationFranchises(YieldTypes eIndex, int iTot
 {
 	if(GetYieldChangeFromCorporationFranchises(eIndex) != iTotal)
 	{
-		m_aiYieldChangeFromCorporationFranchises.setAt(eIndex, iTotal);
+		m_aiYieldChangeFromCorporationFranchises[eIndex] = iTotal;
 	}
 }
 int CvCity::GetYieldChangeFromCorporationFranchises(YieldTypes eIndex) const
@@ -27210,7 +27216,7 @@ void CvCity::ChangeResourceQuantityPerXFranchises(ResourceTypes eResource, int i
 
 	if(iChange != 0)
 	{
-		m_aiResourceQuantityPerXFranchises.setAt(eResource, m_aiResourceQuantityPerXFranchises[eResource] + iChange);
+		m_aiResourceQuantityPerXFranchises[eResource] = m_aiResourceQuantityPerXFranchises[eResource] + iChange;
 //		CvAssert(GetCorporationResourceQuantity(eResource) >= 0); 
 	}
 }
@@ -27218,7 +27224,7 @@ void CvCity::SetResourceQuantityPerXFranchises(ResourceTypes eResource, int iVal
 {
 	if(GetResourceQuantityPerXFranchises(eResource) != iValue)
 	{
-		m_aiResourceQuantityPerXFranchises.setAt(eResource, iValue);
+		m_aiResourceQuantityPerXFranchises[eResource] = iValue;
 	}
 }
 //	--------------------------------------------------------------------------------
@@ -27447,7 +27453,7 @@ void CvCity::SetPurchased(BuildingClassTypes eBuildingClass, bool bValue)
 	CvAssertMsg(eBuildingClass < GC.getNumBuildingClassInfos(), "eIndex expected to be < MAX_PLAYERS");
 	if (m_abIsPurchased[eBuildingClass] != bValue)
 	{
-		m_abIsPurchased.setAt(eBuildingClass, bValue);
+		m_abIsPurchased[eBuildingClass] = bValue;
 	}
 }
 bool CvCity::IsPurchased(BuildingClassTypes eBuildingClass)
@@ -27464,7 +27470,7 @@ void CvCity::SetBestForWonder(BuildingClassTypes eBuildingClass, bool bValue)
 	CvAssertMsg(eBuildingClass < GC.getNumBuildingClassInfos(), "eBuildingClass expected to be < GC.getNumBuildingClassInfos()");
 	if (m_abIsBestForWonder[eBuildingClass] != bValue)
 	{
-		m_abIsBestForWonder.setAt(eBuildingClass, bValue);
+		m_abIsBestForWonder[eBuildingClass] = bValue;
 	}
 }
 bool CvCity::IsBestForWonder(BuildingClassTypes eBuildingClass)
@@ -27496,7 +27502,7 @@ void CvCity::ChangeYieldPerPopTimes100(YieldTypes eIndex, int iChange)
 	CvAssertMsg(eIndex < NUM_YIELD_TYPES, "eIndex expected to be < NUM_YIELD_TYPES");
 
 	if(iChange != 0)
-		m_aiYieldPerPop.setAt(eIndex, m_aiYieldPerPop[eIndex] + iChange);
+		m_aiYieldPerPop[eIndex] = m_aiYieldPerPop[eIndex] + iChange;
 }
 
 #if defined(MOD_BALANCE_CORE)
@@ -27551,7 +27557,7 @@ void CvCity::ChangeYieldPerReligionTimes100(YieldTypes eIndex, int iChange)
 
 	if(iChange != 0)
 	{
-		m_aiYieldPerReligion.setAt(eIndex, m_aiYieldPerReligion[eIndex] + iChange);
+		m_aiYieldPerReligion[eIndex] = m_aiYieldPerReligion[eIndex] + iChange;
 	}
 }
 
@@ -27573,7 +27579,7 @@ void CvCity::changeYieldRateModifier(YieldTypes eIndex, int iChange)
 	CvAssertMsg(eIndex < NUM_YIELD_TYPES, "eIndex expected to be < NUM_YIELD_TYPES");
 	if(iChange != 0)
 	{
-		m_aiYieldRateModifier.setAt(eIndex, m_aiYieldRateModifier[eIndex] + iChange);
+		m_aiYieldRateModifier[eIndex] = m_aiYieldRateModifier[eIndex] + iChange;
 		CvAssert(getYieldRate(eIndex, false) != 0);
 
 		GET_PLAYER(getOwner()).invalidateYieldRankCache(eIndex);
@@ -27627,7 +27633,7 @@ void CvCity::ChangeGreatWorkYieldChange(YieldTypes eIndex, int iChange)
 
 	if (iChange != 0)
 	{
-		m_aiGreatWorkYieldChange.setAt(eIndex, m_aiGreatWorkYieldChange[eIndex] + iChange);
+		m_aiGreatWorkYieldChange[eIndex] = m_aiGreatWorkYieldChange[eIndex] + iChange;
 	}
 }
 #endif
@@ -27651,7 +27657,7 @@ void CvCity::changeResourceYieldRateModifier(YieldTypes eIndex, int iChange)
 
 	if(iChange != 0)
 	{
-		m_aiResourceYieldRateModifier.setAt(eIndex, m_aiResourceYieldRateModifier[eIndex] + iChange);
+		m_aiResourceYieldRateModifier[eIndex] = m_aiResourceYieldRateModifier[eIndex] + iChange;
 		CvAssert(getYieldRate(eIndex, false) >= 0);
 
 		GET_PLAYER(getOwner()).invalidateYieldRankCache(eIndex);
@@ -27759,7 +27765,7 @@ void CvCity::updateExtraSpecialistYield(YieldTypes eYield)
 
 	if(iOldYield != iNewYield)
 	{
-		m_aiExtraSpecialistYield.setAt(eYield, iNewYield);
+		m_aiExtraSpecialistYield[eYield] = iNewYield;
 		CvAssert(getExtraSpecialistYield(eYield) >= 0);
 
 		ChangeBaseYieldRateFromSpecialists(eYield, (iNewYield - iOldYield));
@@ -27799,7 +27805,7 @@ void CvCity::changeProductionToYieldModifier(YieldTypes eIndex, int iChange)
 
 	if(iChange != 0)
 	{
-		m_aiProductionToYieldModifier.setAt(eIndex, m_aiProductionToYieldModifier[eIndex] + iChange);
+		m_aiProductionToYieldModifier[eIndex] = m_aiProductionToYieldModifier[eIndex] + iChange;
 	}
 }
 
@@ -27871,7 +27877,7 @@ void CvCity::changeDomainFreeExperience(DomainTypes eIndex, int iChange)
 	VALIDATE_OBJECT
 	CvAssertMsg(eIndex >= 0, "eIndex expected to be >= 0");
 	CvAssertMsg(eIndex < NUM_DOMAIN_TYPES, "eIndex expected to be < NUM_DOMAIN_TYPES");
-	m_aiDomainFreeExperience.setAt(eIndex, m_aiDomainFreeExperience[eIndex] + iChange);
+	m_aiDomainFreeExperience[eIndex] = m_aiDomainFreeExperience[eIndex] + iChange;
 	CvAssert(getDomainFreeExperience(eIndex) >= 0);
 }
 
@@ -27952,7 +27958,7 @@ void CvCity::changeDomainProductionModifier(DomainTypes eIndex, int iChange)
 	VALIDATE_OBJECT
 	CvAssertMsg(eIndex >= 0, "eIndex expected to be >= 0");
 	CvAssertMsg(eIndex < NUM_DOMAIN_TYPES, "eIndex expected to be < NUM_DOMAIN_TYPES");
-	m_aiDomainProductionModifier.setAt(eIndex, m_aiDomainProductionModifier[eIndex] + iChange);
+	m_aiDomainProductionModifier[eIndex] = m_aiDomainProductionModifier[eIndex] + iChange;
 }
 
 
@@ -27972,7 +27978,7 @@ void CvCity::setEverOwned(PlayerTypes eIndex, bool bNewValue)
 	VALIDATE_OBJECT
 	CvAssertMsg(eIndex >= 0, "eIndex expected to be >= 0");
 	CvAssertMsg(eIndex < MAX_PLAYERS, "eIndex expected to be < MAX_PLAYERS");
-	m_abEverOwned.setAt(eIndex, bNewValue);
+	m_abEverOwned[eIndex] = bNewValue;
 }
 
 //	--------------------------------------------------------------------------------
@@ -27996,7 +28002,7 @@ bool CvCity::setRevealed(TeamTypes eIndex, bool bNewValue)
 const char* CvCity::getNameKey() const
 {
 	VALIDATE_OBJECT
-	return m_strName.get();
+	return m_strName;
 }
 
 
@@ -28004,7 +28010,7 @@ const char* CvCity::getNameKey() const
 const CvString CvCity::getName() const
 {
 	VALIDATE_OBJECT
-	return GetLocalizedText(m_strName.get());
+	return GetLocalizedText(m_strName);
 }
 
 const CvString CvCity::getNameNoSpace() const
@@ -28124,7 +28130,7 @@ void CvCity::setProjectProductionTimes100(ProjectTypes eIndex, int iNewValue)
 
 	if(getProjectProductionTimes100(eIndex) != iNewValue)
 	{
-		m_paiProjectProduction.setAt(eIndex, max(0,iNewValue));
+		m_paiProjectProduction[eIndex] = max(0,iNewValue);
 		CvAssert(getProjectProductionTimes100(eIndex) >= 0);
 
 		if((getOwner() == GC.getGame().getActivePlayer()) && isCitySelected())
@@ -28192,7 +28198,7 @@ void CvCity::setSpecialistProductionTimes100(SpecialistTypes eIndex, int iNewVal
 
 	if(getSpecialistProductionTimes100(eIndex) != iNewValue)
 	{
-		m_paiSpecialistProduction.setAt(eIndex, iNewValue);
+		m_paiSpecialistProduction[eIndex] = iNewValue;
 		CvAssert(getSpecialistProductionTimes100(eIndex) >= 0);
 
 		if((getOwner() == GC.getGame().getActivePlayer()) && isCitySelected())
@@ -28289,7 +28295,7 @@ void CvCity::setUnitProductionTimes100(UnitTypes eIndex, int iNewValue)
 
 	if(getUnitProductionTimes100(eIndex) != iNewValue)
 	{
-		m_paiUnitProduction.setAt(eIndex, max(0,iNewValue));
+		m_paiUnitProduction[eIndex] = max(0,iNewValue);
 		CvAssert(getUnitProductionTimes100(eIndex) >= 0);
 
 		if((getOwner() == GC.getGame().getActivePlayer()) && isCitySelected())
@@ -28327,7 +28333,7 @@ void CvCity::setUnitProductionTime(UnitTypes eIndex, int iNewValue)
 	VALIDATE_OBJECT
 	CvAssertMsg(eIndex >= 0, "eIndex expected to be >= 0");
 	CvAssertMsg(eIndex < GC.getNumUnitInfos(), "eIndex expected to be < GC.getNumUnitInfos()");
-	m_paiUnitProductionTime.setAt(eIndex, iNewValue);
+	m_paiUnitProductionTime[eIndex] = iNewValue;
 	CvAssert(getUnitProductionTime(eIndex) >= 0);
 }
 
@@ -28356,7 +28362,7 @@ void CvCity::changeUnitCombatFreeExperience(UnitCombatTypes eIndex, int iChange)
 	VALIDATE_OBJECT
 	CvAssertMsg(eIndex >= 0, "eIndex expected to be >= 0");
 	CvAssertMsg(eIndex < GC.getNumUnitCombatClassInfos(), "eIndex expected to be < GC.getNumUnitCombatInfos()");
-	m_paiUnitCombatFreeExperience.setAt(eIndex, m_paiUnitCombatFreeExperience[eIndex] + iChange);
+	m_paiUnitCombatFreeExperience[eIndex] = m_paiUnitCombatFreeExperience[eIndex] + iChange;
 	CvAssert(getUnitCombatFreeExperience(eIndex) >= 0);
 }
 
@@ -28377,7 +28383,7 @@ void CvCity::changeUnitCombatProductionModifier(UnitCombatTypes eIndex, int iCha
 	VALIDATE_OBJECT
 	CvAssertMsg(eIndex >= 0, "eIndex expected to be >= 0");
 	CvAssertMsg(eIndex < GC.getNumUnitCombatClassInfos(), "eIndex expected to be < GC.getNumUnitCombatInfos()");
-	m_paiUnitCombatProductionModifier.setAt(eIndex, m_paiUnitCombatProductionModifier[eIndex] + iChange);
+	m_paiUnitCombatProductionModifier[eIndex] = m_paiUnitCombatProductionModifier[eIndex] + iChange;
 	CvAssert(getUnitCombatProductionModifier(eIndex) >= 0);
 }
 
@@ -28388,8 +28394,8 @@ int CvCity::getFreePromotionCount(PromotionTypes eIndex) const
 	VALIDATE_OBJECT
 	CvAssertMsg(eIndex >= 0, "eIndex expected to be >= 0");
 	CvAssertMsg(eIndex < GC.getNumPromotionInfos(), "eIndex expected to be < GC.getNumPromotionInfos()");
-	if (m_paiFreePromotionCount.get().find(eIndex) != m_paiFreePromotionCount.get().end())
-		return m_paiFreePromotionCount.get().find(eIndex)->second;
+	if (m_paiFreePromotionCount.find(eIndex) != m_paiFreePromotionCount.end())
+		return m_paiFreePromotionCount.find(eIndex)->second;
 
 	return 0;
 }
@@ -28398,7 +28404,7 @@ int CvCity::getFreePromotionCount(PromotionTypes eIndex) const
 vector<PromotionTypes> CvCity::getFreePromotions() const
 {
 	vector<PromotionTypes> result; 
-	for (map<PromotionTypes, int>::const_iterator it = m_paiFreePromotionCount.get().begin(); it != m_paiFreePromotionCount.get().end(); ++it)
+	for (map<PromotionTypes, int>::const_iterator it = m_paiFreePromotionCount.begin(); it != m_paiFreePromotionCount.end(); ++it)
 		if (it->second > 0)
 			result.push_back(it->first);
 
@@ -28428,10 +28434,10 @@ void CvCity::changeFreePromotionCount(PromotionTypes eIndex, int iChange)
 	VALIDATE_OBJECT
 	CvAssertMsg(eIndex >= 0, "eIndex expected to be >= 0");
 	CvAssertMsg(eIndex < GC.getNumPromotionInfos(), "eIndex expected to be < GC.getNumPromotionInfos()");
-	m_paiFreePromotionCount.dirtyGet()[eIndex] += iChange;
+	m_paiFreePromotionCount[eIndex] += iChange;
 
-	if (m_paiFreePromotionCount.dirtyGet()[eIndex] == 0)
-		m_paiFreePromotionCount.dirtyGet().erase(eIndex);
+	if (m_paiFreePromotionCount[eIndex] == 0)
+		m_paiFreePromotionCount.erase(eIndex);
 }
 
 #if defined(MOD_BALANCE_CORE)
@@ -31345,7 +31351,7 @@ void CvCity::changeProjectCount(ProjectTypes eProject, int iValue)
 	VALIDATE_OBJECT
 	CvAssertMsg(eProject >= 0, "ePlayer expected to be >= 0");
 	CvAssertMsg(eProject < GC.getNumProjectInfos(), "ePlayer expected to be < NUM_DOMAIN_TYPES");
-	m_aiNumProjects.setAt(eProject, m_aiNumProjects[eProject] + iValue);
+	m_aiNumProjects[eProject] = m_aiNumProjects[eProject] + iValue;
 }
 
 int CvCity::getProjectCount(ProjectTypes eProject) const
@@ -31362,7 +31368,7 @@ void CvCity::changeUnitsBuiltCount(UnitTypes eUnitType, int iValue)
 	CvAssertMsg(eUnitType >= 0, "eUnitType expected to be >= 0");
 	CvAssertMsg(eUnitType < GC.getNumUnitInfos(), "eUnitType expected to be < GC.getNumUnitInfos()");
 
-	m_aiNumUnitsBuilt.setAt(eUnitType, m_aiNumUnitsBuilt[eUnitType] + iValue);
+	m_aiNumUnitsBuilt[eUnitType] = m_aiNumUnitsBuilt[eUnitType] + iValue;
 }
 
 int CvCity::getUnitsBuiltCount(UnitTypes eUnitType) const
@@ -33235,10 +33241,311 @@ CvCityEspionage* CvCity::GetCityEspionage() const
 CvCityCulture* CvCity::GetCityCulture() const
 {
 	VALIDATE_OBJECT
-		return m_pCityCulture;
+	return m_pCityCulture;
 }
 
 // Private Functions...
+
+template<typename City, typename Visitor>
+void CvCity::Serialize(City& city, Visitor& visitor)
+{
+	visitor(city.m_eOwner);
+	visitor(city.m_iX);
+	visitor(city.m_iY);
+	visitor(city.m_iID);
+	visitor(city.m_iRallyX);
+	visitor(city.m_iRallyY);
+	visitor(city.m_iGameTurnFounded);
+	visitor(city.m_iGameTurnAcquired);
+	visitor(city.m_iGameTurnLastExpanded);
+	visitor(city.m_iPopulation);
+	visitor(city.m_iHighestPopulation);
+	visitor(city.m_iExtraHitPoints);
+	visitor(city.m_iNumGreatPeople);
+	visitor(city.m_iBaseGreatPeopleRate);
+	visitor(city.m_iGreatPeopleRateModifier);
+	visitor(city.m_iJONSCultureStored);
+	visitor(city.m_iJONSCultureLevel);
+#if !defined(MOD_API_UNIFIED_YIELDS_CONSOLIDATION)
+	visitor(city.m_iJONSCulturePerTurnFromBuildings);
+#endif
+	visitor(city.m_iJONSCulturePerTurnFromPolicies);
+	visitor(city.m_iJONSCulturePerTurnFromSpecialists);
+	visitor(city.m_iaAddedYieldPerTurnFromTraits);
+#if !defined(MOD_API_UNIFIED_YIELDS_CONSOLIDATION)
+	visitor(city.m_iJONSCulturePerTurnFromReligion);
+#endif
+#if !defined(MOD_API_UNIFIED_YIELDS_CONSOLIDATION)
+	visitor(city.m_iFaithPerTurnFromBuildings);
+#endif
+	visitor(city.m_iFaithPerTurnFromPolicies);
+#if !defined(MOD_API_UNIFIED_YIELDS_CONSOLIDATION)
+	visitor(city.m_iFaithPerTurnFromReligion);
+#endif
+	visitor(city.m_iAdditionalFood);
+	visitor(city.m_iCityBuildingBombardRange);
+	visitor(city.m_iCityIndirectFire);
+	visitor(city.m_iCityBuildingRangeStrikeModifier);
+	visitor(city.m_iCultureRateModifier);
+	visitor(city.m_iNumWorldWonders);
+	visitor(city.m_iNumTeamWonders);
+	visitor(city.m_iNumNationalWonders);
+	visitor(city.m_iWonderProductionModifier);
+	visitor(city.m_iCapturePlunderModifier);
+	visitor(city.m_iPlotCultureCostModifier);
+	visitor(city.m_iPlotBuyCostModifier);
+	visitor(city.m_iCityWorkingChange);
+	visitor(city.m_iCitySupplyModifier);
+	visitor(city.m_iCitySupplyFlat);
+	visitor(city.m_bAllowsProductionTradeRoutes);
+	visitor(city.m_bAllowsFoodTradeRoutes);
+	visitor(city.m_bAllowPuppetPurchase);
+	visitor(city.m_iCityAutomatonWorkersChange);
+	visitor(city.m_iMaintenance);
+	visitor(city.m_iHealRate);
+	visitor(city.m_iNoOccupiedUnhappinessCount);
+	visitor(city.m_iLocalGainlessPillageCount);
+	visitor(city.m_iFood);
+	visitor(city.m_iFoodKept);
+	visitor(city.m_iMaxFoodKeptPercent);
+	visitor(city.m_iOverflowProduction);
+	visitor(city.m_iFeatureProduction);
+	visitor(city.m_iMilitaryProductionModifier);
+	visitor(city.m_iSpaceProductionModifier);
+	visitor(city.m_iFreeExperience);
+	visitor(city.m_iCurrAirlift);
+	visitor(city.m_iMaxAirUnits);
+	visitor(city.m_iAirModifier);
+	visitor(city.m_iNukeModifier);
+	visitor(city.m_iTradeRouteTargetBonus);
+	visitor(city.m_iTradeRouteRecipientBonus);
+	visitor(city.m_iTradeRouteSeaGoldBonus);
+	visitor(city.m_iTradeRouteLandGoldBonus);
+	visitor(city.m_iNumTradeRouteBonus);
+	visitor(city.m_iCityConnectionTradeRouteGoldModifier);
+	visitor(city.m_iCultureUpdateTimer);
+	visitor(city.m_iCitySizeBoost);
+	visitor(city.m_iSpecialistFreeExperience);
+	visitor(city.m_iStrengthValue);
+	visitor(city.m_iDamage);
+	visitor(city.m_iThreatValue);
+	visitor(city.m_hGarrison);
+	visitor(city.m_iResourceDemanded);
+	visitor(city.m_iWeLoveTheKingDayCounter);
+	visitor(city.m_iLastTurnGarrisonAssigned);
+	visitor(city.m_iThingsProduced);
+	visitor(city.m_iDemandResourceCounter);
+	visitor(city.m_iResistanceTurns);
+	visitor(city.m_iRazingTurns);
+	visitor(city.m_iLowestRazingPop);
+	visitor(city.m_iCountExtraLuxuries);
+	visitor(city.m_iCheapestPlotInfluenceDistance);
+	visitor(city.m_iEspionageModifier);
+	visitor(city.m_iConversionModifier);
+	visitor(city.m_bNeverLost);
+	visitor(city.m_bDrafted);
+	visitor(city.m_bAirliftTargeted);
+	visitor(city.m_bProductionAutomated);
+	visitor(city.m_bLayoutDirty);
+	visitor(city.m_bMadeAttack);
+	visitor(city.m_bOccupied);
+	visitor(city.m_bPuppet);
+	visitor(city.m_bIgnoreCityForHappiness);
+	visitor(city.m_bIndustrialRouteToCapital);
+	visitor(city.m_iTerrainImprovementNeed);
+	visitor(city.m_ePreviousOwner);
+	visitor(city.m_eOriginalOwner);
+	visitor(city.m_ePlayersReligion);
+	visitor(city.m_aiSeaPlotYield);
+	visitor(city.m_aiRiverPlotYield);
+	visitor(city.m_aiLakePlotYield);
+	visitor(city.m_aiSeaResourceYield);
+	visitor(city.m_aiBaseYieldRateFromTerrain);
+	visitor(city.m_aiBaseYieldRateFromBuildings);
+	visitor(city.m_aiBaseYieldRateFromSpecialists);
+	visitor(city.m_aiBaseYieldRateFromMisc);
+	visitor(city.m_aiBaseYieldRateFromLeague);
+	visitor(city.m_iTotalScienceyAid);
+	visitor(city.m_iTotalArtsyAid);
+	visitor(city.m_iTotalGreatWorkAid);
+	visitor(city.m_aiChangeGrowthExtraYield);
+	visitor(city.m_iHappinessFromEmpire);
+	visitor(city.m_iHappinessFromLuxuries);
+	visitor(city.m_iUnhappinessFromEmpire);
+	visitor(city.m_iStaticTechDeviation);
+	visitor(city.m_aiNumProjects);
+	visitor(city.m_aiNumUnitsBuilt);
+	visitor(city.m_aiStaticGlobalYield);
+	visitor(city.m_aiStaticNeedAdditives);
+	visitor(city.m_aiLongestPotentialTradeRoute);
+	visitor(city.m_aiNumTimesAttackedThisTurn);
+	visitor(city.m_aiYieldFromKnownPantheons);
+	visitor(city.m_aiYieldFromVictory);
+	visitor(city.m_aiYieldFromVictoryGlobal);
+	visitor(city.m_aiYieldFromPillage);
+	visitor(city.m_aiYieldFromPillageGlobal);
+	visitor(city.m_aiGoldenAgeYieldMod);
+	visitor(city.m_aiYieldFromWLTKD);
+	visitor(city.m_aiYieldFromConstruction);
+	visitor(city.m_aiYieldFromTech);
+	visitor(city.m_aiYieldFromBirth);
+	visitor(city.m_aiYieldFromUnitProduction);
+	visitor(city.m_aiYieldFromBorderGrowth);
+	visitor(city.m_aiYieldFromPolicyUnlock);
+	visitor(city.m_aiYieldFromPurchase);
+	visitor(city.m_aiYieldFromFaithPurchase);
+	visitor(city.m_aiYieldFromUnitLevelUp);
+	visitor(city.m_aiYieldPerAlly);
+	visitor(city.m_aiYieldPerFriend);
+	visitor(city.m_aiYieldFromInternalTREnd);
+	visitor(city.m_aiYieldFromInternalTR);
+	visitor(city.m_aiYieldFromProcessModifier);
+	visitor(city.m_aiSpecialistRateModifier);
+	visitor(city.m_aiThemingYieldBonus);
+	visitor(city.m_aiYieldFromSpyAttack);
+	visitor(city.m_aiYieldFromSpyDefense);
+	visitor(city.m_aiNumTimesOwned);
+	visitor(city.m_aiStaticCityYield);
+	visitor(city.m_iTradePriorityLand);
+	visitor(city.m_iTradePrioritySea);
+	visitor(city.m_iUnitPurchaseCooldown);
+	visitor(city.m_iUnitPurchaseCooldownCivilian);
+	visitor(city.m_iUnitFaithPurchaseCooldown);
+	visitor(city.m_iUnitFaithPurchaseCooldownCivilian);
+	visitor(city.m_iBuildingPurchaseCooldown);
+	visitor(city.m_iReligiousTradeModifier);
+	visitor(city.m_iCityAirStrikeDefense);
+	visitor(city.m_iFreeBuildingTradeTargetCity);
+	visitor(city.m_iBaseTourism);
+	visitor(city.m_iBaseTourismBeforeModifiers);
+	visitor(city.m_iBorderObstacleCity);
+	visitor(city.m_iBorderObstacleWater);
+	visitor(city.m_iDeepWaterTileDamage);
+	visitor(city.m_iNumNearbyMountains);
+	visitor(city.m_iLocalUnhappinessMod);
+	visitor(city.m_bNoWarmonger);
+	visitor(city.m_iCitySpyRank);
+	visitor(city.m_iTurnsSinceRankAnnouncement);
+	visitor(city.m_iChangePovertyUnhappiness);
+	visitor(city.m_iEmpireNeedsModifier);
+	visitor(city.m_iChangeDefenseUnhappiness);
+	visitor(city.m_iChangeUnculturedUnhappiness);
+	visitor(city.m_iChangeIlliteracyUnhappiness);
+	visitor(city.m_iChangeMinorityUnhappiness);
+	visitor(city.m_iTradeRouteSeaDistanceModifier);
+	visitor(city.m_iTradeRouteLandDistanceModifier);
+	visitor(city.m_iNukeInterceptionChance);
+	visitor(city.m_aiEconomicValue);
+	visitor(city.m_aiBaseYieldRateFromReligion);
+	visitor(city.m_aiBaseYieldRateFromCSAlliance);
+	visitor(city.m_aiBaseYieldRateFromCSFriendship);
+	visitor(city.m_aiYieldFromMinors);
+	visitor(city.m_aiResourceQuantityPerXFranchises);
+	visitor(city.m_aiYieldChangeFromCorporationFranchises);
+	visitor(city.m_aiNeedsFlatReduction);
+	visitor(city.m_iLandTourismBonus);
+	visitor(city.m_iSeaTourismBonus);
+	visitor(city.m_iAlwaysHeal);
+	visitor(city.m_iResourceDiversityModifier);
+	visitor(city.m_iNoUnhappfromXSpecialists);
+	visitor(city.m_aiStaticNeedsUpdateTurn);
+	visitor(city.m_aiGreatWorkYieldChange);
+	visitor(city.m_aiYieldRateModifier);
+	visitor(city.m_aiYieldPerPop);
+	visitor(city.m_aiYieldPerReligion);
+	visitor(city.m_aiPowerYieldRateModifier);
+	visitor(city.m_aiResourceYieldRateModifier);
+	visitor(city.m_aiExtraSpecialistYield);
+	visitor(city.m_aiProductionToYieldModifier);
+	visitor(city.m_aiDomainFreeExperience);
+	visitor(city.m_aiDomainProductionModifier);
+	visitor(city.m_abEverOwned);
+	visitor(city.m_abIsBestForWonder);
+	visitor(city.m_abIsPurchased);
+	visitor(city.m_abTraded);
+	visitor(city.m_abPaidAdoptionBonus);
+	visitor(city.m_aiReligiousPressureModifier);
+	visitor(city.m_iExtraBuildingMaintenance);
+	visitor(city.m_paiNumTerrainWorked);
+	visitor(city.m_paiNumFeaturelessTerrainWorked);
+	visitor(city.m_paiNumFeatureWorked);
+	visitor(city.m_paiNumResourceWorked);
+	visitor(city.m_paiNumImprovementWorked);
+	visitor(city.m_strScriptData);
+	visitor(city.m_iDamageTakenThisTurn);
+	visitor(city.m_iDamageTakenLastTurn);
+	visitor(city.m_paiNoResource);
+	visitor(city.m_paiFreeResource);
+	visitor(city.m_paiNumResourcesLocal);
+	visitor(city.m_paiNumUnimprovedResourcesLocal);
+	visitor(city.m_paiProjectProduction);
+	visitor(city.m_paiSpecialistProduction);
+	visitor(city.m_paiUnitProduction);
+	visitor(city.m_paiUnitProductionTime);
+	visitor(city.m_paiSpecialistCount);
+	visitor(city.m_paiMaxSpecialistCount);
+	visitor(city.m_paiForceSpecialistCount);
+	visitor(city.m_paiFreeSpecialistCount);
+	visitor(city.m_paiImprovementFreeSpecialists);
+	visitor(city.m_paiUnitCombatFreeExperience);
+	visitor(city.m_paiUnitCombatProductionModifier);
+	visitor(city.m_paiFreePromotionCount);
+	visitor(city.m_paiBuildingClassCulture);
+	visitor(city.m_paiHurryModifier);
+	visitor(city.m_iHappinessDelta);
+	visitor(city.m_iPillagedPlots);
+	visitor(city.m_iGrowthEvent);
+	visitor(city.m_iGrowthFromTourism);
+	visitor(city.m_iBuildingClassHappiness);
+	visitor(city.m_iReligionHappiness);
+	visitor(city.m_vClosestNeighbors);
+	visitor(city.m_iBaseHappinessFromBuildings);
+	visitor(city.m_iUnmoddedHappinessFromBuildings);
+	visitor(city.m_bRouteToCapitalConnectedLastTurn);
+	visitor(city.m_bRouteToCapitalConnectedThisTurn);
+	visitor(city.m_strName);
+	visitor(city.m_bOwedCultureBuilding);
+	visitor(city.m_bOwedFoodBuilding);
+	visitor(city.m_aiEventCooldown);
+	visitor(city.m_abEventActive);
+	visitor(city.m_abEventChoiceActive);
+	visitor(city.m_abEventChoiceFired);
+	visitor(city.m_abEventFired);
+	visitor(city.m_aiEventChoiceDuration);
+	visitor(city.m_aiEventIncrement);
+	visitor(city.m_aiEventCityYield);
+	visitor(city.m_iEventHappiness);
+	visitor(city.m_iCityEventCooldown);
+	visitor(city.m_bIsColony);
+	visitor(city.m_iProvinceLevel);
+	visitor(city.m_iOrganizedCrime);
+	visitor(city.m_iResistanceCounter);
+	visitor(city.m_iPlagueCounter);
+	visitor(city.m_iPlagueTurns);
+	visitor(city.m_iPlagueType);
+	visitor(city.m_iSappedTurns);
+	visitor(city.m_iLoyaltyCounter);
+	visitor(city.m_iDisloyaltyCounter);
+	visitor(city.m_iLoyaltyStateType);
+	visitor(city.m_aiYieldModifierFromHappiness);
+	visitor(city.m_aiYieldModifierFromHealth);
+	visitor(city.m_aiYieldModifierFromCrime);
+	visitor(city.m_aiYieldModifierFromDevelopment);
+	visitor(city.m_aiYieldFromHappiness);
+	visitor(city.m_aiYieldFromHealth);
+	visitor(city.m_aiYieldFromCrime);
+	visitor(city.m_aiYieldFromDevelopment);
+	visitor(city.m_iPopulationRank);
+	visitor(city.m_bPopulationRankValid);
+	visitor(city.m_aiBaseYieldRank);
+	visitor(city.m_abBaseYieldRankValid);
+	visitor(city.m_aiYieldRank);
+	visitor(city.m_abYieldRankValid);
+	visitor(city.m_abOwedChosenBuilding);
+	visitor(city.m_abBuildingInvestment);
+	visitor(city.m_abUnitInvestment);
+	visitor(city.m_abBuildingConstructed);
+}
 
 //	--------------------------------------------------------------------------------
 void CvCity::read(FDataStream& kStream)
@@ -33256,8 +33563,9 @@ void CvCity::read(FDataStream& kStream)
 #endif
 
 #if defined(MOD_BALANCE_CORE)
-	kStream >> m_syncArchive;
-	//Values below deleted, as they're already in the sync archive!
+	// Perform shared serialize
+	CvStreamLoadVisitor serialVisitor(kStream);
+	Serialize(*this, serialVisitor);
 #endif
 
 	m_pCityBuildings->Read(kStream);
@@ -33391,8 +33699,9 @@ VALIDATE_OBJECT
 	MOD_SERIALIZE_WRITE(kStream, m_iAutomatons);
 #endif
 #if defined(MOD_BALANCE_CORE)
-	kStream << m_syncArchive;
-	//Values below deleted, as they're already in the sync archive!
+	// Perform shared serialize
+	CvStreamSaveVisitor serialVisitor(kStream);
+	Serialize(*this, serialVisitor);
 #endif
 
 	m_pCityBuildings->Write(kStream);
@@ -33671,14 +33980,14 @@ void CvCity::invalidateYieldRankCache(YieldTypes eYield)
 	{
 		for(int iI = 0; iI < NUM_YIELD_TYPES; iI++)
 		{
-			m_abBaseYieldRankValid.setAt(iI, false);
-			m_abYieldRankValid.setAt(iI, false);
+			m_abBaseYieldRankValid[iI] = false;
+			m_abYieldRankValid[iI] = false;
 		}
 	}
 	else
 	{
-		m_abBaseYieldRankValid.setAt(eYield, false);
-		m_abYieldRankValid.setAt(eYield, false);
+		m_abBaseYieldRankValid[eYield] = false;
+		m_abYieldRankValid[eYield] = false;
 	}
 }
 
@@ -33701,7 +34010,7 @@ void CvCity::ChangeNumTimesAttackedThisTurn(PlayerTypes ePlayer, int iValue)
 	VALIDATE_OBJECT
 	CvAssertMsg(ePlayer >= 0, "ePlayer expected to be >= 0");
 	CvAssertMsg(ePlayer < REALLY_MAX_PLAYERS, "ePlayer expected to be < NUM_DOMAIN_TYPES");
-	m_aiNumTimesAttackedThisTurn.setAt(ePlayer, m_aiNumTimesAttackedThisTurn[ePlayer] + iValue);
+	m_aiNumTimesAttackedThisTurn[ePlayer] = m_aiNumTimesAttackedThisTurn[ePlayer] + iValue;
 }
 int CvCity::GetNumTimesAttackedThisTurn(PlayerTypes ePlayer) const
 {
@@ -34839,13 +35148,13 @@ void CvCity::ChangeExtraHitPoints(int iValue)
 }
 
 //	--------------------------------------------------------------------------------
-const FAutoArchive& CvCity::getSyncArchive() const
+const CvSyncArchive<CvCity>& CvCity::getSyncArchive() const
 {
 	return m_syncArchive;
 }
 
 //	--------------------------------------------------------------------------------
-FAutoArchive& CvCity::getSyncArchive()
+CvSyncArchive<CvCity>& CvCity::getSyncArchive()
 {
 	return m_syncArchive;
 }
@@ -36218,7 +36527,7 @@ void CvCity::SetYieldModifierFromHappiness(YieldTypes eYield, int iValue)
 {
 	if (GetYieldModifierFromHappiness(eYield) != iValue)
 	{
-		m_aiYieldModifierFromHappiness.setAt(eYield, iValue);
+		m_aiYieldModifierFromHappiness[eYield] = iValue;
 		UpdateCityYields(eYield);
 	}
 }
@@ -36235,7 +36544,7 @@ void CvCity::SetYieldModifierFromHealth(YieldTypes eYield, int iValue)
 {
 	if (GetYieldModifierFromHealth(eYield) != iValue)
 	{
-		m_aiYieldModifierFromHealth.setAt(eYield, iValue);
+		m_aiYieldModifierFromHealth[eYield] = iValue;
 		UpdateCityYields(eYield);
 	}
 }
@@ -36249,7 +36558,7 @@ void CvCity::SetYieldModifierFromCrime(YieldTypes eYield, int iValue)
 {
 	if (GetYieldModifierFromCrime(eYield) != iValue)
 	{
-		m_aiYieldModifierFromCrime.setAt(eYield, iValue);
+		m_aiYieldModifierFromCrime[eYield] = iValue;
 		UpdateCityYields(eYield);
 	}
 }
@@ -36263,7 +36572,7 @@ void CvCity::SetYieldModifierFromDevelopment(YieldTypes eYield, int iValue)
 {
 	if (GetYieldModifierFromDevelopment(eYield) != iValue)
 	{
-		m_aiYieldModifierFromDevelopment.setAt(eYield, iValue);
+		m_aiYieldModifierFromDevelopment[eYield] = iValue;
 		UpdateCityYields(eYield);
 	}
 }
@@ -36277,7 +36586,7 @@ void CvCity::SetYieldFromHappiness(YieldTypes eYield, int iValue)
 {
 	if (GetYieldFromHappiness(eYield) != iValue)
 	{
-		m_aiYieldFromHappiness.setAt(eYield, iValue);
+		m_aiYieldFromHappiness[eYield] = iValue;
 		UpdateCityYields(eYield);
 	}
 }
@@ -36291,7 +36600,7 @@ void CvCity::SetYieldFromHealth(YieldTypes eYield, int iValue)
 {
 	if (GetYieldFromHealth(eYield) != iValue)
 	{
-		m_aiYieldFromHealth.setAt(eYield, iValue);
+		m_aiYieldFromHealth[eYield] = iValue;
 		UpdateCityYields(eYield);
 	}
 }
@@ -36304,7 +36613,7 @@ void CvCity::SetYieldFromCrime(YieldTypes eYield, int iValue)
 {
 	if (GetYieldFromCrime(eYield) != iValue)
 	{
-		m_aiYieldFromCrime.setAt(eYield, iValue);
+		m_aiYieldFromCrime[eYield] = iValue;
 		UpdateCityYields(eYield);
 	}
 }
@@ -36321,7 +36630,7 @@ void CvCity::SetYieldFromDevelopment(YieldTypes eYield, int iValue)
 {
 	if (GetYieldFromDevelopment(eYield) != iValue)
 	{
-		m_aiYieldFromDevelopment.setAt(eYield, iValue);
+		m_aiYieldFromDevelopment[eYield] = iValue;
 		UpdateCityYields(eYield);
 	}
 }

--- a/CvGameCoreDLL_Expansion2/CvCity.h
+++ b/CvGameCoreDLL_Expansion2/CvCity.h
@@ -19,6 +19,7 @@
 #include "FStlContainerSerialization.h"
 #include "FAutoVariable.h"
 #include "CvPreGame.h"
+#include "CvSerialize.h"
 
 // 0 = center of city, 1-6 = the edge of city on points, 7-12 = one tile out
 #define NUM_CITY_BUILDING_DISPLAY_SLOTS (13)
@@ -1546,6 +1547,8 @@ public:
 	CvCityEspionage* GetCityEspionage() const;
 	CvCityCulture* GetCityCulture() const;
 
+	template<typename City, typename Visitor>
+	static void Serialize(City& city, Visitor& visitor);
 	void read(FDataStream& kStream);
 	void write(FDataStream& kStream) const;
 
@@ -1575,8 +1578,8 @@ public:
 	void ChangeExtraHitPoints(int iValue);
 
 	int GetMaxHitPoints() const;
-	const FAutoArchive& getSyncArchive() const;
-	FAutoArchive& getSyncArchive();
+	const CvSyncArchive<CvCity>& getSyncArchive() const;
+	CvSyncArchive<CvCity>& getSyncArchive();
 	std::string debugDump(const FAutoVariableBase&) const;
 	std::string stackTraceRemark(const FAutoVariableBase&) const;
 
@@ -1746,314 +1749,314 @@ public:
 #endif
 
 protected:
-	FAutoArchiveClassContainer<CvCity> m_syncArchive;
+	SYNC_ARCHIVE_MEMBER(CvCity)
 
-	FAutoVariable<PlayerTypes, CvCity> m_eOwner;
-	FAutoVariable<int, CvCity> m_iX;
-	FAutoVariable<int, CvCity> m_iY;
-	FAutoVariable<int, CvCity> m_iID;
+	PlayerTypes m_eOwner;
+	int m_iX;
+	int m_iY;
+	int m_iID;
 
-	FAutoVariable<int, CvCity> m_iRallyX;
-	FAutoVariable<int, CvCity> m_iRallyY;
-	FAutoVariable<int, CvCity> m_iGameTurnFounded;
-	FAutoVariable<int, CvCity> m_iGameTurnAcquired;
-	FAutoVariable<int, CvCity> m_iGameTurnLastExpanded;
-	FAutoVariable<int, CvCity> m_iPopulation;
+	int m_iRallyX;
+	int m_iRallyY;
+	int m_iGameTurnFounded;
+	int m_iGameTurnAcquired;
+	int m_iGameTurnLastExpanded;
+	int m_iPopulation;
 #if defined(MOD_GLOBAL_CITY_AUTOMATON_WORKERS)
 	int m_iAutomatons;
 #endif
-	FAutoVariable<int, CvCity> m_iHighestPopulation;
-	FAutoVariable<int, CvCity> m_iExtraHitPoints;
+	int m_iHighestPopulation;
+	int m_iExtraHitPoints;
 
-	FAutoVariable<int, CvCity> m_iNumGreatPeople;
-	FAutoVariable<int, CvCity> m_iBaseGreatPeopleRate;
-	FAutoVariable<int, CvCity> m_iGreatPeopleRateModifier;
-	FAutoVariable<int, CvCity> m_iJONSCultureStored;
-	FAutoVariable<int, CvCity> m_iJONSCultureLevel;
+	int m_iNumGreatPeople;
+	int m_iBaseGreatPeopleRate;
+	int m_iGreatPeopleRateModifier;
+	int m_iJONSCultureStored;
+	int m_iJONSCultureLevel;
 #if !defined(MOD_API_UNIFIED_YIELDS_CONSOLIDATION)
-	FAutoVariable<int, CvCity> m_iJONSCulturePerTurnFromBuildings;
+	int m_iJONSCulturePerTurnFromBuildings;
 #endif
-	FAutoVariable<int, CvCity> m_iJONSCulturePerTurnFromPolicies;
-	FAutoVariable<int, CvCity> m_iJONSCulturePerTurnFromSpecialists;
-	FAutoVariable<std::vector<int>, CvCity> m_iaAddedYieldPerTurnFromTraits;
+	int m_iJONSCulturePerTurnFromPolicies;
+	int m_iJONSCulturePerTurnFromSpecialists;
+	std::vector<int> m_iaAddedYieldPerTurnFromTraits;
 #if !defined(MOD_API_UNIFIED_YIELDS_CONSOLIDATION)
-	FAutoVariable<int, CvCity> m_iJONSCulturePerTurnFromReligion;
+	int m_iJONSCulturePerTurnFromReligion;
 #endif
 #if !defined(MOD_API_UNIFIED_YIELDS_CONSOLIDATION)
-	FAutoVariable<int, CvCity> m_iFaithPerTurnFromBuildings;
+	int m_iFaithPerTurnFromBuildings;
 #endif
-	FAutoVariable<int, CvCity> m_iFaithPerTurnFromPolicies;
+	int m_iFaithPerTurnFromPolicies;
 #if !defined(MOD_API_UNIFIED_YIELDS_CONSOLIDATION)
-	FAutoVariable<int, CvCity> m_iFaithPerTurnFromReligion;
+	int m_iFaithPerTurnFromReligion;
 #endif
 #if defined(MOD_BALANCE_CORE)
-	FAutoVariable<int, CvCity> m_iAdditionalFood;
-	FAutoVariable<int, CvCity> m_iCityBuildingBombardRange;
-	FAutoVariable<int, CvCity> m_iCityIndirectFire;
-	FAutoVariable<int, CvCity> m_iCityBuildingRangeStrikeModifier;
+	int m_iAdditionalFood;
+	int m_iCityBuildingBombardRange;
+	int m_iCityIndirectFire;
+	int m_iCityBuildingRangeStrikeModifier;
 #endif
-	FAutoVariable<int, CvCity> m_iCultureRateModifier;
-	FAutoVariable<int, CvCity> m_iNumWorldWonders;
-	FAutoVariable<int, CvCity> m_iNumTeamWonders;
-	FAutoVariable<int, CvCity> m_iNumNationalWonders;
-	FAutoVariable<int, CvCity> m_iWonderProductionModifier;
-	FAutoVariable<int, CvCity> m_iCapturePlunderModifier;
-	FAutoVariable<int, CvCity> m_iPlotCultureCostModifier;
-	FAutoVariable<int, CvCity> m_iPlotBuyCostModifier;
+	int m_iCultureRateModifier;
+	int m_iNumWorldWonders;
+	int m_iNumTeamWonders;
+	int m_iNumNationalWonders;
+	int m_iWonderProductionModifier;
+	int m_iCapturePlunderModifier;
+	int m_iPlotCultureCostModifier;
+	int m_iPlotBuyCostModifier;
 #if defined(MOD_BUILDINGS_CITY_WORKING)
-	FAutoVariable<int, CvCity> m_iCityWorkingChange;
-	FAutoVariable<int, CvCity> m_iCitySupplyModifier;
-	FAutoVariable<int, CvCity> m_iCitySupplyFlat;
-	FAutoVariable<bool, CvCity> m_bAllowsProductionTradeRoutes;
-	FAutoVariable<bool, CvCity> m_bAllowsFoodTradeRoutes;
-	FAutoVariable<bool, CvCity> m_bAllowPuppetPurchase;
+	int m_iCityWorkingChange;
+	int m_iCitySupplyModifier;
+	int m_iCitySupplyFlat;
+	bool m_bAllowsProductionTradeRoutes;
+	bool m_bAllowsFoodTradeRoutes;
+	bool m_bAllowPuppetPurchase;
 #endif
 #if defined(MOD_BUILDINGS_CITY_AUTOMATON_WORKERS)
-	FAutoVariable<int, CvCity> m_iCityAutomatonWorkersChange;
+	int m_iCityAutomatonWorkersChange;
 #endif
-	FAutoVariable<int, CvCity> m_iMaintenance;
-	FAutoVariable<int, CvCity> m_iHealRate;
-	FAutoVariable<int, CvCity> m_iNoOccupiedUnhappinessCount;
+	int m_iMaintenance;
+	int m_iHealRate;
+	int m_iNoOccupiedUnhappinessCount;
 #if defined(HH_MOD_BUILDINGS_FRUITLESS_PILLAGE)
-	FAutoVariable<int, CvCity> m_iLocalGainlessPillageCount;
+	int m_iLocalGainlessPillageCount;
 #endif
-	FAutoVariable<int, CvCity> m_iFood;
-	FAutoVariable<int, CvCity> m_iFoodKept; //unused
-	FAutoVariable<int, CvCity> m_iMaxFoodKeptPercent;
-	FAutoVariable<int, CvCity> m_iOverflowProduction;
-	FAutoVariable<int, CvCity> m_iFeatureProduction;
-	FAutoVariable<int, CvCity> m_iMilitaryProductionModifier;
-	FAutoVariable<int, CvCity> m_iSpaceProductionModifier;
-	FAutoVariable<int, CvCity> m_iFreeExperience;
-	FAutoVariable<int, CvCity> m_iCurrAirlift; // unused
-	FAutoVariable<int, CvCity> m_iMaxAirUnits;
-	FAutoVariable<int, CvCity> m_iAirModifier; // unused
-	FAutoVariable<int, CvCity> m_iNukeModifier;
-	FAutoVariable<int, CvCity> m_iTradeRouteTargetBonus;
-	FAutoVariable<int, CvCity> m_iTradeRouteRecipientBonus;
-	FAutoVariable<int, CvCity> m_iTradeRouteSeaGoldBonus;
-	FAutoVariable<int, CvCity> m_iTradeRouteLandGoldBonus;
-	FAutoVariable<int, CvCity> m_iNumTradeRouteBonus;
-	FAutoVariable<int, CvCity> m_iCityConnectionTradeRouteGoldModifier;
-	FAutoVariable<int, CvCity> m_iCultureUpdateTimer;
-	FAutoVariable<int, CvCity> m_iCitySizeBoost;
-	FAutoVariable<int, CvCity> m_iSpecialistFreeExperience;
-	FAutoVariable<int, CvCity> m_iStrengthValue;
-	FAutoVariable<int, CvCity> m_iDamage;
-	FAutoVariable<int, CvCity> m_iThreatValue;
-	FAutoVariable<int, CvCity> m_hGarrison;  // unused
+	int m_iFood;
+	int m_iFoodKept; //unused
+	int m_iMaxFoodKeptPercent;
+	int m_iOverflowProduction;
+	int m_iFeatureProduction;
+	int m_iMilitaryProductionModifier;
+	int m_iSpaceProductionModifier;
+	int m_iFreeExperience;
+	int m_iCurrAirlift; // unused
+	int m_iMaxAirUnits;
+	int m_iAirModifier; // unused
+	int m_iNukeModifier;
+	int m_iTradeRouteTargetBonus;
+	int m_iTradeRouteRecipientBonus;
+	int m_iTradeRouteSeaGoldBonus;
+	int m_iTradeRouteLandGoldBonus;
+	int m_iNumTradeRouteBonus;
+	int m_iCityConnectionTradeRouteGoldModifier;
+	int m_iCultureUpdateTimer;
+	int m_iCitySizeBoost;
+	int m_iSpecialistFreeExperience;
+	int m_iStrengthValue;
+	int m_iDamage;
+	int m_iThreatValue;
+	int m_hGarrison;  // unused
 	mutable int m_hGarrisonOverride; //only temporary, not serialized
-	FAutoVariable<int, CvCity> m_iResourceDemanded;
-	FAutoVariable<int, CvCity> m_iWeLoveTheKingDayCounter;
-	FAutoVariable<int, CvCity> m_iLastTurnGarrisonAssigned;
-	FAutoVariable<int, CvCity> m_iThingsProduced; // total number of units, buildings, wonders, etc. this city has constructed
-	FAutoVariable<int, CvCity> m_iDemandResourceCounter;
-	FAutoVariable<int, CvCity> m_iResistanceTurns;
-	FAutoVariable<int, CvCity> m_iRazingTurns;
-	FAutoVariable<int, CvCity> m_iLowestRazingPop;
-	FAutoVariable<int, CvCity> m_iCountExtraLuxuries;
-	FAutoVariable<int, CvCity> m_iCheapestPlotInfluenceDistance;
-	FAutoVariable<int, CvCity> m_iEspionageModifier;
+	int m_iResourceDemanded;
+	int m_iWeLoveTheKingDayCounter;
+	int m_iLastTurnGarrisonAssigned;
+	int m_iThingsProduced; // total number of units, buildings, wonders, etc. this city has constructed
+	int m_iDemandResourceCounter;
+	int m_iResistanceTurns;
+	int m_iRazingTurns;
+	int m_iLowestRazingPop;
+	int m_iCountExtraLuxuries;
+	int m_iCheapestPlotInfluenceDistance;
+	int m_iEspionageModifier;
 #if defined(MOD_RELIGION_CONVERSION_MODIFIERS)
-	FAutoVariable<int, CvCity> m_iConversionModifier;
+	int m_iConversionModifier;
 #endif
 
 	OperationSlot m_unitBeingBuiltForOperation;
 
-	FAutoVariable<bool, CvCity> m_bNeverLost;
-	FAutoVariable<bool, CvCity> m_bDrafted;
-	FAutoVariable<bool, CvCity> m_bAirliftTargeted;   // unused
-	FAutoVariable<bool, CvCity> m_bProductionAutomated;
-	FAutoVariable<bool, CvCity> m_bLayoutDirty;
-	FAutoVariable<bool, CvCity> m_bMadeAttack;
-	FAutoVariable<bool, CvCity> m_bOccupied;
-	FAutoVariable<bool, CvCity> m_bPuppet;
-	FAutoVariable<bool, CvCity> m_bIgnoreCityForHappiness;
-	FAutoVariable<bool, CvCity> m_bIndustrialRouteToCapital; //also set for water connection once railroad is available
-	FAutoVariable<int, CvCity> m_iTerrainImprovementNeed;
+	bool m_bNeverLost;
+	bool m_bDrafted;
+	bool m_bAirliftTargeted;   // unused
+	bool m_bProductionAutomated;
+	bool m_bLayoutDirty;
+	bool m_bMadeAttack;
+	bool m_bOccupied;
+	bool m_bPuppet;
+	bool m_bIgnoreCityForHappiness;
+	bool m_bIndustrialRouteToCapital; //also set for water connection once railroad is available
+	int m_iTerrainImprovementNeed;
 
-	FAutoVariable<PlayerTypes, CvCity> m_ePreviousOwner;
-	FAutoVariable<PlayerTypes, CvCity> m_eOriginalOwner;
-	FAutoVariable<PlayerTypes, CvCity> m_ePlayersReligion;
+	PlayerTypes m_ePreviousOwner;
+	PlayerTypes m_eOriginalOwner;
+	PlayerTypes m_ePlayersReligion;
 
-	FAutoVariable<std::vector<int>, CvCity> m_aiSeaPlotYield;
-	FAutoVariable<std::vector<int>, CvCity> m_aiRiverPlotYield;
-	FAutoVariable<std::vector<int>, CvCity> m_aiLakePlotYield;
-	FAutoVariable<std::vector<int>, CvCity> m_aiSeaResourceYield;
-	FAutoVariable<std::vector<int>, CvCity> m_aiBaseYieldRateFromTerrain;
-	FAutoVariable<std::vector<int>, CvCity> m_aiBaseYieldRateFromBuildings;
-	FAutoVariable<std::vector<int>, CvCity> m_aiBaseYieldRateFromSpecialists;
-	FAutoVariable<std::vector<int>, CvCity> m_aiBaseYieldRateFromMisc;
+	std::vector<int> m_aiSeaPlotYield;
+	std::vector<int> m_aiRiverPlotYield;
+	std::vector<int> m_aiLakePlotYield;
+	std::vector<int> m_aiSeaResourceYield;
+	std::vector<int> m_aiBaseYieldRateFromTerrain;
+	std::vector<int> m_aiBaseYieldRateFromBuildings;
+	std::vector<int> m_aiBaseYieldRateFromSpecialists;
+	std::vector<int> m_aiBaseYieldRateFromMisc;
 #if defined(MOD_DIPLOMACY_CITYSTATES)
-	FAutoVariable<std::vector<int>, CvCity> m_aiBaseYieldRateFromLeague;
-	FAutoVariable<int, CvCity> m_iTotalScienceyAid;
-	FAutoVariable<int, CvCity> m_iTotalArtsyAid;
-	FAutoVariable<int, CvCity> m_iTotalGreatWorkAid;
+	std::vector<int> m_aiBaseYieldRateFromLeague;
+	int m_iTotalScienceyAid;
+	int m_iTotalArtsyAid;
+	int m_iTotalGreatWorkAid;
 #endif
 #if defined(MOD_DIPLOMACY_CITYSTATES) || defined(MOD_BALANCE_CORE)
-	FAutoVariable<std::vector<int>, CvCity> m_aiChangeGrowthExtraYield;
+	std::vector<int> m_aiChangeGrowthExtraYield;
 #endif
 #if defined(MOD_BALANCE_CORE)
-	FAutoVariable<int, CvCity> m_iHappinessFromEmpire;
-	FAutoVariable<int, CvCity> m_iHappinessFromLuxuries;
-	FAutoVariable<int, CvCity> m_iUnhappinessFromEmpire;
-	FAutoVariable<int, CvCity> m_iStaticTechDeviation;
-	FAutoVariable<std::vector<int>, CvCity> m_aiNumProjects;
-	FAutoVariable<std::vector<int>, CvCity> m_aiNumUnitsBuilt;
-	FAutoVariable<std::vector<int>, CvCity> m_aiStaticGlobalYield;
-	FAutoVariable<std::vector<int>, CvCity> m_aiStaticNeedAdditives;
-	FAutoVariable<std::vector<int>, CvCity> m_aiLongestPotentialTradeRoute;
-	FAutoVariable<std::vector<int>, CvCity> m_aiNumTimesAttackedThisTurn;
-	FAutoVariable<std::vector<int>, CvCity> m_aiYieldFromKnownPantheons;
-	FAutoVariable<std::vector<int>, CvCity> m_aiYieldFromVictory;
-	FAutoVariable<std::vector<int>, CvCity> m_aiYieldFromVictoryGlobal;
-	FAutoVariable<std::vector<int>, CvCity> m_aiYieldFromPillage;
-	FAutoVariable<std::vector<int>, CvCity> m_aiYieldFromPillageGlobal;
-	FAutoVariable<std::vector<int>, CvCity> m_aiGoldenAgeYieldMod;
-	FAutoVariable<std::vector<int>, CvCity> m_aiYieldFromWLTKD;
-	FAutoVariable<std::vector<int>, CvCity> m_aiYieldFromConstruction;
-	FAutoVariable<std::vector<int>, CvCity> m_aiYieldFromTech;
-	FAutoVariable<std::vector<int>, CvCity> m_aiYieldFromBirth;
-	FAutoVariable<std::vector<int>, CvCity> m_aiYieldFromUnitProduction;
-	FAutoVariable<std::vector<int>, CvCity> m_aiYieldFromBorderGrowth;
-	FAutoVariable<std::vector<int>, CvCity> m_aiYieldFromPolicyUnlock;
-	FAutoVariable<std::vector<int>, CvCity> m_aiYieldFromPurchase;
-	FAutoVariable<std::vector<int>, CvCity> m_aiYieldFromFaithPurchase;
-	FAutoVariable<std::vector<int>, CvCity> m_aiYieldFromUnitLevelUp;
-	FAutoVariable<std::vector<int>, CvCity> m_aiYieldPerAlly;
-	FAutoVariable<std::vector<int>, CvCity> m_aiYieldPerFriend;
-	FAutoVariable<std::vector<int>, CvCity> m_aiYieldFromInternalTREnd;
-	FAutoVariable<std::vector<int>, CvCity> m_aiYieldFromInternalTR;
-	FAutoVariable<std::vector<int>, CvCity> m_aiYieldFromProcessModifier;
-	FAutoVariable<std::vector<int>, CvCity> m_aiSpecialistRateModifier;
-	FAutoVariable<std::vector<int>, CvCity> m_aiThemingYieldBonus;
-	FAutoVariable<std::vector<int>, CvCity> m_aiYieldFromSpyAttack;
-	FAutoVariable<std::vector<int>, CvCity> m_aiYieldFromSpyDefense;
-	FAutoVariable<std::vector<int>, CvCity> m_aiNumTimesOwned;
-	FAutoVariable<std::vector<int>, CvCity> m_aiStaticCityYield;
-	FAutoVariable<int, CvCity> m_iTradePriorityLand;
-	FAutoVariable<int, CvCity> m_iTradePrioritySea;
-	FAutoVariable<int, CvCity> m_iUnitPurchaseCooldown;
-	FAutoVariable<int, CvCity> m_iUnitPurchaseCooldownCivilian;
-	FAutoVariable<int, CvCity> m_iUnitFaithPurchaseCooldown;
-	FAutoVariable<int, CvCity> m_iUnitFaithPurchaseCooldownCivilian;
-	FAutoVariable<int, CvCity> m_iBuildingPurchaseCooldown;
-	FAutoVariable<int, CvCity> m_iReligiousTradeModifier;
-	FAutoVariable<int, CvCity> m_iCityAirStrikeDefense;
-	FAutoVariable<int, CvCity> m_iFreeBuildingTradeTargetCity;
-	FAutoVariable<int, CvCity> m_iBaseTourism;
-	FAutoVariable<int, CvCity> m_iBaseTourismBeforeModifiers;
-	FAutoVariable<int, CvCity> m_iBorderObstacleCity;
-	FAutoVariable<int, CvCity> m_iBorderObstacleWater;
-	FAutoVariable<int, CvCity> m_iDeepWaterTileDamage;
-	FAutoVariable<int, CvCity> m_iNumNearbyMountains;
-	FAutoVariable<int, CvCity> m_iLocalUnhappinessMod;
-	FAutoVariable<bool, CvCity> m_bNoWarmonger;
-	FAutoVariable<int, CvCity> m_iCitySpyRank;
-	FAutoVariable<int, CvCity> m_iTurnsSinceRankAnnouncement;
-	FAutoVariable<int, CvCity> m_iChangePovertyUnhappiness;
-	FAutoVariable<int, CvCity> m_iEmpireNeedsModifier;
-	FAutoVariable<int, CvCity> m_iChangeDefenseUnhappiness;
-	FAutoVariable<int, CvCity> m_iChangeUnculturedUnhappiness;
-	FAutoVariable<int, CvCity> m_iChangeIlliteracyUnhappiness;
-	FAutoVariable<int, CvCity> m_iChangeMinorityUnhappiness;
-	FAutoVariable<int, CvCity> m_iTradeRouteSeaDistanceModifier;
-	FAutoVariable<int, CvCity> m_iTradeRouteLandDistanceModifier;
-	FAutoVariable<int, CvCity> m_iNukeInterceptionChance;
-	FAutoVariable<std::vector<int>, CvCity> m_aiEconomicValue;
+	int m_iHappinessFromEmpire;
+	int m_iHappinessFromLuxuries;
+	int m_iUnhappinessFromEmpire;
+	int m_iStaticTechDeviation;
+	std::vector<int> m_aiNumProjects;
+	std::vector<int> m_aiNumUnitsBuilt;
+	std::vector<int> m_aiStaticGlobalYield;
+	std::vector<int> m_aiStaticNeedAdditives;
+	std::vector<int> m_aiLongestPotentialTradeRoute;
+	std::vector<int> m_aiNumTimesAttackedThisTurn;
+	std::vector<int> m_aiYieldFromKnownPantheons;
+	std::vector<int> m_aiYieldFromVictory;
+	std::vector<int> m_aiYieldFromVictoryGlobal;
+	std::vector<int> m_aiYieldFromPillage;
+	std::vector<int> m_aiYieldFromPillageGlobal;
+	std::vector<int> m_aiGoldenAgeYieldMod;
+	std::vector<int> m_aiYieldFromWLTKD;
+	std::vector<int> m_aiYieldFromConstruction;
+	std::vector<int> m_aiYieldFromTech;
+	std::vector<int> m_aiYieldFromBirth;
+	std::vector<int> m_aiYieldFromUnitProduction;
+	std::vector<int> m_aiYieldFromBorderGrowth;
+	std::vector<int> m_aiYieldFromPolicyUnlock;
+	std::vector<int> m_aiYieldFromPurchase;
+	std::vector<int> m_aiYieldFromFaithPurchase;
+	std::vector<int> m_aiYieldFromUnitLevelUp;
+	std::vector<int> m_aiYieldPerAlly;
+	std::vector<int> m_aiYieldPerFriend;
+	std::vector<int> m_aiYieldFromInternalTREnd;
+	std::vector<int> m_aiYieldFromInternalTR;
+	std::vector<int> m_aiYieldFromProcessModifier;
+	std::vector<int> m_aiSpecialistRateModifier;
+	std::vector<int> m_aiThemingYieldBonus;
+	std::vector<int> m_aiYieldFromSpyAttack;
+	std::vector<int> m_aiYieldFromSpyDefense;
+	std::vector<int> m_aiNumTimesOwned;
+	std::vector<int> m_aiStaticCityYield;
+	int m_iTradePriorityLand;
+	int m_iTradePrioritySea;
+	int m_iUnitPurchaseCooldown;
+	int m_iUnitPurchaseCooldownCivilian;
+	int m_iUnitFaithPurchaseCooldown;
+	int m_iUnitFaithPurchaseCooldownCivilian;
+	int m_iBuildingPurchaseCooldown;
+	int m_iReligiousTradeModifier;
+	int m_iCityAirStrikeDefense;
+	int m_iFreeBuildingTradeTargetCity;
+	int m_iBaseTourism;
+	int m_iBaseTourismBeforeModifiers;
+	int m_iBorderObstacleCity;
+	int m_iBorderObstacleWater;
+	int m_iDeepWaterTileDamage;
+	int m_iNumNearbyMountains;
+	int m_iLocalUnhappinessMod;
+	bool m_bNoWarmonger;
+	int m_iCitySpyRank;
+	int m_iTurnsSinceRankAnnouncement;
+	int m_iChangePovertyUnhappiness;
+	int m_iEmpireNeedsModifier;
+	int m_iChangeDefenseUnhappiness;
+	int m_iChangeUnculturedUnhappiness;
+	int m_iChangeIlliteracyUnhappiness;
+	int m_iChangeMinorityUnhappiness;
+	int m_iTradeRouteSeaDistanceModifier;
+	int m_iTradeRouteLandDistanceModifier;
+	int m_iNukeInterceptionChance;
+	std::vector<int> m_aiEconomicValue;
 #endif
-	FAutoVariable<std::vector<int>, CvCity> m_aiBaseYieldRateFromReligion;
+	std::vector<int> m_aiBaseYieldRateFromReligion;
 #if defined(MOD_BALANCE_CORE)
-	FAutoVariable<std::vector<int>, CvCity> m_aiBaseYieldRateFromCSAlliance;
-	FAutoVariable<std::vector<int>, CvCity> m_aiBaseYieldRateFromCSFriendship;
-	FAutoVariable<std::vector<int>, CvCity> m_aiYieldFromMinors;
-	FAutoVariable<std::vector<int>, CvCity> m_aiResourceQuantityPerXFranchises;
-	FAutoVariable<std::vector<int>, CvCity> m_aiYieldChangeFromCorporationFranchises;
-	FAutoVariable<std::vector<int>, CvCity> m_aiNeedsFlatReduction;
-	FAutoVariable<int, CvCity> m_iLandTourismBonus;
-	FAutoVariable<int, CvCity> m_iSeaTourismBonus;
-	FAutoVariable<int, CvCity> m_iAlwaysHeal;
-	FAutoVariable<int, CvCity> m_iResourceDiversityModifier;
-	FAutoVariable<int, CvCity> m_iNoUnhappfromXSpecialists;
-	FAutoVariable<int, CvCity> m_aiStaticNeedsUpdateTurn;
-	FAutoVariable<std::vector<int>, CvCity> m_aiGreatWorkYieldChange;
+	std::vector<int> m_aiBaseYieldRateFromCSAlliance;
+	std::vector<int> m_aiBaseYieldRateFromCSFriendship;
+	std::vector<int> m_aiYieldFromMinors;
+	std::vector<int> m_aiResourceQuantityPerXFranchises;
+	std::vector<int> m_aiYieldChangeFromCorporationFranchises;
+	std::vector<int> m_aiNeedsFlatReduction;
+	int m_iLandTourismBonus;
+	int m_iSeaTourismBonus;
+	int m_iAlwaysHeal;
+	int m_iResourceDiversityModifier;
+	int m_iNoUnhappfromXSpecialists;
+	int m_aiStaticNeedsUpdateTurn;
+	std::vector<int> m_aiGreatWorkYieldChange;
 #endif
-	FAutoVariable<std::vector<int>, CvCity> m_aiYieldRateModifier;
-	FAutoVariable<std::vector<int>, CvCity> m_aiYieldPerPop;
+	std::vector<int> m_aiYieldRateModifier;
+	std::vector<int> m_aiYieldPerPop;
 #if defined(MOD_BALANCE_CORE)
 	std::map<int, int> m_aiYieldPerPopInEmpire;
 #endif
-	FAutoVariable<std::vector<int>, CvCity> m_aiYieldPerReligion;
-	FAutoVariable<std::vector<int>, CvCity> m_aiPowerYieldRateModifier;
-	FAutoVariable<std::vector<int>, CvCity> m_aiResourceYieldRateModifier;
-	FAutoVariable<std::vector<int>, CvCity> m_aiExtraSpecialistYield;
-	FAutoVariable<std::vector<int>, CvCity> m_aiProductionToYieldModifier;
-	FAutoVariable<std::vector<int>, CvCity> m_aiDomainFreeExperience;
-	FAutoVariable<std::vector<int>, CvCity> m_aiDomainProductionModifier;
+	std::vector<int> m_aiYieldPerReligion;
+	std::vector<int> m_aiPowerYieldRateModifier;
+	std::vector<int> m_aiResourceYieldRateModifier;
+	std::vector<int> m_aiExtraSpecialistYield;
+	std::vector<int> m_aiProductionToYieldModifier;
+	std::vector<int> m_aiDomainFreeExperience;
+	std::vector<int> m_aiDomainProductionModifier;
 
-	FAutoVariable<std::vector<bool>, CvCity> m_abEverOwned;
+	std::vector<bool> m_abEverOwned;
 #if defined(MOD_BALANCE_CORE)
-	FAutoVariable<std::vector<bool>, CvCity> m_abIsBestForWonder;
-	FAutoVariable<std::vector<bool>, CvCity> m_abIsPurchased;
-	FAutoVariable<std::vector<bool>, CvCity> m_abTraded;
-	FAutoVariable<std::vector<bool>, CvCity> m_abPaidAdoptionBonus;
-	FAutoVariable<std::vector<int>, CvCity> m_aiReligiousPressureModifier;
-	FAutoVariable<int, CvCity> m_iExtraBuildingMaintenance;
-	FAutoVariable<std::vector<int>, CvCity> m_paiNumTerrainWorked;
-	FAutoVariable<std::vector<int>, CvCity> m_paiNumFeaturelessTerrainWorked;
-	FAutoVariable<std::vector<int>, CvCity> m_paiNumFeatureWorked;
-	FAutoVariable<std::vector<int>, CvCity> m_paiNumResourceWorked;
-	FAutoVariable<std::vector<int>, CvCity> m_paiNumImprovementWorked;
+	std::vector<bool> m_abIsBestForWonder;
+	std::vector<bool> m_abIsPurchased;
+	std::vector<bool> m_abTraded;
+	std::vector<bool> m_abPaidAdoptionBonus;
+	std::vector<int> m_aiReligiousPressureModifier;
+	int m_iExtraBuildingMaintenance;
+	std::vector<int> m_paiNumTerrainWorked;
+	std::vector<int> m_paiNumFeaturelessTerrainWorked;
+	std::vector<int> m_paiNumFeatureWorked;
+	std::vector<int> m_paiNumResourceWorked;
+	std::vector<int> m_paiNumImprovementWorked;
 #endif
-	FAutoVariable<CvString, CvCity> m_strScriptData;
+	CvString m_strScriptData;
 
 #if defined(MOD_CORE_PER_TURN_DAMAGE)
-	FAutoVariable<int, CvCity> m_iDamageTakenThisTurn;
-	FAutoVariable<int, CvCity> m_iDamageTakenLastTurn;
+	int m_iDamageTakenThisTurn;
+	int m_iDamageTakenLastTurn;
 #endif
 
-	FAutoVariable<std::vector<int>, CvCity> m_paiNoResource;
-	FAutoVariable<std::vector<int>, CvCity> m_paiFreeResource;
-	FAutoVariable<std::vector<int>, CvCity> m_paiNumResourcesLocal;
-	FAutoVariable<std::vector<int>, CvCity> m_paiNumUnimprovedResourcesLocal;
-	FAutoVariable<std::vector<int>, CvCity> m_paiProjectProduction;
-	FAutoVariable<std::vector<int>, CvCity> m_paiSpecialistProduction;
-	FAutoVariable<std::vector<int>, CvCity> m_paiUnitProduction;
-	FAutoVariable<std::vector<int>, CvCity> m_paiUnitProductionTime;
-	FAutoVariable<std::vector<int>, CvCity> m_paiSpecialistCount;
-	FAutoVariable<std::vector<int>, CvCity> m_paiMaxSpecialistCount;
-	FAutoVariable<std::vector<int>, CvCity> m_paiForceSpecialistCount;
-	FAutoVariable<std::vector<int>, CvCity> m_paiFreeSpecialistCount;
-	FAutoVariable<std::vector<int>, CvCity> m_paiImprovementFreeSpecialists;
-	FAutoVariable<std::vector<int>, CvCity> m_paiUnitCombatFreeExperience;
-	FAutoVariable<std::vector<int>, CvCity> m_paiUnitCombatProductionModifier;
-	FAutoVariable<std::map<PromotionTypes,int>, CvCity> m_paiFreePromotionCount;
+	std::vector<int> m_paiNoResource;
+	std::vector<int> m_paiFreeResource;
+	std::vector<int> m_paiNumResourcesLocal;
+	std::vector<int> m_paiNumUnimprovedResourcesLocal;
+	std::vector<int> m_paiProjectProduction;
+	std::vector<int> m_paiSpecialistProduction;
+	std::vector<int> m_paiUnitProduction;
+	std::vector<int> m_paiUnitProductionTime;
+	std::vector<int> m_paiSpecialistCount;
+	std::vector<int> m_paiMaxSpecialistCount;
+	std::vector<int> m_paiForceSpecialistCount;
+	std::vector<int> m_paiFreeSpecialistCount;
+	std::vector<int> m_paiImprovementFreeSpecialists;
+	std::vector<int> m_paiUnitCombatFreeExperience;
+	std::vector<int> m_paiUnitCombatProductionModifier;
+	std::map<PromotionTypes,int> m_paiFreePromotionCount;
 #if defined(MOD_BALANCE_CORE_POLICIES)
-	FAutoVariable<std::vector<int>, CvCity> m_paiBuildingClassCulture;
-	FAutoVariable<std::vector<int>, CvCity> m_paiHurryModifier;
+	std::vector<int> m_paiBuildingClassCulture;
+	std::vector<int> m_paiHurryModifier;
 #endif
 
 #if defined(MOD_BALANCE_CORE)
-	FAutoVariable<int, CvCity> m_iHappinessDelta;
-	FAutoVariable<int, CvCity> m_iPillagedPlots;
-	FAutoVariable<int, CvCity> m_iGrowthEvent;
-	FAutoVariable<int, CvCity> m_iGrowthFromTourism;
-	FAutoVariable<int, CvCity> m_iBuildingClassHappiness;
-	FAutoVariable<int, CvCity> m_iReligionHappiness;
-	FAutoVariable<std::vector<int>, CvCity> m_vClosestNeighbors;
+	int m_iHappinessDelta;
+	int m_iPillagedPlots;
+	int m_iGrowthEvent;
+	int m_iGrowthFromTourism;
+	int m_iBuildingClassHappiness;
+	int m_iReligionHappiness;
+	std::vector<int> m_vClosestNeighbors;
 	std::vector<int> m_vAttachedUnits;
 #endif
 
-	FAutoVariable<int, CvCity> m_iBaseHappinessFromBuildings;
-	FAutoVariable<int, CvCity> m_iUnmoddedHappinessFromBuildings;
+	int m_iBaseHappinessFromBuildings;
+	int m_iUnmoddedHappinessFromBuildings;
 
-	FAutoVariable<bool, CvCity> m_bRouteToCapitalConnectedLastTurn;
-	FAutoVariable<bool, CvCity> m_bRouteToCapitalConnectedThisTurn;
+	bool m_bRouteToCapitalConnectedLastTurn;
+	bool m_bRouteToCapitalConnectedThisTurn;
 
-	FAutoVariable<CvString, CvCity> m_strName;
+	CvString m_strName;
 
-	FAutoVariable<bool, CvCity> m_bOwedCultureBuilding;
-	FAutoVariable<bool, CvCity> m_bOwedFoodBuilding;
+	bool m_bOwedCultureBuilding;
+	bool m_bOwedFoodBuilding;
 
 	mutable FFastSmallFixedList< OrderData, 25, true, c_eCiv5GameplayDLL > m_orderQueue;
 
@@ -2063,39 +2066,39 @@ protected:
 	std::map<std::pair<int, int>, short> m_ppiGreatPersonProgressFromConstruction;
 #endif
 #if defined(MOD_BALANCE_CORE_EVENTS)
-	FAutoVariable<std::vector<int>, CvCity> m_aiEventCooldown;
-	FAutoVariable<std::vector<bool>, CvCity> m_abEventActive;
-	FAutoVariable<std::vector<bool>, CvCity> m_abEventChoiceActive;
-	FAutoVariable<std::vector<bool>, CvCity> m_abEventChoiceFired;
-	FAutoVariable<std::vector<bool>, CvCity> m_abEventFired;
-	FAutoVariable<std::vector<int>, CvCity> m_aiEventChoiceDuration;
-	FAutoVariable<std::vector<int>, CvCity> m_aiEventIncrement;
-	FAutoVariable<std::vector<int>, CvCity> m_aiEventCityYield;
-	FAutoVariable<int, CvCity> m_iEventHappiness;
-	FAutoVariable<int, CvCity> m_iCityEventCooldown;
+	std::vector<int> m_aiEventCooldown;
+	std::vector<bool> m_abEventActive;
+	std::vector<bool> m_abEventChoiceActive;
+	std::vector<bool> m_abEventChoiceFired;
+	std::vector<bool> m_abEventFired;
+	std::vector<int> m_aiEventChoiceDuration;
+	std::vector<int> m_aiEventIncrement;
+	std::vector<int> m_aiEventCityYield;
+	int m_iEventHappiness;
+	int m_iCityEventCooldown;
 	vector<SCityEventYields> m_eventYields; //[NUM_YIELD_TYPES]
 #endif
 
 #if defined(MOD_BALANCE_CORE)
-	FAutoVariable<bool, CvCity> m_bIsColony;
-	FAutoVariable<int, CvCity> m_iProvinceLevel;
-	FAutoVariable<int, CvCity> m_iOrganizedCrime;
-	FAutoVariable<int, CvCity> m_iResistanceCounter;
-	FAutoVariable<int, CvCity> m_iPlagueCounter;
-	FAutoVariable<int, CvCity> m_iPlagueTurns;
-	FAutoVariable<int, CvCity> m_iPlagueType;
-	FAutoVariable<int, CvCity> m_iSappedTurns;
-	FAutoVariable<int, CvCity> m_iLoyaltyCounter;
-	FAutoVariable<int, CvCity> m_iDisloyaltyCounter;
-	FAutoVariable<int, CvCity> m_iLoyaltyStateType;
-	FAutoVariable<std::vector<int>, CvCity> m_aiYieldModifierFromHappiness;
-	FAutoVariable<std::vector<int>, CvCity> m_aiYieldModifierFromHealth;
-	FAutoVariable<std::vector<int>, CvCity> m_aiYieldModifierFromCrime;
-	FAutoVariable<std::vector<int>, CvCity> m_aiYieldModifierFromDevelopment;
-	FAutoVariable<std::vector<int>, CvCity> m_aiYieldFromHappiness;
-	FAutoVariable<std::vector<int>, CvCity> m_aiYieldFromHealth;
-	FAutoVariable<std::vector<int>, CvCity> m_aiYieldFromCrime;
-	FAutoVariable<std::vector<int>, CvCity> m_aiYieldFromDevelopment;
+	bool m_bIsColony;
+	int m_iProvinceLevel;
+	int m_iOrganizedCrime;
+	int m_iResistanceCounter;
+	int m_iPlagueCounter;
+	int m_iPlagueTurns;
+	int m_iPlagueType;
+	int m_iSappedTurns;
+	int m_iLoyaltyCounter;
+	int m_iDisloyaltyCounter;
+	int m_iLoyaltyStateType;
+	std::vector<int> m_aiYieldModifierFromHappiness;
+	std::vector<int> m_aiYieldModifierFromHealth;
+	std::vector<int> m_aiYieldModifierFromCrime;
+	std::vector<int> m_aiYieldModifierFromDevelopment;
+	std::vector<int> m_aiYieldFromHappiness;
+	std::vector<int> m_aiYieldFromHealth;
+	std::vector<int> m_aiYieldFromCrime;
+	std::vector<int> m_aiYieldFromDevelopment;
 #endif
 
 	CvCityBuildings* m_pCityBuildings;
@@ -2109,17 +2112,17 @@ protected:
 	mutable int m_bombardCheckTurn;
 
 	// CACHE: cache frequently used values
-	FAutoVariable<int, CvCity> m_iPopulationRank;
-	FAutoVariable<bool, CvCity> m_bPopulationRankValid;
-	FAutoVariable<std::vector<int>, CvCity> m_aiBaseYieldRank;
-	FAutoVariable<std::vector<bool>, CvCity> m_abBaseYieldRankValid;
-	FAutoVariable<std::vector<int>, CvCity> m_aiYieldRank;
-	FAutoVariable<std::vector<bool>, CvCity> m_abYieldRankValid;
+	int m_iPopulationRank;
+	bool m_bPopulationRankValid;
+	std::vector<int> m_aiBaseYieldRank;
+	std::vector<bool> m_abBaseYieldRankValid;
+	std::vector<int> m_aiYieldRank;
+	std::vector<bool> m_abYieldRankValid;
 #if defined(MOD_BALANCE_CORE)
-	FAutoVariable<std::vector<bool>, CvCity> m_abOwedChosenBuilding;
-	FAutoVariable<std::vector<bool>, CvCity> m_abBuildingInvestment;
-	FAutoVariable<std::vector<bool>, CvCity> m_abUnitInvestment;
-	FAutoVariable<std::vector<bool>, CvCity> m_abBuildingConstructed;
+	std::vector<bool> m_abOwedChosenBuilding;
+	std::vector<bool> m_abBuildingInvestment;
+	std::vector<bool> m_abUnitInvestment;
+	std::vector<bool> m_abBuildingConstructed;
 #endif
 
 	//cache for great work yields, they are need often during citizen re-assignment but they don't change
@@ -2160,6 +2163,305 @@ namespace FSerialization
 void SyncCities();
 void ClearCityDeltas();
 }
+
+SYNC_ARCHIVE_BEGIN(CvCity)
+SYNC_ARCHIVE_VAR(PlayerTypes, m_eOwner)
+SYNC_ARCHIVE_VAR(int, m_iX)
+SYNC_ARCHIVE_VAR(int, m_iY)
+SYNC_ARCHIVE_VAR(int, m_iID)
+SYNC_ARCHIVE_VAR(int, m_iRallyX)
+SYNC_ARCHIVE_VAR(int, m_iRallyY)
+SYNC_ARCHIVE_VAR(int, m_iGameTurnFounded)
+SYNC_ARCHIVE_VAR(int, m_iGameTurnAcquired)
+SYNC_ARCHIVE_VAR(int, m_iGameTurnLastExpanded)
+SYNC_ARCHIVE_VAR(int, m_iPopulation)
+SYNC_ARCHIVE_VAR(int, m_iHighestPopulation)
+SYNC_ARCHIVE_VAR(int, m_iExtraHitPoints)
+SYNC_ARCHIVE_VAR(int, m_iNumGreatPeople)
+SYNC_ARCHIVE_VAR(int, m_iBaseGreatPeopleRate)
+SYNC_ARCHIVE_VAR(int, m_iGreatPeopleRateModifier)
+SYNC_ARCHIVE_VAR(int, m_iJONSCultureStored)
+SYNC_ARCHIVE_VAR(int, m_iJONSCultureLevel)
+#if !defined(MOD_API_UNIFIED_YIELDS_CONSOLIDATION)
+SYNC_ARCHIVE_VAR(int, m_iJONSCulturePerTurnFromBuildings)
+#endif
+SYNC_ARCHIVE_VAR(int, m_iJONSCulturePerTurnFromPolicies)
+SYNC_ARCHIVE_VAR(int, m_iJONSCulturePerTurnFromSpecialists)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_iaAddedYieldPerTurnFromTraits)
+#if !defined(MOD_API_UNIFIED_YIELDS_CONSOLIDATION)
+SYNC_ARCHIVE_VAR(int, m_iJONSCulturePerTurnFromReligion)
+#endif
+#if !defined(MOD_API_UNIFIED_YIELDS_CONSOLIDATION)
+SYNC_ARCHIVE_VAR(int, m_iFaithPerTurnFromBuildings)
+#endif
+SYNC_ARCHIVE_VAR(int, m_iFaithPerTurnFromPolicies)
+#if !defined(MOD_API_UNIFIED_YIELDS_CONSOLIDATION)
+SYNC_ARCHIVE_VAR(int, m_iFaithPerTurnFromReligion)
+#endif
+SYNC_ARCHIVE_VAR(int, m_iAdditionalFood)
+SYNC_ARCHIVE_VAR(int, m_iCityBuildingBombardRange)
+SYNC_ARCHIVE_VAR(int, m_iCityIndirectFire)
+SYNC_ARCHIVE_VAR(int, m_iCityBuildingRangeStrikeModifier)
+SYNC_ARCHIVE_VAR(int, m_iCultureRateModifier)
+SYNC_ARCHIVE_VAR(int, m_iNumWorldWonders)
+SYNC_ARCHIVE_VAR(int, m_iNumTeamWonders)
+SYNC_ARCHIVE_VAR(int, m_iNumNationalWonders)
+SYNC_ARCHIVE_VAR(int, m_iWonderProductionModifier)
+SYNC_ARCHIVE_VAR(int, m_iCapturePlunderModifier)
+SYNC_ARCHIVE_VAR(int, m_iPlotCultureCostModifier)
+SYNC_ARCHIVE_VAR(int, m_iPlotBuyCostModifier)
+SYNC_ARCHIVE_VAR(int, m_iCityWorkingChange)
+SYNC_ARCHIVE_VAR(int, m_iCitySupplyModifier)
+SYNC_ARCHIVE_VAR(int, m_iCitySupplyFlat)
+SYNC_ARCHIVE_VAR(bool, m_bAllowsProductionTradeRoutes)
+SYNC_ARCHIVE_VAR(bool, m_bAllowsFoodTradeRoutes)
+SYNC_ARCHIVE_VAR(bool, m_bAllowPuppetPurchase)
+SYNC_ARCHIVE_VAR(int, m_iCityAutomatonWorkersChange)
+SYNC_ARCHIVE_VAR(int, m_iMaintenance)
+SYNC_ARCHIVE_VAR(int, m_iHealRate)
+SYNC_ARCHIVE_VAR(int, m_iNoOccupiedUnhappinessCount)
+SYNC_ARCHIVE_VAR(int, m_iLocalGainlessPillageCount)
+SYNC_ARCHIVE_VAR(int, m_iFood)
+SYNC_ARCHIVE_VAR(int, m_iFoodKept)
+SYNC_ARCHIVE_VAR(int, m_iMaxFoodKeptPercent)
+SYNC_ARCHIVE_VAR(int, m_iOverflowProduction)
+SYNC_ARCHIVE_VAR(int, m_iFeatureProduction)
+SYNC_ARCHIVE_VAR(int, m_iMilitaryProductionModifier)
+SYNC_ARCHIVE_VAR(int, m_iSpaceProductionModifier)
+SYNC_ARCHIVE_VAR(int, m_iFreeExperience)
+SYNC_ARCHIVE_VAR(int, m_iCurrAirlift)
+SYNC_ARCHIVE_VAR(int, m_iMaxAirUnits)
+SYNC_ARCHIVE_VAR(int, m_iAirModifier)
+SYNC_ARCHIVE_VAR(int, m_iNukeModifier)
+SYNC_ARCHIVE_VAR(int, m_iTradeRouteTargetBonus)
+SYNC_ARCHIVE_VAR(int, m_iTradeRouteRecipientBonus)
+SYNC_ARCHIVE_VAR(int, m_iTradeRouteSeaGoldBonus)
+SYNC_ARCHIVE_VAR(int, m_iTradeRouteLandGoldBonus)
+SYNC_ARCHIVE_VAR(int, m_iNumTradeRouteBonus)
+SYNC_ARCHIVE_VAR(int, m_iCityConnectionTradeRouteGoldModifier)
+SYNC_ARCHIVE_VAR(int, m_iCultureUpdateTimer)
+SYNC_ARCHIVE_VAR(int, m_iCitySizeBoost)
+SYNC_ARCHIVE_VAR(int, m_iSpecialistFreeExperience)
+SYNC_ARCHIVE_VAR(int, m_iStrengthValue)
+SYNC_ARCHIVE_VAR(int, m_iDamage)
+SYNC_ARCHIVE_VAR(int, m_iThreatValue)
+SYNC_ARCHIVE_VAR(int, m_hGarrison)
+SYNC_ARCHIVE_VAR(int, m_iResourceDemanded)
+SYNC_ARCHIVE_VAR(int, m_iWeLoveTheKingDayCounter)
+SYNC_ARCHIVE_VAR(int, m_iLastTurnGarrisonAssigned)
+SYNC_ARCHIVE_VAR(int, m_iThingsProduced)
+SYNC_ARCHIVE_VAR(int, m_iDemandResourceCounter)
+SYNC_ARCHIVE_VAR(int, m_iResistanceTurns)
+SYNC_ARCHIVE_VAR(int, m_iRazingTurns)
+SYNC_ARCHIVE_VAR(int, m_iLowestRazingPop)
+SYNC_ARCHIVE_VAR(int, m_iCountExtraLuxuries)
+SYNC_ARCHIVE_VAR(int, m_iCheapestPlotInfluenceDistance)
+SYNC_ARCHIVE_VAR(int, m_iEspionageModifier)
+SYNC_ARCHIVE_VAR(int, m_iConversionModifier)
+SYNC_ARCHIVE_VAR(bool, m_bNeverLost)
+SYNC_ARCHIVE_VAR(bool, m_bDrafted)
+SYNC_ARCHIVE_VAR(bool, m_bAirliftTargeted)
+SYNC_ARCHIVE_VAR(bool, m_bProductionAutomated)
+SYNC_ARCHIVE_VAR(bool, m_bLayoutDirty)
+SYNC_ARCHIVE_VAR(bool, m_bMadeAttack)
+SYNC_ARCHIVE_VAR(bool, m_bOccupied)
+SYNC_ARCHIVE_VAR(bool, m_bPuppet)
+SYNC_ARCHIVE_VAR(bool, m_bIgnoreCityForHappiness)
+SYNC_ARCHIVE_VAR(bool, m_bIndustrialRouteToCapital)
+SYNC_ARCHIVE_VAR(int, m_iTerrainImprovementNeed)
+SYNC_ARCHIVE_VAR(PlayerTypes, m_ePreviousOwner)
+SYNC_ARCHIVE_VAR(PlayerTypes, m_eOriginalOwner)
+SYNC_ARCHIVE_VAR(PlayerTypes, m_ePlayersReligion)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiSeaPlotYield)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiRiverPlotYield)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiLakePlotYield)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiSeaResourceYield)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiBaseYieldRateFromTerrain)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiBaseYieldRateFromBuildings)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiBaseYieldRateFromSpecialists)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiBaseYieldRateFromMisc)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiBaseYieldRateFromLeague)
+SYNC_ARCHIVE_VAR(int, m_iTotalScienceyAid)
+SYNC_ARCHIVE_VAR(int, m_iTotalArtsyAid)
+SYNC_ARCHIVE_VAR(int, m_iTotalGreatWorkAid)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiChangeGrowthExtraYield)
+SYNC_ARCHIVE_VAR(int, m_iHappinessFromEmpire)
+SYNC_ARCHIVE_VAR(int, m_iHappinessFromLuxuries)
+SYNC_ARCHIVE_VAR(int, m_iUnhappinessFromEmpire)
+SYNC_ARCHIVE_VAR(int, m_iStaticTechDeviation)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiNumProjects)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiNumUnitsBuilt)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiStaticGlobalYield)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiStaticNeedAdditives)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiLongestPotentialTradeRoute)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiNumTimesAttackedThisTurn)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldFromKnownPantheons)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldFromVictory)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldFromVictoryGlobal)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldFromPillage)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldFromPillageGlobal)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiGoldenAgeYieldMod)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldFromWLTKD)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldFromConstruction)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldFromTech)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldFromBirth)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldFromUnitProduction)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldFromBorderGrowth)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldFromPolicyUnlock)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldFromPurchase)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldFromFaithPurchase)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldFromUnitLevelUp)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldPerAlly)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldPerFriend)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldFromInternalTREnd)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldFromInternalTR)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldFromProcessModifier)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiSpecialistRateModifier)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiThemingYieldBonus)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldFromSpyAttack)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldFromSpyDefense)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiNumTimesOwned)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiStaticCityYield)
+SYNC_ARCHIVE_VAR(int, m_iTradePriorityLand)
+SYNC_ARCHIVE_VAR(int, m_iTradePrioritySea)
+SYNC_ARCHIVE_VAR(int, m_iUnitPurchaseCooldown)
+SYNC_ARCHIVE_VAR(int, m_iUnitPurchaseCooldownCivilian)
+SYNC_ARCHIVE_VAR(int, m_iUnitFaithPurchaseCooldown)
+SYNC_ARCHIVE_VAR(int, m_iUnitFaithPurchaseCooldownCivilian)
+SYNC_ARCHIVE_VAR(int, m_iBuildingPurchaseCooldown)
+SYNC_ARCHIVE_VAR(int, m_iReligiousTradeModifier)
+SYNC_ARCHIVE_VAR(int, m_iCityAirStrikeDefense)
+SYNC_ARCHIVE_VAR(int, m_iFreeBuildingTradeTargetCity)
+SYNC_ARCHIVE_VAR(int, m_iBaseTourism)
+SYNC_ARCHIVE_VAR(int, m_iBaseTourismBeforeModifiers)
+SYNC_ARCHIVE_VAR(int, m_iBorderObstacleCity)
+SYNC_ARCHIVE_VAR(int, m_iBorderObstacleWater)
+SYNC_ARCHIVE_VAR(int, m_iDeepWaterTileDamage)
+SYNC_ARCHIVE_VAR(int, m_iNumNearbyMountains)
+SYNC_ARCHIVE_VAR(int, m_iLocalUnhappinessMod)
+SYNC_ARCHIVE_VAR(bool, m_bNoWarmonger)
+SYNC_ARCHIVE_VAR(int, m_iCitySpyRank)
+SYNC_ARCHIVE_VAR(int, m_iTurnsSinceRankAnnouncement)
+SYNC_ARCHIVE_VAR(int, m_iChangePovertyUnhappiness)
+SYNC_ARCHIVE_VAR(int, m_iEmpireNeedsModifier)
+SYNC_ARCHIVE_VAR(int, m_iChangeDefenseUnhappiness)
+SYNC_ARCHIVE_VAR(int, m_iChangeUnculturedUnhappiness)
+SYNC_ARCHIVE_VAR(int, m_iChangeIlliteracyUnhappiness)
+SYNC_ARCHIVE_VAR(int, m_iChangeMinorityUnhappiness)
+SYNC_ARCHIVE_VAR(int, m_iTradeRouteSeaDistanceModifier)
+SYNC_ARCHIVE_VAR(int, m_iTradeRouteLandDistanceModifier)
+SYNC_ARCHIVE_VAR(int, m_iNukeInterceptionChance)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiEconomicValue)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiBaseYieldRateFromReligion)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiBaseYieldRateFromCSAlliance)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiBaseYieldRateFromCSFriendship)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldFromMinors)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiResourceQuantityPerXFranchises)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldChangeFromCorporationFranchises)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiNeedsFlatReduction)
+SYNC_ARCHIVE_VAR(int, m_iLandTourismBonus)
+SYNC_ARCHIVE_VAR(int, m_iSeaTourismBonus)
+SYNC_ARCHIVE_VAR(int, m_iAlwaysHeal)
+SYNC_ARCHIVE_VAR(int, m_iResourceDiversityModifier)
+SYNC_ARCHIVE_VAR(int, m_iNoUnhappfromXSpecialists)
+SYNC_ARCHIVE_VAR(int, m_aiStaticNeedsUpdateTurn)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiGreatWorkYieldChange)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldRateModifier)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldPerPop)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldPerReligion)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiPowerYieldRateModifier)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiResourceYieldRateModifier)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiExtraSpecialistYield)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiProductionToYieldModifier)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiDomainFreeExperience)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiDomainProductionModifier)
+SYNC_ARCHIVE_VAR(std::vector<bool>, m_abEverOwned)
+SYNC_ARCHIVE_VAR(std::vector<bool>, m_abIsBestForWonder)
+SYNC_ARCHIVE_VAR(std::vector<bool>, m_abIsPurchased)
+SYNC_ARCHIVE_VAR(std::vector<bool>, m_abTraded)
+SYNC_ARCHIVE_VAR(std::vector<bool>, m_abPaidAdoptionBonus)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiReligiousPressureModifier)
+SYNC_ARCHIVE_VAR(int, m_iExtraBuildingMaintenance)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiNumTerrainWorked)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiNumFeaturelessTerrainWorked)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiNumFeatureWorked)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiNumResourceWorked)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiNumImprovementWorked)
+SYNC_ARCHIVE_VAR(CvString, m_strScriptData)
+SYNC_ARCHIVE_VAR(int, m_iDamageTakenThisTurn)
+SYNC_ARCHIVE_VAR(int, m_iDamageTakenLastTurn)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiNoResource)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiFreeResource)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiNumResourcesLocal)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiNumUnimprovedResourcesLocal)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiProjectProduction)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiSpecialistProduction)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiUnitProduction)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiUnitProductionTime)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiSpecialistCount)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiMaxSpecialistCount)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiForceSpecialistCount)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiFreeSpecialistCount)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiImprovementFreeSpecialists)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiUnitCombatFreeExperience)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiUnitCombatProductionModifier)
+SYNC_ARCHIVE_VAR(SYNC_ARCHIVE_VAR_TYPE(std::map<PromotionTypes, int>), m_paiFreePromotionCount)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiBuildingClassCulture)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiHurryModifier)
+SYNC_ARCHIVE_VAR(int, m_iHappinessDelta)
+SYNC_ARCHIVE_VAR(int, m_iPillagedPlots)
+SYNC_ARCHIVE_VAR(int, m_iGrowthEvent)
+SYNC_ARCHIVE_VAR(int, m_iGrowthFromTourism)
+SYNC_ARCHIVE_VAR(int, m_iBuildingClassHappiness)
+SYNC_ARCHIVE_VAR(int, m_iReligionHappiness)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_vClosestNeighbors)
+SYNC_ARCHIVE_VAR(int, m_iBaseHappinessFromBuildings)
+SYNC_ARCHIVE_VAR(int, m_iUnmoddedHappinessFromBuildings)
+SYNC_ARCHIVE_VAR(bool, m_bRouteToCapitalConnectedLastTurn)
+SYNC_ARCHIVE_VAR(bool, m_bRouteToCapitalConnectedThisTurn)
+SYNC_ARCHIVE_VAR(CvString, m_strName)
+SYNC_ARCHIVE_VAR(bool, m_bOwedCultureBuilding)
+SYNC_ARCHIVE_VAR(bool, m_bOwedFoodBuilding)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiEventCooldown)
+SYNC_ARCHIVE_VAR(std::vector<bool>, m_abEventActive)
+SYNC_ARCHIVE_VAR(std::vector<bool>, m_abEventChoiceActive)
+SYNC_ARCHIVE_VAR(std::vector<bool>, m_abEventChoiceFired)
+SYNC_ARCHIVE_VAR(std::vector<bool>, m_abEventFired)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiEventChoiceDuration)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiEventIncrement)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiEventCityYield)
+SYNC_ARCHIVE_VAR(int, m_iEventHappiness)
+SYNC_ARCHIVE_VAR(int, m_iCityEventCooldown)
+SYNC_ARCHIVE_VAR(bool, m_bIsColony)
+SYNC_ARCHIVE_VAR(int, m_iProvinceLevel)
+SYNC_ARCHIVE_VAR(int, m_iOrganizedCrime)
+SYNC_ARCHIVE_VAR(int, m_iResistanceCounter)
+SYNC_ARCHIVE_VAR(int, m_iPlagueCounter)
+SYNC_ARCHIVE_VAR(int, m_iPlagueTurns)
+SYNC_ARCHIVE_VAR(int, m_iPlagueType)
+SYNC_ARCHIVE_VAR(int, m_iSappedTurns)
+SYNC_ARCHIVE_VAR(int, m_iLoyaltyCounter)
+SYNC_ARCHIVE_VAR(int, m_iDisloyaltyCounter)
+SYNC_ARCHIVE_VAR(int, m_iLoyaltyStateType)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldModifierFromHappiness)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldModifierFromHealth)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldModifierFromCrime)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldModifierFromDevelopment)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldFromHappiness)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldFromHealth)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldFromCrime)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldFromDevelopment)
+SYNC_ARCHIVE_VAR(int, m_iPopulationRank)
+SYNC_ARCHIVE_VAR(bool, m_bPopulationRankValid)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiBaseYieldRank)
+SYNC_ARCHIVE_VAR(std::vector<bool>, m_abBaseYieldRankValid)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldRank)
+SYNC_ARCHIVE_VAR(std::vector<bool>, m_abYieldRankValid)
+SYNC_ARCHIVE_VAR(std::vector<bool>, m_abOwedChosenBuilding)
+SYNC_ARCHIVE_VAR(std::vector<bool>, m_abBuildingInvestment)
+SYNC_ARCHIVE_VAR(std::vector<bool>, m_abUnitInvestment)
+SYNC_ARCHIVE_VAR(std::vector<bool>, m_abBuildingConstructed)
+SYNC_ARCHIVE_END()
 
 //just a guard class so we never forget to unset the garrison override
 class CvCityGarrisonOverride

--- a/CvGameCoreDLL_Expansion2/CvPlayer.h
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.h
@@ -23,6 +23,7 @@
 #if defined(MOD_BALANCE_CORE)
 #include "CvMinorCivAI.h"
 #endif
+#include "CvSerialize.h"
 
 class CvPlayerPolicies;
 class CvEconomicAI;
@@ -2784,6 +2785,8 @@ public:
 #endif
 
 	// for serialization
+	template<typename Player, typename Visitor>
+	static void Serialize(Player& player , Visitor& visitor);
 	virtual void Read(FDataStream& kStream);
 	virtual void Write(FDataStream& kStream) const;
 
@@ -2817,8 +2820,8 @@ public:
 	virtual void CityUncommitToBuildUnitForOperationSlot(OperationSlot thisSlot) = 0;
 	virtual void CityFinishedBuildingUnitForOperationSlot(OperationSlot thisSlot, CvUnit* pThisUnit) = 0;
 	virtual int GetNumUnitsNeededToBeBuilt() = 0;
-	const FAutoArchive& getSyncArchive() const;
-	FAutoArchive& getSyncArchive();
+	const CvSyncArchive<CvPlayer>& getSyncArchive() const;
+	CvSyncArchive<CvPlayer>& getSyncArchive();
 	void disconnected();
 	void reconnected();
 	bool hasBusyUnitUpdatesRemaining() const;
@@ -2924,632 +2927,632 @@ protected:
 	int calculateEconomicMight() const;
 	int calculateProductionMight() const;
 
-	FAutoArchiveClassContainer<CvPlayer> m_syncArchive;
+	SYNC_ARCHIVE_MEMBER(CvPlayer)
 
-	FAutoVariable<PlayerTypes, CvPlayer> m_eID;
-	FAutoVariable<LeaderHeadTypes, CvPlayer> m_ePersonalityType;
+	PlayerTypes m_eID;
+	LeaderHeadTypes m_ePersonalityType;
 
-	FAutoVariable<int, CvPlayer> m_iStartingX;
-	FAutoVariable<int, CvPlayer> m_iStartingY;
-	FAutoVariable<int, CvPlayer> m_iTotalPopulation;
-	FAutoVariable<int, CvPlayer> m_iTotalLand;
-	FAutoVariable<int, CvPlayer> m_iTotalLandScored;
-	FAutoVariable<int, CvPlayer> m_iJONSCulturePerTurnForFree;
-	FAutoVariable<int, CvPlayer> m_iJONSCultureCityModifier;
-	FAutoVariable<int, CvPlayer> m_iJONSCulture;
-	FAutoVariable<int, CvPlayer> m_iJONSCultureEverGenerated;
-	FAutoVariable<int, CvPlayer> m_iWondersConstructed;
-	FAutoVariable<int, CvPlayer> m_iCulturePerWonder;
-	FAutoVariable<int, CvPlayer> m_iCultureWonderMultiplier;
-	FAutoVariable<int, CvPlayer> m_iCulturePerTechResearched;
-	FAutoVariable<int, CvPlayer> m_iFaith;
-	FAutoVariable<int, CvPlayer> m_iFaithEverGenerated;
-	FAutoVariable<int, CvPlayer> m_iHappiness;
+	int m_iStartingX;
+	int m_iStartingY;
+	int m_iTotalPopulation;
+	int m_iTotalLand;
+	int m_iTotalLandScored;
+	int m_iJONSCulturePerTurnForFree;
+	int m_iJONSCultureCityModifier;
+	int m_iJONSCulture;
+	int m_iJONSCultureEverGenerated;
+	int m_iWondersConstructed;
+	int m_iCulturePerWonder;
+	int m_iCultureWonderMultiplier;
+	int m_iCulturePerTechResearched;
+	int m_iFaith;
+	int m_iFaithEverGenerated;
+	int m_iHappiness;
 #if defined(MOD_BALANCE_CORE_HAPPINESS)
-	FAutoVariable<int, CvPlayer> m_iUnhappiness;
-	FAutoVariable<int, CvPlayer> m_iHappinessTotal;
-	FAutoVariable<int, CvPlayer> m_iEmpireNeedsModifierGlobal;
-	FAutoVariable<int, CvPlayer> m_iChangePovertyUnhappinessGlobal;
-	FAutoVariable<int, CvPlayer> m_iChangeDefenseUnhappinessGlobal;
-	FAutoVariable<int, CvPlayer> m_iChangeUnculturedUnhappinessGlobal;
-	FAutoVariable<int, CvPlayer> m_iChangeIlliteracyUnhappinessGlobal;
-	FAutoVariable<int, CvPlayer> m_iChangeMinorityUnhappinessGlobal;
+	int m_iUnhappiness;
+	int m_iHappinessTotal;
+	int m_iEmpireNeedsModifierGlobal;
+	int m_iChangePovertyUnhappinessGlobal;
+	int m_iChangeDefenseUnhappinessGlobal;
+	int m_iChangeUnculturedUnhappinessGlobal;
+	int m_iChangeIlliteracyUnhappinessGlobal;
+	int m_iChangeMinorityUnhappinessGlobal;
 #endif
 #if defined(MOD_BALANCE_CORE)
-	FAutoVariable<int, CvPlayer> m_iLandmarksTourismPercentGlobal;
-	FAutoVariable<int, CvPlayer> m_iGreatWorksTourismModifierGlobal;
-	FAutoVariable<int, CvPlayer> m_iCenterOfMassX;
-	FAutoVariable<int, CvPlayer> m_iCenterOfMassY;
-	FAutoVariable<int, CvPlayer> m_iReferenceFoundValue;
-	FAutoVariable<int, CvPlayer> m_iReformationFollowerReduction;
-	FAutoVariable<bool, CvPlayer> m_bIsReformation;
-	FAutoVariable<std::vector<int>, CvPlayer> m_viInstantYieldsTotal;
-	FAutoVariable<std::vector<int>, CvPlayer> m_viTourismHistory;
-	FAutoVariable<std::vector<int>, CvPlayer> m_viGAPHistory;
-	FAutoVariable<std::vector<int>, CvPlayer> m_viCultureHistory;
-	FAutoVariable<std::vector<int>, CvPlayer> m_viScienceHistory;
+	int m_iLandmarksTourismPercentGlobal;
+	int m_iGreatWorksTourismModifierGlobal;
+	int m_iCenterOfMassX;
+	int m_iCenterOfMassY;
+	int m_iReferenceFoundValue;
+	int m_iReformationFollowerReduction;
+	bool m_bIsReformation;
+	std::vector<int> m_viInstantYieldsTotal;
+	std::vector<int> m_viTourismHistory;
+	std::vector<int> m_viGAPHistory;
+	std::vector<int> m_viCultureHistory;
+	std::vector<int> m_viScienceHistory;
 #endif
-	FAutoVariable<int, CvPlayer> m_iUprisingCounter;
-	FAutoVariable<int, CvPlayer> m_iExtraHappinessPerLuxury;
-	FAutoVariable<int, CvPlayer> m_iUnhappinessFromUnits;
-	FAutoVariable<int, CvPlayer> m_iUnhappinessFromUnitsMod;
-	FAutoVariable<int, CvPlayer> m_iUnhappinessMod;
-	FAutoVariable<int, CvPlayer> m_iCityCountUnhappinessMod;
-	FAutoVariable<int, CvPlayer> m_iOccupiedPopulationUnhappinessMod;
-	FAutoVariable<int, CvPlayer> m_iCapitalUnhappinessMod;
-	FAutoVariable<int, CvPlayer> m_iCityRevoltCounter;
-	FAutoVariable<int, CvPlayer> m_iHappinessPerGarrisonedUnitCount;
-	FAutoVariable<int, CvPlayer> m_iHappinessPerTradeRouteCount;
-	FAutoVariable<int, CvPlayer> m_iHappinessPerXPopulation;
+	int m_iUprisingCounter;
+	int m_iExtraHappinessPerLuxury;
+	int m_iUnhappinessFromUnits;
+	int m_iUnhappinessFromUnitsMod;
+	int m_iUnhappinessMod;
+	int m_iCityCountUnhappinessMod;
+	int m_iOccupiedPopulationUnhappinessMod;
+	int m_iCapitalUnhappinessMod;
+	int m_iCityRevoltCounter;
+	int m_iHappinessPerGarrisonedUnitCount;
+	int m_iHappinessPerTradeRouteCount;
+	int m_iHappinessPerXPopulation;
 #if defined(MOD_BALANCE_CORE_POLICIES)
-	FAutoVariable<int, CvPlayer> m_iHappinessPerXPopulationGlobal;
-	FAutoVariable<int, CvPlayer> m_iIdeologyPoint;
-	FAutoVariable<int, CvPlayer> m_iNoXPLossUnitPurchase;
-	FAutoVariable<int, CvPlayer> m_iXCSAlliesLowersPolicyNeedWonders;
-	FAutoVariable<int, CvPlayer> m_iHappinessFromMinorCivs;
-	FAutoVariable<int, CvPlayer> m_iPositiveWarScoreTourismMod;
-	FAutoVariable<int, CvPlayer> m_iIsNoCSDecayAtWar;
-	FAutoVariable<int, CvPlayer> m_iCanBullyFriendlyCS;
-	FAutoVariable<int, CvPlayer> m_iBullyGlobalCSReduction;	
+	int m_iHappinessPerXPopulationGlobal;
+	int m_iIdeologyPoint;
+	int m_iNoXPLossUnitPurchase;
+	int m_iXCSAlliesLowersPolicyNeedWonders;
+	int m_iHappinessFromMinorCivs;
+	int m_iPositiveWarScoreTourismMod;
+	int m_iIsNoCSDecayAtWar;
+	int m_iCanBullyFriendlyCS;
+	int m_iBullyGlobalCSReduction;	
 #endif
 #if defined(MOD_DIPLOMACY_CIV4_FEATURES)
-	FAutoVariable<int, CvPlayer> m_iIsVassalsNoRebel;
-	FAutoVariable<int, CvPlayer> m_iVassalCSBonusModifier;		
+	int m_iIsVassalsNoRebel;
+	int m_iVassalCSBonusModifier;		
 #endif
-	FAutoVariable<int, CvPlayer> m_iHappinessFromLeagues;
-	FAutoVariable<int, CvPlayer> m_iDummy;  //unused
-	FAutoVariable<int, CvPlayer> m_iWoundedUnitDamageMod;
-	FAutoVariable<int, CvPlayer> m_iUnitUpgradeCostMod;
-	FAutoVariable<int, CvPlayer> m_iBarbarianCombatBonus;
-	FAutoVariable<int, CvPlayer> m_iAlwaysSeeBarbCampsCount;
-	FAutoVariable<int, CvPlayer> m_iHappinessPerCity;
-	FAutoVariable<int, CvPlayer> m_iHappinessPerXPolicies;
-	FAutoVariable<int, CvPlayer> m_iExtraHappinessPerXPoliciesFromPolicies;
-	FAutoVariable<int, CvPlayer> m_iHappinessPerXGreatWorks;
-	FAutoVariable<int, CvPlayer> m_iEspionageModifier;
-	FAutoVariable<int, CvPlayer> m_iSpyStartingRank;
+	int m_iHappinessFromLeagues;
+	int m_iDummy;  //unused
+	int m_iWoundedUnitDamageMod;
+	int m_iUnitUpgradeCostMod;
+	int m_iBarbarianCombatBonus;
+	int m_iAlwaysSeeBarbCampsCount;
+	int m_iHappinessPerCity;
+	int m_iHappinessPerXPolicies;
+	int m_iExtraHappinessPerXPoliciesFromPolicies;
+	int m_iHappinessPerXGreatWorks;
+	int m_iEspionageModifier;
+	int m_iSpyStartingRank;
 #if defined(MOD_RELIGION_CONVERSION_MODIFIERS)
-	FAutoVariable<int, CvPlayer> m_iConversionModifier;
+	int m_iConversionModifier;
 #endif
-	FAutoVariable<int, CvPlayer> m_iExtraLeagueVotes;
+	int m_iExtraLeagueVotes;
 #if defined(MOD_DIPLOMACY_CITYSTATES)
-	FAutoVariable<int, CvPlayer> m_iImprovementLeagueVotes;
-	FAutoVariable<int, CvPlayer> m_iFaithToVotes;
-	FAutoVariable<int, CvPlayer> m_iCapitalsToVotes;
-	FAutoVariable<int, CvPlayer> m_iDoFToVotes;
-	FAutoVariable<int, CvPlayer> m_iRAToVotes;
-	FAutoVariable<int, CvPlayer> m_iDefensePactsToVotes;
-	FAutoVariable<int, CvPlayer> m_iGPExpendInfluence;
-	FAutoVariable<bool, CvPlayer> m_bIsLeagueAid;
-	FAutoVariable<bool, CvPlayer> m_bIsLeagueScholar;
-	FAutoVariable<bool, CvPlayer> m_bIsLeagueArt;
-	FAutoVariable<int, CvPlayer> m_iScienceRateFromLeague;
-	FAutoVariable<int, CvPlayer> m_iScienceRateFromLeagueAid;
-	FAutoVariable<int, CvPlayer> m_iLeagueCultureCityModifier;
+	int m_iImprovementLeagueVotes;
+	int m_iFaithToVotes;
+	int m_iCapitalsToVotes;
+	int m_iDoFToVotes;
+	int m_iRAToVotes;
+	int m_iDefensePactsToVotes;
+	int m_iGPExpendInfluence;
+	bool m_bIsLeagueAid;
+	bool m_bIsLeagueScholar;
+	bool m_bIsLeagueArt;
+	int m_iScienceRateFromLeague;
+	int m_iScienceRateFromLeagueAid;
+	int m_iLeagueCultureCityModifier;
 #endif
-	FAutoVariable<int, CvPlayer> m_iAdvancedStartPoints;
-	FAutoVariable<int, CvPlayer> m_iAttackBonusTurns;
-	FAutoVariable<int, CvPlayer> m_iCultureBonusTurns;
-	FAutoVariable<int, CvPlayer> m_iTourismBonusTurns;
-	FAutoVariable<int, CvPlayer> m_iGoldenAgeProgressMeter;
-	FAutoVariable<int, CvPlayer> m_iGoldenAgeMeterMod;
-	FAutoVariable<int, CvPlayer> m_iNumGoldenAges;
-	FAutoVariable<int, CvPlayer> m_iGoldenAgeTurns;
-	FAutoVariable<int, CvPlayer> m_iNumUnitGoldenAges;
-	FAutoVariable<int, CvPlayer> m_iStrikeTurns;
-	FAutoVariable<int, CvPlayer> m_iGoldenAgeModifier;
+	int m_iAdvancedStartPoints;
+	int m_iAttackBonusTurns;
+	int m_iCultureBonusTurns;
+	int m_iTourismBonusTurns;
+	int m_iGoldenAgeProgressMeter;
+	int m_iGoldenAgeMeterMod;
+	int m_iNumGoldenAges;
+	int m_iGoldenAgeTurns;
+	int m_iNumUnitGoldenAges;
+	int m_iStrikeTurns;
+	int m_iGoldenAgeModifier;
 #if defined(MOD_GLOBAL_TRULY_FREE_GP)
-	FAutoVariable<int, CvPlayer> m_iProductionBonusTurnsConquest;
-	FAutoVariable<int, CvPlayer> m_iCultureBonusTurnsConquest;
-	FAutoVariable<int, CvPlayer> m_iFreeGreatPeopleCreated;
-	FAutoVariable<int, CvPlayer> m_iFreeGreatGeneralsCreated;
-	FAutoVariable<int, CvPlayer> m_iFreeGreatAdmiralsCreated;
+	int m_iProductionBonusTurnsConquest;
+	int m_iCultureBonusTurnsConquest;
+	int m_iFreeGreatPeopleCreated;
+	int m_iFreeGreatGeneralsCreated;
+	int m_iFreeGreatAdmiralsCreated;
 #if defined(MOD_GLOBAL_SEPARATE_GP_COUNTERS)
-	FAutoVariable<int, CvPlayer> m_iFreeGreatMerchantsCreated;
-	FAutoVariable<int, CvPlayer> m_iFreeGreatScientistsCreated;
-	FAutoVariable<int, CvPlayer> m_iFreeGreatEngineersCreated;
+	int m_iFreeGreatMerchantsCreated;
+	int m_iFreeGreatScientistsCreated;
+	int m_iFreeGreatEngineersCreated;
 #endif
-	FAutoVariable<int, CvPlayer> m_iFreeGreatWritersCreated;
-	FAutoVariable<int, CvPlayer> m_iFreeGreatArtistsCreated;
-	FAutoVariable<int, CvPlayer> m_iFreeGreatMusiciansCreated;
+	int m_iFreeGreatWritersCreated;
+	int m_iFreeGreatArtistsCreated;
+	int m_iFreeGreatMusiciansCreated;
 #if defined(MOD_DIPLOMACY_CITYSTATES)
-	FAutoVariable<int, CvPlayer> m_iFreeGreatDiplomatsCreated;
+	int m_iFreeGreatDiplomatsCreated;
 #endif
 #if defined(MOD_BALANCE_CORE)
-	FAutoVariable<int, CvPlayer> m_iGPExtra1Created;
-	FAutoVariable<int, CvPlayer> m_iGPExtra2Created;
-	FAutoVariable<int, CvPlayer> m_iGPExtra3Created;
-	FAutoVariable<int, CvPlayer> m_iGPExtra4Created;
-	FAutoVariable<int, CvPlayer> m_iGPExtra5Created;
-	FAutoVariable<int, CvPlayer> m_iFreeGPExtra1Created;
-	FAutoVariable<int, CvPlayer> m_iFreeGPExtra2Created;
-	FAutoVariable<int, CvPlayer> m_iFreeGPExtra3Created;
-	FAutoVariable<int, CvPlayer> m_iFreeGPExtra4Created;
-	FAutoVariable<int, CvPlayer> m_iFreeGPExtra5Created;
+	int m_iGPExtra1Created;
+	int m_iGPExtra2Created;
+	int m_iGPExtra3Created;
+	int m_iGPExtra4Created;
+	int m_iGPExtra5Created;
+	int m_iFreeGPExtra1Created;
+	int m_iFreeGPExtra2Created;
+	int m_iFreeGPExtra3Created;
+	int m_iFreeGPExtra4Created;
+	int m_iFreeGPExtra5Created;
 #endif
 #endif
-	FAutoVariable<int, CvPlayer> m_iGreatPeopleCreated;
-	FAutoVariable<int, CvPlayer> m_iGreatGeneralsCreated;
-	FAutoVariable<int, CvPlayer> m_iGreatAdmiralsCreated;
+	int m_iGreatPeopleCreated;
+	int m_iGreatGeneralsCreated;
+	int m_iGreatAdmiralsCreated;
 #if defined(MOD_GLOBAL_SEPARATE_GP_COUNTERS)
-	FAutoVariable<int, CvPlayer> m_iGreatMerchantsCreated;
-	FAutoVariable<int, CvPlayer> m_iGreatScientistsCreated;
-	FAutoVariable<int, CvPlayer> m_iGreatEngineersCreated;
+	int m_iGreatMerchantsCreated;
+	int m_iGreatScientistsCreated;
+	int m_iGreatEngineersCreated;
 #endif
-	FAutoVariable<int, CvPlayer> m_iGreatWritersCreated;
-	FAutoVariable<int, CvPlayer> m_iGreatArtistsCreated;
-	FAutoVariable<int, CvPlayer> m_iGreatMusiciansCreated;
+	int m_iGreatWritersCreated;
+	int m_iGreatArtistsCreated;
+	int m_iGreatMusiciansCreated;
 #if defined(MOD_DIPLOMACY_CITYSTATES)
-	FAutoVariable<int, CvPlayer> m_iGreatDiplomatsCreated;
-	FAutoVariable<int, CvPlayer> m_iDiplomatsFromFaith;
+	int m_iGreatDiplomatsCreated;
+	int m_iDiplomatsFromFaith;
 #endif
 #if defined(MOD_BALANCE_CORE)
-	FAutoVariable<int, CvPlayer> m_iGPExtra1FromFaith;
-	FAutoVariable<int, CvPlayer> m_iGPExtra2FromFaith;
-	FAutoVariable<int, CvPlayer> m_iGPExtra3FromFaith;
-	FAutoVariable<int, CvPlayer> m_iGPExtra4FromFaith;
-	FAutoVariable<int, CvPlayer> m_iGPExtra5FromFaith;
+	int m_iGPExtra1FromFaith;
+	int m_iGPExtra2FromFaith;
+	int m_iGPExtra3FromFaith;
+	int m_iGPExtra4FromFaith;
+	int m_iGPExtra5FromFaith;
 #endif
-	FAutoVariable<int, CvPlayer> m_iMerchantsFromFaith;
-	FAutoVariable<int, CvPlayer> m_iScientistsFromFaith;
-	FAutoVariable<int, CvPlayer> m_iWritersFromFaith;
-	FAutoVariable<int, CvPlayer> m_iArtistsFromFaith;
-	FAutoVariable<int, CvPlayer> m_iMusiciansFromFaith;
-	FAutoVariable<int, CvPlayer> m_iGeneralsFromFaith;
-	FAutoVariable<int, CvPlayer> m_iAdmiralsFromFaith;
-	FAutoVariable<int, CvPlayer> m_iEngineersFromFaith;
-	FAutoVariable<int, CvPlayer> m_iGreatPeopleThresholdModifier;
-	FAutoVariable<int, CvPlayer> m_iGreatGeneralsThresholdModifier;
-	FAutoVariable<int, CvPlayer> m_iGreatAdmiralsThresholdModifier;
-	FAutoVariable<int, CvPlayer> m_iGreatGeneralCombatBonus;
-	FAutoVariable<int, CvPlayer> m_iAnarchyNumTurns;
-	FAutoVariable<int, CvPlayer> m_iPolicyCostModifier;
-	FAutoVariable<int, CvPlayer> m_iGreatPeopleRateModifier;
-	FAutoVariable<int, CvPlayer> m_iGreatPeopleRateModFromBldgs;
-	FAutoVariable<int, CvPlayer> m_iGreatGeneralRateModifier;
-	FAutoVariable<int, CvPlayer> m_iGreatGeneralRateModFromBldgs;
-	FAutoVariable<int, CvPlayer> m_iDomesticGreatGeneralRateModifier;
-	FAutoVariable<int, CvPlayer> m_iGreatAdmiralRateModifier;
-	FAutoVariable<int, CvPlayer> m_iGreatWriterRateModifier;
-	FAutoVariable<int, CvPlayer> m_iGreatArtistRateModifier;
-	FAutoVariable<int, CvPlayer> m_iGreatMusicianRateModifier;
-	FAutoVariable<int, CvPlayer> m_iGreatMerchantRateModifier;
+	int m_iMerchantsFromFaith;
+	int m_iScientistsFromFaith;
+	int m_iWritersFromFaith;
+	int m_iArtistsFromFaith;
+	int m_iMusiciansFromFaith;
+	int m_iGeneralsFromFaith;
+	int m_iAdmiralsFromFaith;
+	int m_iEngineersFromFaith;
+	int m_iGreatPeopleThresholdModifier;
+	int m_iGreatGeneralsThresholdModifier;
+	int m_iGreatAdmiralsThresholdModifier;
+	int m_iGreatGeneralCombatBonus;
+	int m_iAnarchyNumTurns;
+	int m_iPolicyCostModifier;
+	int m_iGreatPeopleRateModifier;
+	int m_iGreatPeopleRateModFromBldgs;
+	int m_iGreatGeneralRateModifier;
+	int m_iGreatGeneralRateModFromBldgs;
+	int m_iDomesticGreatGeneralRateModifier;
+	int m_iGreatAdmiralRateModifier;
+	int m_iGreatWriterRateModifier;
+	int m_iGreatArtistRateModifier;
+	int m_iGreatMusicianRateModifier;
+	int m_iGreatMerchantRateModifier;
 #if defined(MOD_DIPLOMACY_CITYSTATES)
-	FAutoVariable<int, CvPlayer> m_iGreatDiplomatRateModifier;
+	int m_iGreatDiplomatRateModifier;
 #endif
-	FAutoVariable<int, CvPlayer> m_iGreatScientistRateModifier;
-	FAutoVariable<int, CvPlayer> m_iGreatScientistBeakerModifier;
-	FAutoVariable<int, CvPlayer> m_iGreatEngineerHurryMod;
-	FAutoVariable<int, CvPlayer> m_iTechCostXCitiesModifier;
-	FAutoVariable<int, CvPlayer> m_iTourismCostXCitiesMod;
-	FAutoVariable<int, CvPlayer> m_iGreatEngineerRateModifier;
-	FAutoVariable<int, CvPlayer> m_iGreatPersonExpendGold;
+	int m_iGreatScientistRateModifier;
+	int m_iGreatScientistBeakerModifier;
+	int m_iGreatEngineerHurryMod;
+	int m_iTechCostXCitiesModifier;
+	int m_iTourismCostXCitiesMod;
+	int m_iGreatEngineerRateModifier;
+	int m_iGreatPersonExpendGold;
 #if defined(MOD_BALANCE_CORE_HAPPINESS)
-	FAutoVariable<int, CvPlayer> m_iPovertyUnhappinessMod;
-	FAutoVariable<int, CvPlayer> m_iDefenseUnhappinessMod;
-	FAutoVariable<int, CvPlayer> m_iUnculturedUnhappinessMod;
-	FAutoVariable<int, CvPlayer> m_iIlliteracyUnhappinessMod;
-	FAutoVariable<int, CvPlayer> m_iMinorityUnhappinessMod;
-	FAutoVariable<int, CvPlayer> m_iPovertyUnhappinessModCapital;
-	FAutoVariable<int, CvPlayer> m_iDefenseUnhappinessModCapital;
-	FAutoVariable<int, CvPlayer> m_iUnculturedUnhappinessModCapital;
-	FAutoVariable<int, CvPlayer> m_iIlliteracyUnhappinessModCapital;
-	FAutoVariable<int, CvPlayer> m_iMinorityUnhappinessModCapital;
-	FAutoVariable<int, CvPlayer> m_iPuppetUnhappinessMod;
-	FAutoVariable<int, CvPlayer> m_iNoUnhappfromXSpecialists;
-	FAutoVariable<int, CvPlayer> m_iHappfromXSpecialists;
-	FAutoVariable<int, CvPlayer> m_iNoUnhappfromXSpecialistsCapital;
-	FAutoVariable<int, CvPlayer> m_iSpecialistFoodChange;
-	FAutoVariable<int, CvPlayer> m_iWarWearinessModifier;
-	FAutoVariable<int, CvPlayer> m_iWarScoreModifier;
-	FAutoVariable<bool, CvPlayer> m_bEnablesTechSteal;
-	FAutoVariable<bool, CvPlayer> m_bEnablesGWSteal;
+	int m_iPovertyUnhappinessMod;
+	int m_iDefenseUnhappinessMod;
+	int m_iUnculturedUnhappinessMod;
+	int m_iIlliteracyUnhappinessMod;
+	int m_iMinorityUnhappinessMod;
+	int m_iPovertyUnhappinessModCapital;
+	int m_iDefenseUnhappinessModCapital;
+	int m_iUnculturedUnhappinessModCapital;
+	int m_iIlliteracyUnhappinessModCapital;
+	int m_iMinorityUnhappinessModCapital;
+	int m_iPuppetUnhappinessMod;
+	int m_iNoUnhappfromXSpecialists;
+	int m_iHappfromXSpecialists;
+	int m_iNoUnhappfromXSpecialistsCapital;
+	int m_iSpecialistFoodChange;
+	int m_iWarWearinessModifier;
+	int m_iWarScoreModifier;
+	bool m_bEnablesTechSteal;
+	bool m_bEnablesGWSteal;
 	
 #endif
 #if defined(MOD_BALANCE_CORE_POLICIES)
-	FAutoVariable<int, CvPlayer> m_iGarrisonsOccupiedUnhapppinessMod;
-	FAutoVariable<int, CvPlayer> m_iXPopulationConscription;
-	FAutoVariable<int, CvPlayer> m_iExtraMoves;
-	FAutoVariable<int, CvPlayer> m_iNoUnhappinessExpansion;
-	FAutoVariable<int, CvPlayer> m_iNoUnhappyIsolation;
-	FAutoVariable<int, CvPlayer> m_iDoubleBorderGA;
-	FAutoVariable<int, CvPlayer> m_iIncreasedQuestInfluence;
-	FAutoVariable<int, CvPlayer> m_iCultureBombBoost;
-	FAutoVariable<int, CvPlayer> m_iPuppetProdMod;
-	FAutoVariable<int, CvPlayer> m_iOccupiedProdMod;
-	FAutoVariable<int, CvPlayer> m_iGoldInternalTrade;
-	FAutoVariable<int, CvPlayer> m_iFreeWCVotes;
-	FAutoVariable<int, CvPlayer> m_iInfluenceGPExpend;
-	FAutoVariable<int, CvPlayer> m_iFreeTradeRoute;
-	FAutoVariable<int, CvPlayer> m_iFreeSpy;
-	FAutoVariable<int, CvPlayer> m_iReligionDistance;
-	FAutoVariable<int, CvPlayer> m_iPressureMod;
-	FAutoVariable<int, CvPlayer> m_iTradeReligionModifier;
-	FAutoVariable<int, CvPlayer> m_iCityStateCombatModifier;
+	int m_iGarrisonsOccupiedUnhapppinessMod;
+	int m_iXPopulationConscription;
+	int m_iExtraMoves;
+	int m_iNoUnhappinessExpansion;
+	int m_iNoUnhappyIsolation;
+	int m_iDoubleBorderGA;
+	int m_iIncreasedQuestInfluence;
+	int m_iCultureBombBoost;
+	int m_iPuppetProdMod;
+	int m_iOccupiedProdMod;
+	int m_iGoldInternalTrade;
+	int m_iFreeWCVotes;
+	int m_iInfluenceGPExpend;
+	int m_iFreeTradeRoute;
+	int m_iFreeSpy;
+	int m_iReligionDistance;
+	int m_iPressureMod;
+	int m_iTradeReligionModifier;
+	int m_iCityStateCombatModifier;
 #endif
 #if defined(MOD_BALANCE_CORE_SPIES)
-	FAutoVariable<int, CvPlayer> m_iMaxAirUnits;
+	int m_iMaxAirUnits;
 #endif
 #if defined(MOD_BALANCE_CORE_BUILDING_INVESTMENTS)
-	FAutoVariable<int, CvPlayer> m_iInvestmentModifier;
-	FAutoVariable<int, CvPlayer> m_iMissionInfluenceModifier;
-	FAutoVariable<int, CvPlayer> m_iHappinessPerActiveTradeRoute;
-	FAutoVariable<int, CvPlayer> m_iCSResourcesCountMonopolies;
-	FAutoVariable<int, CvPlayer> m_iConquestPerEraBuildingProductionMod;
-	FAutoVariable<int, CvPlayer> m_iAdmiralLuxuryBonus;
-	FAutoVariable<int, CvPlayer> m_iPuppetYieldPenaltyMod;
-	FAutoVariable<int, CvPlayer> m_iNeedsModifierFromAirUnits;
-	FAutoVariable<int, CvPlayer> m_iFlatDefenseFromAirUnits;
+	int m_iInvestmentModifier;
+	int m_iMissionInfluenceModifier;
+	int m_iHappinessPerActiveTradeRoute;
+	int m_iCSResourcesCountMonopolies;
+	int m_iConquestPerEraBuildingProductionMod;
+	int m_iAdmiralLuxuryBonus;
+	int m_iPuppetYieldPenaltyMod;
+	int m_iNeedsModifierFromAirUnits;
+	int m_iFlatDefenseFromAirUnits;
 #endif
 #if defined(MOD_POLICIES_UNIT_CLASS_REPLACEMENTS)
 	std::map<UnitClassTypes, UnitClassTypes> m_piUnitClassReplacements;
 #endif
-	FAutoVariable<int, CvPlayer> m_iMaxGlobalBuildingProductionModifier;
-	FAutoVariable<int, CvPlayer> m_iMaxTeamBuildingProductionModifier;
-	FAutoVariable<int, CvPlayer> m_iMaxPlayerBuildingProductionModifier;
-	FAutoVariable<int, CvPlayer> m_iFreeExperience;
-	FAutoVariable<int, CvPlayer> m_iFreeExperienceFromBldgs;
-	FAutoVariable<int, CvPlayer> m_iFreeExperienceFromMinors;
-	FAutoVariable<int, CvPlayer> m_iFeatureProductionModifier;
-	FAutoVariable<int, CvPlayer> m_iWorkerSpeedModifier;
-	FAutoVariable<int, CvPlayer> m_iImprovementCostModifier;
-	FAutoVariable<int, CvPlayer> m_iImprovementUpgradeRateModifier;
-	FAutoVariable<int, CvPlayer> m_iSpecialistProductionModifier;
-	FAutoVariable<int, CvPlayer> m_iMilitaryProductionModifier;
-	FAutoVariable<int, CvPlayer> m_iSpaceProductionModifier;
-	FAutoVariable<int, CvPlayer> m_iCityDefenseModifier;
-	FAutoVariable<int, CvPlayer> m_iUnitFortificationModifier;
-	FAutoVariable<int, CvPlayer> m_iUnitBaseHealModifier;
-	FAutoVariable<int, CvPlayer> m_iWonderProductionModifier;
-	FAutoVariable<int, CvPlayer> m_iSettlerProductionModifier;
-	FAutoVariable<int, CvPlayer> m_iCapitalSettlerProductionModifier;
-	FAutoVariable<int, CvPlayer> m_iUnitProductionMaintenanceMod;
-	FAutoVariable<int, CvPlayer> m_iUnitGrowthMaintenanceMod;
-	FAutoVariable<int, CvPlayer> m_iPolicyCostBuildingModifier;
-	FAutoVariable<int, CvPlayer> m_iPolicyCostMinorCivModifier;
-	FAutoVariable<int, CvPlayer> m_iInfluenceSpreadModifier;
-	FAutoVariable<int, CvPlayer> m_iExtraVotesPerDiplomat;
-	FAutoVariable<int, CvPlayer> m_iNumNukeUnits;
-	FAutoVariable<int, CvPlayer> m_iNumOutsideUnits;
-	FAutoVariable<int, CvPlayer> m_iBaseFreeUnits;
-	FAutoVariable<int, CvPlayer> m_iBaseFreeMilitaryUnits;
-	FAutoVariable<int, CvPlayer> m_iFreeUnitsPopulationPercent;
-	FAutoVariable<int, CvPlayer> m_iFreeMilitaryUnitsPopulationPercent;
-	FAutoVariable<int, CvPlayer> m_iGoldPerUnit;
-	FAutoVariable<int, CvPlayer> m_iGoldPerMilitaryUnit;
-	FAutoVariable<int, CvPlayer> m_iImprovementGoldMaintenanceMod;
+	int m_iMaxGlobalBuildingProductionModifier;
+	int m_iMaxTeamBuildingProductionModifier;
+	int m_iMaxPlayerBuildingProductionModifier;
+	int m_iFreeExperience;
+	int m_iFreeExperienceFromBldgs;
+	int m_iFreeExperienceFromMinors;
+	int m_iFeatureProductionModifier;
+	int m_iWorkerSpeedModifier;
+	int m_iImprovementCostModifier;
+	int m_iImprovementUpgradeRateModifier;
+	int m_iSpecialistProductionModifier;
+	int m_iMilitaryProductionModifier;
+	int m_iSpaceProductionModifier;
+	int m_iCityDefenseModifier;
+	int m_iUnitFortificationModifier;
+	int m_iUnitBaseHealModifier;
+	int m_iWonderProductionModifier;
+	int m_iSettlerProductionModifier;
+	int m_iCapitalSettlerProductionModifier;
+	int m_iUnitProductionMaintenanceMod;
+	int m_iUnitGrowthMaintenanceMod;
+	int m_iPolicyCostBuildingModifier;
+	int m_iPolicyCostMinorCivModifier;
+	int m_iInfluenceSpreadModifier;
+	int m_iExtraVotesPerDiplomat;
+	int m_iNumNukeUnits;
+	int m_iNumOutsideUnits;
+	int m_iBaseFreeUnits;
+	int m_iBaseFreeMilitaryUnits;
+	int m_iFreeUnitsPopulationPercent;
+	int m_iFreeMilitaryUnitsPopulationPercent;
+	int m_iGoldPerUnit;
+	int m_iGoldPerMilitaryUnit;
+	int m_iImprovementGoldMaintenanceMod;
 #if defined(MOD_CIV6_WORKER)
-	FAutoVariable<int, CvPlayer> m_iRouteBuilderCostMod;
+	int m_iRouteBuilderCostMod;
 #endif
-	FAutoVariable<int, CvPlayer> m_iBuildingGoldMaintenanceMod;
-	FAutoVariable<int, CvPlayer> m_iUnitGoldMaintenanceMod;
-	FAutoVariable<int, CvPlayer> m_iUnitSupplyMod;
-	FAutoVariable<int, CvPlayer> m_iExtraUnitCost;
-	FAutoVariable<int, CvPlayer> m_iNumMilitaryUnits;
-	FAutoVariable<int, CvPlayer> m_iHappyPerMilitaryUnit;
-	FAutoVariable<int, CvPlayer> m_iHappinessToCulture;
-	FAutoVariable<int, CvPlayer> m_iHappinessToScience;
-	FAutoVariable<int, CvPlayer> m_iHalfSpecialistUnhappinessCount;
-	FAutoVariable<int, CvPlayer> m_iHalfSpecialistFoodCount;
+	int m_iBuildingGoldMaintenanceMod;
+	int m_iUnitGoldMaintenanceMod;
+	int m_iUnitSupplyMod;
+	int m_iExtraUnitCost;
+	int m_iNumMilitaryUnits;
+	int m_iHappyPerMilitaryUnit;
+	int m_iHappinessToCulture;
+	int m_iHappinessToScience;
+	int m_iHalfSpecialistUnhappinessCount;
+	int m_iHalfSpecialistFoodCount;
 #if defined(MOD_BALANCE_CORE)
-	FAutoVariable<int, CvPlayer> m_iHalfSpecialistFoodCapitalCount;
-	FAutoVariable<int, CvPlayer> m_iTradeRouteLandDistanceModifier;
-	FAutoVariable<int, CvPlayer> m_iTradeRouteSeaDistanceModifier;
-	FAutoVariable<bool, CvPlayer> m_bNullifyInfluenceModifier;
+	int m_iHalfSpecialistFoodCapitalCount;
+	int m_iTradeRouteLandDistanceModifier;
+	int m_iTradeRouteSeaDistanceModifier;
+	bool m_bNullifyInfluenceModifier;
 #endif
-	FAutoVariable<int, CvPlayer> m_iMilitaryFoodProductionCount;
-	FAutoVariable<int, CvPlayer> m_iGoldenAgeCultureBonusDisabledCount;
-	FAutoVariable<int, CvPlayer> m_iNumMissionarySpreads;
-	FAutoVariable<int, CvPlayer> m_iSecondReligionPantheonCount;
-	FAutoVariable<int, CvPlayer> m_iEnablesSSPartHurryCount;
-	FAutoVariable<int, CvPlayer> m_iEnablesSSPartPurchaseCount;
-	FAutoVariable<int, CvPlayer> m_iConscriptCount;
-	FAutoVariable<int, CvPlayer> m_iMaxConscript;
-	FAutoVariable<int, CvPlayer> m_iHighestUnitLevel;
-	FAutoVariable<int, CvPlayer> m_iOverflowResearch;
-	FAutoVariable<int, CvPlayer> m_iExpModifier;
-	FAutoVariable<int, CvPlayer> m_iExpInBorderModifier;
-	FAutoVariable<int, CvPlayer> m_iLevelExperienceModifier;
-	FAutoVariable<int, CvPlayer> m_iMinorQuestFriendshipMod;
-	FAutoVariable<int, CvPlayer> m_iMinorGoldFriendshipMod;
-	FAutoVariable<int, CvPlayer> m_iMinorFriendshipMinimum;
-	FAutoVariable<int, CvPlayer> m_iMinorFriendshipDecayMod;
-	FAutoVariable<int, CvPlayer> m_iMinorScienceAlliesCount;
-	FAutoVariable<int, CvPlayer> m_iMinorResourceBonusCount;
-	FAutoVariable<int, CvPlayer> m_iAbleToAnnexCityStatesCount;
-	FAutoVariable<int, CvPlayer> m_iOnlyTradeSameIdeology;
+	int m_iMilitaryFoodProductionCount;
+	int m_iGoldenAgeCultureBonusDisabledCount;
+	int m_iNumMissionarySpreads;
+	int m_iSecondReligionPantheonCount;
+	int m_iEnablesSSPartHurryCount;
+	int m_iEnablesSSPartPurchaseCount;
+	int m_iConscriptCount;
+	int m_iMaxConscript;
+	int m_iHighestUnitLevel;
+	int m_iOverflowResearch;
+	int m_iExpModifier;
+	int m_iExpInBorderModifier;
+	int m_iLevelExperienceModifier;
+	int m_iMinorQuestFriendshipMod;
+	int m_iMinorGoldFriendshipMod;
+	int m_iMinorFriendshipMinimum;
+	int m_iMinorFriendshipDecayMod;
+	int m_iMinorScienceAlliesCount;
+	int m_iMinorResourceBonusCount;
+	int m_iAbleToAnnexCityStatesCount;
+	int m_iOnlyTradeSameIdeology;
 #if defined(MOD_BALANCE_CORE)
-	FAutoVariable<int, CvPlayer> m_iSupplyFreeUnits; //military units which don't count against the supply limit
-	FAutoVariable<std::vector<CvString>, CvPlayer> m_aistrInstantYield;
+	int m_iSupplyFreeUnits; //military units which don't count against the supply limit
+	std::vector<CvString> m_aistrInstantYield;
 	std::map<int, CvString> m_aistrInstantGreatPersonProgress;
-	FAutoVariable<std::vector<bool>, CvPlayer> m_abActiveContract;
-	FAutoVariable<int, CvPlayer> m_iJFDReformCooldownRate;
-	FAutoVariable<int, CvPlayer> m_iJFDGovernmentCooldownRate;
-	FAutoVariable<CvString, CvPlayer> m_strJFDPoliticKey;
-	FAutoVariable<CvString, CvPlayer> m_strJFDLegislatureName;
-	FAutoVariable<int, CvPlayer> m_iJFDPoliticLeader;
-	FAutoVariable<int, CvPlayer> m_iJFDSovereignty;
-	FAutoVariable<int, CvPlayer> m_iJFDGovernment;
-	FAutoVariable<int, CvPlayer> m_iJFDReformCooldown;
-	FAutoVariable<int, CvPlayer> m_iJFDGovernmentCooldown;
-	FAutoVariable<int, CvPlayer> m_iJFDPiety;
-	FAutoVariable<int, CvPlayer> m_iJFDPietyRate;
-	FAutoVariable<int, CvPlayer> m_iJFDConversionTurn;
-	FAutoVariable<bool, CvPlayer> m_bJFDSecularized;
-	FAutoVariable<CvString, CvPlayer> m_strJFDCurrencyName;
-	FAutoVariable<int, CvPlayer> m_iJFDProsperity;
-	FAutoVariable<int, CvPlayer> m_iJFDCurrency;
-	FAutoVariable<int, CvPlayer> m_iGoldenAgeTourism;
-	FAutoVariable<int, CvPlayer> m_iExtraCultureandScienceTradeRoutes;
-	FAutoVariable<int, CvPlayer> m_iArchaeologicalDigTourism;
-	FAutoVariable<int, CvPlayer> m_iUpgradeCSVassalTerritory;
-	FAutoVariable<int, CvPlayer> m_iRazingSpeedBonus;
-	FAutoVariable<int, CvPlayer> m_iNoPartisans;
-	FAutoVariable<int, CvPlayer> m_iSpawnCooldown;
-	FAutoVariable<int, CvPlayer> m_iAbleToMarryCityStatesCount;
-	FAutoVariable<bool, CvPlayer> m_bTradeRoutesInvulnerable;
-	FAutoVariable<int, CvPlayer> m_iTRSpeedBoost;
-	FAutoVariable<int, CvPlayer> m_iVotesPerGPT;
-	FAutoVariable<int, CvPlayer> m_iTRVisionBoost;
-	FAutoVariable<int, CvPlayer> m_iEventTourism;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiGlobalTourismAlreadyReceived;
-	FAutoVariable<int, CvPlayer> m_iEventTourismCS;
-	FAutoVariable<int, CvPlayer> m_iNumHistoricEvent;
-	FAutoVariable<int, CvPlayer> m_iSingleVotes;
-	FAutoVariable<int, CvPlayer> m_iMonopolyModFlat;
-	FAutoVariable<int, CvPlayer> m_iMonopolyModPercent;
-	FAutoVariable<int, CvPlayer> m_iCachedValueOfPeaceWithHuman;
-	FAutoVariable<int, CvPlayer> m_iFaithPurchaseCooldown;
-	FAutoVariable<int, CvPlayer> m_iCSAllies;
-	FAutoVariable<int, CvPlayer> m_iCSFriends;
+	std::vector<bool> m_abActiveContract;
+	int m_iJFDReformCooldownRate;
+	int m_iJFDGovernmentCooldownRate;
+	CvString m_strJFDPoliticKey;
+	CvString m_strJFDLegislatureName;
+	int m_iJFDPoliticLeader;
+	int m_iJFDSovereignty;
+	int m_iJFDGovernment;
+	int m_iJFDReformCooldown;
+	int m_iJFDGovernmentCooldown;
+	int m_iJFDPiety;
+	int m_iJFDPietyRate;
+	int m_iJFDConversionTurn;
+	bool m_bJFDSecularized;
+	CvString m_strJFDCurrencyName;
+	int m_iJFDProsperity;
+	int m_iJFDCurrency;
+	int m_iGoldenAgeTourism;
+	int m_iExtraCultureandScienceTradeRoutes;
+	int m_iArchaeologicalDigTourism;
+	int m_iUpgradeCSVassalTerritory;
+	int m_iRazingSpeedBonus;
+	int m_iNoPartisans;
+	int m_iSpawnCooldown;
+	int m_iAbleToMarryCityStatesCount;
+	bool m_bTradeRoutesInvulnerable;
+	int m_iTRSpeedBoost;
+	int m_iVotesPerGPT;
+	int m_iTRVisionBoost;
+	int m_iEventTourism;
+	std::vector<int> m_aiGlobalTourismAlreadyReceived;
+	int m_iEventTourismCS;
+	int m_iNumHistoricEvent;
+	int m_iSingleVotes;
+	int m_iMonopolyModFlat;
+	int m_iMonopolyModPercent;
+	int m_iCachedValueOfPeaceWithHuman;
+	int m_iFaithPurchaseCooldown;
+	int m_iCSAllies;
+	int m_iCSFriends;
 	std::vector<int> m_piCityFeatures;
 	std::vector<int> m_piNumBuildings;
 	std::vector<int> m_piNumBuildingsInPuppets;
-	FAutoVariable<int, CvPlayer> m_iCitiesNeedingTerrainImprovements;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiBestMilitaryCombatClassCity;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiBestMilitaryDomainCity;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiEventChoiceDuration;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiEventIncrement;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiEventCooldown;
-	FAutoVariable<std::vector<bool>, CvPlayer> m_abEventActive;
-	FAutoVariable<std::vector<bool>, CvPlayer> m_abEventChoiceActive;
-	FAutoVariable<std::vector<bool>, CvPlayer> m_abEventChoiceFired;
-	FAutoVariable<std::vector<bool>, CvPlayer> m_abEventFired;
-	FAutoVariable<int, CvPlayer> m_iPlayerEventCooldown;
-	FAutoVariable<std::vector<bool>, CvPlayer> m_abNWOwned;
-	FAutoVariable<std::vector<int>, CvPlayer> m_paiUnitClassProductionModifiers;
-	FAutoVariable<int, CvPlayer> m_iExtraSupplyPerPopulation;
-	FAutoVariable<int, CvPlayer> m_iCitySupplyFlatGlobal;
-	FAutoVariable<int, CvPlayer> m_iMissionaryExtraStrength;
+	int m_iCitiesNeedingTerrainImprovements;
+	std::vector<int> m_aiBestMilitaryCombatClassCity;
+	std::vector<int> m_aiBestMilitaryDomainCity;
+	std::vector<int> m_aiEventChoiceDuration;
+	std::vector<int> m_aiEventIncrement;
+	std::vector<int> m_aiEventCooldown;
+	std::vector<bool> m_abEventActive;
+	std::vector<bool> m_abEventChoiceActive;
+	std::vector<bool> m_abEventChoiceFired;
+	std::vector<bool> m_abEventFired;
+	int m_iPlayerEventCooldown;
+	std::vector<bool> m_abNWOwned;
+	std::vector<int> m_paiUnitClassProductionModifiers;
+	int m_iExtraSupplyPerPopulation;
+	int m_iCitySupplyFlatGlobal;
+	int m_iMissionaryExtraStrength;
 #endif
-	FAutoVariable<int, CvPlayer> m_iFreeSpecialist;
-	FAutoVariable<int, CvPlayer> m_iCultureBombTimer;
-	FAutoVariable<int, CvPlayer> m_iConversionTimer;
-	FAutoVariable<int, CvPlayer> m_iCapitalCityID;
-	FAutoVariable<int, CvPlayer> m_iCitiesLost;
-	FAutoVariable<int, CvPlayer> m_iMilitaryRating;
-	FAutoVariable<int, CvPlayer> m_iMilitaryMight;
-	FAutoVariable<int, CvPlayer> m_iEconomicMight;
-	FAutoVariable<int, CvPlayer> m_iProductionMight;
-	FAutoVariable<int, CvPlayer> m_iTurnSliceMightRecomputed;
-	FAutoVariable<int, CvPlayer> m_iNewCityExtraPopulation;
-	FAutoVariable<int, CvPlayer> m_iFreeFoodBox;
-	FAutoVariable<int, CvPlayer> m_iScenarioScore1;
-	FAutoVariable<int, CvPlayer> m_iScenarioScore2;
-	FAutoVariable<int, CvPlayer> m_iScenarioScore3;
-	FAutoVariable<int, CvPlayer> m_iScenarioScore4;
-	FAutoVariable<int, CvPlayer> m_iScoreFromFutureTech;
-	FAutoVariable<int, CvPlayer> m_iTurnLastAttackedMinorCiv;
-	FAutoVariable<int, CvPlayer> m_iCombatExperienceTimes100;
-	FAutoVariable<int, CvPlayer> m_iLifetimeCombatExperienceTimes100;
-	FAutoVariable<int, CvPlayer> m_iNavalCombatExperienceTimes100;
-	FAutoVariable<int, CvPlayer> m_iBorderObstacleCount;
+	int m_iFreeSpecialist;
+	int m_iCultureBombTimer;
+	int m_iConversionTimer;
+	int m_iCapitalCityID;
+	int m_iCitiesLost;
+	int m_iMilitaryRating;
+	int m_iMilitaryMight;
+	int m_iEconomicMight;
+	int m_iProductionMight;
+	int m_iTurnSliceMightRecomputed;
+	int m_iNewCityExtraPopulation;
+	int m_iFreeFoodBox;
+	int m_iScenarioScore1;
+	int m_iScenarioScore2;
+	int m_iScenarioScore3;
+	int m_iScenarioScore4;
+	int m_iScoreFromFutureTech;
+	int m_iTurnLastAttackedMinorCiv;
+	int m_iCombatExperienceTimes100;
+	int m_iLifetimeCombatExperienceTimes100;
+	int m_iNavalCombatExperienceTimes100;
+	int m_iBorderObstacleCount;
 #if defined(HH_MOD_BUILDINGS_FRUITLESS_PILLAGE)
-	FAutoVariable<int, CvPlayer> m_iBorderGainlessPillageCount;
+	int m_iBorderGainlessPillageCount;
 #endif
-	FAutoVariable<int, CvPlayer> m_iPopRushHurryCount;
-	FAutoVariable<int, CvPlayer> m_iTotalImprovementsBuilt;
-	FAutoVariable<int, CvPlayer> m_iCostNextPolicy;
-	FAutoVariable<int, CvPlayer> m_iNumBuilders;
-	FAutoVariable<int, CvPlayer> m_iMaxNumBuilders;
-	FAutoVariable<int, CvPlayer> m_iCityStrengthMod;
-	FAutoVariable<int, CvPlayer> m_iCityGrowthMod;
-	FAutoVariable<int, CvPlayer> m_iCapitalGrowthMod;
-	FAutoVariable<int, CvPlayer> m_iNumPlotsBought;
-	FAutoVariable<int, CvPlayer> m_iPlotGoldCostMod;
+	int m_iPopRushHurryCount;
+	int m_iTotalImprovementsBuilt;
+	int m_iCostNextPolicy;
+	int m_iNumBuilders;
+	int m_iMaxNumBuilders;
+	int m_iCityStrengthMod;
+	int m_iCityGrowthMod;
+	int m_iCapitalGrowthMod;
+	int m_iNumPlotsBought;
+	int m_iPlotGoldCostMod;
 #if defined(MOD_TRAITS_CITY_WORKING) || defined(MOD_BUILDINGS_CITY_WORKING) || defined(MOD_POLICIES_CITY_WORKING) || defined(MOD_TECHS_CITY_WORKING)
-	FAutoVariable<int, CvPlayer> m_iCityWorkingChange;
+	int m_iCityWorkingChange;
 #endif
 #if defined(MOD_TRAITS_CITY_AUTOMATON_WORKERS) || defined(MOD_BUILDINGS_CITY_AUTOMATON_WORKERS) || defined(MOD_POLICIES_CITY_AUTOMATON_WORKERS) || defined(MOD_TECHS_CITY_AUTOMATON_WORKERS)
-	FAutoVariable<int, CvPlayer> m_iCityAutomatonWorkersChange;
+	int m_iCityAutomatonWorkersChange;
 #endif
-	FAutoVariable<int, CvPlayer> m_iCachedGoldRate;
-	FAutoVariable<int, CvPlayer> m_iPlotCultureCostModifier;
-	FAutoVariable<int, CvPlayer> m_iPlotCultureExponentModifier;
-	FAutoVariable<int, CvPlayer> m_iNumCitiesPolicyCostDiscount;
-	FAutoVariable<int, CvPlayer> m_iGarrisonedCityRangeStrikeModifier;
-	FAutoVariable<int, CvPlayer> m_iGarrisonFreeMaintenanceCount;
-	FAutoVariable<int, CvPlayer> m_iNumCitiesFreeCultureBuilding;
-	FAutoVariable<int, CvPlayer> m_iNumCitiesFreeFoodBuilding;
-	FAutoVariable<int, CvPlayer> m_iUnitPurchaseCostModifier;
-	FAutoVariable<int, CvPlayer> m_iAllFeatureProduction;
-	FAutoVariable<int, CvPlayer> m_iCityDistanceHighwaterMark; // this is used to determine camera zoom
-	FAutoVariable<int, CvPlayer> m_iOriginalCapitalX;
-	FAutoVariable<int, CvPlayer> m_iOriginalCapitalY;
-	FAutoVariable<int, CvPlayer> m_iHolyCityX;
-	FAutoVariable<int, CvPlayer> m_iHolyCityY;
-	FAutoVariable<int, CvPlayer> m_iNumWonders;
-	FAutoVariable<int, CvPlayer> m_iNumPolicies;
-	FAutoVariable<int, CvPlayer> m_iNumGreatPeople;
-	FAutoVariable<int, CvPlayer> m_iCityConnectionHappiness;
-	FAutoVariable<int, CvPlayer> m_iHolyCityID;
-	FAutoVariable<int, CvPlayer> m_iTurnsSinceSettledLastCity;
-	FAutoVariable<int, CvPlayer> m_iNumNaturalWondersDiscoveredInArea;
-	FAutoVariable<int, CvPlayer> m_iStrategicResourceMod;
-	FAutoVariable<int, CvPlayer> m_iSpecialistCultureChange;
-	FAutoVariable<int, CvPlayer> m_iGreatPeopleSpawnCounter;
+	int m_iCachedGoldRate;
+	int m_iPlotCultureCostModifier;
+	int m_iPlotCultureExponentModifier;
+	int m_iNumCitiesPolicyCostDiscount;
+	int m_iGarrisonedCityRangeStrikeModifier;
+	int m_iGarrisonFreeMaintenanceCount;
+	int m_iNumCitiesFreeCultureBuilding;
+	int m_iNumCitiesFreeFoodBuilding;
+	int m_iUnitPurchaseCostModifier;
+	int m_iAllFeatureProduction;
+	int m_iCityDistanceHighwaterMark; // this is used to determine camera zoom
+	int m_iOriginalCapitalX;
+	int m_iOriginalCapitalY;
+	int m_iHolyCityX;
+	int m_iHolyCityY;
+	int m_iNumWonders;
+	int m_iNumPolicies;
+	int m_iNumGreatPeople;
+	int m_iCityConnectionHappiness;
+	int m_iHolyCityID;
+	int m_iTurnsSinceSettledLastCity;
+	int m_iNumNaturalWondersDiscoveredInArea;
+	int m_iStrategicResourceMod;
+	int m_iSpecialistCultureChange;
+	int m_iGreatPeopleSpawnCounter;
 
-	FAutoVariable<int, CvPlayer> m_iFreeTechCount;
-	FAutoVariable<int, CvPlayer> m_iMedianTechPercentage;
-	FAutoVariable<int, CvPlayer> m_iNumFreePolicies;
-	FAutoVariable<int, CvPlayer> m_iNumFreePoliciesEver; 
-	FAutoVariable<int, CvPlayer> m_iNumFreeTenets;
+	int m_iFreeTechCount;
+	int m_iMedianTechPercentage;
+	int m_iNumFreePolicies;
+	int m_iNumFreePoliciesEver; 
+	int m_iNumFreeTenets;
 
-	FAutoVariable<int, CvPlayer> m_iLastSliceMoved;
+	int m_iLastSliceMoved;
 
-	FAutoVariable<uint, CvPlayer> m_uiStartTime;  // XXX save these?
+	uint m_uiStartTime;  // XXX save these?
 
-	FAutoVariable<bool, CvPlayer> m_bHasUUPeriod;
-	FAutoVariable<bool, CvPlayer> m_bNoNewWars;
-	FAutoVariable<bool, CvPlayer> m_bHasBetrayedMinorCiv;
-	FAutoVariable<bool, CvPlayer> m_bAlive;
-	FAutoVariable<bool, CvPlayer> m_bEverAlive;
-	FAutoVariable<bool, CvPlayer> m_bPotentiallyAlive;
-	FAutoVariable<bool, CvPlayer> m_bBeingResurrected;
-	FAutoVariable<bool, CvPlayer> m_bTurnActive;
-	FAutoVariable<bool, CvPlayer> m_bAutoMoves;					// Signal that we can process the auto moves when ready.
+	bool m_bHasUUPeriod;
+	bool m_bNoNewWars;
+	bool m_bHasBetrayedMinorCiv;
+	bool m_bAlive;
+	bool m_bEverAlive;
+	bool m_bPotentiallyAlive;
+	bool m_bBeingResurrected;
+	bool m_bTurnActive;
+	bool m_bAutoMoves;					// Signal that we can process the auto moves when ready.
 	bool						  m_bProcessedAutoMoves;		// Signal that we have processed the auto moves
-	FAutoVariable<bool, CvPlayer> m_bEndTurn;					// Signal that the player has completed their turn.  The turn will still be active until the auto-moves have been processed.
-	FAutoVariable<bool, CvPlayer> m_bDynamicTurnsSimultMode;
-	FAutoVariable<bool, CvPlayer> m_bPbemNewTurn;
-	FAutoVariable<bool, CvPlayer> m_bExtendedGame;
-	FAutoVariable<bool, CvPlayer> m_bFoundedFirstCity;
-	FAutoVariable<int, CvPlayer> m_iNumCitiesFounded;
-	FAutoVariable<bool, CvPlayer> m_bStrike;
-	FAutoVariable<bool, CvPlayer> m_bCramped;
-	FAutoVariable<bool, CvPlayer> m_bLostCapital;
-	FAutoVariable<PlayerTypes, CvPlayer> m_eConqueror;
-	FAutoVariable<bool, CvPlayer> m_bLostHolyCity;
-	FAutoVariable<PlayerTypes, CvPlayer> m_eHolyCityConqueror;
-	FAutoVariable<bool, CvPlayer> m_bHasAdoptedStateReligion;
-	FAutoVariable<bool, CvPlayer> m_bAlliesGreatPersonBiasApplied;
+	bool m_bEndTurn;					// Signal that the player has completed their turn.  The turn will still be active until the auto-moves have been processed.
+	bool m_bDynamicTurnsSimultMode;
+	bool m_bPbemNewTurn;
+	bool m_bExtendedGame;
+	bool m_bFoundedFirstCity;
+	int m_iNumCitiesFounded;
+	bool m_bStrike;
+	bool m_bCramped;
+	bool m_bLostCapital;
+	PlayerTypes m_eConqueror;
+	bool m_bLostHolyCity;
+	PlayerTypes m_eHolyCityConqueror;
+	bool m_bHasAdoptedStateReligion;
+	bool m_bAlliesGreatPersonBiasApplied;
 
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiCityYieldChange;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiCoastalCityYieldChange;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiCapitalYieldChange;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiCapitalYieldPerPopChange;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiCapitalYieldPerPopChangeEmpire;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiSeaPlotYield;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiYieldRateModifier;
+	std::vector<int> m_aiCityYieldChange;
+	std::vector<int> m_aiCoastalCityYieldChange;
+	std::vector<int> m_aiCapitalYieldChange;
+	std::vector<int> m_aiCapitalYieldPerPopChange;
+	std::vector<int> m_aiCapitalYieldPerPopChangeEmpire;
+	std::vector<int> m_aiSeaPlotYield;
+	std::vector<int> m_aiYieldRateModifier;
 #if defined(MOD_BALANCE_CORE_POLICIES)
-	FAutoVariable<std::vector<int>, CvPlayer> m_paiJFDPoliticPercent;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiYieldFromMinors;
-	FAutoVariable<std::vector<int>, CvPlayer> m_paiResourceFromCSAlliances;
-	FAutoVariable<std::vector<int>, CvPlayer> m_paiResourceShortageValue;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiYieldFromBirth;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiYieldFromBirthCapital;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiYieldFromDeath;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiYieldFromPillage;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiYieldFromVictory;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiYieldFromConstruction;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiYieldFromwonderConstruction;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiYieldFromTech;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiYieldFromBorderGrowth;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiYieldGPExpend;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiConquerorYield;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiFounderYield;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiArtifactYieldBonus;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiArtYieldBonus;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiMusicYieldBonus;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiLitYieldBonus;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiFilmYieldBonus;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiRelicYieldBonus;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiReligionYieldRateModifier;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiGoldenAgeYieldMod;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiYieldFromNonSpecialistCitizens;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiYieldModifierFromGreatWorks;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiYieldModifierFromActiveSpies;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiYieldFromDelegateCount;
-	FAutoVariable<std::vector<int>, CvPlayer> m_paiBuildingClassCulture;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiDomainFreeExperiencePerGreatWorkGlobal;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiCityYieldModFromMonopoly;
-	FAutoVariable<std::vector<UnitAITypes>, CvPlayer> m_neededUnitAITypes;
-	FAutoVariable<bool, CvPlayer> m_bAllowsProductionTradeRoutesGlobal;
-	FAutoVariable<bool, CvPlayer> m_bAllowsFoodTradeRoutesGlobal;
+	std::vector<int> m_paiJFDPoliticPercent;
+	std::vector<int> m_aiYieldFromMinors;
+	std::vector<int> m_paiResourceFromCSAlliances;
+	std::vector<int> m_paiResourceShortageValue;
+	std::vector<int> m_aiYieldFromBirth;
+	std::vector<int> m_aiYieldFromBirthCapital;
+	std::vector<int> m_aiYieldFromDeath;
+	std::vector<int> m_aiYieldFromPillage;
+	std::vector<int> m_aiYieldFromVictory;
+	std::vector<int> m_aiYieldFromConstruction;
+	std::vector<int> m_aiYieldFromwonderConstruction;
+	std::vector<int> m_aiYieldFromTech;
+	std::vector<int> m_aiYieldFromBorderGrowth;
+	std::vector<int> m_aiYieldGPExpend;
+	std::vector<int> m_aiConquerorYield;
+	std::vector<int> m_aiFounderYield;
+	std::vector<int> m_aiArtifactYieldBonus;
+	std::vector<int> m_aiArtYieldBonus;
+	std::vector<int> m_aiMusicYieldBonus;
+	std::vector<int> m_aiLitYieldBonus;
+	std::vector<int> m_aiFilmYieldBonus;
+	std::vector<int> m_aiRelicYieldBonus;
+	std::vector<int> m_aiReligionYieldRateModifier;
+	std::vector<int> m_aiGoldenAgeYieldMod;
+	std::vector<int> m_aiYieldFromNonSpecialistCitizens;
+	std::vector<int> m_aiYieldModifierFromGreatWorks;
+	std::vector<int> m_aiYieldModifierFromActiveSpies;
+	std::vector<int> m_aiYieldFromDelegateCount;
+	std::vector<int> m_paiBuildingClassCulture;
+	std::vector<int> m_aiDomainFreeExperiencePerGreatWorkGlobal;
+	std::vector<int> m_aiCityYieldModFromMonopoly;
+	std::vector<UnitAITypes> m_neededUnitAITypes;
+	bool m_bAllowsProductionTradeRoutesGlobal;
+	bool m_bAllowsFoodTradeRoutesGlobal;
 	
 #endif
 #if defined(MOD_BALANCE_CORE)
 	std::map<int, int> m_piDomainFreeExperience;
 #endif
 
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiCapitalYieldRateModifier;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiExtraYieldThreshold;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiSpecialistExtraYield;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiPlayerNumTurnsAtPeace;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiPlayerNumTurnsAtWar;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiPlayerNumTurnsSinceCityCapture;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiProximityToPlayer;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiResearchAgreementCounter;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiIncomingUnitTypes;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiIncomingUnitCountdowns;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiSiphonLuxuryCount;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiGreatWorkYieldChange;
-	FAutoVariable<std::vector<int>, CvPlayer> m_aiTourismBonusTurnsPlayer;
+	std::vector<int> m_aiCapitalYieldRateModifier;
+	std::vector<int> m_aiExtraYieldThreshold;
+	std::vector<int> m_aiSpecialistExtraYield;
+	std::vector<int> m_aiPlayerNumTurnsAtPeace;
+	std::vector<int> m_aiPlayerNumTurnsAtWar;
+	std::vector<int> m_aiPlayerNumTurnsSinceCityCapture;
+	std::vector<int> m_aiProximityToPlayer;
+	std::vector<int> m_aiResearchAgreementCounter;
+	std::vector<int> m_aiIncomingUnitTypes;
+	std::vector<int> m_aiIncomingUnitCountdowns;
+	std::vector<int> m_aiSiphonLuxuryCount;
+	std::vector<int> m_aiGreatWorkYieldChange;
+	std::vector<int> m_aiTourismBonusTurnsPlayer;
 
 	typedef std::pair<uint, int> PlayerOptionEntry;
 	typedef std::vector< PlayerOptionEntry > PlayerOptionsVector;
-	FAutoVariable<PlayerOptionsVector, CvPlayer> m_aOptions;
+	PlayerOptionsVector m_aOptions;
 
-	FAutoVariable<CvString, CvPlayer> m_strReligionKey;
-	FAutoVariable<CvString, CvPlayer> m_strScriptData;
+	CvString m_strReligionKey;
+	CvString m_strScriptData;
 
 	CvString m_strEmbarkedGraphicOverride;
 
-	FAutoVariable<std::vector<int>, CvPlayer> m_paiNumResourceUsed;
-	FAutoVariable<std::vector<int>, CvPlayer> m_paiNumResourceTotal;
-	FAutoVariable<std::vector<int>, CvPlayer> m_paiResourceGiftedToMinors;
-	FAutoVariable<std::vector<int>, CvPlayer> m_paiResourceExport; //always to majors
-	FAutoVariable<std::vector<int>, CvPlayer> m_paiResourceImportFromMajor;
-	FAutoVariable<std::vector<int>, CvPlayer> m_paiResourceFromMinors;
-	FAutoVariable<std::vector<int>, CvPlayer> m_paiResourcesSiphoned;
-	FAutoVariable<std::vector<int>, CvPlayer> m_paiImprovementCount;
+	std::vector<int> m_paiNumResourceUsed;
+	std::vector<int> m_paiNumResourceTotal;
+	std::vector<int> m_paiResourceGiftedToMinors;
+	std::vector<int> m_paiResourceExport; //always to majors
+	std::vector<int> m_paiResourceImportFromMajor;
+	std::vector<int> m_paiResourceFromMinors;
+	std::vector<int> m_paiResourcesSiphoned;
+	std::vector<int> m_paiImprovementCount;
 #if defined(MOD_BALANCE_CORE)
-	FAutoVariable<std::vector<int>, CvPlayer> m_paiTotalImprovementsBuilt;
+	std::vector<int> m_paiTotalImprovementsBuilt;
 #endif
 #if defined(MOD_IMPROVEMENTS_EXTENSIONS)
 	std::map<RouteTypes, int> m_piResponsibleForRouteCount;
 	std::map<ImprovementTypes, int> m_piResponsibleForImprovementCount;
 
-	FAutoVariable<std::vector<int>, CvPlayer> m_paiBuildingChainSteps;
+	std::vector<int> m_paiBuildingChainSteps;
 #endif
-	FAutoVariable<std::vector<int>, CvPlayer> m_paiFreeBuildingCount;
-	FAutoVariable<std::vector<int>, CvPlayer> m_paiFreePromotionCount;
-	FAutoVariable<std::vector<int>, CvPlayer> m_paiUnitCombatProductionModifiers;
-	FAutoVariable<std::vector<int>, CvPlayer> m_paiUnitCombatFreeExperiences;
-	FAutoVariable<std::vector<int>, CvPlayer> m_paiUnitClassCount;
-	FAutoVariable<std::vector<int>, CvPlayer> m_paiUnitClassMaking;
-	FAutoVariable<std::vector<int>, CvPlayer> m_paiBuildingClassCount;
-	FAutoVariable<std::vector<int>, CvPlayer> m_paiBuildingClassMaking;
-	FAutoVariable<std::vector<int>, CvPlayer> m_paiProjectMaking;
-	FAutoVariable<std::vector<int>, CvPlayer> m_paiHurryCount;
-	FAutoVariable<std::vector<int>, CvPlayer> m_paiHurryModifier;
+	std::vector<int> m_paiFreeBuildingCount;
+	std::vector<int> m_paiFreePromotionCount;
+	std::vector<int> m_paiUnitCombatProductionModifiers;
+	std::vector<int> m_paiUnitCombatFreeExperiences;
+	std::vector<int> m_paiUnitClassCount;
+	std::vector<int> m_paiUnitClassMaking;
+	std::vector<int> m_paiBuildingClassCount;
+	std::vector<int> m_paiBuildingClassMaking;
+	std::vector<int> m_paiProjectMaking;
+	std::vector<int> m_paiHurryCount;
+	std::vector<int> m_paiHurryModifier;
 
 #if defined(MOD_DIPLOMACY_CIV4_FEATURES)
-	FAutoVariable<bool, CvPlayer> m_bVassalLevy;
-	FAutoVariable<int, CvPlayer> m_iVassalGoldMaintenanceMod;
+	bool m_bVassalLevy;
+	int m_iVassalGoldMaintenanceMod;
 #endif
 #if defined(MOD_BALANCE_CORE)
-	FAutoVariable<std::vector<int>, CvPlayer> m_paiNumCitiesFreeChosenBuilding;
-	FAutoVariable<std::vector<int>, CvPlayer> m_pabFreeChosenBuildingNewCity;
-	FAutoVariable<std::vector<int>, CvPlayer> m_pabAllCityFreeBuilding;
-	FAutoVariable<std::vector<int>, CvPlayer> m_pabNewFoundCityFreeUnit;
-	FAutoVariable<std::vector<int>, CvPlayer> m_pabNewFoundCityFreeBuilding;
+	std::vector<int> m_paiNumCitiesFreeChosenBuilding;
+	std::vector<int> m_pabFreeChosenBuildingNewCity;
+	std::vector<int> m_pabAllCityFreeBuilding;
+	std::vector<int> m_pabNewFoundCityFreeUnit;
+	std::vector<int> m_pabNewFoundCityFreeBuilding;
 #endif
 
-	FAutoVariable<std::vector<bool>, CvPlayer> m_pabLoyalMember;
+	std::vector<bool> m_pabLoyalMember;
 
 #if defined(MOD_BALANCE_CORE_RESOURCE_MONOPOLIES)
-	FAutoVariable<std::vector<bool>, CvPlayer> m_pabHasGlobalMonopoly;
-	FAutoVariable<std::vector<bool>, CvPlayer> m_pabHasStrategicMonopoly;
+	std::vector<bool> m_pabHasGlobalMonopoly;
+	std::vector<bool> m_pabHasStrategicMonopoly;
 	std::vector<ResourceTypes> m_vResourcesWGlobalMonopoly;
 	std::vector<ResourceTypes> m_vResourcesWStrategicMonopoly;
 	int m_iCombatAttackBonusFromMonopolies;
 	int m_iCombatDefenseBonusFromMonopolies;
 #endif
 
-	FAutoVariable<std::vector<bool>, CvPlayer> m_pabGetsScienceFromPlayer;
+	std::vector<bool> m_pabGetsScienceFromPlayer;
 
-	FAutoVariable< std::vector< Firaxis::Array<int, NUM_YIELD_TYPES > >, CvPlayer> m_ppaaiSpecialistExtraYield;
+	std::vector< Firaxis::Array<int, NUM_YIELD_TYPES > > m_ppaaiSpecialistExtraYield;
 #if defined(MOD_API_UNIFIED_YIELDS) && defined(MOD_API_PLOT_YIELDS)
 	std::vector< Firaxis::Array<int, NUM_YIELD_TYPES > > m_ppiPlotYieldChange;
 #endif
@@ -3572,8 +3575,8 @@ protected:
 	std::vector<int> m_piYieldChangeWorldWonder;
 	std::vector<int> m_piYieldFromMinorDemand;
 	std::vector<int> m_piYieldFromWLTKD;
-	FAutoVariable< std::vector< Firaxis::Array<int, NUM_YIELD_TYPES > >, CvPlayer> m_ppiBuildingClassYieldChange;
-	FAutoVariable< std::vector< Firaxis::Array<int, NUM_YIELD_TYPES > >, CvPlayer> m_ppaaiImprovementYieldChange;
+	std::vector< Firaxis::Array<int, NUM_YIELD_TYPES > > m_ppiBuildingClassYieldChange;
+	std::vector< Firaxis::Array<int, NUM_YIELD_TYPES > > m_ppaaiImprovementYieldChange;
 #endif
 #if defined(MOD_API_UNIFIED_YIELDS) && defined(MOD_BALANCE_CORE_RESOURCE_MONOPOLIES)
 	std::map<GreatPersonTypes, std::map<MonopolyTypes, int>> m_ppiSpecificGreatPersonRateModifierFromMonopoly;
@@ -3583,8 +3586,8 @@ protected:
 	CvUnitCycler	m_UnitCycle;	
 
 	// slewis's tutorial variables!
-	FAutoVariable<bool, CvPlayer> m_bEverPoppedGoody;
-	FAutoVariable<bool, CvPlayer> m_bEverTrainedBuilder;
+	bool m_bEverPoppedGoody;
+	bool m_bEverTrainedBuilder;
 	// end slewis's tutorial variables
 
 	EndTurnBlockingTypes  m_eEndTurnBlockingType;
@@ -3613,8 +3616,8 @@ protected:
 	// Danger plots!
 	CvDangerPlots* m_pDangerPlots;
 
-	FAutoVariable<int, CvPlayer> m_iPreviousBestSettlePlot;
-	FAutoVariable<int, CvPlayer> m_iFoundValueOfCapital;
+	int m_iPreviousBestSettlePlot;
+	int m_iFoundValueOfCapital;
 
 	// not serialized
 	std::vector<int> m_viPlotFoundValues;
@@ -3701,13 +3704,13 @@ protected:
 
 	ConqueredByBoolField m_bfEverConqueredBy;
 
-	FAutoVariable<int, CvPlayer> m_iNumFreeGreatPeople;
-	FAutoVariable<int, CvPlayer> m_iNumMayaBoosts;
-	FAutoVariable<int, CvPlayer> m_iNumFaithGreatPeople;
-	FAutoVariable<int, CvPlayer> m_iNumArchaeologyChoices;
+	int m_iNumFreeGreatPeople;
+	int m_iNumMayaBoosts;
+	int m_iNumFaithGreatPeople;
+	int m_iNumArchaeologyChoices;
 
 	FaithPurchaseTypes m_eFaithPurchaseType;
-	FAutoVariable<int, CvPlayer> m_iFaithPurchaseIndex;
+	int m_iFaithPurchaseIndex;
 
 	void checkArmySizeAchievement();
 
@@ -3717,8 +3720,8 @@ protected:
 
 #if defined(MOD_BALANCE_CORE_MILITARY)
 	//percent
-	FAutoVariable<int, CvPlayer> m_iFractionOriginalCapitalsUnderControl;
-	FAutoVariable<int, CvPlayer> m_iAvgUnitExp100;
+	int m_iFractionOriginalCapitalsUnderControl;
+	int m_iAvgUnitExp100;
 	std::vector< std::pair<int,int> > m_unitsAreaEffectPositive; //unit / plot
 	std::vector< std::pair<int,int> > m_unitsAreaEffectNegative; //unit / plot
 	std::vector< std::pair<int,int> > m_unitsAreaEffectPromotion; //unit / plot
@@ -3731,12 +3734,12 @@ protected:
 	mutable int m_iNumUnitsSuppliedCached; //not serialized
 
 #if defined(MOD_BATTLE_ROYALE)
-	FAutoVariable<int, CvPlayer> m_iNumMilitarySeaUnits;
-	FAutoVariable<int, CvPlayer> m_iNumMilitaryAirUnits;
-	FAutoVariable<int, CvPlayer> m_iNumMilitaryLandUnits;
-	FAutoVariable<int, CvPlayer> m_iMilitarySeaMight;
-	FAutoVariable<int, CvPlayer> m_iMilitaryAirMight;
-	FAutoVariable<int, CvPlayer> m_iMilitaryLandMight;
+	int m_iNumMilitarySeaUnits;
+	int m_iNumMilitaryAirUnits;
+	int m_iNumMilitaryLandUnits;
+	int m_iMilitarySeaMight;
+	int m_iMilitaryAirMight;
+	int m_iMilitaryLandMight;
 #endif
 
 	std::vector<int> m_vCityConnectionPlots; //serialized
@@ -3749,5 +3752,552 @@ namespace FSerialization
 void SyncPlayer();
 void ClearPlayerDeltas();
 }
+
+SYNC_ARCHIVE_BEGIN(CvPlayer)
+SYNC_ARCHIVE_VAR(PlayerTypes, m_eID)
+SYNC_ARCHIVE_VAR(LeaderHeadTypes, m_ePersonalityType)
+SYNC_ARCHIVE_VAR(int, m_iStartingX)
+SYNC_ARCHIVE_VAR(int, m_iStartingY)
+SYNC_ARCHIVE_VAR(int, m_iTotalPopulation)
+SYNC_ARCHIVE_VAR(int, m_iTotalLand)
+SYNC_ARCHIVE_VAR(int, m_iTotalLandScored)
+SYNC_ARCHIVE_VAR(int, m_iJONSCulturePerTurnForFree)
+SYNC_ARCHIVE_VAR(int, m_iJONSCultureCityModifier)
+SYNC_ARCHIVE_VAR(int, m_iJONSCulture)
+SYNC_ARCHIVE_VAR(int, m_iJONSCultureEverGenerated)
+SYNC_ARCHIVE_VAR(int, m_iWondersConstructed)
+SYNC_ARCHIVE_VAR(int, m_iCulturePerWonder)
+SYNC_ARCHIVE_VAR(int, m_iCultureWonderMultiplier)
+SYNC_ARCHIVE_VAR(int, m_iCulturePerTechResearched)
+SYNC_ARCHIVE_VAR(int, m_iFaith)
+SYNC_ARCHIVE_VAR(int, m_iFaithEverGenerated)
+SYNC_ARCHIVE_VAR(int, m_iHappiness)
+SYNC_ARCHIVE_VAR(int, m_iUnhappiness)
+SYNC_ARCHIVE_VAR(int, m_iHappinessTotal)
+SYNC_ARCHIVE_VAR(int, m_iEmpireNeedsModifierGlobal)
+SYNC_ARCHIVE_VAR(int, m_iChangePovertyUnhappinessGlobal)
+SYNC_ARCHIVE_VAR(int, m_iChangeDefenseUnhappinessGlobal)
+SYNC_ARCHIVE_VAR(int, m_iChangeUnculturedUnhappinessGlobal)
+SYNC_ARCHIVE_VAR(int, m_iChangeIlliteracyUnhappinessGlobal)
+SYNC_ARCHIVE_VAR(int, m_iChangeMinorityUnhappinessGlobal)
+SYNC_ARCHIVE_VAR(int, m_iLandmarksTourismPercentGlobal)
+SYNC_ARCHIVE_VAR(int, m_iGreatWorksTourismModifierGlobal)
+SYNC_ARCHIVE_VAR(int, m_iCenterOfMassX)
+SYNC_ARCHIVE_VAR(int, m_iCenterOfMassY)
+SYNC_ARCHIVE_VAR(int, m_iReferenceFoundValue)
+SYNC_ARCHIVE_VAR(int, m_iReformationFollowerReduction)
+SYNC_ARCHIVE_VAR(bool, m_bIsReformation)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_viInstantYieldsTotal)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_viTourismHistory)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_viGAPHistory)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_viCultureHistory)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_viScienceHistory)
+SYNC_ARCHIVE_VAR(int, m_iUprisingCounter)
+SYNC_ARCHIVE_VAR(int, m_iExtraHappinessPerLuxury)
+SYNC_ARCHIVE_VAR(int, m_iUnhappinessFromUnits)
+SYNC_ARCHIVE_VAR(int, m_iUnhappinessFromUnitsMod)
+SYNC_ARCHIVE_VAR(int, m_iUnhappinessMod)
+SYNC_ARCHIVE_VAR(int, m_iCityCountUnhappinessMod)
+SYNC_ARCHIVE_VAR(int, m_iOccupiedPopulationUnhappinessMod)
+SYNC_ARCHIVE_VAR(int, m_iCapitalUnhappinessMod)
+SYNC_ARCHIVE_VAR(int, m_iCityRevoltCounter)
+SYNC_ARCHIVE_VAR(int, m_iHappinessPerGarrisonedUnitCount)
+SYNC_ARCHIVE_VAR(int, m_iHappinessPerTradeRouteCount)
+SYNC_ARCHIVE_VAR(int, m_iHappinessPerXPopulation)
+SYNC_ARCHIVE_VAR(int, m_iHappinessPerXPopulationGlobal)
+SYNC_ARCHIVE_VAR(int, m_iIdeologyPoint)
+SYNC_ARCHIVE_VAR(int, m_iNoXPLossUnitPurchase)
+SYNC_ARCHIVE_VAR(int, m_iXCSAlliesLowersPolicyNeedWonders)
+SYNC_ARCHIVE_VAR(int, m_iHappinessFromMinorCivs)
+SYNC_ARCHIVE_VAR(int, m_iPositiveWarScoreTourismMod)
+SYNC_ARCHIVE_VAR(int, m_iIsNoCSDecayAtWar)
+SYNC_ARCHIVE_VAR(int, m_iCanBullyFriendlyCS)
+SYNC_ARCHIVE_VAR(int, m_iBullyGlobalCSReduction)
+SYNC_ARCHIVE_VAR(int, m_iIsVassalsNoRebel)
+SYNC_ARCHIVE_VAR(int, m_iVassalCSBonusModifier)
+SYNC_ARCHIVE_VAR(int, m_iHappinessFromLeagues)
+SYNC_ARCHIVE_VAR(int, m_iDummy)
+SYNC_ARCHIVE_VAR(int, m_iWoundedUnitDamageMod)
+SYNC_ARCHIVE_VAR(int, m_iUnitUpgradeCostMod)
+SYNC_ARCHIVE_VAR(int, m_iBarbarianCombatBonus)
+SYNC_ARCHIVE_VAR(int, m_iAlwaysSeeBarbCampsCount)
+SYNC_ARCHIVE_VAR(int, m_iHappinessPerCity)
+SYNC_ARCHIVE_VAR(int, m_iHappinessPerXPolicies)
+SYNC_ARCHIVE_VAR(int, m_iExtraHappinessPerXPoliciesFromPolicies)
+SYNC_ARCHIVE_VAR(int, m_iHappinessPerXGreatWorks)
+SYNC_ARCHIVE_VAR(int, m_iEspionageModifier)
+SYNC_ARCHIVE_VAR(int, m_iSpyStartingRank)
+SYNC_ARCHIVE_VAR(int, m_iConversionModifier)
+SYNC_ARCHIVE_VAR(int, m_iExtraLeagueVotes)
+SYNC_ARCHIVE_VAR(int, m_iImprovementLeagueVotes)
+SYNC_ARCHIVE_VAR(int, m_iFaithToVotes)
+SYNC_ARCHIVE_VAR(int, m_iCapitalsToVotes)
+SYNC_ARCHIVE_VAR(int, m_iDoFToVotes)
+SYNC_ARCHIVE_VAR(int, m_iRAToVotes)
+SYNC_ARCHIVE_VAR(int, m_iDefensePactsToVotes)
+SYNC_ARCHIVE_VAR(int, m_iGPExpendInfluence)
+SYNC_ARCHIVE_VAR(bool, m_bIsLeagueAid)
+SYNC_ARCHIVE_VAR(bool, m_bIsLeagueScholar)
+SYNC_ARCHIVE_VAR(bool, m_bIsLeagueArt)
+SYNC_ARCHIVE_VAR(int, m_iScienceRateFromLeague)
+SYNC_ARCHIVE_VAR(int, m_iScienceRateFromLeagueAid)
+SYNC_ARCHIVE_VAR(int, m_iLeagueCultureCityModifier)
+SYNC_ARCHIVE_VAR(int, m_iAdvancedStartPoints)
+SYNC_ARCHIVE_VAR(int, m_iAttackBonusTurns)
+SYNC_ARCHIVE_VAR(int, m_iCultureBonusTurns)
+SYNC_ARCHIVE_VAR(int, m_iTourismBonusTurns)
+SYNC_ARCHIVE_VAR(int, m_iGoldenAgeProgressMeter)
+SYNC_ARCHIVE_VAR(int, m_iGoldenAgeMeterMod)
+SYNC_ARCHIVE_VAR(int, m_iNumGoldenAges)
+SYNC_ARCHIVE_VAR(int, m_iGoldenAgeTurns)
+SYNC_ARCHIVE_VAR(int, m_iNumUnitGoldenAges)
+SYNC_ARCHIVE_VAR(int, m_iStrikeTurns)
+SYNC_ARCHIVE_VAR(int, m_iGoldenAgeModifier)
+SYNC_ARCHIVE_VAR(int, m_iProductionBonusTurnsConquest)
+SYNC_ARCHIVE_VAR(int, m_iCultureBonusTurnsConquest)
+SYNC_ARCHIVE_VAR(int, m_iFreeGreatPeopleCreated)
+SYNC_ARCHIVE_VAR(int, m_iFreeGreatGeneralsCreated)
+SYNC_ARCHIVE_VAR(int, m_iFreeGreatAdmiralsCreated)
+SYNC_ARCHIVE_VAR(int, m_iFreeGreatMerchantsCreated)
+SYNC_ARCHIVE_VAR(int, m_iFreeGreatScientistsCreated)
+SYNC_ARCHIVE_VAR(int, m_iFreeGreatEngineersCreated)
+SYNC_ARCHIVE_VAR(int, m_iFreeGreatWritersCreated)
+SYNC_ARCHIVE_VAR(int, m_iFreeGreatArtistsCreated)
+SYNC_ARCHIVE_VAR(int, m_iFreeGreatMusiciansCreated)
+SYNC_ARCHIVE_VAR(int, m_iFreeGreatDiplomatsCreated)
+SYNC_ARCHIVE_VAR(int, m_iGPExtra1Created)
+SYNC_ARCHIVE_VAR(int, m_iGPExtra2Created)
+SYNC_ARCHIVE_VAR(int, m_iGPExtra3Created)
+SYNC_ARCHIVE_VAR(int, m_iGPExtra4Created)
+SYNC_ARCHIVE_VAR(int, m_iGPExtra5Created)
+SYNC_ARCHIVE_VAR(int, m_iFreeGPExtra1Created)
+SYNC_ARCHIVE_VAR(int, m_iFreeGPExtra2Created)
+SYNC_ARCHIVE_VAR(int, m_iFreeGPExtra3Created)
+SYNC_ARCHIVE_VAR(int, m_iFreeGPExtra4Created)
+SYNC_ARCHIVE_VAR(int, m_iFreeGPExtra5Created)
+SYNC_ARCHIVE_VAR(int, m_iGreatPeopleCreated)
+SYNC_ARCHIVE_VAR(int, m_iGreatGeneralsCreated)
+SYNC_ARCHIVE_VAR(int, m_iGreatAdmiralsCreated)
+SYNC_ARCHIVE_VAR(int, m_iGreatMerchantsCreated)
+SYNC_ARCHIVE_VAR(int, m_iGreatScientistsCreated)
+SYNC_ARCHIVE_VAR(int, m_iGreatEngineersCreated)
+SYNC_ARCHIVE_VAR(int, m_iGreatWritersCreated)
+SYNC_ARCHIVE_VAR(int, m_iGreatArtistsCreated)
+SYNC_ARCHIVE_VAR(int, m_iGreatMusiciansCreated)
+SYNC_ARCHIVE_VAR(int, m_iGreatDiplomatsCreated)
+SYNC_ARCHIVE_VAR(int, m_iDiplomatsFromFaith)
+SYNC_ARCHIVE_VAR(int, m_iGPExtra1FromFaith)
+SYNC_ARCHIVE_VAR(int, m_iGPExtra2FromFaith)
+SYNC_ARCHIVE_VAR(int, m_iGPExtra3FromFaith)
+SYNC_ARCHIVE_VAR(int, m_iGPExtra4FromFaith)
+SYNC_ARCHIVE_VAR(int, m_iGPExtra5FromFaith)
+SYNC_ARCHIVE_VAR(int, m_iMerchantsFromFaith)
+SYNC_ARCHIVE_VAR(int, m_iScientistsFromFaith)
+SYNC_ARCHIVE_VAR(int, m_iWritersFromFaith)
+SYNC_ARCHIVE_VAR(int, m_iArtistsFromFaith)
+SYNC_ARCHIVE_VAR(int, m_iMusiciansFromFaith)
+SYNC_ARCHIVE_VAR(int, m_iGeneralsFromFaith)
+SYNC_ARCHIVE_VAR(int, m_iAdmiralsFromFaith)
+SYNC_ARCHIVE_VAR(int, m_iEngineersFromFaith)
+SYNC_ARCHIVE_VAR(int, m_iGreatPeopleThresholdModifier)
+SYNC_ARCHIVE_VAR(int, m_iGreatGeneralsThresholdModifier)
+SYNC_ARCHIVE_VAR(int, m_iGreatAdmiralsThresholdModifier)
+SYNC_ARCHIVE_VAR(int, m_iGreatGeneralCombatBonus)
+SYNC_ARCHIVE_VAR(int, m_iAnarchyNumTurns)
+SYNC_ARCHIVE_VAR(int, m_iPolicyCostModifier)
+SYNC_ARCHIVE_VAR(int, m_iGreatPeopleRateModifier)
+SYNC_ARCHIVE_VAR(int, m_iGreatPeopleRateModFromBldgs)
+SYNC_ARCHIVE_VAR(int, m_iGreatGeneralRateModifier)
+SYNC_ARCHIVE_VAR(int, m_iGreatGeneralRateModFromBldgs)
+SYNC_ARCHIVE_VAR(int, m_iDomesticGreatGeneralRateModifier)
+SYNC_ARCHIVE_VAR(int, m_iGreatAdmiralRateModifier)
+SYNC_ARCHIVE_VAR(int, m_iGreatWriterRateModifier)
+SYNC_ARCHIVE_VAR(int, m_iGreatArtistRateModifier)
+SYNC_ARCHIVE_VAR(int, m_iGreatMusicianRateModifier)
+SYNC_ARCHIVE_VAR(int, m_iGreatMerchantRateModifier)
+SYNC_ARCHIVE_VAR(int, m_iGreatDiplomatRateModifier)
+SYNC_ARCHIVE_VAR(int, m_iGreatScientistRateModifier)
+SYNC_ARCHIVE_VAR(int, m_iGreatScientistBeakerModifier)
+SYNC_ARCHIVE_VAR(int, m_iGreatEngineerHurryMod)
+SYNC_ARCHIVE_VAR(int, m_iTechCostXCitiesModifier)
+SYNC_ARCHIVE_VAR(int, m_iTourismCostXCitiesMod)
+SYNC_ARCHIVE_VAR(int, m_iGreatEngineerRateModifier)
+SYNC_ARCHIVE_VAR(int, m_iGreatPersonExpendGold)
+SYNC_ARCHIVE_VAR(int, m_iPovertyUnhappinessMod)
+SYNC_ARCHIVE_VAR(int, m_iDefenseUnhappinessMod)
+SYNC_ARCHIVE_VAR(int, m_iUnculturedUnhappinessMod)
+SYNC_ARCHIVE_VAR(int, m_iIlliteracyUnhappinessMod)
+SYNC_ARCHIVE_VAR(int, m_iMinorityUnhappinessMod)
+SYNC_ARCHIVE_VAR(int, m_iPovertyUnhappinessModCapital)
+SYNC_ARCHIVE_VAR(int, m_iDefenseUnhappinessModCapital)
+SYNC_ARCHIVE_VAR(int, m_iUnculturedUnhappinessModCapital)
+SYNC_ARCHIVE_VAR(int, m_iIlliteracyUnhappinessModCapital)
+SYNC_ARCHIVE_VAR(int, m_iMinorityUnhappinessModCapital)
+SYNC_ARCHIVE_VAR(int, m_iPuppetUnhappinessMod)
+SYNC_ARCHIVE_VAR(int, m_iNoUnhappfromXSpecialists)
+SYNC_ARCHIVE_VAR(int, m_iHappfromXSpecialists)
+SYNC_ARCHIVE_VAR(int, m_iNoUnhappfromXSpecialistsCapital)
+SYNC_ARCHIVE_VAR(int, m_iSpecialistFoodChange)
+SYNC_ARCHIVE_VAR(int, m_iWarWearinessModifier)
+SYNC_ARCHIVE_VAR(int, m_iWarScoreModifier)
+SYNC_ARCHIVE_VAR(bool, m_bEnablesTechSteal)
+SYNC_ARCHIVE_VAR(bool, m_bEnablesGWSteal)
+SYNC_ARCHIVE_VAR(int, m_iGarrisonsOccupiedUnhapppinessMod)
+SYNC_ARCHIVE_VAR(int, m_iXPopulationConscription)
+SYNC_ARCHIVE_VAR(int, m_iExtraMoves)
+SYNC_ARCHIVE_VAR(int, m_iNoUnhappinessExpansion)
+SYNC_ARCHIVE_VAR(int, m_iNoUnhappyIsolation)
+SYNC_ARCHIVE_VAR(int, m_iDoubleBorderGA)
+SYNC_ARCHIVE_VAR(int, m_iIncreasedQuestInfluence)
+SYNC_ARCHIVE_VAR(int, m_iCultureBombBoost)
+SYNC_ARCHIVE_VAR(int, m_iPuppetProdMod)
+SYNC_ARCHIVE_VAR(int, m_iOccupiedProdMod)
+SYNC_ARCHIVE_VAR(int, m_iGoldInternalTrade)
+SYNC_ARCHIVE_VAR(int, m_iFreeWCVotes)
+SYNC_ARCHIVE_VAR(int, m_iInfluenceGPExpend)
+SYNC_ARCHIVE_VAR(int, m_iFreeTradeRoute)
+SYNC_ARCHIVE_VAR(int, m_iFreeSpy)
+SYNC_ARCHIVE_VAR(int, m_iReligionDistance)
+SYNC_ARCHIVE_VAR(int, m_iPressureMod)
+SYNC_ARCHIVE_VAR(int, m_iTradeReligionModifier)
+SYNC_ARCHIVE_VAR(int, m_iCityStateCombatModifier)
+SYNC_ARCHIVE_VAR(int, m_iMaxAirUnits)
+SYNC_ARCHIVE_VAR(int, m_iInvestmentModifier)
+SYNC_ARCHIVE_VAR(int, m_iMissionInfluenceModifier)
+SYNC_ARCHIVE_VAR(int, m_iHappinessPerActiveTradeRoute)
+SYNC_ARCHIVE_VAR(int, m_iCSResourcesCountMonopolies)
+SYNC_ARCHIVE_VAR(int, m_iConquestPerEraBuildingProductionMod)
+SYNC_ARCHIVE_VAR(int, m_iAdmiralLuxuryBonus)
+SYNC_ARCHIVE_VAR(int, m_iPuppetYieldPenaltyMod)
+SYNC_ARCHIVE_VAR(int, m_iNeedsModifierFromAirUnits)
+SYNC_ARCHIVE_VAR(int, m_iFlatDefenseFromAirUnits)
+SYNC_ARCHIVE_VAR(int, m_iMaxGlobalBuildingProductionModifier)
+SYNC_ARCHIVE_VAR(int, m_iMaxTeamBuildingProductionModifier)
+SYNC_ARCHIVE_VAR(int, m_iMaxPlayerBuildingProductionModifier)
+SYNC_ARCHIVE_VAR(int, m_iFreeExperience)
+SYNC_ARCHIVE_VAR(int, m_iFreeExperienceFromBldgs)
+SYNC_ARCHIVE_VAR(int, m_iFreeExperienceFromMinors)
+SYNC_ARCHIVE_VAR(int, m_iFeatureProductionModifier)
+SYNC_ARCHIVE_VAR(int, m_iWorkerSpeedModifier)
+SYNC_ARCHIVE_VAR(int, m_iImprovementCostModifier)
+SYNC_ARCHIVE_VAR(int, m_iImprovementUpgradeRateModifier)
+SYNC_ARCHIVE_VAR(int, m_iSpecialistProductionModifier)
+SYNC_ARCHIVE_VAR(int, m_iMilitaryProductionModifier)
+SYNC_ARCHIVE_VAR(int, m_iSpaceProductionModifier)
+SYNC_ARCHIVE_VAR(int, m_iCityDefenseModifier)
+SYNC_ARCHIVE_VAR(int, m_iUnitFortificationModifier)
+SYNC_ARCHIVE_VAR(int, m_iUnitBaseHealModifier)
+SYNC_ARCHIVE_VAR(int, m_iWonderProductionModifier)
+SYNC_ARCHIVE_VAR(int, m_iSettlerProductionModifier)
+SYNC_ARCHIVE_VAR(int, m_iCapitalSettlerProductionModifier)
+SYNC_ARCHIVE_VAR(int, m_iUnitProductionMaintenanceMod)
+SYNC_ARCHIVE_VAR(int, m_iUnitGrowthMaintenanceMod)
+SYNC_ARCHIVE_VAR(int, m_iPolicyCostBuildingModifier)
+SYNC_ARCHIVE_VAR(int, m_iPolicyCostMinorCivModifier)
+SYNC_ARCHIVE_VAR(int, m_iInfluenceSpreadModifier)
+SYNC_ARCHIVE_VAR(int, m_iExtraVotesPerDiplomat)
+SYNC_ARCHIVE_VAR(int, m_iNumNukeUnits)
+SYNC_ARCHIVE_VAR(int, m_iNumOutsideUnits)
+SYNC_ARCHIVE_VAR(int, m_iBaseFreeUnits)
+SYNC_ARCHIVE_VAR(int, m_iBaseFreeMilitaryUnits)
+SYNC_ARCHIVE_VAR(int, m_iFreeUnitsPopulationPercent)
+SYNC_ARCHIVE_VAR(int, m_iFreeMilitaryUnitsPopulationPercent)
+SYNC_ARCHIVE_VAR(int, m_iGoldPerUnit)
+SYNC_ARCHIVE_VAR(int, m_iGoldPerMilitaryUnit)
+SYNC_ARCHIVE_VAR(int, m_iImprovementGoldMaintenanceMod)
+SYNC_ARCHIVE_VAR(int, m_iRouteBuilderCostMod)
+SYNC_ARCHIVE_VAR(int, m_iBuildingGoldMaintenanceMod)
+SYNC_ARCHIVE_VAR(int, m_iUnitGoldMaintenanceMod)
+SYNC_ARCHIVE_VAR(int, m_iUnitSupplyMod)
+SYNC_ARCHIVE_VAR(int, m_iExtraUnitCost)
+SYNC_ARCHIVE_VAR(int, m_iNumMilitaryUnits)
+SYNC_ARCHIVE_VAR(int, m_iHappyPerMilitaryUnit)
+SYNC_ARCHIVE_VAR(int, m_iHappinessToCulture)
+SYNC_ARCHIVE_VAR(int, m_iHappinessToScience)
+SYNC_ARCHIVE_VAR(int, m_iHalfSpecialistUnhappinessCount)
+SYNC_ARCHIVE_VAR(int, m_iHalfSpecialistFoodCount)
+SYNC_ARCHIVE_VAR(int, m_iHalfSpecialistFoodCapitalCount)
+SYNC_ARCHIVE_VAR(int, m_iTradeRouteLandDistanceModifier)
+SYNC_ARCHIVE_VAR(int, m_iTradeRouteSeaDistanceModifier)
+SYNC_ARCHIVE_VAR(bool, m_bNullifyInfluenceModifier)
+SYNC_ARCHIVE_VAR(int, m_iMilitaryFoodProductionCount)
+SYNC_ARCHIVE_VAR(int, m_iGoldenAgeCultureBonusDisabledCount)
+SYNC_ARCHIVE_VAR(int, m_iNumMissionarySpreads)
+SYNC_ARCHIVE_VAR(int, m_iSecondReligionPantheonCount)
+SYNC_ARCHIVE_VAR(int, m_iEnablesSSPartHurryCount)
+SYNC_ARCHIVE_VAR(int, m_iEnablesSSPartPurchaseCount)
+SYNC_ARCHIVE_VAR(int, m_iConscriptCount)
+SYNC_ARCHIVE_VAR(int, m_iMaxConscript)
+SYNC_ARCHIVE_VAR(int, m_iHighestUnitLevel)
+SYNC_ARCHIVE_VAR(int, m_iOverflowResearch)
+SYNC_ARCHIVE_VAR(int, m_iExpModifier)
+SYNC_ARCHIVE_VAR(int, m_iExpInBorderModifier)
+SYNC_ARCHIVE_VAR(int, m_iLevelExperienceModifier)
+SYNC_ARCHIVE_VAR(int, m_iMinorQuestFriendshipMod)
+SYNC_ARCHIVE_VAR(int, m_iMinorGoldFriendshipMod)
+SYNC_ARCHIVE_VAR(int, m_iMinorFriendshipMinimum)
+SYNC_ARCHIVE_VAR(int, m_iMinorFriendshipDecayMod)
+SYNC_ARCHIVE_VAR(int, m_iMinorScienceAlliesCount)
+SYNC_ARCHIVE_VAR(int, m_iMinorResourceBonusCount)
+SYNC_ARCHIVE_VAR(int, m_iAbleToAnnexCityStatesCount)
+SYNC_ARCHIVE_VAR(int, m_iOnlyTradeSameIdeology)
+SYNC_ARCHIVE_VAR(int, m_iSupplyFreeUnits)
+SYNC_ARCHIVE_VAR(std::vector<CvString>, m_aistrInstantYield)
+SYNC_ARCHIVE_VAR(std::vector<bool>, m_abActiveContract)
+SYNC_ARCHIVE_VAR(int, m_iJFDReformCooldownRate)
+SYNC_ARCHIVE_VAR(int, m_iJFDGovernmentCooldownRate)
+SYNC_ARCHIVE_VAR(CvString, m_strJFDPoliticKey)
+SYNC_ARCHIVE_VAR(CvString, m_strJFDLegislatureName)
+SYNC_ARCHIVE_VAR(int, m_iJFDPoliticLeader)
+SYNC_ARCHIVE_VAR(int, m_iJFDSovereignty)
+SYNC_ARCHIVE_VAR(int, m_iJFDGovernment)
+SYNC_ARCHIVE_VAR(int, m_iJFDReformCooldown)
+SYNC_ARCHIVE_VAR(int, m_iJFDGovernmentCooldown)
+SYNC_ARCHIVE_VAR(int, m_iJFDPiety)
+SYNC_ARCHIVE_VAR(int, m_iJFDPietyRate)
+SYNC_ARCHIVE_VAR(int, m_iJFDConversionTurn)
+SYNC_ARCHIVE_VAR(bool, m_bJFDSecularized)
+SYNC_ARCHIVE_VAR(CvString, m_strJFDCurrencyName)
+SYNC_ARCHIVE_VAR(int, m_iJFDProsperity)
+SYNC_ARCHIVE_VAR(int, m_iJFDCurrency)
+SYNC_ARCHIVE_VAR(int, m_iGoldenAgeTourism)
+SYNC_ARCHIVE_VAR(int, m_iExtraCultureandScienceTradeRoutes)
+SYNC_ARCHIVE_VAR(int, m_iArchaeologicalDigTourism)
+SYNC_ARCHIVE_VAR(int, m_iUpgradeCSVassalTerritory)
+SYNC_ARCHIVE_VAR(int, m_iRazingSpeedBonus)
+SYNC_ARCHIVE_VAR(int, m_iNoPartisans)
+SYNC_ARCHIVE_VAR(int, m_iSpawnCooldown)
+SYNC_ARCHIVE_VAR(int, m_iAbleToMarryCityStatesCount)
+SYNC_ARCHIVE_VAR(bool, m_bTradeRoutesInvulnerable)
+SYNC_ARCHIVE_VAR(int, m_iTRSpeedBoost)
+SYNC_ARCHIVE_VAR(int, m_iVotesPerGPT)
+SYNC_ARCHIVE_VAR(int, m_iTRVisionBoost)
+SYNC_ARCHIVE_VAR(int, m_iEventTourism)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiGlobalTourismAlreadyReceived)
+SYNC_ARCHIVE_VAR(int, m_iEventTourismCS)
+SYNC_ARCHIVE_VAR(int, m_iNumHistoricEvent)
+SYNC_ARCHIVE_VAR(int, m_iSingleVotes)
+SYNC_ARCHIVE_VAR(int, m_iMonopolyModFlat)
+SYNC_ARCHIVE_VAR(int, m_iMonopolyModPercent)
+SYNC_ARCHIVE_VAR(int, m_iCachedValueOfPeaceWithHuman)
+SYNC_ARCHIVE_VAR(int, m_iFaithPurchaseCooldown)
+SYNC_ARCHIVE_VAR(int, m_iCSAllies)
+SYNC_ARCHIVE_VAR(int, m_iCSFriends)
+SYNC_ARCHIVE_VAR(int, m_iCitiesNeedingTerrainImprovements)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiBestMilitaryCombatClassCity)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiBestMilitaryDomainCity)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiEventChoiceDuration)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiEventIncrement)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiEventCooldown)
+SYNC_ARCHIVE_VAR(std::vector<bool>, m_abEventActive)
+SYNC_ARCHIVE_VAR(std::vector<bool>, m_abEventChoiceActive)
+SYNC_ARCHIVE_VAR(std::vector<bool>, m_abEventChoiceFired)
+SYNC_ARCHIVE_VAR(std::vector<bool>, m_abEventFired)
+SYNC_ARCHIVE_VAR(int, m_iPlayerEventCooldown)
+SYNC_ARCHIVE_VAR(std::vector<bool>, m_abNWOwned)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiUnitClassProductionModifiers)
+SYNC_ARCHIVE_VAR(int, m_iExtraSupplyPerPopulation)
+SYNC_ARCHIVE_VAR(int, m_iCitySupplyFlatGlobal)
+SYNC_ARCHIVE_VAR(int, m_iMissionaryExtraStrength)
+SYNC_ARCHIVE_VAR(int, m_iFreeSpecialist)
+SYNC_ARCHIVE_VAR(int, m_iCultureBombTimer)
+SYNC_ARCHIVE_VAR(int, m_iConversionTimer)
+SYNC_ARCHIVE_VAR(int, m_iCapitalCityID)
+SYNC_ARCHIVE_VAR(int, m_iCitiesLost)
+SYNC_ARCHIVE_VAR(int, m_iMilitaryRating)
+SYNC_ARCHIVE_VAR(int, m_iMilitaryMight)
+SYNC_ARCHIVE_VAR(int, m_iEconomicMight)
+SYNC_ARCHIVE_VAR(int, m_iProductionMight)
+SYNC_ARCHIVE_VAR(int, m_iTurnSliceMightRecomputed)
+SYNC_ARCHIVE_VAR(int, m_iNewCityExtraPopulation)
+SYNC_ARCHIVE_VAR(int, m_iFreeFoodBox)
+SYNC_ARCHIVE_VAR(int, m_iScenarioScore1)
+SYNC_ARCHIVE_VAR(int, m_iScenarioScore2)
+SYNC_ARCHIVE_VAR(int, m_iScenarioScore3)
+SYNC_ARCHIVE_VAR(int, m_iScenarioScore4)
+SYNC_ARCHIVE_VAR(int, m_iScoreFromFutureTech)
+SYNC_ARCHIVE_VAR(int, m_iTurnLastAttackedMinorCiv)
+SYNC_ARCHIVE_VAR(int, m_iCombatExperienceTimes100)
+SYNC_ARCHIVE_VAR(int, m_iLifetimeCombatExperienceTimes100)
+SYNC_ARCHIVE_VAR(int, m_iNavalCombatExperienceTimes100)
+SYNC_ARCHIVE_VAR(int, m_iBorderObstacleCount)
+SYNC_ARCHIVE_VAR(int, m_iBorderGainlessPillageCount)
+SYNC_ARCHIVE_VAR(int, m_iPopRushHurryCount)
+SYNC_ARCHIVE_VAR(int, m_iTotalImprovementsBuilt)
+SYNC_ARCHIVE_VAR(int, m_iCostNextPolicy)
+SYNC_ARCHIVE_VAR(int, m_iNumBuilders)
+SYNC_ARCHIVE_VAR(int, m_iMaxNumBuilders)
+SYNC_ARCHIVE_VAR(int, m_iCityStrengthMod)
+SYNC_ARCHIVE_VAR(int, m_iCityGrowthMod)
+SYNC_ARCHIVE_VAR(int, m_iCapitalGrowthMod)
+SYNC_ARCHIVE_VAR(int, m_iNumPlotsBought)
+SYNC_ARCHIVE_VAR(int, m_iPlotGoldCostMod)
+SYNC_ARCHIVE_VAR(int, m_iCityWorkingChange)
+SYNC_ARCHIVE_VAR(int, m_iCityAutomatonWorkersChange)
+SYNC_ARCHIVE_VAR(int, m_iCachedGoldRate)
+SYNC_ARCHIVE_VAR(int, m_iPlotCultureCostModifier)
+SYNC_ARCHIVE_VAR(int, m_iPlotCultureExponentModifier)
+SYNC_ARCHIVE_VAR(int, m_iNumCitiesPolicyCostDiscount)
+SYNC_ARCHIVE_VAR(int, m_iGarrisonedCityRangeStrikeModifier)
+SYNC_ARCHIVE_VAR(int, m_iGarrisonFreeMaintenanceCount)
+SYNC_ARCHIVE_VAR(int, m_iNumCitiesFreeCultureBuilding)
+SYNC_ARCHIVE_VAR(int, m_iNumCitiesFreeFoodBuilding)
+SYNC_ARCHIVE_VAR(int, m_iUnitPurchaseCostModifier)
+SYNC_ARCHIVE_VAR(int, m_iAllFeatureProduction)
+SYNC_ARCHIVE_VAR(int, m_iCityDistanceHighwaterMark)
+SYNC_ARCHIVE_VAR(int, m_iOriginalCapitalX)
+SYNC_ARCHIVE_VAR(int, m_iOriginalCapitalY)
+SYNC_ARCHIVE_VAR(int, m_iHolyCityX)
+SYNC_ARCHIVE_VAR(int, m_iHolyCityY)
+SYNC_ARCHIVE_VAR(int, m_iNumWonders)
+SYNC_ARCHIVE_VAR(int, m_iNumPolicies)
+SYNC_ARCHIVE_VAR(int, m_iNumGreatPeople)
+SYNC_ARCHIVE_VAR(int, m_iCityConnectionHappiness)
+SYNC_ARCHIVE_VAR(int, m_iHolyCityID)
+SYNC_ARCHIVE_VAR(int, m_iTurnsSinceSettledLastCity)
+SYNC_ARCHIVE_VAR(int, m_iNumNaturalWondersDiscoveredInArea)
+SYNC_ARCHIVE_VAR(int, m_iStrategicResourceMod)
+SYNC_ARCHIVE_VAR(int, m_iSpecialistCultureChange)
+SYNC_ARCHIVE_VAR(int, m_iGreatPeopleSpawnCounter)
+SYNC_ARCHIVE_VAR(int, m_iFreeTechCount)
+SYNC_ARCHIVE_VAR(int, m_iMedianTechPercentage)
+SYNC_ARCHIVE_VAR(int, m_iNumFreePolicies)
+SYNC_ARCHIVE_VAR(int, m_iNumFreePoliciesEver)
+SYNC_ARCHIVE_VAR(int, m_iNumFreeTenets)
+SYNC_ARCHIVE_VAR(int, m_iLastSliceMoved)
+SYNC_ARCHIVE_VAR(uint, m_uiStartTime)
+SYNC_ARCHIVE_VAR(bool, m_bHasUUPeriod)
+SYNC_ARCHIVE_VAR(bool, m_bNoNewWars)
+SYNC_ARCHIVE_VAR(bool, m_bHasBetrayedMinorCiv)
+SYNC_ARCHIVE_VAR(bool, m_bAlive)
+SYNC_ARCHIVE_VAR(bool, m_bEverAlive)
+SYNC_ARCHIVE_VAR(bool, m_bPotentiallyAlive)
+SYNC_ARCHIVE_VAR(bool, m_bBeingResurrected)
+SYNC_ARCHIVE_VAR(bool, m_bTurnActive)
+SYNC_ARCHIVE_VAR(bool, m_bAutoMoves)
+SYNC_ARCHIVE_VAR(bool, m_bEndTurn)
+SYNC_ARCHIVE_VAR(bool, m_bDynamicTurnsSimultMode)
+SYNC_ARCHIVE_VAR(bool, m_bPbemNewTurn)
+SYNC_ARCHIVE_VAR(bool, m_bExtendedGame)
+SYNC_ARCHIVE_VAR(bool, m_bFoundedFirstCity)
+SYNC_ARCHIVE_VAR(int, m_iNumCitiesFounded)
+SYNC_ARCHIVE_VAR(bool, m_bStrike)
+SYNC_ARCHIVE_VAR(bool, m_bCramped)
+SYNC_ARCHIVE_VAR(bool, m_bLostCapital)
+SYNC_ARCHIVE_VAR(PlayerTypes, m_eConqueror)
+SYNC_ARCHIVE_VAR(bool, m_bLostHolyCity)
+SYNC_ARCHIVE_VAR(PlayerTypes, m_eHolyCityConqueror)
+SYNC_ARCHIVE_VAR(bool, m_bHasAdoptedStateReligion)
+SYNC_ARCHIVE_VAR(bool, m_bAlliesGreatPersonBiasApplied)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiCityYieldChange)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiCoastalCityYieldChange)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiCapitalYieldChange)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiCapitalYieldPerPopChange)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiCapitalYieldPerPopChangeEmpire)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiSeaPlotYield)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldRateModifier)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiJFDPoliticPercent)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldFromMinors)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiResourceFromCSAlliances)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiResourceShortageValue)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldFromBirth)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldFromBirthCapital)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldFromDeath)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldFromPillage)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldFromVictory)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldFromConstruction)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldFromwonderConstruction)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldFromTech)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldFromBorderGrowth)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldGPExpend)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiConquerorYield)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiFounderYield)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiArtifactYieldBonus)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiArtYieldBonus)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiMusicYieldBonus)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiLitYieldBonus)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiFilmYieldBonus)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiRelicYieldBonus)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiReligionYieldRateModifier)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiGoldenAgeYieldMod)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldFromNonSpecialistCitizens)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldModifierFromGreatWorks)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldModifierFromActiveSpies)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldFromDelegateCount)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiBuildingClassCulture)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiDomainFreeExperiencePerGreatWorkGlobal)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiCityYieldModFromMonopoly)
+SYNC_ARCHIVE_VAR(std::vector<UnitAITypes>, m_neededUnitAITypes)
+SYNC_ARCHIVE_VAR(bool, m_bAllowsProductionTradeRoutesGlobal)
+SYNC_ARCHIVE_VAR(bool, m_bAllowsFoodTradeRoutesGlobal)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiCapitalYieldRateModifier)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiExtraYieldThreshold)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiSpecialistExtraYield)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiPlayerNumTurnsAtPeace)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiPlayerNumTurnsAtWar)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiPlayerNumTurnsSinceCityCapture)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiProximityToPlayer)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiResearchAgreementCounter)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiIncomingUnitTypes)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiIncomingUnitCountdowns)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiSiphonLuxuryCount)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiGreatWorkYieldChange)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiTourismBonusTurnsPlayer)
+SYNC_ARCHIVE_VAR(SYNC_ARCHIVE_VAR_TYPE(std::vector< std::pair<uint, int> >), m_aOptions)
+SYNC_ARCHIVE_VAR(CvString, m_strReligionKey)
+SYNC_ARCHIVE_VAR(CvString, m_strScriptData)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiNumResourceUsed)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiNumResourceTotal)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiResourceGiftedToMinors)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiResourceExport)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiResourceImportFromMajor)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiResourceFromMinors)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiResourcesSiphoned)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiImprovementCount)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiTotalImprovementsBuilt)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiBuildingChainSteps)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiFreeBuildingCount)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiFreePromotionCount)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiUnitCombatProductionModifiers)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiUnitCombatFreeExperiences)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiUnitClassCount)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiUnitClassMaking)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiBuildingClassCount)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiBuildingClassMaking)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiProjectMaking)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiHurryCount)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiHurryModifier)
+SYNC_ARCHIVE_VAR(bool, m_bVassalLevy)
+SYNC_ARCHIVE_VAR(int, m_iVassalGoldMaintenanceMod)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiNumCitiesFreeChosenBuilding)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_pabFreeChosenBuildingNewCity)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_pabAllCityFreeBuilding)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_pabNewFoundCityFreeUnit)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_pabNewFoundCityFreeBuilding)
+SYNC_ARCHIVE_VAR(std::vector<bool>, m_pabLoyalMember)
+SYNC_ARCHIVE_VAR(std::vector<bool>, m_pabHasGlobalMonopoly)
+SYNC_ARCHIVE_VAR(std::vector<bool>, m_pabHasStrategicMonopoly)
+SYNC_ARCHIVE_VAR(std::vector<bool>, m_pabGetsScienceFromPlayer)
+SYNC_ARCHIVE_VAR(SYNC_ARCHIVE_VAR_TYPE(std::vector< Firaxis::Array<int, NUM_YIELD_TYPES > >), m_ppaaiSpecialistExtraYield)
+SYNC_ARCHIVE_VAR(SYNC_ARCHIVE_VAR_TYPE(std::vector< Firaxis::Array<int, NUM_YIELD_TYPES > >), m_ppiBuildingClassYieldChange)
+SYNC_ARCHIVE_VAR(SYNC_ARCHIVE_VAR_TYPE(std::vector< Firaxis::Array<int, NUM_YIELD_TYPES > >), m_ppaaiImprovementYieldChange)
+SYNC_ARCHIVE_VAR(bool, m_bEverPoppedGoody)
+SYNC_ARCHIVE_VAR(bool, m_bEverTrainedBuilder)
+SYNC_ARCHIVE_VAR(int, m_iPreviousBestSettlePlot)
+SYNC_ARCHIVE_VAR(int, m_iFoundValueOfCapital)
+SYNC_ARCHIVE_VAR(int, m_iNumFreeGreatPeople)
+SYNC_ARCHIVE_VAR(int, m_iNumMayaBoosts)
+SYNC_ARCHIVE_VAR(int, m_iNumFaithGreatPeople)
+SYNC_ARCHIVE_VAR(int, m_iNumArchaeologyChoices)
+SYNC_ARCHIVE_VAR(int, m_iFaithPurchaseIndex)
+SYNC_ARCHIVE_VAR(int, m_iFractionOriginalCapitalsUnderControl)
+SYNC_ARCHIVE_VAR(int, m_iAvgUnitExp100)
+SYNC_ARCHIVE_VAR(int, m_iNumMilitarySeaUnits)
+SYNC_ARCHIVE_VAR(int, m_iNumMilitaryAirUnits)
+SYNC_ARCHIVE_VAR(int, m_iNumMilitaryLandUnits)
+SYNC_ARCHIVE_VAR(int, m_iMilitarySeaMight)
+SYNC_ARCHIVE_VAR(int, m_iMilitaryAirMight)
+SYNC_ARCHIVE_VAR(int, m_iMilitaryLandMight)
+SYNC_ARCHIVE_END()
 
 #endif

--- a/CvGameCoreDLL_Expansion2/CvPlot.h
+++ b/CvGameCoreDLL_Expansion2/CvPlot.h
@@ -27,6 +27,7 @@
 #include "CvGlobals.h"
 #include "CvGame.h"
 #include "CvEnums.h"
+#include "CvSerialize.h"
 
 #pragma warning( disable: 4251 )		// needs to have dll-interface to be used by clients of class
 
@@ -480,7 +481,7 @@ public:
 	}
 	inline FeatureTypes getFeatureType() const
 	{
-		return (FeatureTypes)m_eFeatureType.get();
+		return (FeatureTypes)m_eFeatureType;
 	}
 
 	int getTurnDamage(bool bIgnoreTerrainDamage, bool bIgnoreFeatureDamage, bool bExtraTerrainDamage, bool bExtraFeatureDamage) const
@@ -837,6 +838,8 @@ public:
 
 	bool canTrain(UnitTypes eUnit, bool bContinue, bool bTestVisible) const;
 
+	template<typename Plot, typename Visitor>
+	static void Serialize(Plot& plot, Visitor& visitor);
 	void read(FDataStream& kStream);
 	void write(FDataStream& kStream) const;
 
@@ -845,8 +848,8 @@ public:
 	char GetContinentType() const;
 	void SetContinentType(const char cContinent);
 
-	const FAutoArchive& getSyncArchive() const;
-	FAutoArchive& getSyncArchive();
+	const CvSyncArchive<CvPlot>& getSyncArchive() const;
+	CvSyncArchive<CvPlot>& getSyncArchive();
 	std::string debugDump(const FAutoVariableBase&) const;
 	std::string stackTraceRemark(const FAutoVariableBase&) const;
 
@@ -1058,8 +1061,8 @@ protected:
 	short m_iImprovementDuration;
 	short m_iUpgradeProgress;
 
-	FAutoArchiveClassContainer<CvPlot> m_syncArchive; // this must appear before the first auto variable in the class
-	FAutoVariable<char, CvPlot> /*FeatureTypes*/ m_eFeatureType; 
+	SYNC_ARCHIVE_MEMBER(CvPlot)
+	char /*FeatureTypes*/ m_eFeatureType; 
 	//why only one autovariable? probably should extend this to everything the players may change about the plot
 	//ie improvements, routes, etc
 
@@ -1134,6 +1137,10 @@ namespace FSerialization
 void SyncPlots();
 void ClearPlotDeltas();
 }
+
+SYNC_ARCHIVE_BEGIN(CvPlot)
+SYNC_ARCHIVE_VAR(char, m_eFeatureType)
+SYNC_ARCHIVE_END()
 
 #if defined(MOD_BALANCE_CORE_MILITARY)
 struct SPlotWithScore

--- a/CvGameCoreDLL_Expansion2/CvSerialize.cpp
+++ b/CvGameCoreDLL_Expansion2/CvSerialize.cpp
@@ -2,3 +2,16 @@
 #include "CvSerialize.h"
 
 const std::string EmptyString = "";
+
+void CvSyncArchiveCollectDeltas(FAutoArchive& syncArchive, const std::vector<FAutoVariableBase*>& vars)
+{
+	for (std::vector<FAutoVariableBase*>::const_iterator it = vars.begin(); it != vars.end(); ++it)
+	{
+		ICvSyncVar& syncVar = static_cast<ICvSyncVar&>(*(*it));
+		if (syncVar.hasDelta())
+		{
+			syncArchive.touch(syncVar);
+			syncVar.clearDelta();
+		}
+	}
+}

--- a/CvGameCoreDLL_Expansion2/CvSerialize.h
+++ b/CvGameCoreDLL_Expansion2/CvSerialize.h
@@ -6,237 +6,278 @@
 // Shared empty string
 extern const std::string EmptyString;
 
-// Shared behavior for CvSyncVar specializations
-template<typename SyncTraits, typename T>
-class CvSyncVarBase
+// A serialize visitor that saves items it visits into a stream
+class CvStreamSaveVisitor
 {
 public:
-	typedef SyncTraits Traits;
-	typedef typename Traits::SyncArchive SyncArchive;
-	typedef typename Traits::ValueType ValueType;
-	enum
-	{
-		INDEX = Traits::INDEX,
-		SAVE = Traits::SAVE,
-	};
-
-	inline const ValueType& get() const
-	{
-		return m_value;
-	}
-
-	inline ValueType& dirtyGet(SyncArchive& syncArchive)
-	{
-		markDirty(syncArchive);
-		return m_value;
-	}
-
-	inline ValueType& unsafeGet()
-	{
-		return m_value;
-	}
-
-	inline void set(SyncArchive& syncArchive, const ValueType& value)
-	{
-		markDirty(syncArchive);
-		m_value = value;
-	}
-
-	inline operator const ValueType&() const
-	{
-		return m_value;
-	}
-
-	inline void markDirty(SyncArchive& syncArchive)
-	{
-		const std::vector<FAutoVariableBase*>& autoVars = syncArchive.getAutoVars();
-		if (!autoVars.empty())
-		{
-			FAssert(Traits::INDEX < autoVars.size());
-			syncArchive.touch(*autoVars[Traits::INDEX]);
-		}
-	}
-
-protected:
-	inline CvSyncVarBase() : m_value() {}
-	inline CvSyncVarBase(const ValueType& value) : m_value(value) {}
-
-	ValueType m_value;
-};
-
-// Holds a value that should maintain synchronization
-// Please do not specify the second template parameter! It is used for specialization deduction.
-template<typename SyncTraits, typename T = typename SyncTraits::ValueType>
-class CvSyncVar : public CvSyncVarBase<SyncTraits, T>
-{
-public:
-	inline CvSyncVar() {}
-	inline CvSyncVar(const ValueType& value)
-		: CvSyncVarBase<SyncTraits, T>(value)
-	{}
-};
-
-// Specialization for std::vector
-template<typename SyncTraits, typename T, typename Alloc>
-class CvSyncVar<SyncTraits, std::vector<T, Alloc>> : public CvSyncVarBase<SyncTraits, std::vector<T, Alloc>>
-{
-public:
-	typedef typename CvSyncVarBase<SyncTraits, std::vector<T, Alloc>>::ValueType ValueType;
-	typedef typename CvSyncVarBase<SyncTraits, std::vector<T, Alloc>>::SyncArchive SyncArchive;
-	typedef typename std::vector<T, Alloc>::const_iterator const_iterator;
-	typedef typename std::vector<T, Alloc>::const_reference const_reference;
-
-	inline CvSyncVar() {}
-	inline CvSyncVar(const ValueType& value)
-		: CvSyncVarBase<SyncTraits, T>(value)
+	CvStreamSaveVisitor(FDataStream& stream)
+		: m_stream(stream)
 	{}
 
-	inline void setAt(SyncArchive& syncArchive, size_t i, const_reference value)
+	template<typename T>
+	inline void operator()(const T& value)
 	{
-		markDirty(syncArchive);
-		this->m_value[i] = value;
+		m_stream << value;
 	}
 
-	inline const_reference getAt(size_t i) const
+	template<typename T>
+	inline CvStreamSaveVisitor operator<<(const T& value)
 	{
-		return this->m_value[i];
+		m_stream << value;
+		return *this;
 	}
 
-	inline const_reference operator[](size_t i) const
+	template<typename T>
+	inline CvStreamSaveVisitor operator>>(const T& value)
 	{
-		return this->m_value[i];
+		FAssertMsg(false, "CvStreamSaveVisitor is not meant for loading");
+		return *this;
 	}
 
-	inline size_t size() const { return this->m_value.size(); }
-	inline const_iterator begin() const { return this->m_value.begin(); }
-	inline const_iterator end() const { return this->m_value.end(); }
+	inline bool isSaving() const
+	{
+		return true;
+	}
 
-	inline void push_back(SyncArchive& syncArchive, const_reference src)
+	inline bool isLoading() const
 	{
-		dirtyGet(syncArchive).push_back(src);
+		return false;
 	}
-	inline void erase(SyncArchive& syncArchive, size_t i)
-	{
-		dirtyGet(syncArchive).erase(i);
-	}
-	inline void insert(SyncArchive& syncArchive, size_t i, const_reference src)
-	{
-		dirtyGet(syncArchive).insert(i, src);
-	}
-	inline void clear(SyncArchive& syncArchive)
-	{
-		dirtyGet(syncArchive).clear();
-	}
-	inline void resize(SyncArchive& syncArchive, size_t n)
-	{
-		dirtyGet(syncArchive).resize(n);
-	}
-	inline void resize(SyncArchive& syncArchive, size_t n, const_reference v)
-	{
-		dirtyGet(syncArchive).resize(n, v);
-	}
-	inline void reserve(SyncArchive& syncArchive, size_t n)
-	{
-		dirtyGet(syncArchive).reserve(n);
-	}
+
+private:
+	FDataStream& m_stream;
 };
 
-// Write CvSyncVar's value to a FDataStream
-template<typename SyncTraits>
-inline FDataStream& operator<<(FDataStream& stream, const CvSyncVar<SyncTraits>& syncVar)
+// A serialize visitor that loads items it visits from a stream
+class CvStreamLoadVisitor
 {
-	return stream << syncVar.get();
-}
+public:
+	CvStreamLoadVisitor(FDataStream& stream)
+		: m_stream(stream)
+	{}
 
-// Contains synchronization meta-data
-template<typename T>
-class CvSyncArchive;
-
-// Utility for visiting var traits of a CvSyncArchive
-template<typename SyncArchive, typename Visitor, size_t N, size_t VarCount>
-struct CvSyncArchiveVarsVisit
-{
-	static __forceinline void Step(Visitor& visitor)
+	template<typename T>
+	inline void operator()(T& value)
 	{
-		typedef typename SyncArchive::SyncVars SyncVars;
-		typedef typename SyncVars::template VarTraits<N>::Type Traits;
-		if (visitor(Traits()))
-		{
-			CvSyncArchiveVarsVisit<SyncArchive, Visitor, N + 1, VarCount>::Step(visitor);
-		}
+		m_stream >> value;
 	}
+
+	template<typename T>
+	inline CvStreamSaveVisitor operator<<(const T& value)
+	{
+		FAssertMsg(false, "CvStreamSaveVisitor is not meant for saving");
+		return *this;
+	}
+
+	template<typename T>
+	inline CvStreamSaveVisitor operator>>(T& value)
+	{
+		m_stream >> value;
+		return *this;
+	}
+
+	inline bool isSaving() const
+	{
+		return false;
+	}
+
+	inline bool isLoading() const
+	{
+		return true;
+	}
+
+private:
+	FDataStream& m_stream;
 };
 
-// Utility for visiting var traits of a CvSyncArchive
-template<typename SyncArchive, typename Visitor, size_t N>
-struct CvSyncArchiveVarsVisit<SyncArchive, Visitor, N, N>
+class ICvSyncVar : public FAutoVariableBase
 {
-	static __forceinline void Step(Visitor& visitor)
-	{
-		// Intentionally empty to terminate recursion
-	}
+public:
+	ICvSyncVar(const std::string& name, FAutoArchive& owner)
+		: FAutoVariableBase(name, owner)
+	{}
+	virtual bool hasDelta() const = 0;
 };
 
 template<typename T>
-class CvSyncArchiveBase;
+class CvSyncVarBase : public ICvSyncVar
+{
+public:
+	typedef T ValueType;
+
+	CvSyncVarBase(const std::string& name, FAutoArchive& owner, const ValueType& value)
+		: ICvSyncVar(name, owner)
+		, m_prevValue(value)
+	{}
+
+	inline const ValueType& previousValue() const
+	{
+		return m_prevValue;
+	}
+
+	inline ValueType& previousValue()
+	{
+		return m_prevValue;
+	}
+
+private:
+	// This contains the variable's last known value at the time of the most recent
+	// synchronization event. It is compared againstthe most recent value to determine 
+	// if we should send it.
+	ValueType m_prevValue;
+};
+
+template<typename VarTraits>
+class CvSyncVar : public CvSyncVarBase<typename VarTraits::ValueType>
+{
+public:
+	typedef typename VarTraits::ValueType ValueType;
+	typedef typename VarTraits::ContainerType ContainerType;
+	typedef typename VarTraits::SyncVarsType SyncVarsType;
+
+	CvSyncVar()
+		: CvSyncVarBase<ValueType>(EmptyString, getContainer().getSyncArchive(), currentValue())
+	{}
+	~CvSyncVar() {}
+
+	inline const SyncVarsType& getStorage() const
+	{
+		return VarTraits::GetStorage(*this);
+	}
+	inline SyncVarsType& getStorage() 
+	{
+		return VarTraits::GetStorage(*this);
+	}
+
+	inline const ContainerType& getContainer() const
+	{
+		return getStorage().getContainer();
+	}
+	inline ContainerType& getContainer()
+	{
+		return getStorage().getContainer();
+	}
+
+	inline const ValueType& currentValue() const
+	{
+		return VarTraits::Get(getContainer());
+	}
+	inline ValueType& currentValue()
+	{
+		return VarTraits::Get(getContainer());
+	}
+
+	inline void updateValue()
+	{
+		this->previousValue() = currentValue();
+	}
+
+	// ICvSyncVar Interface
+	virtual bool hasDelta() const
+	{
+		return this->previousValue() != currentValue();
+	}
+
+	// FAutoVariableBase interface
+	virtual void load(FDataStream& loadFrom)
+	{
+		loadFrom >> currentValue();
+	}
+	virtual void loadDelta(FDataStream& loadFrom)
+	{
+		load(loadFrom);
+	}
+	virtual void save(FDataStream& saveTo) const
+	{
+		saveTo << currentValue();
+	}
+	virtual void saveDelta(FDataStream& saveTo) const
+	{
+		save(saveTo);
+	}
+	virtual void clearDelta()
+	{
+		updateValue();
+	}
+	virtual bool compare(FDataStream& otherValue) const
+	{
+		ValueType other;
+		otherValue >> other;
+		const bool result = other == currentValue();
+		return result; // Place a conditional breakpoint here to help debug sync errors.
+	}
+	virtual void reset()
+	{
+		currentValue() = this->previousValue() = ValueType();
+	}
+	virtual const std::string& name() const
+	{
+		return EmptyString;
+	}
+	virtual void setStackTraceRemark()
+	{
+	}
+	virtual std::string debugDump(const std::vector<std::pair<std::string, std::string> >& callStacks) const
+	{
+		std::string result = FAutoVariableBase::debugDump(callStacks);
+		result += std::string("\n") + getContainer().debugDump(*this) + std::string("\n");
+#if !defined(FINAL_RELEASE)
+		result += std::string("local value=") + FSerialization::toString(m_value) + "\n";
+		result += std::string("remote value=") + FSerialization::toString(m_remoteValue) + "\n";
+#endif
+		return result;
+	}
+	virtual std::string toString() const
+	{
+		return FSerialization::toString(currentValue());
+	}
+};
+
+// This is intentionally outside of CvSyncArchive so that the compiler generates only one code path
+void CvSyncArchiveCollectDeltas(FAutoArchive& syncArchive, const std::vector<FAutoVariableBase*>& vars);
 
 template<typename Container>
-class CvSyncArchiveBase<CvSyncArchive<Container>> : public FAutoArchive
+class CvSyncArchive : public FAutoArchive
 {
-	typedef CvSyncArchive<Container> Derived;
+public:
+	typedef typename Container ContainerType;
+	friend Container;
+	class SyncVars;
 
-	struct WriteVisitor
-	{
-		inline WriteVisitor(FDataStream& stream, const Container& container)
-			: stream(stream)
-			, container(container)
-		{}
-
-		template<typename VarTraits>
-		__forceinline bool operator()(VarTraits)
-		{
-			if (VarTraits::SAVE)
-			{
-				stream << VarTraits::GetC(container);
-			}
-			return true;
-		}
-
-		FDataStream& stream;
-		const Container& container;
-	};
-
-	struct ReadVisitor
-	{
-		inline ReadVisitor(FDataStream& stream, Container& container)
-			: stream(stream)
-			, container(container)
-		{}
-
-		template<typename VarTraits>
-		__forceinline bool operator()(VarTraits)
-		{
-			if (VarTraits::SAVE)
-			{
-				typename VarTraits::VarType& var = VarTraits::Get(container);
-				stream >> var.unsafeGet();
-			}
-			return true;
-		}
-
-		FDataStream& stream;
-		Container& container;
-	};
+private:
+	CvSyncArchive()
+		: m_syncVarsStorage(NULL)
+	{}
 
 public:
-	CvSyncArchiveBase(Container& container)
-		: m_container(container)
-	{}
-	virtual ~CvSyncArchiveBase() {}
+	~CvSyncArchive()
+	{
+		SAFE_DELETE(m_syncVarsStorage);
+	}
 
-	//
+	const ContainerType& getContainer() const;
+	ContainerType& getContainer();
+
+	// Call once at initialization in multiplayer
+	inline void initSyncVars(SyncVars& syncVars)
+	{
+		FAssert(m_syncVarsStorage == NULL);
+		m_syncVarsStorage = &syncVars;
+	}
+	inline const std::vector<FAutoVariableBase*>& getContents() const
+	{
+		return m_contents;
+	}
+	inline std::vector<FAutoVariableBase*>& getContents()
+	{
+		return m_contents;
+	}
+	inline void collectDeltas()
+	{
+		CvSyncArchiveCollectDeltas(*this, getContents());
+	}
+
 	// FAutoArchive Interface
-	//
 	virtual const std::string* getVariableName(const FAutoVariableBase&) const
 	{
 		return NULL;
@@ -252,184 +293,62 @@ public:
 	{
 		return getContainer().stackTraceRemark(var);
 	}
-
-	// Sends a visitor to all the CvSyncVar traits
-	// The visitor may cancel at any time by returning false
-	template<typename Visitor>
-	static inline void Visit(Visitor& visitor)
-	{
-		CvSyncArchiveVarsVisit<Derived, Visitor, 0, Derived::VAR_COUNT>::Step(visitor);
-	}
-
-	inline void write(FDataStream& stream) const
-	{
-		WriteVisitor visitor(stream, getContainer());
-		Visit(visitor);
-	}
-
-	inline void read(FDataStream& stream)
-	{
-		ReadVisitor visitor(stream, getContainer());
-		Visit(visitor);
-	}
-
-	inline const Container& getContainer() const
-	{
-		return m_container;
-	}
-
-	inline Container& getContainer()
-	{
-		return m_container;
-	}
-
-	inline const std::vector<FAutoVariableBase*>& getAutoVars() const
-	{
-		return m_contents;
-	}
-
 private:
-	Container& m_container;
+	SyncVars* m_syncVarsStorage;
 };
-
-// Implements Fraxis' auto variable base interface for a sync var in an archive
-template<typename Traits>
-struct CvSyncVarAutoVariableBase : public FAutoVariableBase
-{
-	inline CvSyncVarAutoVariableBase()
-		: FAutoVariableBase("", static_cast<typename Traits::AutoVar*>(this)->getSyncArchive())
-	{}
-
-	virtual ~CvSyncVarAutoVariableBase() {}
-	virtual void load(FDataStream& loadFrom)
-	{
-		typename Traits::SyncArchive& syncArchive = static_cast<typename Traits::AutoVar*>(this)->getSyncArchive();
-		loadFrom >> Traits::Get(syncArchive.getContainer()).unsafeGet();
-	}
-	virtual void loadDelta(FDataStream& loadFrom)
-	{
-		load(loadFrom);
-	}
-	virtual void save(FDataStream& saveTo) const
-	{
-		const typename Traits::SyncArchive& syncArchive = static_cast<const typename Traits::AutoVar*>(this)->getSyncArchive();
-		saveTo << Traits::GetC(syncArchive.getContainer());
-	}
-	virtual void saveDelta(FDataStream& saveTo) const
-	{
-		save(saveTo);
-	}
-	virtual void clearDelta()
-	{
-	}
-	virtual bool compare(FDataStream& otherValue) const
-	{
-		typedef typename Traits::VarType VarType;
-
-		const typename Traits::SyncArchive& syncArchive = static_cast<const typename Traits::AutoVar*>(this)->getSyncArchive();
-		const VarType& var = Traits::GetC(syncArchive.getContainer());
-		
-		typename VarType::ValueType value;
-		otherValue >> value;
-		return var.get() == value;
-	}
-	virtual void reset()
-	{
-		typedef typename Traits::VarType VarType;
-		typename Traits::SyncArchive& syncArchive = static_cast<typename Traits::AutoVar*>(this)->getSyncArchive();
-		VarType& var = Traits::Get(syncArchive.getContainer());
-		var.unsafeGet() = typename VarType::ValueType();
-	}
-	virtual const std::string& name() const
-	{
-		// We could technically declare names somewhere just for this function.
-		// Without inline statics it would become a headache, so empty for now.
-		return EmptyString;
-	}
-	virtual void setStackTraceRemark()
-	{
-	}
-	virtual std::string debugDump(const std::vector<std::pair<std::string, std::string> >& callStacks) const
-	{
-		const typename Traits::SyncArchive& syncArchive = static_cast<const typename Traits::AutoVar*>(this)->getSyncArchive();
-		std::string result = FAutoVariableBase::debugDump(callStacks);
-		result += std::string("\n") + syncArchive.getContainer().debugDump(*this) + std::string("\n");
-		return result;
-	}
-	virtual std::string toString() const
-	{
-		const typename Traits::SyncArchive& syncArchive = static_cast<const typename Traits::AutoVar*>(this)->getSyncArchive();
-		return FSerialization::toString(Traits::GetC(syncArchive.getContainer()).get());
-	}
-};
-
-// Automagically begins a CvSyncArchive specialization
-#define SYNC_ARCHIVE_BEGIN(type) \
-class type; \
-template<> class CvSyncArchive<type> : public CvSyncArchiveBase<CvSyncArchive<type>> { \
-	typedef type Container; \
-	enum { INIT_VAR_N_ = __COUNTER__ + 1 }; \
-public: \
-	CvSyncArchive(Container& container) : CvSyncArchiveBase<CvSyncArchive<type>>(container), m_syncVars(NULL) {} \
-	struct SyncVars { \
-		SyncVars(CvSyncArchive<type>& archive) : archive(archive) {} \
-		CvSyncArchive<type>& archive; \
-		template<size_t, typename = void> struct VarTraits { typedef void Type; };
 
 // Gets the next index for a sync var
 // Useful if you don't want to use the SYNC_ARCHIVE_VAR macro!
-#define SYNC_ARCHIVE_VAR_NEXT_INDEX __COUNTER__ - INIT_VAR_N_
+#define SYNC_ARCHIVE_VAR_NEXT_INDEX (__COUNTER__ - INIT_VAR_INDEX_)
+
+// Helper to declare a CvSyncArchive member for a type
+#define SYNC_ARCHIVE_MEMBER(containerType) \
+	friend CvSyncArchive<containerType>; \
+	CvSyncArchive<containerType> m_syncArchive;
+
+// Automagically begins a CvSyncArchive specialization
+#define SYNC_ARCHIVE_BEGIN(containerType) \
+template<> inline const containerType& CvSyncArchive<containerType>::getContainer() const { \
+	return *reinterpret_cast<const containerType*>(reinterpret_cast<const char*>(this) - offsetof(containerType, m_syncArchive)); \
+} \
+template<> inline containerType& CvSyncArchive<containerType>::getContainer() { \
+	return const_cast<containerType&>(const_cast<const CvSyncArchive<containerType>*>(this)->getContainer()); \
+} \
+template<> class CvSyncArchive<containerType>::SyncVars { \
+	enum { INIT_VAR_INDEX_ = (__COUNTER__ + 1) }; \
+public: \
+	typedef containerType ContainerType; \
+	const ContainerType& getContainer() const { return m_container; } \
+	ContainerType& getContainer() { return m_container; } \
+	SyncVars(ContainerType& container) : m_container(container) {} \
+private: \
+	ContainerType& m_container; \
+public:
+
+// Automagically creates a traits entry for a CvSyncVar
+#define SYNC_ARCHIVE_VAR(memberType, memberName) \
+	struct memberName##_Traits { \
+		enum { INDEX = SYNC_ARCHIVE_VAR_NEXT_INDEX }; \
+		typedef memberType ValueType; \
+		typedef ContainerType ContainerType; \
+		typedef CvSyncArchive<ContainerType>::SyncVars SyncVarsType; \
+		static inline const ValueType& Get(const ContainerType& container) { return container.memberName; } \
+		static inline ValueType& Get(ContainerType& container) { return container.memberName; } \
+		static inline const SyncVarsType& GetStorage(const CvSyncVar<memberName##_Traits>& var) { \
+			return *reinterpret_cast<const SyncVarsType*>(reinterpret_cast<const char*>(&var) - offsetof(SyncVarsType, memberName)); \
+		} \
+		static inline SyncVarsType& GetStorage(CvSyncVar<memberName##_Traits>& var) { \
+			return const_cast<SyncVarsType&>(GetStorage(const_cast<const CvSyncVar<memberName##_Traits>&>(var))); \
+		} \
+	}; \
+	CvSyncVar<memberName##_Traits> memberName;
+
+// Automagically ends a CvSyncArchive specialization
+#define SYNC_ARCHIVE_END() };
 
 // Expands into what you pass it
 // Useful if you need to pass multiple template parameters since the preprocessor wont cooperate otherwise
 // Feel free to move this to another file and give it a better name
 #define SYNC_ARCHIVE_VAR_TYPE(...) __VA_ARGS__
 
-// Automagically creates a traits entry for a CvSyncVar
-#define SYNC_ARCHIVE_VAR(type, name, save) \
-		struct name { \
-			typedef CvSyncArchive<Container> SyncArchive; \
-			typedef type ValueType; \
-			typedef CvSyncVar<name> VarType; \
-			enum { INDEX = SYNC_ARCHIVE_VAR_NEXT_INDEX, SAVE = size_t(save) }; \
-			template<typename T> static inline const VarType& GetC(const T& container) { return container.name; } \
-			template<typename T> static inline VarType& Get(T& container) { return container.name; } \
-			class AutoVar : public CvSyncVarAutoVariableBase<name> { \
-				friend SyncVars; \
-				inline AutoVar() {} \
-			public: \
-				typedef name Traits; \
-				static __forceinline const AutoVar& GetC(const SyncVars& archive) { return archive.syncVar_##name; } \
-				static __forceinline AutoVar& Get(SyncVars& archive) { return archive.syncVar_##name; } \
-				__forceinline const SyncArchive& getSyncArchive() const { /* This is technically not standard compliant, but I promise it is safe */ \
-					return (reinterpret_cast<const SyncVars*>(reinterpret_cast<const char*>(this) - offsetof(SyncVars, syncVar_##name))->archive); \
-				} \
-				__forceinline SyncArchive& getSyncArchive() { return const_cast<SyncArchive&>(const_cast<const AutoVar*>(this)->getSyncArchive()); } \
-			}; \
-		}; \
-		template<typename Dummy> struct VarTraits<name::INDEX, Dummy> { \
-			typedef name Type; \
-		}; \
-		name::AutoVar syncVar_##name;
-
-// Automagically ends a CvSyncArchive specialization
-#define SYNC_ARCHIVE_END() \
-	}; \
-	enum { VAR_COUNT = __COUNTER__ - INIT_VAR_N_ }; \
-	inline SyncVars* getSyncVars() { return m_syncVars; } \
-	inline const SyncVars* getSyncVars() const { return m_syncVars; } \
-	inline void setSyncVars(SyncVars& syncVars) { FAssert(m_syncVars == NULL); m_syncVars = &syncVars; } \
-private: \
-	SyncVars* m_syncVars; \
-};
-
-// Helper to declare a CvSyncArchive member for a type
-#define SYNC_ARCHIVE_MEMBER(type) \
-	typedef CvSyncArchive<type> SyncArchive; \
-	friend SyncArchive; \
-	CvSyncArchive<type> m_syncArchive;
-
-// Helper to declare a CvSyncVar member for a type
-#define SYNC_VAR_MEMBER(name) CvSyncVar<SyncArchive::SyncVars::name> name;
-
-#endif
+#endif CVSERIALIZE_H

--- a/CvGameCoreDLL_Expansion2/CvSerialize.h
+++ b/CvGameCoreDLL_Expansion2/CvSerialize.h
@@ -252,7 +252,7 @@ private:
 public:
 	~CvSyncArchive()
 	{
-		SAFE_DELETE(m_syncVarsStorage);
+		destroySyncVars();
 	}
 
 	const ContainerType& getContainer() const;
@@ -263,6 +263,10 @@ public:
 	{
 		FAssert(m_syncVarsStorage == NULL);
 		m_syncVarsStorage = &syncVars;
+	}
+	inline void destroySyncVars()
+	{
+		SAFE_DELETE(m_syncVarsStorage);
 	}
 	inline const std::vector<FAutoVariableBase*>& getContents() const
 	{

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -80,19 +80,20 @@ void SyncUnits()
 		std::vector<CvUnit*>::const_iterator i;
 		for(i = unitsToCheck.begin(); i != unitsToCheck.end(); ++i)
 		{
-			const CvUnit* unit = *i;
+			CvUnit* unit = *i;
 
 			if(unit)
 			{
 				const CvPlayer& player = GET_PLAYER(unit->getOwner());
 				if(unit->getOwner() == authoritativePlayer || (gDLL->IsHost() && !player.isHuman() && player.isAlive()))
 				{
-					const CvSyncArchive<CvUnit>& syncArchive = unit->getSyncArchive();
-					if(syncArchive.hasDeltas())
+					CvSyncArchive<CvUnit>& archive = unit->getSyncArchive();
+					archive.collectDeltas();
+					if(archive.hasDeltas())
 					{
 						FMemoryStream memoryStream;
 						std::vector<std::pair<std::string, std::string> > callStacks;
-						syncArchive.saveDelta(memoryStream, callStacks);
+						archive.saveDelta(memoryStream, callStacks);
 						gDLL->sendUnitSyncCheck(unit->getOwner(), unit->GetID(), memoryStream, callStacks);
 					}
 				}
@@ -112,7 +113,8 @@ void ClearUnitDeltas()
 
 		if(unit)
 		{
-			unit->getSyncArchive().clearDelta();
+			FAutoArchive& archive = unit->getSyncArchive();
+			archive.clearDelta();
 		}
 	}
 }
@@ -124,11 +126,217 @@ OBJECT_VALIDATE_DEFINITION(CvUnit)
 
 //	--------------------------------------------------------------------------------
 // Public Functions...
-CvUnit::CvUnit()
-	: m_syncArchive(*this)
+CvUnit::CvUnit() :
+	m_syncArchive()
+	, m_iID()
+	, m_iHotKeyNumber()
+	, m_iX()
+	, m_iY()
+	, m_iLastMoveTurn()
+	, m_iDeployFromOperationTurn()
+	, m_iReconX()
+	, m_iReconY()
+	, m_iReconCount()
+	, m_iGameTurnCreated()
+	, m_iDamage()
+	, m_iMoves()
+	, m_bImmobile()
+	, m_iExperienceTimes100()
+	, m_iLevel()
+	, m_iCargo()
+	, m_iCargoCapacity()
+	, m_iAttackPlotX()
+	, m_iAttackPlotY()
+	, m_iCombatTimer()
+	, m_iCombatFirstStrikes()
+	, m_iCombatDamage()
+	, m_bMovedThisTurn()
+	, m_bFortified()
+	, m_iBlitzCount()
+	, m_iAmphibCount()
+	, m_iRiverCrossingNoPenaltyCount()
+	, m_iEnemyRouteCount()
+	, m_iRivalTerritoryCount()
+	, m_iIsSlowInEnemyLandCount()
+	, m_iRangeAttackIgnoreLOSCount()
+	, m_iCityAttackOnlyCount()
+	, m_iCaptureDefeatedEnemyCount()
+	, m_iRangedSupportFireCount()
+	, m_iAlwaysHealCount()
+	, m_iHealOutsideFriendlyCount()
+	, m_iHillsDoubleMoveCount()
+#if defined(MOD_BALANCE_CORE)
+	, m_iMountainsDoubleMoveCount()
+	, m_iEmbarkFlatCostCount()
+	, m_iDisembarkFlatCostCount()
+	, m_iAOEDamageOnKill()
+	, m_iAoEDamageOnMove()
+	, m_iSplashDamage()
+	, m_iMultiAttackBonus()
+	, m_iLandAirDefenseValue()
+#endif
+	, m_iImmuneToFirstStrikesCount()
+	, m_iExtraVisibilityRange()
+	, m_iExtraMoves()
+	, m_iExtraMoveDiscount()
+	, m_iExtraRange()
+	, m_iInterceptChance()
+#if defined(MOD_BALANCE_CORE)
+	, m_iExtraAirInterceptRange()  // JJ: This is new
+#endif
+	, m_iExtraEvasion()
+	, m_iExtraFirstStrikes()
+	, m_iExtraChanceFirstStrikes()
+	, m_iExtraWithdrawal()
+#if defined(MOD_BALANCE_CORE_JFD)
+	, m_iPlagueChance()
+	, m_iIsPlagued()
+	, m_iPlagueID()
+	, m_iPlaguePriority()
+	, m_iPlagueIDImmunity()
+	, m_iPlaguePromotion()
+	, m_eUnitContract()
+	, m_iNegatorPromotion()
+#endif
+	, m_bIsNoMaintenance()
+	, m_iExtraEnemyHeal()
+	, m_iExtraNeutralHeal()
+	, m_iExtraFriendlyHeal()
+	, m_iSameTileHeal()
+	, m_iAdjacentTileHeal()
+	, m_iEnemyDamageChance()
+	, m_iNeutralDamageChance()
+	, m_iEnemyDamage()
+	, m_iNeutralDamage()
+	, m_iNearbyEnemyCombatMod()
+	, m_iNearbyEnemyCombatRange()
+	, m_iSapperCount()
+	, m_iCanHeavyCharge()
+	, m_iNumExoticGoods()
+	, m_iAdjacentModifier()
+	, m_iRangedAttackModifier()
+	, m_iInterceptionCombatModifier()
+	, m_iInterceptionDefenseDamageModifier()
+	, m_iAirSweepCombatModifier()
+	, m_iAttackModifier()
+	, m_iDefenseModifier()
+	, m_iGroundAttackDamage()
+	, m_iExtraCombatPercent()
+	, m_iExtraCityAttackPercent()
+	, m_iExtraCityDefensePercent()
+	, m_iExtraRangedDefenseModifier()
+	, m_iExtraHillsAttackPercent()
+	, m_iExtraHillsDefensePercent()
+	, m_iExtraOpenAttackPercent()
+	, m_iExtraOpenRangedAttackMod()
+	, m_iExtraRoughAttackPercent()
+	, m_iExtraRoughRangedAttackMod()
+	, m_iExtraAttackFortifiedMod()
+	, m_iExtraAttackWoundedMod()
+	, m_iExtraFullyHealedMod()
+	, m_iExtraAttackAboveHealthMod()
+	, m_iExtraAttackBelowHealthMod()
+	, m_iFlankAttackModifier()
+	, m_iExtraOpenDefensePercent()
+	, m_iExtraRoughDefensePercent()
+	, m_iExtraOpenFromPercent()
+	, m_iExtraRoughFromPercent()
+	, m_iPillageChange()
+	, m_iUpgradeDiscount()
+	, m_iExperiencePercent()
+	, m_iDropRange()
+	, m_iAirSweepCapableCount()
+	, m_iExtraNavalMoves()
+	, m_iKamikazePercent()
+	, m_iBaseCombat()
+	, m_eFacingDirection()
+	, m_iArmyId()
+	, m_iIgnoreTerrainCostCount()
+#if defined(MOD_PROMOTIONS_GG_FROM_BARBARIANS)
+	, m_iGGFromBarbariansCount()
+#endif
+	, m_iRoughTerrainEndsTurnCount()
+	, m_iEmbarkAbilityCount()
+	, m_iHoveringUnitCount()
+	, m_iFlatMovementCostCount()
+	, m_iCanMoveImpassableCount()
+	, m_iOnlyDefensiveCount()
+	, m_iNoDefensiveBonusCount()
+	, m_iNoCaptureCount()
+	, m_iNukeImmuneCount()
+	, m_iHiddenNationalityCount()
+	, m_iAlwaysHostileCount()
+	, m_iNoRevealMapCount()
+	, m_iCanMoveAllTerrainCount()
+	, m_iCanMoveAfterAttackingCount()
+	, m_iFreePillageMoveCount()
+	, m_iHealOnPillageCount()
+	, m_iHPHealedIfDefeatEnemy()
+	, m_iGoldenAgeValueFromKills()
+	, m_iHealIfDefeatExcludeBarbariansCount()
+	, m_iTacticalAIPlotX()
+	, m_iTacticalAIPlotY()
+	, m_iGarrisonCityID()
+	, m_iNumAttacks()
+	, m_iAttacksMade()
+	, m_iGreatGeneralCount()
+	, m_iGreatAdmiralCount()
+#if defined(MOD_PROMOTIONS_AURA_CHANGE)
+	, m_iAuraRangeChange()
+	, m_iAuraEffectChange()
+	, m_iNumRepairCharges()
+	, m_iMilitaryCapChange()
+#endif
+	, m_iGreatGeneralModifier()
+	, m_iGreatGeneralReceivesMovementCount()
+	, m_iGreatGeneralCombatModifier()
+	, m_iIgnoreGreatGeneralBenefit()
+	, m_iIgnoreZOC()
+#if defined(MOD_UNITS_NO_SUPPLY)
+	, m_iNoSupply()
+#endif
 	, m_iMaxHitPointsBase(GC.getMAX_HIT_POINTS())
+	, m_iMaxHitPointsChange()
+	, m_iMaxHitPointsModifier()
+	, m_iFriendlyLandsModifier()
+	, m_iFriendlyLandsAttackModifier()
+	, m_iOutsideFriendlyLandsModifier()
+	, m_iNumInterceptions()
+	, m_iMadeInterceptionCount()
+	, m_iEverSelectedCount()
+	, m_iEmbarkedAllWaterCount()
+	, m_iEmbarkExtraVisibility()
+	, m_iEmbarkDefensiveModifier()
+	, m_iCapitalDefenseModifier()
+	, m_iCapitalDefenseFalloff()
+	, m_iCityAttackPlunderModifier()
+	, m_iReligiousStrengthLossRivalTerritory()
+	, m_iTradeMissionInfluenceModifier()
+	, m_iTradeMissionGoldModifier()
+	, m_iDiploMissionInfluence()
 	, m_strName("")
 	, m_eGreatWork(NO_GREAT_WORK)
+	, m_iTourismBlastStrength()
+	, m_iTourismBlastLength()
+	, m_bPromotionReady()
+	, m_bDeathDelay()
+	, m_bCombatFocus()
+	, m_bInfoBarDirty()
+	, m_bNotConverting()
+	, m_bAirCombat()
+	, m_bSetUpForRangedAttack()
+	, m_bEmbarked()
+	, m_bPromotedFromGoody()
+	, m_bAITurnProcessed()
+	, m_eOwner()
+	, m_eOriginalOwner()
+	, m_eCapturingPlayer()
+	, m_bCapturedAsIs()
+	, m_eUnitType()
+	, m_eLeaderUnitType()
+	, m_eInvisibleType()
+	, m_eSeeInvisibleType()
+	, m_eGreatPeopleDirectiveType()
 	, m_combatUnit()
 	, m_transportUnit()
 	, m_extraDomainModifiers()
@@ -136,22 +344,173 @@ CvUnit::CvUnit()
 	, m_YieldChange()
 	, m_iGarrisonYieldChange()
 	, m_iFortificationYieldChange()
+	, m_strScriptData()
+	, m_iScenarioData()
+	, m_terrainDoubleMoveCount()
+	, m_featureDoubleMoveCount()
+	, m_terrainImpassableCount()
+	, m_featureImpassableCount()
+	, m_extraTerrainAttackPercent()
+	, m_extraTerrainDefensePercent()
+	, m_extraFeatureAttackPercent()
+	, m_extraFeatureDefensePercent()
+	, m_extraUnitClassAttackMod()
+	, m_extraUnitClassDefenseMod()
+	, m_extraUnitCombatModifier()
+	, m_unitClassModifier()
+#if defined(MOD_BALANCE_CORE)
+	, m_iCombatModPerAdjacentUnitCombatModifier()
+	, m_iCombatModPerAdjacentUnitCombatAttackMod()
+	, m_iCombatModPerAdjacentUnitCombatDefenseMod()
+#endif
+	, m_iMissionTimer()
+	, m_iMissionAIX()
+	, m_iMissionAIY()
+	, m_eMissionAIType()
 	, m_missionAIUnit()
+	, m_eActivityType()
+	, m_eAutomateType()
+	, m_eUnitAIType()
 	, m_bWaitingForMove(false)
 	, m_pReligion(FNEW(CvUnitReligion, c_eCiv5GameplayDLL, 0))
+	, m_iMapLayer()
+	, m_iNumGoodyHutsPopped()
+	, m_eCombatType()
+#if defined(MOD_BALANCE_CORE)
+	, m_iOriginCity()
+	, m_iCannotBeCapturedCount()
+	, m_iForcedDamage()
+	, m_iChangeDamage()
+	, m_PromotionDuration()
+	, m_TurnPromotionGained()
+	, m_iNumTilesRevealedThisTurn()
+	, m_bSpottedEnemy()
+	, m_iGainsXPFromScouting()
+	, m_iGainsXPFromPillaging()
+	, m_iGainsXPFromSpotting()
+	, m_iCaptureDefeatedEnemyChance()
+	, m_iBarbCombatBonus()
+	, m_iAdjacentEnemySapMovement()
+	, m_iCanMoraleBreak()
+	, m_iDamageAoEFortified()
+	, m_iWorkRateMod()
+	, m_iDamageReductionCityAssault()
+	, m_iStrongerDamaged()
+	, m_iFightWellDamaged()
+	, m_iGoodyHutYieldBonus()
+	, m_iReligiousPressureModifier()
+#endif
+#if defined(MOD_PROMOTIONS_VARIABLE_RECON)
+	, m_iExtraReconRange()
+#endif
+#if defined(MOD_API_EXTENSIONS)
+	, m_iBaseRangedCombat()
+#endif
+	, m_iIgnoreTerrainDamageCount()
+	, m_iIgnoreFeatureDamageCount()
+	, m_iExtraTerrainDamageCount()
+	, m_iExtraFeatureDamageCount()
+#if defined(MOD_PROMOTIONS_IMPROVEMENT_BONUS)
+	, m_iNearbyImprovementCombatBonus()
+	, m_iNearbyImprovementBonusRange()
+	, m_eCombatBonusImprovement()
+#endif
+#if defined(MOD_BALANCE_CORE)
+	, m_iCombatBonusFromNearbyUnitClass()
+	, m_iNearbyUnitClassBonusRange()
+	, m_iNearbyUnitClassBonus()
+	, m_bNearbyPromotion()
+	, m_iNearbyUnitPromotionRange()
+	, m_iNearbyCityCombatMod()
+	, m_iNearbyFriendlyCityCombatMod()
+	, m_iNearbyEnemyCityCombatMod()
+	, m_iPillageBonusStrengthPercent()
+	, m_iStackedGreatGeneralExperience()
+	, m_bIsHighSeaRaider()
+	, m_iWonderProductionModifier()
+	, m_iUnitProductionModifier()
+	, m_iNearbyEnemyDamage()
+	, m_iGGGAXPPercent()
+	, m_iGiveCombatMod()
+	, m_iGiveHPIfEnemyKilled()
+	, m_iGiveExperiencePercent()
+	, m_iGiveOutsideFriendlyLandsModifier()
+	, m_eGiveDomain()
+	, m_iGiveExtraAttacks()
+	, m_iGiveDefenseMod()
+	, m_bGiveInvisibility()
+	, m_bGiveOnlyOnStartingTurn()
+	, m_bConvertUnit()
+	, m_eConvertDomain()
+	, m_eConvertDomainUnit()
+	, m_bConvertEnemyUnitToBarbarian()
+	, m_bConvertOnFullHP()
+	, m_bConvertOnDamage()
+	, m_iDamageThreshold()
+	, m_eConvertDamageOrFullHPUnit()
+	, m_iNumberOfCultureBombs()
+	, m_iNearbyHealEnemyTerritory()
+	, m_iNearbyHealNeutralTerritory()
+	, m_iNearbyHealFriendlyTerritory()
+#endif
+#if defined(MOD_PROMOTIONS_CROSS_MOUNTAINS)
+	, m_iCanCrossMountainsCount()
+#endif
+#if defined(MOD_PROMOTIONS_CROSS_OCEANS)
+	, m_iCanCrossOceansCount()
+#endif
+#if defined(MOD_PROMOTIONS_CROSS_ICE)
+	, m_iCanCrossIceCount()
+#endif
+#if defined(MOD_PROMOTIONS_DEEP_WATER_EMBARKATION)
+	, m_iEmbarkedDeepWaterCount()
+#endif
 #if defined(MOD_PROMOTIONS_UNIT_NAMING)
 	, m_strUnitName("")
 #endif
+#if defined(MOD_CORE_PER_TURN_DAMAGE)
+	, m_iDamageTakenThisTurn()
+	, m_iDamageTakenLastTurn()
+#endif
+#if defined(MOD_PROMOTIONS_HALF_MOVE)
+	, m_terrainHalfMoveCount()
+	, m_featureHalfMoveCount()
+	, m_terrainExtraMoveCount()
+	, m_featureExtraMoveCount()
+#endif
+#if defined(MOD_BALANCE_CORE)
+	, m_iHurryStrength()
+	, m_iScienceBlastStrength()
+	, m_iCultureBlastStrength()
+	, m_iGAPBlastStrength()
+	, m_abPromotionEverObtained()
+	, m_terrainDoubleHeal()
+	, m_featureDoubleHeal()
+#endif
+#if defined(MOD_API_UNIFIED_YIELDS)
+	, m_yieldFromKills()
+	, m_yieldFromBarbarianKills()
+#endif
+#if defined(MOD_BALANCE_CORE)
+	, m_aiNumTimesAttackedThisTurn()
+	, m_yieldFromScouting()
+#endif
+#if defined(MOD_CIV6_WORKER)
+	, m_iBuilderStrength()
+#endif
+	, m_eTacticalMove()
+	, m_iTacticalMoveSetTurn()
+	, m_eHomelandMove()
+	, m_iHomelandMoveSetTurn()
 {
 	initPromotions();
 	OBJECT_ALLOCATED
 	FSerialization::unitsToCheck.push_back(this);
 	reset(0, NO_UNIT, NO_PLAYER, true);
 
-	// Units only get sync var interfaces in multiplayer
 	if (GC.getGame().isNetworkMultiPlayer())
 	{
-		m_syncArchive.setSyncVars(*(FNEW(SyncArchive::SyncVars(m_syncArchive), c_eCiv5GameplayDLL, 0)));
+		m_syncArchive.initSyncVars(*FNEW(CvSyncArchive<CvUnit>::SyncVars(*this), c_eCiv5GameplayDLL, 0));
 	}
 }
 
@@ -174,9 +533,6 @@ CvUnit::~CvUnit()
 		GC.getMap().plotManager().RemoveUnit(GetIDInfo(), m_iX, m_iY, m_iMapLayer);
 
 	uninit();
-
-	SyncArchive::SyncVars* syncVars = m_syncArchive.getSyncVars();
-	SAFE_DELETE(syncVars);
 
 	OBJECT_DESTROYED
 }
@@ -1051,297 +1407,298 @@ void CvUnit::reset(int iID, UnitTypes eUnit, PlayerTypes eOwner, bool bConstruct
 	VALIDATE_OBJECT
 	int iI;
 
-	SyncArchive& syncArchive = getSyncArchive();
-	syncArchive.clearDelta();
+	FAutoArchive& archive = getSyncArchive();
+	archive.clearDelta();
+	archive.reset();
 
-	m_iID.set(m_syncArchive, iID);
+	m_iID = iID;
 	m_iHotKeyNumber = -1;
-	m_iX.set(m_syncArchive, INVALID_PLOT_COORD);
-	m_iY.set(m_syncArchive, INVALID_PLOT_COORD);
-	m_iLastMoveTurn.set(m_syncArchive, 0);
+	m_iX = INVALID_PLOT_COORD;
+	m_iY = INVALID_PLOT_COORD;
+	m_iLastMoveTurn = 0;
 	m_iDeployFromOperationTurn = -100;
-	m_iReconX.set(m_syncArchive, INVALID_PLOT_COORD);
-	m_iReconY.set(m_syncArchive, INVALID_PLOT_COORD);
-	m_iReconCount.set(m_syncArchive, 0);
-	m_iGameTurnCreated.set(m_syncArchive, 0);
-	m_iDamage.set(m_syncArchive, 0);
-	m_iMoves.set(m_syncArchive, 0);
-	m_bImmobile.set(m_syncArchive, false);
-	m_iExperienceTimes100.set(m_syncArchive, 0);
-	m_iLevel.set(m_syncArchive, 1);
-	m_iCargo.set(m_syncArchive, 0);
-	m_iAttackPlotX.set(m_syncArchive, INVALID_PLOT_COORD);
-	m_iAttackPlotY.set(m_syncArchive, INVALID_PLOT_COORD);
-	m_iCombatTimer.set(m_syncArchive, 0);
-	m_iCombatFirstStrikes.set(m_syncArchive, 0);
-	m_iCombatDamage.set(m_syncArchive, 0);
-	m_bMovedThisTurn.set(m_syncArchive, false);
-	m_bFortified.set(m_syncArchive, false);
-	m_iBlitzCount.set(m_syncArchive, 0);
-	m_iAmphibCount.set(m_syncArchive, 0);
-	m_iRiverCrossingNoPenaltyCount.set(m_syncArchive, 0);
-	m_iEnemyRouteCount.set(m_syncArchive, 0);
-	m_iRivalTerritoryCount.set(m_syncArchive, 0);
-	m_iIsSlowInEnemyLandCount.set(m_syncArchive, 0);
-	m_iRangeAttackIgnoreLOSCount.set(m_syncArchive, 0);
-	m_iCityAttackOnlyCount.set(m_syncArchive, 0);
-	m_iCaptureDefeatedEnemyCount.set(m_syncArchive, 0);
+	m_iReconX = INVALID_PLOT_COORD;
+	m_iReconY = INVALID_PLOT_COORD;
+	m_iReconCount = 0;
+	m_iGameTurnCreated = 0;
+	m_iDamage = 0;
+	m_iMoves = 0;
+	m_bImmobile = false;
+	m_iExperienceTimes100 = 0;
+	m_iLevel = 1;
+	m_iCargo = 0;
+	m_iAttackPlotX = INVALID_PLOT_COORD;
+	m_iAttackPlotY = INVALID_PLOT_COORD;
+	m_iCombatTimer = 0;
+	m_iCombatFirstStrikes = 0;
+	m_iCombatDamage = 0;
+	m_bMovedThisTurn = false;
+	m_bFortified = false;
+	m_iBlitzCount = 0;
+	m_iAmphibCount = 0;
+	m_iRiverCrossingNoPenaltyCount = 0;
+	m_iEnemyRouteCount = 0;
+	m_iRivalTerritoryCount = 0;
+	m_iIsSlowInEnemyLandCount = 0;
+	m_iRangeAttackIgnoreLOSCount = 0;
+	m_iCityAttackOnlyCount = 0;
+	m_iCaptureDefeatedEnemyCount = 0;
 #if defined(MOD_BALANCE_CORE)
 	m_iOriginCity = -1;
-	m_iCannotBeCapturedCount.set(m_syncArchive, 0);
-	m_iForcedDamage.set(m_syncArchive, 0);
-	m_iChangeDamage.set(m_syncArchive, 0);
+	m_iCannotBeCapturedCount = 0;
+	m_iForcedDamage = 0;
+	m_iChangeDamage = 0;
 #endif
-	m_iRangedSupportFireCount.set(m_syncArchive, 0);
-	m_iAlwaysHealCount.set(m_syncArchive, 0);
-	m_iHealOutsideFriendlyCount.set(m_syncArchive, 0);
-	m_iHillsDoubleMoveCount.set(m_syncArchive, 0);
+	m_iRangedSupportFireCount = 0;
+	m_iAlwaysHealCount = 0;
+	m_iHealOutsideFriendlyCount = 0;
+	m_iHillsDoubleMoveCount = 0;
 #if defined(MOD_BALANCE_CORE)
-	m_iMountainsDoubleMoveCount.set(m_syncArchive, 0);
-	m_iEmbarkFlatCostCount.set(m_syncArchive, 0);
-	m_iDisembarkFlatCostCount.set(m_syncArchive, 0);
-	m_iAOEDamageOnKill.set(m_syncArchive, 0);
-	m_iAoEDamageOnMove.set(m_syncArchive, 0);
-	m_iSplashDamage.set(m_syncArchive, 0);
-	m_iMultiAttackBonus.set(m_syncArchive, 0);
-	m_iLandAirDefenseValue.set(m_syncArchive, 0);
+	m_iMountainsDoubleMoveCount = 0;
+	m_iEmbarkFlatCostCount = 0;
+	m_iDisembarkFlatCostCount = 0;
+	m_iAOEDamageOnKill = 0;
+	m_iAoEDamageOnMove = 0;
+	m_iSplashDamage = 0;
+	m_iMultiAttackBonus = 0;
+	m_iLandAirDefenseValue = 0;
 #endif
-	m_iImmuneToFirstStrikesCount.set(m_syncArchive, 0);
-	m_iExtraVisibilityRange.set(m_syncArchive, 0);
+	m_iImmuneToFirstStrikesCount = 0;
+	m_iExtraVisibilityRange = 0;
 #if defined(MOD_PROMOTIONS_VARIABLE_RECON)
-	m_iExtraReconRange.set(m_syncArchive, 0);
+	m_iExtraReconRange = 0;
 #endif
-	m_iExtraMoves.set(m_syncArchive, 0);
-	m_iExtraMoveDiscount.set(m_syncArchive, 0);
-	m_iExtraRange.set(m_syncArchive, 0);
-	m_iInterceptChance.set(m_syncArchive, 0);
+	m_iExtraMoves = 0;
+	m_iExtraMoveDiscount = 0;
+	m_iExtraRange = 0;
+	m_iInterceptChance = 0;
 #if defined(MOD_BALANCE_CORE)
-	m_iExtraAirInterceptRange.set(m_syncArchive, 0); // JJ: This is new
+	m_iExtraAirInterceptRange = 0; // JJ: This is new
 #endif
-	m_iExtraEvasion.set(m_syncArchive, 0);
-	m_iExtraFirstStrikes.set(m_syncArchive, 0);
-	m_iExtraChanceFirstStrikes.set(m_syncArchive, 0);
-	m_iExtraWithdrawal.set(m_syncArchive, 0);
+	m_iExtraEvasion = 0;
+	m_iExtraFirstStrikes = 0;
+	m_iExtraChanceFirstStrikes = 0;
+	m_iExtraWithdrawal = 0;
 #if defined(MOD_BALANCE_CORE_JFD)
-	m_iPlagueChance.set(m_syncArchive, 0);
+	m_iPlagueChance = 0;
 	m_iIsPlagued = -1;
-	m_iPlagueID.set(m_syncArchive, 0);
-	m_iPlaguePriority.set(m_syncArchive, 0);
+	m_iPlagueID = 0;
+	m_iPlaguePriority = 0;
 	m_iPlagueIDImmunity = -1;
-	m_iPlaguePromotion.set(m_syncArchive, NO_PROMOTION);
-	m_eUnitContract.set(m_syncArchive, NO_CONTRACT);
+	m_iPlaguePromotion = NO_PROMOTION;
+	m_eUnitContract = NO_CONTRACT;
 	m_iNegatorPromotion = -1;
 #endif
-	m_bIsNoMaintenance.set(m_syncArchive, false);
-	m_iExtraEnemyHeal.set(m_syncArchive, 0);
-	m_iExtraNeutralHeal.set(m_syncArchive, 0);
-	m_iExtraFriendlyHeal.set(m_syncArchive, 0);
-	m_iSameTileHeal.set(m_syncArchive, 0);
-	m_iAdjacentTileHeal.set(m_syncArchive, 0);
-	m_iEnemyDamageChance.set(m_syncArchive, 0);
-	m_iNeutralDamageChance.set(m_syncArchive, 0);
-	m_iEnemyDamage.set(m_syncArchive, 0);
-	m_iNeutralDamage.set(m_syncArchive, 0);
-	m_iNearbyEnemyCombatMod.set(m_syncArchive, 0);
-	m_iNearbyEnemyCombatRange.set(m_syncArchive, 0);
-	m_iExtraCombatPercent.set(m_syncArchive, 0);
-	m_iAdjacentModifier.set(m_syncArchive, 0);
-	m_iRangedAttackModifier.set(m_syncArchive, 0);
-	m_iInterceptionCombatModifier.set(m_syncArchive, 0);
-	m_iInterceptionDefenseDamageModifier.set(m_syncArchive, 0);
-	m_iAirSweepCombatModifier.set(m_syncArchive, 0);
-	m_iAttackModifier.set(m_syncArchive, 0);
-	m_iDefenseModifier.set(m_syncArchive, 0);
-	m_iGroundAttackDamage.set(m_syncArchive, 0);
-	m_iExtraCityAttackPercent.set(m_syncArchive, 0);
-	m_iExtraCityDefensePercent.set(m_syncArchive, 0);
-	m_iExtraRangedDefenseModifier.set(m_syncArchive, 0);
-	m_iExtraHillsAttackPercent.set(m_syncArchive, 0);
-	m_iExtraHillsDefensePercent.set(m_syncArchive, 0);
-	m_iExtraOpenAttackPercent.set(m_syncArchive, 0);
-	m_iExtraOpenRangedAttackMod.set(m_syncArchive, 0);
-	m_iExtraRoughAttackPercent.set(m_syncArchive, 0);
-	m_iExtraRoughRangedAttackMod.set(m_syncArchive, 0);
-	m_iExtraAttackFortifiedMod.set(m_syncArchive, 0);
-	m_iExtraAttackWoundedMod.set(m_syncArchive, 0);
-	m_iExtraFullyHealedMod.set(m_syncArchive, 0);
-	m_iExtraAttackAboveHealthMod.set(m_syncArchive, 0);
-	m_iExtraAttackBelowHealthMod.set(m_syncArchive, 0);
-	m_iFlankAttackModifier.set(m_syncArchive, 0);
-	m_iExtraOpenDefensePercent.set(m_syncArchive, 0);
-	m_iExtraRoughDefensePercent.set(m_syncArchive, 0);
-	m_iExtraOpenFromPercent.set(m_syncArchive, 0);
-	m_iExtraRoughFromPercent.set(m_syncArchive, 0);
-	m_iPillageChange.set(m_syncArchive, 0);
-	m_iUpgradeDiscount.set(m_syncArchive, 0);
-	m_iExperiencePercent.set(m_syncArchive, 0);
-	m_iDropRange.set(m_syncArchive, 0);
-	m_iAirSweepCapableCount.set(m_syncArchive, 0);
-	m_iExtraNavalMoves.set(m_syncArchive, 0);
-	m_iKamikazePercent.set(m_syncArchive, 0);
-	m_eFacingDirection.set(m_syncArchive, DIRECTION_SOUTHEAST);
-	m_iIgnoreTerrainCostCount.set(m_syncArchive, 0);
-	m_iIgnoreTerrainDamageCount.set(m_syncArchive, 0);
-	m_iIgnoreFeatureDamageCount.set(m_syncArchive, 0);
-	m_iExtraTerrainDamageCount.set(m_syncArchive, 0);
-	m_iExtraFeatureDamageCount.set(m_syncArchive, 0);
+	m_bIsNoMaintenance = false;
+	m_iExtraEnemyHeal = 0;
+	m_iExtraNeutralHeal = 0;
+	m_iExtraFriendlyHeal = 0;
+	m_iSameTileHeal = 0;
+	m_iAdjacentTileHeal = 0;
+	m_iEnemyDamageChance = 0;
+	m_iNeutralDamageChance = 0;
+	m_iEnemyDamage = 0;
+	m_iNeutralDamage = 0;
+	m_iNearbyEnemyCombatMod = 0;
+	m_iNearbyEnemyCombatRange = 0;
+	m_iExtraCombatPercent = 0;
+	m_iAdjacentModifier = 0;
+	m_iRangedAttackModifier = 0;
+	m_iInterceptionCombatModifier = 0;
+	m_iInterceptionDefenseDamageModifier = 0;
+	m_iAirSweepCombatModifier = 0;
+	m_iAttackModifier = 0;
+	m_iDefenseModifier = 0;
+	m_iGroundAttackDamage = 0;
+	m_iExtraCityAttackPercent = 0;
+	m_iExtraCityDefensePercent = 0;
+	m_iExtraRangedDefenseModifier = 0;
+	m_iExtraHillsAttackPercent = 0;
+	m_iExtraHillsDefensePercent = 0;
+	m_iExtraOpenAttackPercent = 0;
+	m_iExtraOpenRangedAttackMod= 0;
+	m_iExtraRoughAttackPercent = 0;
+	m_iExtraRoughRangedAttackMod= 0;
+	m_iExtraAttackFortifiedMod= 0;
+	m_iExtraAttackWoundedMod= 0;
+	m_iExtraFullyHealedMod = 0;
+	m_iExtraAttackAboveHealthMod = 0;
+	m_iExtraAttackBelowHealthMod = 0;
+	m_iFlankAttackModifier=0;
+	m_iExtraOpenDefensePercent = 0;
+	m_iExtraRoughDefensePercent = 0;
+	m_iExtraOpenFromPercent = 0;
+	m_iExtraRoughFromPercent = 0;
+	m_iPillageChange = 0;
+	m_iUpgradeDiscount = 0;
+	m_iExperiencePercent = 0;
+	m_iDropRange = 0;
+	m_iAirSweepCapableCount = 0;
+	m_iExtraNavalMoves = 0;
+	m_iKamikazePercent = 0;
+	m_eFacingDirection = DIRECTION_SOUTHEAST;
+	m_iIgnoreTerrainCostCount = 0;
+	m_iIgnoreTerrainDamageCount = 0;
+	m_iIgnoreFeatureDamageCount = 0;
+	m_iExtraTerrainDamageCount = 0;
+	m_iExtraFeatureDamageCount = 0;
 #if defined(MOD_PROMOTIONS_IMPROVEMENT_BONUS)
-	m_iNearbyImprovementCombatBonus.set(m_syncArchive, 0);
-	m_iNearbyImprovementBonusRange.set(m_syncArchive, 0);
-	m_eCombatBonusImprovement.set(m_syncArchive, NO_IMPROVEMENT);
+	m_iNearbyImprovementCombatBonus = 0;
+	m_iNearbyImprovementBonusRange = 0;
+	m_eCombatBonusImprovement = NO_IMPROVEMENT;
 #endif
 #if defined(MOD_BALANCE_CORE)
-	m_iNearbyUnitClassBonus.set(m_syncArchive, 0);
-	m_iNearbyUnitClassBonusRange.set(m_syncArchive, 0);
-	m_iCombatBonusFromNearbyUnitClass.set(m_syncArchive, NO_UNITCLASS);
-	m_bNearbyPromotion.set(m_syncArchive, false);
-	m_iNearbyUnitPromotionRange.set(m_syncArchive, 0);
-	m_iNearbyCityCombatMod.set(m_syncArchive, 0);
-	m_iNearbyFriendlyCityCombatMod.set(m_syncArchive, 0);
-	m_iNearbyEnemyCityCombatMod.set(m_syncArchive, 0);
-	m_iPillageBonusStrengthPercent.set(m_syncArchive, 0);
-	m_iStackedGreatGeneralExperience.set(m_syncArchive, 0);
-	m_bIsHighSeaRaider.set(m_syncArchive, false);
-	m_iWonderProductionModifier.set(m_syncArchive, 0);
-	m_iUnitProductionModifier.set(m_syncArchive, 0);
-	m_iNearbyEnemyDamage.set(m_syncArchive, 0);
-	m_iGGGAXPPercent.set(m_syncArchive, 0);
-	m_eGiveDomain.set(m_syncArchive, NO_DOMAIN);
-	m_iGiveCombatMod.set(m_syncArchive, 0);
-	m_iGiveHPIfEnemyKilled.set(m_syncArchive, 0);
-	m_iGiveExperiencePercent.set(m_syncArchive, 0);
-	m_iGiveOutsideFriendlyLandsModifier.set(m_syncArchive, 0);
-	m_iGiveExtraAttacks.set(m_syncArchive, 0);
-	m_iGiveDefenseMod.set(m_syncArchive, 0);
-	m_bGiveInvisibility.set(m_syncArchive, false);
-	m_bGiveOnlyOnStartingTurn.set(m_syncArchive, false);
-	m_bConvertUnit.set(m_syncArchive, false);
-	m_eConvertDomainUnit.set(m_syncArchive, NO_UNIT);
-	m_eConvertDomain.set(m_syncArchive, NO_DOMAIN);
-	m_bConvertEnemyUnitToBarbarian.set(m_syncArchive, false);
-	m_bConvertOnFullHP.set(m_syncArchive, false);
-	m_bConvertOnDamage.set(m_syncArchive, false);
-	m_iDamageThreshold.set(m_syncArchive, 0);
-	m_eConvertDamageOrFullHPUnit.set(m_syncArchive, NO_UNIT);
-	m_iNumberOfCultureBombs.set(m_syncArchive, 0);
-	m_iNearbyHealEnemyTerritory.set(m_syncArchive, 0);
-	m_iNearbyHealNeutralTerritory.set(m_syncArchive, 0);
-	m_iNearbyHealFriendlyTerritory.set(m_syncArchive, 0);
+	m_iNearbyUnitClassBonus = 0;
+	m_iNearbyUnitClassBonusRange = 0;
+	m_iCombatBonusFromNearbyUnitClass = NO_UNITCLASS;
+	m_bNearbyPromotion = false;
+	m_iNearbyUnitPromotionRange = 0;
+	m_iNearbyCityCombatMod = 0;
+	m_iNearbyFriendlyCityCombatMod = 0;
+	m_iNearbyEnemyCityCombatMod = 0;
+	m_iPillageBonusStrengthPercent = 0;
+	m_iStackedGreatGeneralExperience = 0;
+	m_bIsHighSeaRaider = false;
+	m_iWonderProductionModifier = 0;
+	m_iUnitProductionModifier = 0;
+	m_iNearbyEnemyDamage = 0;
+	m_iGGGAXPPercent = 0;
+	m_eGiveDomain = NO_DOMAIN;
+	m_iGiveCombatMod = 0;
+	m_iGiveHPIfEnemyKilled = 0;
+	m_iGiveExperiencePercent = 0;
+	m_iGiveOutsideFriendlyLandsModifier = 0;
+	m_iGiveExtraAttacks = 0;
+	m_iGiveDefenseMod = 0;
+	m_bGiveInvisibility = false;
+	m_bGiveOnlyOnStartingTurn = false;
+	m_bConvertUnit = false;
+	m_eConvertDomainUnit = NO_UNIT;
+	m_eConvertDomain = NO_DOMAIN;
+	m_bConvertEnemyUnitToBarbarian = false;
+	m_bConvertOnFullHP = false;
+	m_bConvertOnDamage = false;
+	m_iDamageThreshold = 0;
+	m_eConvertDamageOrFullHPUnit = NO_UNIT;
+	m_iNumberOfCultureBombs = 0;
+	m_iNearbyHealEnemyTerritory = 0;
+	m_iNearbyHealNeutralTerritory = 0;
+	m_iNearbyHealFriendlyTerritory = 0;
 #endif
 #if defined(MOD_CIV6_WORKER)
-	m_iBuilderStrength.set(m_syncArchive, 0);
+	m_iBuilderStrength = 0;
 #endif
 #if defined(MOD_PROMOTIONS_CROSS_MOUNTAINS)
-	m_iCanCrossMountainsCount.set(m_syncArchive, 0);
+	m_iCanCrossMountainsCount = 0;
 #endif
 #if defined(MOD_PROMOTIONS_CROSS_OCEANS)
-	m_iCanCrossOceansCount.set(m_syncArchive, 0);
+	m_iCanCrossOceansCount = 0;
 #endif
 #if defined(MOD_PROMOTIONS_CROSS_ICE)
-	m_iCanCrossIceCount.set(m_syncArchive, 0);
+	m_iCanCrossIceCount = 0;
 #endif
 #if defined(MOD_BALANCE_CORE)
-	m_iNumTilesRevealedThisTurn.set(m_syncArchive, 0);
-	m_bSpottedEnemy.set(m_syncArchive, false);
-	m_iGainsXPFromScouting.set(m_syncArchive, 0);
-	m_iGainsXPFromSpotting.set(m_syncArchive, 0);
-	m_iGainsXPFromPillaging.set(m_syncArchive, 0);
-	m_iCaptureDefeatedEnemyChance.set(m_syncArchive, 0);
-	m_iBarbCombatBonus.set(m_syncArchive, 0);
-	m_iAdjacentEnemySapMovement.set(m_syncArchive, 0);
-	m_iCanMoraleBreak.set(m_syncArchive, 0);
-	m_iDamageAoEFortified.set(m_syncArchive, 0);
-	m_iWorkRateMod.set(m_syncArchive, 0);
-	m_iDamageReductionCityAssault.set(m_syncArchive, 0);
-	m_iStrongerDamaged.set(m_syncArchive, 0);
-	m_iFightWellDamaged.set(m_syncArchive, 0);
-	m_iGoodyHutYieldBonus.set(m_syncArchive, 0);
-	m_iReligiousPressureModifier.set(m_syncArchive, 0);
+	m_iNumTilesRevealedThisTurn = 0;
+	m_bSpottedEnemy = false;
+	m_iGainsXPFromScouting = 0;
+	m_iGainsXPFromSpotting = 0;
+	m_iGainsXPFromPillaging = 0;
+	m_iCaptureDefeatedEnemyChance = 0;
+	m_iBarbCombatBonus = 0;
+	m_iAdjacentEnemySapMovement = 0;
+	m_iCanMoraleBreak = 0;
+	m_iDamageAoEFortified = 0;
+	m_iWorkRateMod = 0;
+	m_iDamageReductionCityAssault = 0;
+	m_iStrongerDamaged = 0;
+	m_iFightWellDamaged = 0;
+	m_iGoodyHutYieldBonus = 0;
+	m_iReligiousPressureModifier = 0;
 #endif
 #if defined(MOD_PROMOTIONS_GG_FROM_BARBARIANS)
-	m_iGGFromBarbariansCount.set(m_syncArchive, 0);
+	m_iGGFromBarbariansCount = 0;
 #endif
-	m_iRoughTerrainEndsTurnCount.set(m_syncArchive, 0);
-	m_iEmbarkAbilityCount.set(m_syncArchive, 0);
-	m_iHoveringUnitCount.set(m_syncArchive, 0);
-	m_iFlatMovementCostCount.set(m_syncArchive, 0);
-	m_iCanMoveImpassableCount.set(m_syncArchive, 0);
-	m_iOnlyDefensiveCount.set(m_syncArchive, 0);
-	m_iNoDefensiveBonusCount.set(m_syncArchive, 0);
-	m_iNoCaptureCount.set(m_syncArchive, 0);
-	m_iNukeImmuneCount.set(m_syncArchive, 0);
-	m_iAlwaysHealCount.set(m_syncArchive, 0);
-	m_iHiddenNationalityCount.set(m_syncArchive, 0);
-	m_iAlwaysHostileCount.set(m_syncArchive, 0);
-	m_iNoRevealMapCount.set(m_syncArchive, 0);
-	m_iCanMoveAllTerrainCount.set(m_syncArchive, 0);
-	m_iCanMoveAfterAttackingCount.set(m_syncArchive, 0);
-	m_iFreePillageMoveCount.set(m_syncArchive, 0);
-	m_iHPHealedIfDefeatEnemy.set(m_syncArchive, 0);
-	m_iGoldenAgeValueFromKills.set(m_syncArchive, 0);
-	m_iSapperCount.set(m_syncArchive, 0);
-	m_iCanHeavyCharge.set(m_syncArchive, 0);
-	m_iNumExoticGoods.set(m_syncArchive, 0);
-	m_iTacticalAIPlotX.set(m_syncArchive, INVALID_PLOT_COORD);
-	m_iTacticalAIPlotY.set(m_syncArchive, INVALID_PLOT_COORD);
+	m_iRoughTerrainEndsTurnCount = 0;
+	m_iEmbarkAbilityCount = 0;
+	m_iHoveringUnitCount = 0;
+	m_iFlatMovementCostCount = 0;
+	m_iCanMoveImpassableCount = 0;
+	m_iOnlyDefensiveCount = 0;
+	m_iNoDefensiveBonusCount = 0;
+	m_iNoCaptureCount = 0;
+	m_iNukeImmuneCount = 0;
+	m_iAlwaysHealCount = 0;
+	m_iHiddenNationalityCount = 0;
+	m_iAlwaysHostileCount = 0;
+	m_iNoRevealMapCount = 0;
+	m_iCanMoveAllTerrainCount = 0;
+	m_iCanMoveAfterAttackingCount = 0;
+	m_iFreePillageMoveCount = 0;
+	m_iHPHealedIfDefeatEnemy = 0;
+	m_iGoldenAgeValueFromKills = 0;
+	m_iSapperCount = 0;
+	m_iCanHeavyCharge = 0;
+	m_iNumExoticGoods = 0;
+	m_iTacticalAIPlotX = INVALID_PLOT_COORD;
+	m_iTacticalAIPlotY = INVALID_PLOT_COORD;
 	m_iGarrisonCityID = -1;   // unused
-	m_iNumAttacks.set(m_syncArchive, 1);
-	m_iAttacksMade.set(m_syncArchive, 0);
-	m_iGreatGeneralCount.set(m_syncArchive, 0);
-	m_iGreatAdmiralCount.set(m_syncArchive, 0);
+	m_iNumAttacks = 1;
+	m_iAttacksMade = 0;
+	m_iGreatGeneralCount = 0;
+	m_iGreatAdmiralCount = 0;
 #if defined(MOD_PROMOTIONS_AURA_CHANGE)
-	m_iAuraRangeChange.set(m_syncArchive, 0);
-	m_iAuraEffectChange.set(m_syncArchive, 0);
-	m_iNumRepairCharges.set(m_syncArchive, 0);
-	m_iMilitaryCapChange.set(m_syncArchive, 0);
+	m_iAuraRangeChange = 0;
+	m_iAuraEffectChange = 0;
+	m_iNumRepairCharges = 0;
+	m_iMilitaryCapChange = 0;
 #endif
-	m_iGreatGeneralModifier.set(m_syncArchive, 0);
-	m_iGreatGeneralReceivesMovementCount.set(m_syncArchive, 0);
-	m_iGreatGeneralCombatModifier.set(m_syncArchive, 0);
-	m_iIgnoreGreatGeneralBenefit.set(m_syncArchive, 0);
-	m_iIgnoreZOC.set(m_syncArchive, 0);
+	m_iGreatGeneralModifier = 0;
+	m_iGreatGeneralReceivesMovementCount = 0;
+	m_iGreatGeneralCombatModifier = 0;
+	m_iIgnoreGreatGeneralBenefit = 0;
+	m_iIgnoreZOC = 0;
 #if defined(MOD_UNITS_NO_SUPPLY)
-	m_iNoSupply.set(m_syncArchive, 0);
+	m_iNoSupply = 0;
 #endif
-	m_iHealIfDefeatExcludeBarbariansCount.set(m_syncArchive, 0);
-	m_iNumInterceptions.set(m_syncArchive, 1);
-	m_iMadeInterceptionCount.set(m_syncArchive, 0);
-	m_iEverSelectedCount.set(m_syncArchive, 0);
+	m_iHealIfDefeatExcludeBarbariansCount = 0;
+	m_iNumInterceptions = 1;
+	m_iMadeInterceptionCount = 0;
+	m_iEverSelectedCount = 0;
 
-	m_iEmbarkedAllWaterCount.set(m_syncArchive, 0);
+	m_iEmbarkedAllWaterCount = 0;
 #if defined(MOD_PROMOTIONS_DEEP_WATER_EMBARKATION)
-	m_iEmbarkedDeepWaterCount.set(m_syncArchive, 0);
+	m_iEmbarkedDeepWaterCount = 0;
 #endif
 #if defined(MOD_CORE_PER_TURN_DAMAGE)
-	m_iDamageTakenThisTurn.set(m_syncArchive, 0);
-	m_iDamageTakenLastTurn.set(m_syncArchive, 0);
+	m_iDamageTakenThisTurn = 0;
+	m_iDamageTakenLastTurn = 0;
 #endif
-	m_iEmbarkExtraVisibility.set(m_syncArchive, 0);
-	m_iEmbarkDefensiveModifier.set(m_syncArchive, 0);
-	m_iCapitalDefenseModifier.set(m_syncArchive, 0);
-	m_iCapitalDefenseFalloff.set(m_syncArchive, 0);
-	m_iCityAttackPlunderModifier.set(m_syncArchive, 0);
-	m_iReligiousStrengthLossRivalTerritory.set(m_syncArchive, 0);
-	m_iTradeMissionInfluenceModifier.set(m_syncArchive, 0);
-	m_iTradeMissionGoldModifier.set(m_syncArchive, 0);
-	m_iDiploMissionInfluence.set(m_syncArchive, 0);
+	m_iEmbarkExtraVisibility = 0;
+	m_iEmbarkDefensiveModifier = 0;
+	m_iCapitalDefenseModifier = 0;
+	m_iCapitalDefenseFalloff = 0;
+	m_iCityAttackPlunderModifier = 0;
+	m_iReligiousStrengthLossRivalTerritory = 0;
+	m_iTradeMissionInfluenceModifier = 0;
+	m_iTradeMissionGoldModifier = 0;
+	m_iDiploMissionInfluence = 0;
 
-	m_bPromotionReady.set(m_syncArchive, false);
-	m_bDeathDelay.set(m_syncArchive, false);
-	m_bCombatFocus.set(m_syncArchive, false);
-	m_bInfoBarDirty.set(m_syncArchive, false);
-	m_bNotConverting.set(m_syncArchive, false);
-	m_bAirCombat.set(m_syncArchive, false);
-	m_bSetUpForRangedAttack.set(m_syncArchive, false);
-	m_bEmbarked.set(m_syncArchive, false);
-	m_bPromotedFromGoody.set(m_syncArchive, false);
-	m_bAITurnProcessed.set(m_syncArchive, false);
+	m_bPromotionReady = false;
+	m_bDeathDelay = false;
+	m_bCombatFocus = false;
+	m_bInfoBarDirty = false;
+	m_bNotConverting = false;
+	m_bAirCombat = false;
+	m_bSetUpForRangedAttack = false;
+	m_bEmbarked = false;
+	m_bPromotedFromGoody = false;
+	m_bAITurnProcessed = false;
 	m_bWaitingForMove = false;
-	m_eOwner.set(m_syncArchive, eOwner);
-	m_eOriginalOwner.set(m_syncArchive, eOwner);
-	m_eCapturingPlayer.set(m_syncArchive, NO_PLAYER);
-	m_bCapturedAsIs.set(m_syncArchive, false);
-	m_eUnitType.set(m_syncArchive, eUnit);
+	m_eOwner = eOwner;
+	m_eOriginalOwner = eOwner;
+	m_eCapturingPlayer = NO_PLAYER;
+	m_bCapturedAsIs = false;
+	m_eUnitType = eUnit;
 	m_pUnitInfo = (NO_UNIT != m_eUnitType) ? GC.getUnitInfo(m_eUnitType) : NULL;
 	m_iBaseCombat = (NO_UNIT != m_eUnitType) ? m_pUnitInfo->GetCombat() : 0;
 	m_eCombatType = (NO_UNIT != m_eUnitType) ? (UnitCombatTypes)m_pUnitInfo->GetUnitCombatType() : NO_UNITCOMBAT;
@@ -1349,13 +1706,13 @@ void CvUnit::reset(int iID, UnitTypes eUnit, PlayerTypes eOwner, bool bConstruct
 	m_iBaseRangedCombat = (NO_UNIT != m_eUnitType) ? m_pUnitInfo->GetRangedCombat() : 0;
 #endif
 	m_iMaxHitPointsBase = (NO_UNIT != m_eUnitType) ? m_pUnitInfo->GetMaxHitPoints() : GC.getMAX_HIT_POINTS();
-	m_iMaxHitPointsChange.set(m_syncArchive, 0);
-	m_iMaxHitPointsModifier.set(m_syncArchive, 0);
-	m_eLeaderUnitType.set(m_syncArchive, NO_UNIT);
-	m_eInvisibleType.set(m_syncArchive, NO_INVISIBLE);
-	m_eSeeInvisibleType.set(m_syncArchive, NO_INVISIBLE);
-	m_eGreatPeopleDirectiveType.set(m_syncArchive, NO_GREAT_PEOPLE_DIRECTIVE_TYPE);
-	m_iCargoCapacity.set(m_syncArchive, 0);
+	m_iMaxHitPointsChange = 0;
+	m_iMaxHitPointsModifier = 0;
+	m_eLeaderUnitType = NO_UNIT;
+	m_eInvisibleType = NO_INVISIBLE;
+	m_eSeeInvisibleType = NO_INVISIBLE;
+	m_eGreatPeopleDirectiveType = NO_GREAT_PEOPLE_DIRECTIVE_TYPE;
+	m_iCargoCapacity = 0;
 
 	m_combatUnit.reset();
 	m_transportUnit.reset();
@@ -1386,130 +1743,130 @@ void CvUnit::reset(int iID, UnitTypes eUnit, PlayerTypes eOwner, bool bConstruct
 	m_strGreatName = "";
 #endif
 	m_eGreatWork = NO_GREAT_WORK;
-	m_iTourismBlastStrength.set(m_syncArchive, 0);
-	m_iTourismBlastLength.set(m_syncArchive, 0);
-	m_strScriptData.set(m_syncArchive, "");
-	m_iScenarioData.set(m_syncArchive, 0);
+	m_iTourismBlastStrength = 0;
+	m_iTourismBlastLength = 0;
+	m_strScriptData ="";
+	m_iScenarioData = 0;
 
 	m_unitMoveLocs.clear();
 
 	uninitInfos();
 
 	// Migrated in from CvSelectionGroup
-	m_iMissionTimer.set(m_syncArchive, 0);
-	m_eActivityType.set(m_syncArchive, ACTIVITY_AWAKE);
-	m_eAutomateType.set(m_syncArchive, NO_AUTOMATE);
+	m_iMissionTimer = 0;
+	m_eActivityType = ACTIVITY_AWAKE;
+	m_eAutomateType = NO_AUTOMATE;
 
 	ClearPathCache();
 
 #if defined(MOD_BALANCE_CORE)
-	m_iHurryStrength.set(m_syncArchive, 0);
-	m_iScienceBlastStrength.set(m_syncArchive, 0);
-	m_iCultureBlastStrength.set(m_syncArchive, 0);
-	m_iGAPBlastStrength.set(m_syncArchive, 0);
-	m_abPromotionEverObtained.resize(m_syncArchive, GC.getNumPromotionInfos());
+	m_iHurryStrength = 0;
+	m_iScienceBlastStrength = 0;
+	m_iCultureBlastStrength = 0;
+	m_iGAPBlastStrength = 0;
+	m_abPromotionEverObtained.resize(GC.getNumPromotionInfos());
 	for (int iI = 0; iI < GC.getNumPromotionInfos(); iI++)
 	{
-		m_abPromotionEverObtained.setAt(m_syncArchive, iI, false);
+		m_abPromotionEverObtained[iI] =  false;
 	}
 #endif
 
-	m_iMapLayer.set(m_syncArchive, DEFAULT_UNIT_MAP_LAYER);
-	m_iNumGoodyHutsPopped.set(m_syncArchive, 0);
+	m_iMapLayer = DEFAULT_UNIT_MAP_LAYER;
+	m_iNumGoodyHutsPopped = 0;
 
-	m_eTacticalMove.set(m_syncArchive, AI_TACTICAL_MOVE_NONE);
-	m_iTacticalMoveSetTurn.set(m_syncArchive, 0);
-	m_eHomelandMove.set(m_syncArchive, AI_HOMELAND_MOVE_NONE);
-	m_iHomelandMoveSetTurn.set(m_syncArchive, 0);
+	m_eTacticalMove = AI_TACTICAL_MOVE_NONE;
+	m_iTacticalMoveSetTurn = 0;
+	m_eHomelandMove = AI_HOMELAND_MOVE_NONE;
+	m_iHomelandMoveSetTurn = 0;
 	m_strMissionInfoString = "";
 
 	if(!bConstructorCall)
 	{
 		m_Promotions.Reset();
 
-		m_terrainDoubleMoveCount.dirtyGet(m_syncArchive).clear();
+		m_terrainDoubleMoveCount.clear();
 #if defined(MOD_PROMOTIONS_HALF_MOVE)
-		m_terrainHalfMoveCount.dirtyGet(m_syncArchive).clear();
-		m_terrainExtraMoveCount.dirtyGet(m_syncArchive).clear();
+		m_terrainHalfMoveCount.clear();
+		m_terrainExtraMoveCount.clear();
 #endif
 #if defined(MOD_BALANCE_CORE)
-		m_terrainDoubleHeal.dirtyGet(m_syncArchive).clear();
+		m_terrainDoubleHeal.clear();
 #endif
 #if defined(MOD_BALANCE_CORE)
-		m_PromotionDuration.dirtyGet(m_syncArchive).clear();
-		m_TurnPromotionGained.dirtyGet(m_syncArchive).clear();
+		m_PromotionDuration.clear();
+		m_TurnPromotionGained.clear();
 #endif
-		m_terrainImpassableCount.dirtyGet(m_syncArchive).clear();
-		m_extraTerrainAttackPercent.dirtyGet(m_syncArchive).clear();
-		m_extraTerrainDefensePercent.dirtyGet(m_syncArchive).clear();
+		m_terrainImpassableCount.clear();
+		m_extraTerrainAttackPercent.clear();
+		m_extraTerrainDefensePercent.clear();
 
-		m_featureDoubleMoveCount.dirtyGet(m_syncArchive).clear();
+		m_featureDoubleMoveCount.clear();
 #if defined(MOD_PROMOTIONS_HALF_MOVE)
-		m_featureHalfMoveCount.dirtyGet(m_syncArchive).clear();
-		m_featureExtraMoveCount.dirtyGet(m_syncArchive).clear();
+		m_featureHalfMoveCount.clear();
+		m_featureExtraMoveCount.clear();
 #endif
 #if defined(MOD_BALANCE_CORE)
-		m_featureDoubleHeal.dirtyGet(m_syncArchive).clear();
+		m_featureDoubleHeal.clear();
 #endif
-		m_featureImpassableCount.dirtyGet(m_syncArchive).clear();
-		m_extraFeatureDefensePercent.dirtyGet(m_syncArchive).clear();
-		m_extraFeatureAttackPercent.dirtyGet(m_syncArchive).clear();
+		m_featureImpassableCount.clear();
+		m_extraFeatureDefensePercent.clear();
+		m_extraFeatureAttackPercent.clear();
 
-		m_extraUnitClassAttackMod.dirtyGet(m_syncArchive).clear();
-		m_extraUnitClassDefenseMod.dirtyGet(m_syncArchive).clear();
+		m_extraUnitClassAttackMod.clear();
+		m_extraUnitClassDefenseMod.clear();
 
 #if defined(MOD_API_UNIFIED_YIELDS)
-		m_yieldFromKills.clear(m_syncArchive);
-		m_yieldFromBarbarianKills.clear(m_syncArchive);
+		m_yieldFromKills.clear();
+		m_yieldFromBarbarianKills.clear();
 #if defined(MOD_BALANCE_CORE)
-		m_aiNumTimesAttackedThisTurn.clear(m_syncArchive);
-		m_aiNumTimesAttackedThisTurn.resize(m_syncArchive, REALLY_MAX_PLAYERS);
-		m_yieldFromScouting.clear(m_syncArchive);
+		m_aiNumTimesAttackedThisTurn.clear();
+		m_aiNumTimesAttackedThisTurn.resize(REALLY_MAX_PLAYERS);
+		m_yieldFromScouting.clear();
 #endif
 		
-		m_yieldFromKills.resize(m_syncArchive, NUM_YIELD_TYPES);
-		m_yieldFromBarbarianKills.resize(m_syncArchive, NUM_YIELD_TYPES);
+		m_yieldFromKills.resize(NUM_YIELD_TYPES);
+		m_yieldFromBarbarianKills.resize(NUM_YIELD_TYPES);
 #if defined(MOD_BALANCE_CORE)
-		m_yieldFromScouting.resize(m_syncArchive, NUM_YIELD_TYPES);
+		m_yieldFromScouting.resize(NUM_YIELD_TYPES);
 #endif
 
 		for(int i = 0; i < NUM_YIELD_TYPES; i++)
 		{
-			m_yieldFromKills.setAt(m_syncArchive,i,0);
-			m_yieldFromBarbarianKills.setAt(m_syncArchive,i,0);
+			m_yieldFromKills[i] = 0;
+			m_yieldFromBarbarianKills[i] = 0;
 #if defined(MOD_BALANCE_CORE)
-			m_yieldFromScouting.setAt(m_syncArchive,i,0);
+			m_yieldFromScouting[i] = 0;
 #endif
 		}
 #endif
 		for (int iI = 0; iI < REALLY_MAX_PLAYERS; iI++)
 		{
-			m_aiNumTimesAttackedThisTurn.setAt(m_syncArchive, iI, 0);
+			m_aiNumTimesAttackedThisTurn[iI] =  0;
 		}
 
 		CvAssertMsg((0 < GC.getNumUnitCombatClassInfos()), "GC.getNumUnitCombatClassInfos() is not greater than zero but an array is being allocated in CvUnit::reset");
-		m_extraUnitCombatModifier.clear(m_syncArchive);
-		m_extraUnitCombatModifier.resize(m_syncArchive, GC.getNumUnitCombatClassInfos());
+		m_extraUnitCombatModifier.clear();
+		m_extraUnitCombatModifier.resize(GC.getNumUnitCombatClassInfos());
 #if defined(MOD_BALANCE_CORE)
-		m_iCombatModPerAdjacentUnitCombatModifier.clear(m_syncArchive);
-		m_iCombatModPerAdjacentUnitCombatModifier.resize(m_syncArchive, GC.getNumUnitCombatClassInfos());
-		m_iCombatModPerAdjacentUnitCombatAttackMod.clear(m_syncArchive);
-		m_iCombatModPerAdjacentUnitCombatAttackMod.resize(m_syncArchive, GC.getNumUnitCombatClassInfos());
-		m_iCombatModPerAdjacentUnitCombatDefenseMod.clear(m_syncArchive);
-		m_iCombatModPerAdjacentUnitCombatDefenseMod.resize(m_syncArchive, GC.getNumUnitCombatClassInfos());
+		m_iCombatModPerAdjacentUnitCombatModifier.clear();
+		m_iCombatModPerAdjacentUnitCombatModifier.resize(GC.getNumUnitCombatClassInfos());
+		m_iCombatModPerAdjacentUnitCombatAttackMod.clear();
+		m_iCombatModPerAdjacentUnitCombatAttackMod.resize(GC.getNumUnitCombatClassInfos());
+		m_iCombatModPerAdjacentUnitCombatDefenseMod.clear();
+		m_iCombatModPerAdjacentUnitCombatDefenseMod.resize(GC.getNumUnitCombatClassInfos());
 #endif
 		for(int i = 0; i < GC.getNumUnitCombatClassInfos(); i++)
 		{
-			m_extraUnitCombatModifier.setAt(m_syncArchive,i,0);
+			m_extraUnitCombatModifier[i] = 0;
 #if defined(MOD_BALANCE_CORE)
-			m_iCombatModPerAdjacentUnitCombatModifier.setAt(m_syncArchive,i,0);
-			m_iCombatModPerAdjacentUnitCombatAttackMod.setAt(m_syncArchive,i,0);
-			m_iCombatModPerAdjacentUnitCombatDefenseMod.setAt(m_syncArchive,i,0);
+			m_iCombatModPerAdjacentUnitCombatModifier[i] = 0;
+			m_iCombatModPerAdjacentUnitCombatAttackMod[i] = 0;
+			m_iCombatModPerAdjacentUnitCombatDefenseMod[i] = 0;
 #endif
 		}
 
-		m_unitClassModifier.clear(m_syncArchive);
-		m_unitClassModifier.resize(m_syncArchive, GC.getNumUnitClassInfos());
+		m_unitClassModifier.clear();
+		m_unitClassModifier.resize(GC.getNumUnitClassInfos());
 		for(int i = 0; i < GC.getNumUnitClassInfos(); i++)
 		{
 			CvUnitClassInfo* pkUnitClassInfo = GC.getUnitClassInfo((UnitClassTypes)i);
@@ -1518,16 +1875,16 @@ void CvUnit::reset(int iID, UnitTypes eUnit, PlayerTypes eOwner, bool bConstruct
 				continue;
 			}
 
-			m_unitClassModifier.setAt(m_syncArchive, i,0);
+			m_unitClassModifier[i] = 0;
 		}
 
 		// Migrated in from CvSelectionGroup
-		m_iMissionAIX.set(m_syncArchive, INVALID_PLOT_COORD);
-		m_iMissionAIY.set(m_syncArchive, INVALID_PLOT_COORD);
-		m_eMissionAIType.set(m_syncArchive, NO_MISSIONAI);
+		m_iMissionAIX = INVALID_PLOT_COORD;
+		m_iMissionAIY = INVALID_PLOT_COORD;
+		m_eMissionAIType = NO_MISSIONAI;
 		m_missionAIUnit.reset();
 
-		m_eUnitAIType.set(m_syncArchive, NO_UNITAI);
+		m_eUnitAIType = NO_UNITAI;
 	}
 }
 
@@ -1594,46 +1951,46 @@ void CvUnit::uninitInfos()
 {
 	VALIDATE_OBJECT
 #if defined(MOD_PROMOTIONS_HALF_MOVE)
-	m_terrainDoubleMoveCount.dirtyGet(m_syncArchive).clear(); // BUG FIX
-	m_featureDoubleMoveCount.dirtyGet(m_syncArchive).clear();
-	m_terrainHalfMoveCount.dirtyGet(m_syncArchive).clear();
-	m_featureHalfMoveCount.dirtyGet(m_syncArchive).clear();
-	m_terrainExtraMoveCount.dirtyGet(m_syncArchive).clear();
-	m_featureExtraMoveCount.dirtyGet(m_syncArchive).clear();
+	m_terrainDoubleMoveCount.clear(); // BUG FIX
+	m_featureDoubleMoveCount.clear();
+	m_terrainHalfMoveCount.clear();
+	m_featureHalfMoveCount.clear();
+	m_terrainExtraMoveCount.clear();
+	m_featureExtraMoveCount.clear();
 #else
 	m_featureDoubleMoveCount.clear();
 #endif
 #if defined(MOD_BALANCE_CORE)
-	m_PromotionDuration.dirtyGet(m_syncArchive).clear();
-	m_TurnPromotionGained.dirtyGet(m_syncArchive).clear();
+	m_PromotionDuration.clear();
+	m_TurnPromotionGained.clear();
 #endif
 #if defined(MOD_BALANCE_CORE)
-	m_terrainDoubleHeal.dirtyGet(m_syncArchive).clear();
-	m_featureDoubleHeal.dirtyGet(m_syncArchive).clear();
+	m_terrainDoubleHeal.clear();
+	m_featureDoubleHeal.clear();
 #endif
-	m_terrainImpassableCount.dirtyGet(m_syncArchive).clear();
-	m_featureImpassableCount.dirtyGet(m_syncArchive).clear();
-	m_extraTerrainAttackPercent.dirtyGet(m_syncArchive).clear();
-	m_extraTerrainDefensePercent.dirtyGet(m_syncArchive).clear();
-	m_extraFeatureAttackPercent.dirtyGet(m_syncArchive).clear();
-	m_extraFeatureDefensePercent.dirtyGet(m_syncArchive).clear();
+	m_terrainImpassableCount.clear();
+	m_featureImpassableCount.clear();
+	m_extraTerrainAttackPercent.clear();
+	m_extraTerrainDefensePercent.clear();
+	m_extraFeatureAttackPercent.clear();
+	m_extraFeatureDefensePercent.clear();
 
-	m_extraUnitClassAttackMod.dirtyGet(m_syncArchive).clear();
-	m_extraUnitClassDefenseMod.dirtyGet(m_syncArchive).clear();
+	m_extraUnitClassAttackMod.clear();
+	m_extraUnitClassDefenseMod.clear();
 #if defined(MOD_BALANCE_CORE)
-	m_iCombatModPerAdjacentUnitCombatModifier.clear(m_syncArchive);
-	m_iCombatModPerAdjacentUnitCombatAttackMod.clear(m_syncArchive);
-	m_iCombatModPerAdjacentUnitCombatDefenseMod.clear(m_syncArchive);
+	m_iCombatModPerAdjacentUnitCombatModifier.clear();
+	m_iCombatModPerAdjacentUnitCombatAttackMod.clear();
+	m_iCombatModPerAdjacentUnitCombatDefenseMod.clear();
 #endif
 #if defined(MOD_API_UNIFIED_YIELDS)
-	m_yieldFromKills.clear(m_syncArchive);
-	m_yieldFromBarbarianKills.clear(m_syncArchive);
+	m_yieldFromKills.clear();
+	m_yieldFromBarbarianKills.clear();
 #endif
 #if defined(MOD_BALANCE_CORE)
-	m_yieldFromScouting.clear(m_syncArchive);
+	m_yieldFromScouting.clear();
 #endif
-	m_extraUnitCombatModifier.clear(m_syncArchive);
-	m_unitClassModifier.clear(m_syncArchive);
+	m_extraUnitCombatModifier.clear();
+	m_unitClassModifier.clear();
 }
 
 
@@ -5891,7 +6248,7 @@ bool CvUnit::CanDistanceGift(PlayerTypes eToPlayer) const
 #if defined(MOD_CORE_PER_TURN_DAMAGE)
 int CvUnit::addDamageReceivedThisTurn(int iDamage, CvUnit* pAttacker)
 {
-	m_iDamageTakenThisTurn.dirtyGet(m_syncArchive) += iDamage;
+	m_iDamageTakenThisTurn+=iDamage;
 
 	//remember the attacker for AI danger calculation - in case he came out of nowhere, now moves and becomes invisible again
 	if (pAttacker && !isHuman())
@@ -5902,8 +6259,8 @@ int CvUnit::addDamageReceivedThisTurn(int iDamage, CvUnit* pAttacker)
 
 void CvUnit::flipDamageReceivedPerTurn()
 {
-	m_iDamageTakenLastTurn.set(m_syncArchive, m_iDamageTakenThisTurn);
-	m_iDamageTakenThisTurn.set(m_syncArchive, 0);
+	m_iDamageTakenLastTurn = m_iDamageTakenThisTurn;
+	m_iDamageTakenThisTurn = 0;
 }
 
 bool CvUnit::isProjectedToDieNextTurn() const
@@ -6293,7 +6650,7 @@ void CvUnit::ChangeRangeAttackIgnoreLOSCount(int iChange)
 	VALIDATE_OBJECT
 	if(iChange != 0)
 	{
-		m_iRangeAttackIgnoreLOSCount.dirtyGet(m_syncArchive) += iChange;
+		m_iRangeAttackIgnoreLOSCount += iChange;
 	}
 }
 
@@ -6316,7 +6673,7 @@ void CvUnit::ChangeCityAttackOnlyCount(int iChange)
 	VALIDATE_OBJECT
 	if(iChange != 0)
 	{
-		m_iCityAttackOnlyCount.dirtyGet(m_syncArchive) += iChange;
+		m_iCityAttackOnlyCount += iChange;
 	}
 }
 
@@ -6333,7 +6690,7 @@ void CvUnit::ChangeCaptureDefeatedEnemyCount(int iChange)
 	VALIDATE_OBJECT
 	if(iChange != 0)
 	{
-		m_iCaptureDefeatedEnemyCount.dirtyGet(m_syncArchive) += iChange;
+		m_iCaptureDefeatedEnemyCount += iChange;
 	}
 }
 
@@ -6379,7 +6736,7 @@ void CvUnit::ChangeCannotBeCapturedCount(int iChange)
 	VALIDATE_OBJECT
 	if(iChange != 0)
 	{
-		m_iCannotBeCapturedCount.dirtyGet(m_syncArchive) += iChange;
+		m_iCannotBeCapturedCount += iChange;
 	}
 }
 //	--------------------------------------------------------------------------------
@@ -6394,7 +6751,7 @@ void CvUnit::ChangeForcedDamageValue(int iChange)
 	VALIDATE_OBJECT
 	if(iChange != 0)
 	{
-		m_iForcedDamage.dirtyGet(m_syncArchive) += iChange;
+		m_iForcedDamage += iChange;
 	}
 }
 //	--------------------------------------------------------------------------------
@@ -6409,7 +6766,7 @@ void CvUnit::ChangeChangeDamageValue(int iChange)
 	VALIDATE_OBJECT
 	if(iChange != 0)
 	{
-		m_iChangeDamage.dirtyGet(m_syncArchive) += iChange;
+		m_iChangeDamage += iChange;
 	}
 }
 //	--------------------------------------------------------------------------------
@@ -6422,7 +6779,7 @@ int CvUnit::getChangeDamageValue()
 //	--------------------------------------------------------------------------------
 void CvUnit::ChangePromotionDuration(PromotionTypes eIndex, int iChange)
 {
-	std::map<PromotionTypes, int>& m_map = m_PromotionDuration.dirtyGet(m_syncArchive);
+	std::map<PromotionTypes, int>& m_map = m_PromotionDuration;
 	if (m_map.find(eIndex) != m_map.end())
 	{
 		m_map[eIndex] += iChange;
@@ -6435,7 +6792,7 @@ void CvUnit::ChangePromotionDuration(PromotionTypes eIndex, int iChange)
 //	--------------------------------------------------------------------------------
 int CvUnit::getPromotionDuration(PromotionTypes eIndex)
 {
-	const std::map<PromotionTypes, int>& m_map = m_PromotionDuration.get();
+	const std::map<PromotionTypes, int>& m_map = m_PromotionDuration;
 	std::map<PromotionTypes, int>::const_iterator it = m_map.find(eIndex);
 	if (it != m_map.end())
 		return it->second;
@@ -6446,7 +6803,7 @@ int CvUnit::getPromotionDuration(PromotionTypes eIndex)
 //	--------------------------------------------------------------------------------
 void CvUnit::SetTurnPromotionGained(PromotionTypes eIndex, int iValue)
 {
-	std::map<PromotionTypes, int>& m_map = m_TurnPromotionGained.dirtyGet(m_syncArchive);
+	std::map<PromotionTypes, int>& m_map = m_TurnPromotionGained;
 	if (iValue>0)
 		m_map[eIndex] = iValue;
 	else
@@ -6455,7 +6812,7 @@ void CvUnit::SetTurnPromotionGained(PromotionTypes eIndex, int iValue)
 //	--------------------------------------------------------------------------------
 int CvUnit::getTurnPromotionGained(PromotionTypes eIndex)
 {
-	const std::map<PromotionTypes, int>& m_map = m_TurnPromotionGained.get();
+	const std::map<PromotionTypes, int>& m_map = m_TurnPromotionGained;
 	std::map<PromotionTypes, int>::const_iterator it = m_map.find(eIndex);
 	if (it != m_map.end())
 		return it->second;
@@ -6675,7 +7032,7 @@ void CvUnit::ChangeEmbarkAbilityCount(int iChange)
 {
 	if(iChange != 0)
 	{
-		m_iEmbarkAbilityCount.dirtyGet(m_syncArchive) += iChange;
+		m_iEmbarkAbilityCount += iChange;
 	}
 }
 
@@ -6689,7 +7046,7 @@ bool CvUnit::IsEmbarkAllWater() const
 //	--------------------------------------------------------------------------------
 void CvUnit::ChangeEmbarkAllWaterCount(int iValue)
 {
-	m_iEmbarkedAllWaterCount.dirtyGet(m_syncArchive) += iValue;
+	m_iEmbarkedAllWaterCount += iValue;
 }
 
 //	--------------------------------------------------------------------------------
@@ -6709,7 +7066,7 @@ bool CvUnit::IsEmbarkDeepWater() const
 //	--------------------------------------------------------------------------------
 void CvUnit::ChangeEmbarkDeepWaterCount(int iValue)
 {
-	m_iEmbarkedDeepWaterCount.dirtyGet(m_syncArchive) += iValue;
+	m_iEmbarkedDeepWaterCount += iValue;
 }
 
 //	--------------------------------------------------------------------------------
@@ -6722,7 +7079,7 @@ int CvUnit::GetEmbarkDeepWaterCount() const
 //	--------------------------------------------------------------------------------
 void CvUnit::ChangeEmbarkExtraVisibility(int iValue)
 {
-	m_iEmbarkExtraVisibility.dirtyGet(m_syncArchive) += iValue;
+	m_iEmbarkExtraVisibility += iValue;
 }
 
 //	--------------------------------------------------------------------------------
@@ -6734,7 +7091,7 @@ int CvUnit::GetEmbarkExtraVisibility() const
 //	--------------------------------------------------------------------------------
 void CvUnit::ChangeEmbarkDefensiveModifier(int iValue)
 {
-	m_iEmbarkDefensiveModifier.dirtyGet(m_syncArchive) += iValue;
+	m_iEmbarkDefensiveModifier += iValue;
 }
 
 //	--------------------------------------------------------------------------------
@@ -6746,7 +7103,7 @@ int CvUnit::GetEmbarkDefensiveModifier() const
 //	--------------------------------------------------------------------------------
 void CvUnit::ChangeCapitalDefenseModifier(int iValue)
 {
-	m_iCapitalDefenseModifier.dirtyGet(m_syncArchive) += iValue;
+	m_iCapitalDefenseModifier += iValue;
 }
 
 //	--------------------------------------------------------------------------------
@@ -6758,7 +7115,7 @@ int CvUnit::GetCapitalDefenseModifier() const
 //	--------------------------------------------------------------------------------
 void CvUnit::ChangeCapitalDefenseFalloff(int iValue)
 {
-	m_iCapitalDefenseFalloff.dirtyGet(m_syncArchive) += iValue;
+	m_iCapitalDefenseFalloff += iValue;
 }
 
 //	--------------------------------------------------------------------------------
@@ -6770,7 +7127,7 @@ int CvUnit::GetCapitalDefenseFalloff() const
 //	--------------------------------------------------------------------------------
 void CvUnit::ChangeCityAttackPlunderModifier(int iValue)
 {
-	m_iCityAttackPlunderModifier.dirtyGet(m_syncArchive) += iValue;
+	m_iCityAttackPlunderModifier += iValue;
 }
 
 //	--------------------------------------------------------------------------------
@@ -6782,7 +7139,7 @@ int CvUnit::GetCityAttackPlunderModifier() const
 //	--------------------------------------------------------------------------------
 void CvUnit::ChangeReligiousStrengthLossRivalTerritory(int iValue)
 {
-	m_iReligiousStrengthLossRivalTerritory.dirtyGet(m_syncArchive) += iValue;
+	m_iReligiousStrengthLossRivalTerritory += iValue;
 }
 
 //	--------------------------------------------------------------------------------
@@ -6794,7 +7151,7 @@ int CvUnit::GetReligiousStrengthLossRivalTerritory() const
 //	--------------------------------------------------------------------------------
 void CvUnit::ChangeTradeMissionInfluenceModifier(int iValue)
 {
-	m_iTradeMissionInfluenceModifier.dirtyGet(m_syncArchive) += iValue;
+	m_iTradeMissionInfluenceModifier += iValue;
 }
 
 //	--------------------------------------------------------------------------------
@@ -6806,7 +7163,7 @@ int CvUnit::GetTradeMissionInfluenceModifier() const
 //	--------------------------------------------------------------------------------
 void CvUnit::ChangeTradeMissionGoldModifier(int iValue)
 {
-	m_iTradeMissionGoldModifier.dirtyGet(m_syncArchive) += iValue;
+	m_iTradeMissionGoldModifier += iValue;
 }
 
 //	--------------------------------------------------------------------------------
@@ -6818,7 +7175,7 @@ int CvUnit::GetTradeMissionGoldModifier() const
 //	--------------------------------------------------------------------------------
 void CvUnit::ChangeDiploMissionInfluence(int iValue)
 {
-	m_iDiploMissionInfluence.dirtyGet(m_syncArchive) += iValue;
+	m_iDiploMissionInfluence += iValue;
 }
 
 //	--------------------------------------------------------------------------------
@@ -12053,7 +12410,7 @@ bool CvUnit::canBuyCityState(const CvPlot* pPlot, bool bTestVisible) const
 
 #if defined(MOD_EVENTS_MINORS_INTERACTION)
 		if (MOD_EVENTS_MINORS_INTERACTION) {
-			if (GAMEEVENTINVOKE_TESTALL(GAMEEVENT_PlayerCanBuyOut, m_eOwner.get(), pPlot->getOwner()) == GAMEEVENTRETURN_FALSE) {
+			if (GAMEEVENTINVOKE_TESTALL(GAMEEVENT_PlayerCanBuyOut, m_eOwner, pPlot->getOwner()) == GAMEEVENTRETURN_FALSE) {
 				return false;
 			}
 		}
@@ -17082,7 +17439,7 @@ void CvUnit::changeIgnoreTerrainCostCount(int iValue)
 	VALIDATE_OBJECT
 	if(iValue != 0)
 	{
-		m_iIgnoreTerrainCostCount.dirtyGet(m_syncArchive) += iValue;
+		m_iIgnoreTerrainCostCount += iValue;
 	}
 }
 
@@ -17106,7 +17463,7 @@ void CvUnit::changeIgnoreTerrainDamageCount(int iValue)
 	VALIDATE_OBJECT
 	if(iValue != 0)
 	{
-		m_iIgnoreTerrainDamageCount.dirtyGet(m_syncArchive) += iValue;
+		m_iIgnoreTerrainDamageCount += iValue;
 	}
 }
 
@@ -17131,7 +17488,7 @@ void CvUnit::changeIgnoreFeatureDamageCount(int iValue)
 	VALIDATE_OBJECT
 	if(iValue != 0)
 	{
-		m_iIgnoreFeatureDamageCount.dirtyGet(m_syncArchive) += iValue;
+		m_iIgnoreFeatureDamageCount += iValue;
 	}
 }
 
@@ -17156,7 +17513,7 @@ void CvUnit::changeExtraTerrainDamageCount(int iValue)
 	VALIDATE_OBJECT
 	if(iValue != 0)
 	{
-		m_iExtraTerrainDamageCount.dirtyGet(m_syncArchive) += iValue;
+		m_iExtraTerrainDamageCount += iValue;
 	}
 }
 
@@ -17181,7 +17538,7 @@ void CvUnit::changeExtraFeatureDamageCount(int iValue)
 	VALIDATE_OBJECT
 	if(iValue != 0)
 	{
-		m_iExtraFeatureDamageCount.dirtyGet(m_syncArchive) += iValue;
+		m_iExtraFeatureDamageCount += iValue;
 	}
 }
 
@@ -17249,7 +17606,7 @@ void CvUnit::SetCombatBonusFromNearbyUnitClass(UnitClassTypes eUnitClass)
 void CvUnit::ChangeNearbyPromotion(int iValue)
 {
 	VALIDATE_OBJECT
-	m_bNearbyPromotion.dirtyGet(m_syncArchive) += iValue;
+	m_bNearbyPromotion += iValue;
 }
 int CvUnit::GetNearbyPromotion() const
 {
@@ -17269,12 +17626,12 @@ int CvUnit::GetNearbyUnitPromotionsRange() const
 void CvUnit::ChangeNearbyUnitPromotionRange(int iBonusRange)
 {
 	VALIDATE_OBJECT
-	m_iNearbyUnitPromotionRange.dirtyGet(m_syncArchive) += iBonusRange;
+	m_iNearbyUnitPromotionRange += iBonusRange;
 }
 void CvUnit::ChangeNearbyCityCombatMod(int iValue)
 {
 	VALIDATE_OBJECT
-	m_iNearbyCityCombatMod.dirtyGet(m_syncArchive) += iValue;
+	m_iNearbyCityCombatMod += iValue;
 }
 int CvUnit::getNearbyCityCombatMod() const
 {
@@ -17284,7 +17641,7 @@ int CvUnit::getNearbyCityCombatMod() const
 void CvUnit::ChangeNearbyFriendlyCityCombatMod(int iValue)
 {
 	VALIDATE_OBJECT
-	m_iNearbyFriendlyCityCombatMod.dirtyGet(m_syncArchive) += iValue;
+	m_iNearbyFriendlyCityCombatMod += iValue;
 }
 int CvUnit::getNearbyFriendlyCityCombatMod() const
 {
@@ -17294,7 +17651,7 @@ int CvUnit::getNearbyFriendlyCityCombatMod() const
 void CvUnit::ChangeNearbyEnemyCityCombatMod(int iValue)
 {
 	VALIDATE_OBJECT
-	m_iNearbyEnemyCityCombatMod.dirtyGet(m_syncArchive) += iValue;
+	m_iNearbyEnemyCityCombatMod += iValue;
 }
 int CvUnit::getNearbyEnemyCityCombatMod() const
 {
@@ -17309,7 +17666,7 @@ int CvUnit::getPillageBonusStrengthPercent() const
 void CvUnit::ChangePillageBonusStrengthPercent(int iBonus)
 {
 	VALIDATE_OBJECT
-	m_iPillageBonusStrengthPercent.dirtyGet(m_syncArchive) += iBonus;
+	m_iPillageBonusStrengthPercent += iBonus;
 }
 int CvUnit::getStackedGreatGeneralExperience() const
 {
@@ -17319,12 +17676,12 @@ int CvUnit::getStackedGreatGeneralExperience() const
 void CvUnit::ChangeStackedGreatGeneralExperience(int iExperience)
 {
 	VALIDATE_OBJECT
-	m_iStackedGreatGeneralExperience.dirtyGet(m_syncArchive) += iExperience;
+	m_iStackedGreatGeneralExperience += iExperience;
 }
 void CvUnit::ChangeIsHighSeaRaider(int iValue)
 {
 	VALIDATE_OBJECT
-	m_bIsHighSeaRaider.dirtyGet(m_syncArchive) += iValue;
+	m_bIsHighSeaRaider += iValue;
 }
 int CvUnit::GetIsHighSeaRaider() const
 {
@@ -17344,7 +17701,7 @@ int CvUnit::getWonderProductionModifier() const
 void CvUnit::ChangeWonderProductionModifier(int iValue)
 {
 	VALIDATE_OBJECT
-	m_iWonderProductionModifier.dirtyGet(m_syncArchive) += iValue;
+	m_iWonderProductionModifier += iValue;
 }
 int CvUnit::getMilitaryProductionModifier() const
 {
@@ -17354,7 +17711,7 @@ int CvUnit::getMilitaryProductionModifier() const
 void CvUnit::ChangeMilitaryProductionModifier(int iValue)
 {
 	VALIDATE_OBJECT
-	m_iUnitProductionModifier.dirtyGet(m_syncArchive) += iValue;
+	m_iUnitProductionModifier += iValue;
 }
 int CvUnit::getNearbyEnemyDamage() const
 {
@@ -17364,7 +17721,7 @@ int CvUnit::getNearbyEnemyDamage() const
 void CvUnit::ChangeNearbyEnemyDamage(int iValue)
 {
 	VALIDATE_OBJECT
-	m_iNearbyEnemyDamage.dirtyGet(m_syncArchive) += iValue;
+	m_iNearbyEnemyDamage += iValue;
 }
 int CvUnit::GetGGGAXPPercent() const
 {
@@ -17374,7 +17731,7 @@ int CvUnit::GetGGGAXPPercent() const
 void CvUnit::ChangeGGGAXPPercent(int iValue)
 {
 	VALIDATE_OBJECT
-	m_iGGGAXPPercent.dirtyGet(m_syncArchive) += iValue;
+	m_iGGGAXPPercent += iValue;
 }
 int CvUnit::getGiveCombatMod() const
 {
@@ -17384,7 +17741,7 @@ int CvUnit::getGiveCombatMod() const
 void CvUnit::ChangeGiveCombatMod(int iValue)
 {
 	VALIDATE_OBJECT
-	m_iGiveCombatMod.dirtyGet(m_syncArchive) += iValue;
+	m_iGiveCombatMod += iValue;
 }
 int CvUnit::getGiveHPIfEnemyKilled() const
 {
@@ -17394,7 +17751,7 @@ int CvUnit::getGiveHPIfEnemyKilled() const
 void CvUnit::ChangeGiveHPIfEnemyKilled(int iValue)
 {
 	VALIDATE_OBJECT
-	m_iGiveHPIfEnemyKilled.dirtyGet(m_syncArchive) += iValue;
+	m_iGiveHPIfEnemyKilled += iValue;
 }
 int CvUnit::getGiveExperiencePercent() const
 {
@@ -17404,7 +17761,7 @@ int CvUnit::getGiveExperiencePercent() const
 void CvUnit::ChangeGiveExperiencePercent(int iValue)
 {
 	VALIDATE_OBJECT
-	m_iGiveExperiencePercent.dirtyGet(m_syncArchive) += iValue;
+	m_iGiveExperiencePercent += iValue;
 }
 int CvUnit::getGiveOutsideFriendlyLandsModifier() const
 {
@@ -17414,7 +17771,7 @@ int CvUnit::getGiveOutsideFriendlyLandsModifier() const
 void CvUnit::ChangeGiveOutsideFriendlyLandsModifier(int iValue)
 {
 	VALIDATE_OBJECT
-	m_iGiveOutsideFriendlyLandsModifier.dirtyGet(m_syncArchive) += iValue;
+	m_iGiveOutsideFriendlyLandsModifier += iValue;
 }
 const DomainTypes CvUnit::getGiveDomain() const
 {
@@ -17434,7 +17791,7 @@ int CvUnit::getGiveExtraAttacks() const
 void CvUnit::ChangeGiveExtraAttacks(int iValue)
 {
 	VALIDATE_OBJECT
-	m_iGiveExtraAttacks.dirtyGet(m_syncArchive) += iValue;
+	m_iGiveExtraAttacks += iValue;
 }
 int CvUnit::getGiveDefenseMod() const
 {
@@ -17444,7 +17801,7 @@ int CvUnit::getGiveDefenseMod() const
 void CvUnit::ChangeGiveDefenseMod(int iValue)
 {
 	VALIDATE_OBJECT
-	m_iGiveDefenseMod.dirtyGet(m_syncArchive) += iValue;
+	m_iGiveDefenseMod += iValue;
 }
 int CvUnit::getNearbyHealEnemyTerritory() const
 {
@@ -17454,7 +17811,7 @@ int CvUnit::getNearbyHealEnemyTerritory() const
 void CvUnit::ChangeNearbyHealEnemyTerritory(int iValue)
 {
 	VALIDATE_OBJECT
-	m_iNearbyHealEnemyTerritory.dirtyGet(m_syncArchive) += iValue;
+	m_iNearbyHealEnemyTerritory += iValue;
 }
 int CvUnit::getNearbyHealNeutralTerritory() const
 {
@@ -17464,7 +17821,7 @@ int CvUnit::getNearbyHealNeutralTerritory() const
 void CvUnit::ChangeNearbyHealNeutralTerritory(int iValue)
 {
 	VALIDATE_OBJECT
-	m_iNearbyHealNeutralTerritory.dirtyGet(m_syncArchive) += iValue;
+	m_iNearbyHealNeutralTerritory += iValue;
 }
 int CvUnit::getNearbyHealFriendlyTerritory() const
 {
@@ -17474,12 +17831,12 @@ int CvUnit::getNearbyHealFriendlyTerritory() const
 void CvUnit::ChangeNearbyHealFriendlyTerritory(int iValue)
 {
 	VALIDATE_OBJECT
-	m_iNearbyHealFriendlyTerritory.dirtyGet(m_syncArchive) += iValue;
+	m_iNearbyHealFriendlyTerritory += iValue;
 }
 void CvUnit::ChangeIsGiveInvisibility(int iValue)
 {
 	VALIDATE_OBJECT
-	m_bGiveInvisibility.dirtyGet(m_syncArchive) += iValue;
+	m_bGiveInvisibility += iValue;
 }
 int CvUnit::GetIsGiveInvisibility() const
 {
@@ -17504,7 +17861,7 @@ void CvUnit::SetIsGiveOnlyOnStartingTurn(bool bNewValue)
 void CvUnit::ChangeIsConvertUnit(int iValue)
 {
 	VALIDATE_OBJECT
-	m_bConvertUnit.dirtyGet(m_syncArchive) += iValue;
+	m_bConvertUnit += iValue;
 }
 int CvUnit::getIsConvertUnit() const
 {
@@ -17524,7 +17881,7 @@ const DomainTypes CvUnit::getConvertDomain() const
 void CvUnit::ChangeConvertDomain(DomainTypes eDomain)
 {
 	VALIDATE_OBJECT
-	m_eConvertDomain.dirtyGet(m_syncArchive) = eDomain;
+	m_eConvertDomain = eDomain;
 }
 const UnitTypes CvUnit::getConvertDomainUnitType() const
 {
@@ -17539,7 +17896,7 @@ void CvUnit::ChangeConvertDomainUnit(UnitTypes eUnit)
 void CvUnit::ChangeIsConvertEnemyUnitToBarbarian(int iValue)
 {
 	VALIDATE_OBJECT
-	m_bConvertEnemyUnitToBarbarian.dirtyGet(m_syncArchive) += iValue;
+	m_bConvertEnemyUnitToBarbarian += iValue;
 }
 int CvUnit::getIsConvertEnemyUnitToBarbarian() const
 {
@@ -17554,7 +17911,7 @@ bool CvUnit::isConvertEnemyUnitToBarbarian() const
 void CvUnit::ChangeIsConvertOnFullHP(int iValue)
 {
 	VALIDATE_OBJECT
-	m_bConvertOnFullHP.dirtyGet(m_syncArchive) += iValue;
+	m_bConvertOnFullHP += iValue;
 }
 int CvUnit::getIsConvertOnFullHP() const
 {
@@ -17569,7 +17926,7 @@ bool CvUnit::isConvertOnFullHP() const
 void CvUnit::ChangeIsConvertOnDamage(int iValue)
 {
 	VALIDATE_OBJECT
-	m_bConvertOnDamage.dirtyGet(m_syncArchive) += iValue;
+	m_bConvertOnDamage += iValue;
 }
 int CvUnit::getIsConvertOnDamage() const
 {
@@ -17589,7 +17946,7 @@ int CvUnit::getDamageThreshold() const
 void CvUnit::ChangeDamageThreshold(int iValue)
 {
 	VALIDATE_OBJECT
-	m_iDamageThreshold.dirtyGet(m_syncArchive) += iValue;
+	m_iDamageThreshold += iValue;
 }
 const UnitTypes CvUnit::getConvertDamageOrFullHPUnit() const
 {
@@ -17640,7 +17997,7 @@ void CvUnit::changeCanCrossMountainsCount(int iValue)
 	VALIDATE_OBJECT
 	if(iValue != 0)
 	{
-		m_iCanCrossMountainsCount.dirtyGet(m_syncArchive) += iValue;
+		m_iCanCrossMountainsCount += iValue;
 	}
 }
 #endif
@@ -17667,7 +18024,7 @@ void CvUnit::changeCanCrossOceansCount(int iValue)
 	VALIDATE_OBJECT
 	if(iValue != 0)
 	{
-		m_iCanCrossOceansCount.dirtyGet(m_syncArchive) += iValue;
+		m_iCanCrossOceansCount += iValue;
 	}
 }
 #endif
@@ -17694,7 +18051,7 @@ void CvUnit::changeCanCrossIceCount(int iValue)
 	VALIDATE_OBJECT
 	if(iValue != 0)
 	{
-		m_iCanCrossIceCount.dirtyGet(m_syncArchive) += iValue;
+		m_iCanCrossIceCount += iValue;
 	}
 }
 #endif
@@ -17705,7 +18062,7 @@ void CvUnit::ChangeNumTilesRevealedThisTurn(int iValue)
 	VALIDATE_OBJECT
 	if(iValue != 0)
 	{
-		m_iNumTilesRevealedThisTurn.dirtyGet(m_syncArchive) += iValue;
+		m_iNumTilesRevealedThisTurn += iValue;
 	}
 }
 //	--------------------------------------------------------------------------------
@@ -17769,7 +18126,7 @@ void CvUnit::ChangeGainsXPFromScouting(int iValue)
 	VALIDATE_OBJECT
 	if(iValue != 0)
 	{
-		m_iGainsXPFromScouting.dirtyGet(m_syncArchive) += iValue;
+		m_iGainsXPFromScouting += iValue;
 	}
 }
 
@@ -17795,7 +18152,7 @@ void CvUnit::ChangeGainsXPFromSpotting(int iValue)
 	VALIDATE_OBJECT
 		if (iValue != 0)
 		{
-			m_iGainsXPFromSpotting.dirtyGet(m_syncArchive) += iValue;
+			m_iGainsXPFromSpotting += iValue;
 		}
 }
 
@@ -17821,7 +18178,7 @@ void CvUnit::ChangeGainsXPFromPillaging(int iValue)
 	VALIDATE_OBJECT
 		if (iValue != 0)
 		{
-			m_iGainsXPFromPillaging.dirtyGet(m_syncArchive) += iValue;
+			m_iGainsXPFromPillaging += iValue;
 		}
 }
 
@@ -17848,7 +18205,7 @@ void CvUnit::changeGGFromBarbariansCount(int iValue)
 	VALIDATE_OBJECT
 	if(iValue != 0)
 	{
-		m_iGGFromBarbariansCount.dirtyGet(m_syncArchive) += iValue;
+		m_iGGFromBarbariansCount += iValue;
 	}
 }
 #endif
@@ -17858,7 +18215,7 @@ int CvUnit::GetCaptureDefeatedEnemyChance() const
 }
 void CvUnit::ChangeCaptureDefeatedEnemyChance(int iValue)
 {
-	m_iCaptureDefeatedEnemyChance.dirtyGet(m_syncArchive) += iValue;
+	m_iCaptureDefeatedEnemyChance += iValue;
 }
 
 //	--------------------------------------------------------------------------------
@@ -17874,7 +18231,7 @@ void CvUnit::ChangeBarbarianCombatBonus(int iValue)
 	VALIDATE_OBJECT
 	if(iValue != 0)
 	{
-		m_iBarbCombatBonus.dirtyGet(m_syncArchive) += iValue;
+		m_iBarbCombatBonus += iValue;
 	}
 }
 
@@ -17889,7 +18246,7 @@ int CvUnit::GetAdjacentEnemySapMovement() const
 void CvUnit::ChangeAdjacentEnemySapMovement(int iValue)
 {
 	VALIDATE_OBJECT
-	m_iAdjacentEnemySapMovement.dirtyGet(m_syncArchive) += iValue;
+	m_iAdjacentEnemySapMovement += iValue;
 }
 
 #endif
@@ -17914,7 +18271,7 @@ void CvUnit::ChangeRoughTerrainEndsTurnCount(int iValue)
 	VALIDATE_OBJECT
 	if(iValue != 0)
 	{
-		m_iRoughTerrainEndsTurnCount.dirtyGet(m_syncArchive) += iValue;
+		m_iRoughTerrainEndsTurnCount += iValue;
 	}
 }
 
@@ -17942,7 +18299,7 @@ void CvUnit::ChangeHoveringUnitCount(int iValue)
 	VALIDATE_OBJECT
 	if(iValue != 0)
 	{
-		m_iHoveringUnitCount.dirtyGet(m_syncArchive) += iValue;
+		m_iHoveringUnitCount += iValue;
 	}
 }
 
@@ -17966,7 +18323,7 @@ void CvUnit::changeFlatMovementCostCount(int iValue)
 	VALIDATE_OBJECT
 	if(iValue != 0)
 	{
-		m_iFlatMovementCostCount.dirtyGet(m_syncArchive) += iValue;
+		m_iFlatMovementCostCount += iValue;
 	}
 }
 
@@ -17990,7 +18347,7 @@ void CvUnit::changeCanMoveImpassableCount(int iValue)
 	VALIDATE_OBJECT
 	if(iValue != 0)
 	{
-		m_iCanMoveImpassableCount.dirtyGet(m_syncArchive) += iValue;
+		m_iCanMoveImpassableCount += iValue;
 	}
 }
 
@@ -17998,7 +18355,7 @@ void CvUnit::changeCanMoveImpassableCount(int iValue)
 void CvUnit::changeCanMoveAllTerrainCount(int iValue)
 {
 	VALIDATE_OBJECT
-	m_iCanMoveAllTerrainCount.dirtyGet(m_syncArchive) += iValue;
+	m_iCanMoveAllTerrainCount += iValue;
 	CvAssert(getCanMoveAllTerrainCount() >= 0);
 }
 
@@ -18020,7 +18377,7 @@ int CvUnit::getCanMoveAllTerrainCount() const
 void CvUnit::changeCanMoveAfterAttackingCount(int iValue)
 {
 	VALIDATE_OBJECT
-	m_iCanMoveAfterAttackingCount.dirtyGet(m_syncArchive) += iValue;
+	m_iCanMoveAfterAttackingCount += iValue;
 	CvAssert(getCanMoveAfterAttackingCount() >= 0);
 }
 
@@ -18056,7 +18413,7 @@ bool CvUnit::hasFreePillageMove() const
 void CvUnit::changeFreePillageMoveCount(int iValue)
 {
 	VALIDATE_OBJECT
-	m_iFreePillageMoveCount.dirtyGet(m_syncArchive) += iValue;
+	m_iFreePillageMoveCount += iValue;
 	CvAssert(getFreePillageMoveCount() >= 0);
 }
 
@@ -18078,7 +18435,7 @@ bool CvUnit::hasHealOnPillage() const
 void CvUnit::changeHealOnPillageCount(int iValue)
 {
 	VALIDATE_OBJECT
-	m_iHealOnPillageCount.dirtyGet(m_syncArchive) += iValue;
+	m_iHealOnPillageCount += iValue;
 	CvAssert(getHealOnPillageCount() >= 0);
 }
 
@@ -18103,7 +18460,7 @@ int CvUnit::getHPHealedIfDefeatEnemy() const
 void CvUnit::changeHPHealedIfDefeatEnemy(int iValue)
 {
 	VALIDATE_OBJECT
-	m_iHPHealedIfDefeatEnemy.dirtyGet(m_syncArchive) += iValue;
+	m_iHPHealedIfDefeatEnemy += iValue;
 	CvAssert(getHPHealedIfDefeatEnemy() >= 0);
 }
 
@@ -18127,7 +18484,7 @@ void CvUnit::ChangeHealIfDefeatExcludeBarbariansCount(int iValue)
 	VALIDATE_OBJECT
 	if(iValue != 0)
 	{
-		m_iHealIfDefeatExcludeBarbariansCount.dirtyGet(m_syncArchive) += iValue;
+		m_iHealIfDefeatExcludeBarbariansCount += iValue;
 	}
 }
 
@@ -18142,7 +18499,7 @@ int CvUnit::GetGoldenAgeValueFromKills() const
 void CvUnit::ChangeGoldenAgeValueFromKills(int iValue)
 {
 	VALIDATE_OBJECT
-	m_iGoldenAgeValueFromKills.dirtyGet(m_syncArchive) += iValue;
+	m_iGoldenAgeValueFromKills += iValue;
 	CvAssert(GetGoldenAgeValueFromKills() >= 0);
 }
 
@@ -18166,7 +18523,7 @@ void CvUnit::changeOnlyDefensiveCount(int iValue)
 	VALIDATE_OBJECT
 	if(iValue != 0)
 	{
-		m_iOnlyDefensiveCount.dirtyGet(m_syncArchive) += iValue;
+		m_iOnlyDefensiveCount += iValue;
 	}
 }
 
@@ -18196,7 +18553,7 @@ void CvUnit::changeNoDefensiveBonusCount(int iValue)
 	VALIDATE_OBJECT
 	if(iValue != 0)
 	{
-		m_iNoDefensiveBonusCount.dirtyGet(m_syncArchive) += iValue;
+		m_iNoDefensiveBonusCount += iValue;
 	}
 }
 
@@ -18220,7 +18577,7 @@ void CvUnit::changeNoCaptureCount(int iValue)
 	VALIDATE_OBJECT
 	if(iValue != 0)
 	{
-		m_iNoCaptureCount.dirtyGet(m_syncArchive) += iValue;
+		m_iNoCaptureCount += iValue;
 	}
 }
 
@@ -18285,7 +18642,7 @@ bool CvUnit::isNukeImmune() const
 void CvUnit::changeNukeImmuneCount(int iValue)
 {
 	VALIDATE_OBJECT
-	m_iNukeImmuneCount.dirtyGet(m_syncArchive) += iValue;
+	m_iNukeImmuneCount += iValue;
 	CvAssert(getNukeImmuneCount() >= 0);
 
 }
@@ -18308,7 +18665,7 @@ bool CvUnit::isHiddenNationality() const
 void CvUnit::changeHiddenNationalityCount(int iValue)
 {
 	VALIDATE_OBJECT
-	m_iHiddenNationalityCount.dirtyGet(m_syncArchive) += iValue;
+	m_iHiddenNationalityCount += iValue;
 	CvAssert(getHiddenNationalityCount() >= 0);
 
 }
@@ -18331,7 +18688,7 @@ bool CvUnit::isNoRevealMap() const
 void CvUnit::changeNoRevealMapCount(int iValue)
 {
 	VALIDATE_OBJECT
-	m_iNoRevealMapCount.dirtyGet(m_syncArchive) += iValue;
+	m_iNoRevealMapCount += iValue;
 	CvAssert(getNoRevealMapCount() >= 0);
 }
 
@@ -18430,7 +18787,7 @@ void CvUnit::ChangeAdjacentModifier(int iValue)
 	VALIDATE_OBJECT
 	if(iValue != 0)
 	{
-		m_iAdjacentModifier.dirtyGet(m_syncArchive) += iValue;
+		m_iAdjacentModifier += iValue;
 	}
 }
 
@@ -18448,7 +18805,7 @@ void CvUnit::ChangeRangedAttackModifier(int iValue)
 	VALIDATE_OBJECT
 	if(iValue != 0)
 	{
-		m_iRangedAttackModifier.dirtyGet(m_syncArchive) += iValue;
+		m_iRangedAttackModifier += iValue;
 	}
 }
 
@@ -18466,7 +18823,7 @@ void CvUnit::ChangeInterceptionCombatModifier(int iValue)
 	VALIDATE_OBJECT
 	if(iValue != 0)
 	{
-		m_iInterceptionCombatModifier.dirtyGet(m_syncArchive) += iValue;
+		m_iInterceptionCombatModifier += iValue;
 	}
 }
 
@@ -18484,7 +18841,7 @@ void CvUnit::ChangeInterceptionDefenseDamageModifier(int iValue)
 	VALIDATE_OBJECT
 	if(iValue != 0)
 	{
-		m_iInterceptionDefenseDamageModifier.dirtyGet(m_syncArchive) += iValue;
+		m_iInterceptionDefenseDamageModifier += iValue;
 	}
 }
 
@@ -18502,7 +18859,7 @@ void CvUnit::ChangeAirSweepCombatModifier(int iValue)
 	VALIDATE_OBJECT
 	if(iValue != 0)
 	{
-		m_iAirSweepCombatModifier.dirtyGet(m_syncArchive) += iValue;
+		m_iAirSweepCombatModifier += iValue;
 	}
 }
 
@@ -18519,7 +18876,7 @@ void CvUnit::changeAttackModifier(int iValue)
 	VALIDATE_OBJECT
 	if(iValue != 0)
 	{
-		m_iAttackModifier.dirtyGet(m_syncArchive) += iValue;
+		m_iAttackModifier += iValue;
 	}
 }
 
@@ -18540,7 +18897,7 @@ void CvUnit::changeDefenseModifier(int iValue)
 	VALIDATE_OBJECT
 	if(iValue != 0)
 	{
-		m_iDefenseModifier.dirtyGet(m_syncArchive) += iValue;
+		m_iDefenseModifier += iValue;
 	}
 }
 
@@ -18557,7 +18914,7 @@ void CvUnit::changeGroundAttackDamage(int iValue)
 	VALIDATE_OBJECT
 	if (iValue != 0)
 	{
-		m_iGroundAttackDamage.dirtyGet(m_syncArchive) += iValue;
+		m_iGroundAttackDamage += iValue;
 	}
 }
 
@@ -18857,7 +19214,7 @@ void CvUnit::changeCargoSpace(int iChange)
 	VALIDATE_OBJECT
 	if(iChange != 0)
 	{
-		m_iCargoCapacity.dirtyGet(m_syncArchive) += iChange;
+		m_iCargoCapacity += iChange;
 		CvAssert(m_iCargoCapacity >= 0);
 		setInfoBarDirty(true);
 	}
@@ -20251,7 +20608,7 @@ void CvUnit::ChangeReconCount(int iChange)
 {
 	if(iChange != 0)
 	{
-		m_iReconCount.dirtyGet(m_syncArchive) += iChange;
+		m_iReconCount += iChange;
 	}
 }
 
@@ -21575,7 +21932,7 @@ int CvUnit::getExtraMoves() const
 void CvUnit::changeExtraMoves(int iChange)
 {
 	VALIDATE_OBJECT
-	m_iExtraMoves.dirtyGet(m_syncArchive) += iChange;
+	m_iExtraMoves += iChange;
 }
 
 //	--------------------------------------------------------------------------------
@@ -21590,7 +21947,7 @@ int CvUnit::getExtraNavalMoves() const
 void CvUnit::changeExtraNavalMoves(int iChange)
 {
 	VALIDATE_OBJECT
-	m_iExtraNavalMoves.dirtyGet(m_syncArchive) += iChange;
+	m_iExtraNavalMoves += iChange;
 	CvAssert(getExtraNavalMoves() >= 0);
 }
 
@@ -21625,7 +21982,7 @@ int CvUnit::getExtraRange() const
 void CvUnit::changeExtraRange(int iChange)
 {
 	VALIDATE_OBJECT
-	m_iExtraRange.dirtyGet(m_syncArchive) += iChange;
+	m_iExtraRange += iChange;
 }
 
 
@@ -21641,7 +21998,7 @@ int CvUnit::getInterceptChance() const
 void CvUnit::changeInterceptChance(int iChange)
 {
 	VALIDATE_OBJECT
-	m_iInterceptChance.dirtyGet(m_syncArchive) += iChange;
+	m_iInterceptChance += iChange;
 }
 
 
@@ -21657,7 +22014,7 @@ int CvUnit::getExtraEvasion() const
 void CvUnit::changeExtraEvasion(int iChange)
 {
 	VALIDATE_OBJECT
-	m_iExtraEvasion.dirtyGet(m_syncArchive) += iChange;
+	m_iExtraEvasion += iChange;
 }
 
 
@@ -22451,7 +22808,7 @@ void CvUnit::changeExtraAttacks(int iChange)
 	VALIDATE_OBJECT
 	if(iChange != 0)
 	{
-		m_iNumAttacks.dirtyGet(m_syncArchive) += iChange;
+		m_iNumAttacks += iChange;
 
 		setInfoBarDirty(true);
 	}
@@ -23634,7 +23991,7 @@ int CvUnit::GetGreatGeneralCount() const
 void CvUnit::ChangeGreatGeneralCount(int iChange)
 {
 	VALIDATE_OBJECT
-	m_iGreatGeneralCount.dirtyGet(m_syncArchive) += iChange;
+	m_iGreatGeneralCount += iChange;
 }
 
 //	--------------------------------------------------------------------------------
@@ -23665,7 +24022,7 @@ int CvUnit::GetGreatAdmiralCount() const
 void CvUnit::ChangeGreatAdmiralCount(int iChange)
 {
 	VALIDATE_OBJECT
-	m_iGreatAdmiralCount.dirtyGet(m_syncArchive) += iChange;
+	m_iGreatAdmiralCount += iChange;
 }
 
 #if defined(MOD_PROMOTIONS_AURA_CHANGE)
@@ -23680,7 +24037,7 @@ int CvUnit::GetAuraRangeChange() const
 void CvUnit::ChangeAuraRangeChange(int iChange)
 {
 	VALIDATE_OBJECT
-	m_iAuraRangeChange.dirtyGet(m_syncArchive) += iChange;
+	m_iAuraRangeChange += iChange;
 }
 
 //	--------------------------------------------------------------------------------
@@ -23694,7 +24051,7 @@ int CvUnit::GetAuraEffectChange() const
 void CvUnit::ChangeAuraEffectChange(int iChange)
 {
 	VALIDATE_OBJECT
-	m_iAuraEffectChange.dirtyGet(m_syncArchive) += iChange;
+	m_iAuraEffectChange += iChange;
 }
 
 
@@ -23709,7 +24066,7 @@ int CvUnit::GetNumRepairCharges() const
 void CvUnit::ChangeNumRepairCharges(int iChange)
 {
 	VALIDATE_OBJECT
-		m_iNumRepairCharges.dirtyGet(m_syncArchive) += iChange;
+		m_iNumRepairCharges += iChange;
 }
 
 int CvUnit::GetMilitaryCapChange() const
@@ -23722,7 +24079,7 @@ int CvUnit::GetMilitaryCapChange() const
 void CvUnit::ChangeMilitaryCapChange(int iChange)
 {
 	VALIDATE_OBJECT
-		m_iMilitaryCapChange.dirtyGet(m_syncArchive) += iChange;
+		m_iMilitaryCapChange += iChange;
 }
 #endif
 
@@ -23739,7 +24096,7 @@ void CvUnit::changeGreatGeneralModifier(int iChange)
 	VALIDATE_OBJECT
 	if(iChange != 0)
 	{
-		m_iGreatGeneralModifier.dirtyGet(m_syncArchive) += iChange;
+		m_iGreatGeneralModifier += iChange;
 	}
 }
 
@@ -23752,7 +24109,7 @@ bool CvUnit::IsGreatGeneralReceivesMovement() const
 //	--------------------------------------------------------------------------------
 void CvUnit::ChangeGreatGeneralReceivesMovementCount(int iChange)
 {
-	m_iGreatGeneralReceivesMovementCount.dirtyGet(m_syncArchive) += iChange;
+	m_iGreatGeneralReceivesMovementCount += iChange;
 }
 
 //	--------------------------------------------------------------------------------
@@ -23764,7 +24121,7 @@ int CvUnit::GetGreatGeneralCombatModifier() const
 //	--------------------------------------------------------------------------------
 void CvUnit::ChangeGreatGeneralCombatModifier(int iChange)
 {
-	m_iGreatGeneralCombatModifier.dirtyGet(m_syncArchive) += iChange;
+	m_iGreatGeneralCombatModifier += iChange;
 }
 
 //	--------------------------------------------------------------------------------
@@ -23776,7 +24133,7 @@ bool CvUnit::IsIgnoreGreatGeneralBenefit() const
 //	--------------------------------------------------------------------------------
 void CvUnit::ChangeIgnoreGreatGeneralBenefitCount(int iChange)
 {
-	m_iIgnoreGreatGeneralBenefit.dirtyGet(m_syncArchive) += iChange;
+	m_iIgnoreGreatGeneralBenefit += iChange;
 }
 #if defined(MOD_UNITS_NO_SUPPLY)
 //	--------------------------------------------------------------------------------
@@ -23789,7 +24146,7 @@ bool CvUnit::isNoSupply() const
 //	--------------------------------------------------------------------------------
 void CvUnit::changeNoSupply(int iChange)
 {
-	m_iNoSupply.dirtyGet(m_syncArchive) += iChange;
+	m_iNoSupply += iChange;
 }
 #endif
 
@@ -23824,7 +24181,7 @@ int CvUnit::getMaxHitPointsChange() const
 //	--------------------------------------------------------------------------------
 void CvUnit::changeMaxHitPointsChange(int iChange)
 {
-	m_iMaxHitPointsChange.dirtyGet(m_syncArchive) += iChange;
+	m_iMaxHitPointsChange += iChange;
 
 	setInfoBarDirty(true);
 }
@@ -23838,7 +24195,7 @@ int CvUnit::getMaxHitPointsModifier() const
 //	--------------------------------------------------------------------------------
 void CvUnit::changeMaxHitPointsModifier(int iChange)
 {
-	m_iMaxHitPointsModifier.dirtyGet(m_syncArchive) += iChange;
+	m_iMaxHitPointsModifier += iChange;
 
 	setInfoBarDirty(true);
 }
@@ -23852,7 +24209,7 @@ bool CvUnit::IsIgnoreZOC() const
 //	--------------------------------------------------------------------------------
 void CvUnit::ChangeIgnoreZOCCount(int iChange)
 {
-	m_iIgnoreZOC.dirtyGet(m_syncArchive) += iChange;
+	m_iIgnoreZOC += iChange;
 }
 
 //	--------------------------------------------------------------------------------
@@ -23864,7 +24221,7 @@ bool CvUnit::IsSapper() const
 //	--------------------------------------------------------------------------------
 void CvUnit::ChangeSapperCount(int iChange)
 {
-	m_iSapperCount.dirtyGet(m_syncArchive) += iChange;
+	m_iSapperCount += iChange;
 }
 
 #if defined(MOD_BALANCE_CORE)
@@ -23878,7 +24235,7 @@ bool CvUnit::IsStrongerDamaged() const
 //	--------------------------------------------------------------------------------
 void CvUnit::ChangeIsStrongerDamaged(int iChange)
 {
-	m_iStrongerDamaged.dirtyGet(m_syncArchive) += iChange;
+	m_iStrongerDamaged += iChange;
 }
 
 // No penalty from being wounded, no combat bonus
@@ -23891,7 +24248,7 @@ bool CvUnit::IsFightWellDamaged() const
 //	--------------------------------------------------------------------------------
 void CvUnit::ChangeIsFightWellDamaged(int iChange)
 {
-	m_iFightWellDamaged.dirtyGet(m_syncArchive) += iChange;
+	m_iFightWellDamaged += iChange;
 }
 
 //	--------------------------------------------------------------------------------
@@ -23903,7 +24260,7 @@ int CvUnit::GetGoodyHutYieldBonus() const
 //	--------------------------------------------------------------------------------
 void CvUnit::ChangeGoodyHutYieldBonus(int iChange)
 {
-	m_iGoodyHutYieldBonus.dirtyGet(m_syncArchive) += iChange;
+	m_iGoodyHutYieldBonus += iChange;
 }
 
 //	--------------------------------------------------------------------------------
@@ -23915,7 +24272,7 @@ int CvUnit::GetReligiousPressureModifier() const
 //	--------------------------------------------------------------------------------
 void CvUnit::ChangeReligiousPressureModifier(int iChange)
 {
-	m_iReligiousPressureModifier.dirtyGet(m_syncArchive) += iChange;
+	m_iReligiousPressureModifier += iChange;
 }
 #endif
 
@@ -23928,7 +24285,7 @@ bool CvUnit::IsCanHeavyCharge() const
 //	--------------------------------------------------------------------------------
 void CvUnit::ChangeCanHeavyChargeCount(int iChange)
 {
-	m_iCanHeavyCharge.dirtyGet(m_syncArchive) += iChange;
+	m_iCanHeavyCharge += iChange;
 }
 #if defined(MOD_BALANCE_CORE)
 //	--------------------------------------------------------------------------------
@@ -23940,7 +24297,7 @@ int CvUnit::GetMoraleBreakChance() const
 //	--------------------------------------------------------------------------------
 void CvUnit::ChangeMoraleBreakChance(int iChange)
 {
-	m_iCanMoraleBreak.dirtyGet(m_syncArchive) += iChange;
+	m_iCanMoraleBreak += iChange;
 }
 
 //	--------------------------------------------------------------------------------
@@ -23952,7 +24309,7 @@ int CvUnit::GetDamageAoEFortified() const
 //	--------------------------------------------------------------------------------
 void CvUnit::ChangeDamageAoEFortified(int iChange)
 {
-	m_iDamageAoEFortified.dirtyGet(m_syncArchive) += iChange;
+	m_iDamageAoEFortified += iChange;
 }
 
 //	--------------------------------------------------------------------------------
@@ -23964,7 +24321,7 @@ int CvUnit::GetWorkRateMod() const
 //	--------------------------------------------------------------------------------
 void CvUnit::ChangeWorkRateMod(int iChange)
 {
-	m_iWorkRateMod.dirtyGet(m_syncArchive) += iChange;
+	m_iWorkRateMod += iChange;
 }
 
 //	--------------------------------------------------------------------------------
@@ -23976,7 +24333,7 @@ int CvUnit::GetDamageReductionCityAssault() const
 //	--------------------------------------------------------------------------------
 void CvUnit::ChangeDamageReductionCityAssault(int iChange)
 {
-	m_iDamageReductionCityAssault.dirtyGet(m_syncArchive) += iChange;
+	m_iDamageReductionCityAssault += iChange;
 }
 
 #endif
@@ -23993,7 +24350,7 @@ void CvUnit::changeFriendlyLandsModifier(int iChange)
 	VALIDATE_OBJECT
 	if(iChange != 0)
 	{
-		m_iFriendlyLandsModifier.dirtyGet(m_syncArchive) += iChange;
+		m_iFriendlyLandsModifier += iChange;
 	}
 }
 
@@ -24010,7 +24367,7 @@ void CvUnit::changeFriendlyLandsAttackModifier(int iChange)
 	VALIDATE_OBJECT
 	if(iChange != 0)
 	{
-		m_iFriendlyLandsAttackModifier.dirtyGet(m_syncArchive) += iChange;
+		m_iFriendlyLandsAttackModifier += iChange;
 	}
 }
 
@@ -24030,7 +24387,7 @@ void CvUnit::changeOutsideFriendlyLandsModifier(int iChange)
 	VALIDATE_OBJECT
 	if(iChange != 0)
 	{
-		m_iOutsideFriendlyLandsModifier.dirtyGet(m_syncArchive) += iChange;
+		m_iOutsideFriendlyLandsModifier += iChange;
 	}
 }
 
@@ -24047,7 +24404,7 @@ void CvUnit::changePillageChange(int iChange)
 	VALIDATE_OBJECT
 	if(iChange != 0)
 	{
-		m_iPillageChange.dirtyGet(m_syncArchive) += iChange;
+		m_iPillageChange += iChange;
 
 		setInfoBarDirty(true);
 	}
@@ -24066,7 +24423,7 @@ void CvUnit::changeUpgradeDiscount(int iChange)
 	VALIDATE_OBJECT
 	if(iChange != 0)
 	{
-		m_iUpgradeDiscount.dirtyGet(m_syncArchive) += iChange;
+		m_iUpgradeDiscount += iChange;
 
 		setInfoBarDirty(true);
 	}
@@ -24088,7 +24445,7 @@ void CvUnit::changeExperiencePercent(int iChange)
 	VALIDATE_OBJECT
 	if(iChange != 0)
 	{
-		m_iExperiencePercent.dirtyGet(m_syncArchive) += iChange;
+		m_iExperiencePercent += iChange;
 
 		setInfoBarDirty(true);
 	}
@@ -24107,7 +24464,7 @@ void CvUnit::changeKamikazePercent(int iChange)
 	VALIDATE_OBJECT
 	if(iChange != 0)
 	{
-		m_iKamikazePercent.dirtyGet(m_syncArchive) += iChange;
+		m_iKamikazePercent += iChange;
 
 		setInfoBarDirty(true);
 	}
@@ -24187,7 +24544,7 @@ void CvUnit::setMadeAttack(bool bNewValue)
 	VALIDATE_OBJECT
 	if(bNewValue)
 	{
-		m_iAttacksMade.dirtyGet(m_syncArchive)++;
+		m_iAttacksMade++;
 		m_bMovedThisTurn = true; //failsafe: attacking means no more fortification bonus, no matter what happens with the moves
 	}
 	else
@@ -24210,7 +24567,7 @@ void CvUnit::ChangeNumInterceptions(int iChange)
 {
 	VALIDATE_OBJECT
 	if(iChange != 0)
-		m_iNumInterceptions.dirtyGet(m_syncArchive) += iChange;
+		m_iNumInterceptions += iChange;
 }
 
 //	--------------------------------------------------------------------------------
@@ -24224,7 +24581,7 @@ int CvUnit::GetExtraAirInterceptRange() const // JJ: NEW
 void CvUnit::ChangeExtraAirInterceptRange(int iChange) // JJ: NEW
 {
 	VALIDATE_OBJECT
-	m_iExtraAirInterceptRange.dirtyGet(m_syncArchive) += iChange;
+	m_iExtraAirInterceptRange += iChange;
 }
 
 //	--------------------------------------------------------------------------------
@@ -24244,7 +24601,7 @@ int CvUnit::getMadeInterceptionCount() const
 //	--------------------------------------------------------------------------------
 void CvUnit::increaseInterceptionCount()
 	{
-		m_iMadeInterceptionCount.dirtyGet(m_syncArchive)++;
+		m_iMadeInterceptionCount++;
 		m_bMovedThisTurn = true; //failsafe: intercepting means no more healing, no matter what happens with the moves
 	}
 
@@ -25035,7 +25392,7 @@ void CvUnit::SetPromotionEverObtained(PromotionTypes eIndex, bool bValue)
 	FAssert(eIndex >= 0);
 	FAssert(eIndex < GC.getNumPromotionInfos());
 
-	m_abPromotionEverObtained.setAt(m_syncArchive, eIndex, bValue);
+	m_abPromotionEverObtained[eIndex] =  bValue;
 }
 
 //	--------------------------------------------------------------------------------
@@ -25056,7 +25413,7 @@ std::string CvUnit::getScriptData() const
 void CvUnit::setScriptData(std::string strNewValue)
 {
 	VALIDATE_OBJECT
-	m_strScriptData.set(m_syncArchive, strNewValue);
+	m_strScriptData = strNewValue;
 }
 
 //	--------------------------------------------------------------------------------
@@ -25091,7 +25448,7 @@ void CvUnit::changeTerrainDoubleMoveCount(TerrainTypes eIndex, int iChange)
 	if (iChange == 0)
 		return;
 
-	TerrainTypeCounter& mVec = m_terrainDoubleMoveCount.dirtyGet(m_syncArchive);
+	TerrainTypeCounter& mVec = m_terrainDoubleMoveCount;
 	for (TerrainTypeCounter::iterator it = mVec.begin(); it != mVec.end(); ++it)
 	{
 		if (it->first == eIndex)
@@ -25105,7 +25462,7 @@ void CvUnit::changeTerrainDoubleMoveCount(TerrainTypes eIndex, int iChange)
 		}
 	}
 
-	m_terrainDoubleMoveCount.push_back(m_syncArchive, make_pair(eIndex, iChange));
+	m_terrainDoubleMoveCount.push_back(make_pair(eIndex, iChange));
 }
 
 //	--------------------------------------------------------------------------------
@@ -25126,7 +25483,7 @@ void CvUnit::changeFeatureDoubleMoveCount(FeatureTypes eIndex, int iChange)
 	if (iChange == 0)
 		return;
 
-	FeatureTypeCounter& mVec = m_featureDoubleMoveCount.dirtyGet(m_syncArchive);
+	FeatureTypeCounter& mVec = m_featureDoubleMoveCount;
 	for (FeatureTypeCounter::iterator it = mVec.begin(); it != mVec.end(); ++it)
 	{
 		if (it->first == eIndex)
@@ -25140,7 +25497,7 @@ void CvUnit::changeFeatureDoubleMoveCount(FeatureTypes eIndex, int iChange)
 		}
 	}
 
-	m_featureDoubleMoveCount.push_back(m_syncArchive, make_pair(eIndex, iChange));
+	m_featureDoubleMoveCount.push_back(make_pair(eIndex, iChange));
 }
 
 
@@ -25163,7 +25520,7 @@ void CvUnit::changeTerrainHalfMoveCount(TerrainTypes eIndex, int iChange)
 	if (iChange == 0)
 		return;
 
-	TerrainTypeCounter& mVec = m_terrainHalfMoveCount.dirtyGet(m_syncArchive);
+	TerrainTypeCounter& mVec = m_terrainHalfMoveCount;
 	for (TerrainTypeCounter::iterator it = mVec.begin(); it != mVec.end(); ++it)
 	{
 		if (it->first == eIndex)
@@ -25177,7 +25534,7 @@ void CvUnit::changeTerrainHalfMoveCount(TerrainTypes eIndex, int iChange)
 		}
 	}
 
-	m_terrainHalfMoveCount.push_back(m_syncArchive, make_pair(eIndex, iChange));
+	m_terrainHalfMoveCount.push_back(make_pair(eIndex, iChange));
 }
 
 //	--------------------------------------------------------------------------------
@@ -25198,7 +25555,7 @@ void CvUnit::changeTerrainExtraMoveCount(TerrainTypes eIndex, int iChange)
 	if (iChange == 0)
 		return;
 
-	TerrainTypeCounter& mVec = m_terrainExtraMoveCount.dirtyGet(m_syncArchive);
+	TerrainTypeCounter& mVec = m_terrainExtraMoveCount;
 	for (TerrainTypeCounter::iterator it = mVec.begin(); it != mVec.end(); ++it)
 	{
 		if (it->first == eIndex)
@@ -25212,7 +25569,7 @@ void CvUnit::changeTerrainExtraMoveCount(TerrainTypes eIndex, int iChange)
 		}
 	}
 
-	m_terrainExtraMoveCount.push_back(m_syncArchive, make_pair(eIndex, iChange));
+	m_terrainExtraMoveCount.push_back(make_pair(eIndex, iChange));
 }
 
 
@@ -25234,7 +25591,7 @@ void CvUnit::changeFeatureHalfMoveCount(FeatureTypes eIndex, int iChange)
 	if (iChange == 0)
 		return;
 
-	FeatureTypeCounter& mVec = m_featureHalfMoveCount.dirtyGet(m_syncArchive);
+	FeatureTypeCounter& mVec = m_featureHalfMoveCount;
 	for (FeatureTypeCounter::iterator it = mVec.begin(); it != mVec.end(); ++it)
 	{
 		if (it->first == eIndex)
@@ -25248,7 +25605,7 @@ void CvUnit::changeFeatureHalfMoveCount(FeatureTypes eIndex, int iChange)
 		}
 	}
 
-	m_featureHalfMoveCount.push_back(m_syncArchive, make_pair(eIndex, iChange));
+	m_featureHalfMoveCount.push_back(make_pair(eIndex, iChange));
 }
 
 //	--------------------------------------------------------------------------------
@@ -25269,7 +25626,7 @@ void CvUnit::changeFeatureExtraMoveCount(FeatureTypes eIndex, int iChange)
 	if (iChange == 0)
 		return;
 
-	FeatureTypeCounter& mVec = m_featureExtraMoveCount.dirtyGet(m_syncArchive);
+	FeatureTypeCounter& mVec = m_featureExtraMoveCount;
 	for (FeatureTypeCounter::iterator it = mVec.begin(); it != mVec.end(); ++it)
 	{
 		if (it->first == eIndex)
@@ -25283,7 +25640,7 @@ void CvUnit::changeFeatureExtraMoveCount(FeatureTypes eIndex, int iChange)
 		}
 	}
 
-	m_featureExtraMoveCount.push_back(m_syncArchive, make_pair(eIndex, iChange));
+	m_featureExtraMoveCount.push_back(make_pair(eIndex, iChange));
 }
 #endif
 
@@ -25314,7 +25671,7 @@ void CvUnit::changeTerrainDoubleHeal(TerrainTypes eIndex, int iChange)
 	if (iChange == 0)
 		return;
 
-	TerrainTypeCounter& mVec = m_terrainDoubleHeal.dirtyGet(m_syncArchive);
+	TerrainTypeCounter& mVec = m_terrainDoubleHeal;
 	for (TerrainTypeCounter::iterator it = mVec.begin(); it != mVec.end(); ++it)
 	{
 		if (it->first == eIndex)
@@ -25328,7 +25685,7 @@ void CvUnit::changeTerrainDoubleHeal(TerrainTypes eIndex, int iChange)
 		}
 	}
 
-	m_terrainDoubleHeal.push_back(m_syncArchive, make_pair(eIndex, iChange));
+	m_terrainDoubleHeal.push_back(make_pair(eIndex, iChange));
 }
 
 
@@ -25358,7 +25715,7 @@ void CvUnit::changeFeatureDoubleHeal(FeatureTypes eIndex, int iChange)
 	if (iChange == 0)
 		return;
 
-	FeatureTypeCounter& mVec = m_featureDoubleHeal.dirtyGet(m_syncArchive);
+	FeatureTypeCounter& mVec = m_featureDoubleHeal;
 	for (FeatureTypeCounter::iterator it = mVec.begin(); it != mVec.end(); ++it)
 	{
 		if (it->first == eIndex)
@@ -25372,7 +25729,7 @@ void CvUnit::changeFeatureDoubleHeal(FeatureTypes eIndex, int iChange)
 		}
 	}
 
-	m_featureDoubleHeal.push_back(m_syncArchive, make_pair(eIndex, iChange));
+	m_featureDoubleHeal.push_back(make_pair(eIndex, iChange));
 }
 
 void CvUnit::ChangeNumTimesAttackedThisTurn(PlayerTypes ePlayer, int iValue)
@@ -25380,7 +25737,7 @@ void CvUnit::ChangeNumTimesAttackedThisTurn(PlayerTypes ePlayer, int iValue)
 	VALIDATE_OBJECT
 		CvAssertMsg(ePlayer >= 0, "ePlayer expected to be >= 0");
 	CvAssertMsg(ePlayer < REALLY_MAX_PLAYERS, "ePlayer expected to be < NUM_DOMAIN_TYPES");
-	m_aiNumTimesAttackedThisTurn.setAt(m_syncArchive, ePlayer, m_aiNumTimesAttackedThisTurn[ePlayer] + iValue);
+	m_aiNumTimesAttackedThisTurn[ePlayer] =  m_aiNumTimesAttackedThisTurn[ePlayer] + iValue;
 }
 int CvUnit::GetNumTimesAttackedThisTurn(PlayerTypes ePlayer) const
 {
@@ -25415,7 +25772,7 @@ void CvUnit::changeTerrainImpassableCount(TerrainTypes eIndex, int iChange)
 	if (iChange == 0)
 		return;
 
-	TerrainTypeCounter& mVec = m_terrainImpassableCount.dirtyGet(m_syncArchive);
+	TerrainTypeCounter& mVec = m_terrainImpassableCount;
 	for (TerrainTypeCounter::iterator it = mVec.begin(); it != mVec.end(); ++it)
 	{
 		if (it->first == eIndex)
@@ -25429,7 +25786,7 @@ void CvUnit::changeTerrainImpassableCount(TerrainTypes eIndex, int iChange)
 		}
 	}
 
-	m_terrainImpassableCount.push_back(m_syncArchive, make_pair(eIndex, iChange));
+	m_terrainImpassableCount.push_back(make_pair(eIndex, iChange));
 }
 
 
@@ -25457,7 +25814,7 @@ void CvUnit::changeFeatureImpassableCount(FeatureTypes eIndex, int iChange)
 	if (iChange == 0)
 		return;
 
-	FeatureTypeCounter& mVec = m_featureImpassableCount.dirtyGet(m_syncArchive);
+	FeatureTypeCounter& mVec = m_featureImpassableCount;
 	for (FeatureTypeCounter::iterator it = mVec.begin(); it != mVec.end(); ++it)
 	{
 		if (it->first == eIndex)
@@ -25471,7 +25828,7 @@ void CvUnit::changeFeatureImpassableCount(FeatureTypes eIndex, int iChange)
 		}
 	}
 
-	m_featureImpassableCount.push_back(m_syncArchive, make_pair(eIndex, iChange));
+	m_featureImpassableCount.push_back(make_pair(eIndex, iChange));
 }
 
 //	--------------------------------------------------------------------------------
@@ -25493,7 +25850,7 @@ void CvUnit::changeExtraTerrainAttackPercent(TerrainTypes eIndex, int iChange)
 	if (iChange == 0)
 		return;
 
-	TerrainTypeCounter& mVec = m_extraTerrainAttackPercent.dirtyGet(m_syncArchive);
+	TerrainTypeCounter& mVec = m_extraTerrainAttackPercent;
 	for (TerrainTypeCounter::iterator it = mVec.begin(); it != mVec.end(); ++it)
 	{
 		if (it->first == eIndex)
@@ -25507,7 +25864,7 @@ void CvUnit::changeExtraTerrainAttackPercent(TerrainTypes eIndex, int iChange)
 		}
 	}
 
-	m_extraTerrainAttackPercent.push_back(m_syncArchive, make_pair(eIndex, iChange));
+	m_extraTerrainAttackPercent.push_back(make_pair(eIndex, iChange));
 }
 
 //	--------------------------------------------------------------------------------
@@ -25529,7 +25886,7 @@ void CvUnit::changeExtraTerrainDefensePercent(TerrainTypes eIndex, int iChange)
 	if (iChange == 0)
 		return;
 
-	TerrainTypeCounter& mVec = m_extraTerrainDefensePercent.dirtyGet(m_syncArchive);
+	TerrainTypeCounter& mVec = m_extraTerrainDefensePercent;
 	for (TerrainTypeCounter::iterator it = mVec.begin(); it != mVec.end(); ++it)
 	{
 		if (it->first == eIndex)
@@ -25543,7 +25900,7 @@ void CvUnit::changeExtraTerrainDefensePercent(TerrainTypes eIndex, int iChange)
 		}
 	}
 
-	m_extraTerrainDefensePercent.push_back(m_syncArchive, make_pair(eIndex, iChange));
+	m_extraTerrainDefensePercent.push_back(make_pair(eIndex, iChange));
 }
 
 //	--------------------------------------------------------------------------------
@@ -25565,7 +25922,7 @@ void CvUnit::changeExtraFeatureAttackPercent(FeatureTypes eIndex, int iChange)
 	if (iChange == 0)
 		return;
 
-	FeatureTypeCounter& mVec = m_extraFeatureAttackPercent.dirtyGet(m_syncArchive);
+	FeatureTypeCounter& mVec = m_extraFeatureAttackPercent;
 	for (FeatureTypeCounter::iterator it = mVec.begin(); it != mVec.end(); ++it)
 	{
 		if (it->first == eIndex)
@@ -25579,7 +25936,7 @@ void CvUnit::changeExtraFeatureAttackPercent(FeatureTypes eIndex, int iChange)
 		}
 	}
 
-	m_extraFeatureAttackPercent.push_back(m_syncArchive, make_pair(eIndex, iChange));
+	m_extraFeatureAttackPercent.push_back(make_pair(eIndex, iChange));
 }
 
 //	--------------------------------------------------------------------------------
@@ -25601,7 +25958,7 @@ void CvUnit::changeExtraFeatureDefensePercent(FeatureTypes eIndex, int iChange)
 	if (iChange == 0)
 		return;
 
-	FeatureTypeCounter& mVec = m_extraFeatureDefensePercent.dirtyGet(m_syncArchive);
+	FeatureTypeCounter& mVec = m_extraFeatureDefensePercent;
 	for (FeatureTypeCounter::iterator it = mVec.begin(); it != mVec.end(); ++it)
 	{
 		if (it->first == eIndex)
@@ -25615,7 +25972,7 @@ void CvUnit::changeExtraFeatureDefensePercent(FeatureTypes eIndex, int iChange)
 		}
 	}
 
-	m_extraFeatureDefensePercent.push_back(m_syncArchive, make_pair(eIndex, iChange));
+	m_extraFeatureDefensePercent.push_back(make_pair(eIndex, iChange));
 }
 
 //	--------------------------------------------------------------------------------
@@ -25637,7 +25994,7 @@ void CvUnit::changeUnitClassAttackMod(UnitClassTypes eIndex, int iChange)
 	if (iChange == 0)
 		return;
 
-	UnitClassCounter& mVec = m_extraUnitClassAttackMod.dirtyGet(m_syncArchive);
+	UnitClassCounter& mVec = m_extraUnitClassAttackMod;
 	for (UnitClassCounter::iterator it = mVec.begin(); it != mVec.end(); ++it)
 	{
 		if (it->first == eIndex)
@@ -25651,7 +26008,7 @@ void CvUnit::changeUnitClassAttackMod(UnitClassTypes eIndex, int iChange)
 		}
 	}
 
-	m_extraUnitClassAttackMod.push_back(m_syncArchive, make_pair(eIndex, iChange));
+	m_extraUnitClassAttackMod.push_back(make_pair(eIndex, iChange));
 }
 
 //	--------------------------------------------------------------------------------
@@ -25673,7 +26030,7 @@ void CvUnit::changeUnitClassDefenseMod(UnitClassTypes eIndex, int iChange)
 	if (iChange == 0)
 		return;
 
-	UnitClassCounter& mVec = m_extraUnitClassDefenseMod.dirtyGet(m_syncArchive);
+	UnitClassCounter& mVec = m_extraUnitClassDefenseMod;
 	for (UnitClassCounter::iterator it = mVec.begin(); it != mVec.end(); ++it)
 	{
 		if (it->first == eIndex)
@@ -25687,7 +26044,7 @@ void CvUnit::changeUnitClassDefenseMod(UnitClassTypes eIndex, int iChange)
 		}
 	}
 
-	m_extraUnitClassDefenseMod.push_back(m_syncArchive, make_pair(eIndex, iChange));
+	m_extraUnitClassDefenseMod.push_back(make_pair(eIndex, iChange));
 }
 
 #if defined(MOD_BALANCE_CORE)
@@ -25707,7 +26064,7 @@ void CvUnit::changeCombatModPerAdjacentUnitCombatModifier(UnitCombatTypes eIndex
 	VALIDATE_OBJECT
 	CvAssertMsg(eIndex >= 0, "eIndex is expected to be non-negative (invalid Index)");
 	CvAssertMsg(eIndex < GC.getNumUnitCombatClassInfos(), "eIndex is expected to be within maximum bounds (invalid Index)");
-	m_iCombatModPerAdjacentUnitCombatModifier.setAt(m_syncArchive, eIndex, m_iCombatModPerAdjacentUnitCombatModifier[eIndex] + iChange);
+	m_iCombatModPerAdjacentUnitCombatModifier[eIndex] =  m_iCombatModPerAdjacentUnitCombatModifier[eIndex] + iChange;
 }
 
 //	--------------------------------------------------------------------------------
@@ -25726,7 +26083,7 @@ void CvUnit::changeCombatModPerAdjacentUnitCombatAttackMod(UnitCombatTypes eInde
 	VALIDATE_OBJECT
 	CvAssertMsg(eIndex >= 0, "eIndex is expected to be non-negative (invalid Index)");
 	CvAssertMsg(eIndex < GC.getNumUnitCombatClassInfos(), "eIndex is expected to be within maximum bounds (invalid Index)");
-	m_iCombatModPerAdjacentUnitCombatAttackMod.setAt(m_syncArchive, eIndex, m_iCombatModPerAdjacentUnitCombatAttackMod[eIndex] + iChange);
+	m_iCombatModPerAdjacentUnitCombatAttackMod[eIndex] =  m_iCombatModPerAdjacentUnitCombatAttackMod[eIndex] + iChange;
 }
 
 //	--------------------------------------------------------------------------------
@@ -25745,7 +26102,7 @@ void CvUnit::changeCombatModPerAdjacentUnitCombatDefenseMod(UnitCombatTypes eInd
 	VALIDATE_OBJECT
 	CvAssertMsg(eIndex >= 0, "eIndex is expected to be non-negative (invalid Index)");
 	CvAssertMsg(eIndex < GC.getNumUnitCombatClassInfos(), "eIndex is expected to be within maximum bounds (invalid Index)");
-	m_iCombatModPerAdjacentUnitCombatDefenseMod.setAt(m_syncArchive, eIndex, m_iCombatModPerAdjacentUnitCombatDefenseMod[eIndex] + iChange);
+	m_iCombatModPerAdjacentUnitCombatDefenseMod[eIndex] =  m_iCombatModPerAdjacentUnitCombatDefenseMod[eIndex] + iChange;
 }
 
 //	--------------------------------------------------------------------------------
@@ -25767,7 +26124,7 @@ void CvUnit::changeYieldFromScouting(YieldTypes eIndex, int iChange)
 
 	if(iChange != 0)
 	{
-		m_yieldFromScouting.setAt(m_syncArchive, eIndex, m_yieldFromScouting[eIndex] + iChange);
+		m_yieldFromScouting[eIndex] =  m_yieldFromScouting[eIndex] + iChange;
 	}
 }
 #endif
@@ -25791,7 +26148,7 @@ void CvUnit::changeYieldFromKills(YieldTypes eIndex, int iChange)
 
 	if(iChange != 0)
 	{
-		m_yieldFromKills.setAt(m_syncArchive, eIndex, m_yieldFromKills[eIndex] + iChange);
+		m_yieldFromKills[eIndex] =  m_yieldFromKills[eIndex] + iChange;
 	}
 }
 
@@ -25814,7 +26171,7 @@ void CvUnit::changeYieldFromBarbarianKills(YieldTypes eIndex, int iChange)
 
 	if(iChange != 0)
 	{
-		m_yieldFromBarbarianKills.setAt(m_syncArchive, eIndex, m_yieldFromBarbarianKills[eIndex] + iChange);
+		m_yieldFromBarbarianKills[eIndex] =  m_yieldFromBarbarianKills[eIndex] + iChange;
 	}
 }
 #endif
@@ -25835,7 +26192,7 @@ void CvUnit::changeExtraUnitCombatModifier(UnitCombatTypes eIndex, int iChange)
 	VALIDATE_OBJECT
 	CvAssertMsg(eIndex >= 0, "eIndex is expected to be non-negative (invalid Index)");
 	CvAssertMsg(eIndex < GC.getNumUnitCombatClassInfos(), "eIndex is expected to be within maximum bounds (invalid Index)");
-	m_extraUnitCombatModifier.setAt(m_syncArchive, eIndex, m_extraUnitCombatModifier[eIndex] + iChange);
+	m_extraUnitCombatModifier[eIndex] =  m_extraUnitCombatModifier[eIndex] + iChange;
 }
 
 
@@ -25855,7 +26212,7 @@ void CvUnit::changeUnitClassModifier(UnitClassTypes eIndex, int iChange)
 	VALIDATE_OBJECT
 	CvAssertMsg(eIndex >= 0, "eIndex is expected to be non-negative (invalid Index)");
 	CvAssertMsg(eIndex < GC.getNumUnitClassInfos(), "eIndex is expected to be within maximum bounds (invalid Index)");
-	m_unitClassModifier.setAt(m_syncArchive, eIndex, m_unitClassModifier[eIndex] + iChange);
+	m_unitClassModifier[eIndex] =  m_unitClassModifier[eIndex] + iChange;
 }
 
 
@@ -26824,6 +27181,326 @@ CvUnit* CvUnit::GetPotentialUnitToSwapWith(CvPlot & swapPlot) const
 }
 
 //	--------------------------------------------------------------------------------
+template<typename Unit, typename Visitor>
+void CvUnit::serialize(Unit& unit, Visitor& visitor)
+{
+	visitor(unit.m_eOwner);
+	visitor(unit.m_eOriginalOwner);
+	visitor(unit.m_eUnitType);
+	visitor(unit.m_iX);
+	visitor(unit.m_iY);
+	visitor(unit.m_iID);
+	visitor(unit.m_iDamage);
+	visitor(unit.m_iMoves);
+	visitor(unit.m_iArmyId);
+	visitor(unit.m_iBaseCombat);
+	visitor(unit.m_iBaseRangedCombat);
+	visitor(unit.m_iHotKeyNumber);
+	visitor(unit.m_iDeployFromOperationTurn);
+	visitor(unit.m_iLastMoveTurn);
+	visitor(unit.m_iReconX);
+	visitor(unit.m_iReconY);
+	visitor(unit.m_iReconCount);
+	visitor(unit.m_iGameTurnCreated);
+	visitor(unit.m_bImmobile);
+	visitor(unit.m_iExperienceTimes100);
+	visitor(unit.m_iLevel);
+	visitor(unit.m_iCargo);
+	visitor(unit.m_iCargoCapacity);
+	visitor(unit.m_iAttackPlotX);
+	visitor(unit.m_iAttackPlotY);
+	visitor(unit.m_iCombatTimer);
+	visitor(unit.m_iCombatFirstStrikes);
+	visitor(unit.m_iCombatDamage);
+	visitor(unit.m_bMovedThisTurn);
+	visitor(unit.m_bFortified);
+	visitor(unit.m_iBlitzCount);
+	visitor(unit.m_iAmphibCount);
+	visitor(unit.m_iRiverCrossingNoPenaltyCount);
+	visitor(unit.m_iEnemyRouteCount);
+	visitor(unit.m_iRivalTerritoryCount);
+	visitor(unit.m_iIsSlowInEnemyLandCount);
+	visitor(unit.m_iRangeAttackIgnoreLOSCount);
+	visitor(unit.m_iCityAttackOnlyCount);
+	visitor(unit.m_iCaptureDefeatedEnemyCount);
+	visitor(unit.m_iOriginCity);
+	visitor(unit.m_iCannotBeCapturedCount);
+	visitor(unit.m_iForcedDamage);
+	visitor(unit.m_iChangeDamage);
+	visitor(unit.m_PromotionDuration);
+	visitor(unit.m_TurnPromotionGained);
+	visitor(unit.m_iRangedSupportFireCount);
+	visitor(unit.m_iAlwaysHealCount);
+	visitor(unit.m_iHealOutsideFriendlyCount);
+	visitor(unit.m_iHillsDoubleMoveCount);
+	visitor(unit.m_iMountainsDoubleMoveCount);
+	visitor(unit.m_iEmbarkFlatCostCount);
+	visitor(unit.m_iDisembarkFlatCostCount);
+	visitor(unit.m_iAOEDamageOnKill);
+	visitor(unit.m_iAoEDamageOnMove);
+	visitor(unit.m_iSplashDamage);
+	visitor(unit.m_iMultiAttackBonus);
+	visitor(unit.m_iLandAirDefenseValue);
+	visitor(unit.m_iImmuneToFirstStrikesCount);
+	visitor(unit.m_iExtraVisibilityRange);
+	visitor(unit.m_iExtraReconRange);
+	visitor(unit.m_iExtraMoves);
+	visitor(unit.m_iExtraMoveDiscount);
+	visitor(unit.m_iExtraRange);
+	visitor(unit.m_iInterceptChance);
+	visitor(unit.m_iExtraEvasion);
+	visitor(unit.m_iExtraFirstStrikes);
+	visitor(unit.m_iExtraChanceFirstStrikes);
+	visitor(unit.m_iExtraWithdrawal);
+	visitor(unit.m_iPlagueChance);
+	visitor(unit.m_iIsPlagued);
+	visitor(unit.m_iPlagueID);
+	visitor(unit.m_iPlaguePriority);
+	visitor(unit.m_iPlagueIDImmunity);
+	visitor(unit.m_iPlaguePromotion);
+	visitor(unit.m_eUnitContract);
+	visitor(unit.m_iNegatorPromotion);
+	visitor(unit.m_bIsNoMaintenance);
+	visitor(unit.m_iExtraEnemyHeal);
+	visitor(unit.m_iExtraNeutralHeal);
+	visitor(unit.m_iExtraFriendlyHeal);
+	visitor(unit.m_iEnemyDamageChance);
+	visitor(unit.m_iNeutralDamageChance);
+	visitor(unit.m_iEnemyDamage);
+	visitor(unit.m_iNeutralDamage);
+	visitor(unit.m_iNearbyEnemyCombatMod);
+	visitor(unit.m_iNearbyEnemyCombatRange);
+	visitor(unit.m_iSameTileHeal);
+	visitor(unit.m_iAdjacentTileHeal);
+	visitor(unit.m_iAdjacentModifier);
+	visitor(unit.m_iRangedAttackModifier);
+	visitor(unit.m_iInterceptionCombatModifier);
+	visitor(unit.m_iInterceptionDefenseDamageModifier);
+	visitor(unit.m_iAirSweepCombatModifier);
+	visitor(unit.m_iAttackModifier);
+	visitor(unit.m_iDefenseModifier);
+	visitor(unit.m_iGroundAttackDamage);
+	visitor(unit.m_iExtraCombatPercent);
+	visitor(unit.m_iExtraCityAttackPercent);
+	visitor(unit.m_iExtraCityDefensePercent);
+	visitor(unit.m_iExtraRangedDefenseModifier);
+	visitor(unit.m_iExtraHillsAttackPercent);
+	visitor(unit.m_iExtraHillsDefensePercent);
+	visitor(unit.m_iExtraOpenAttackPercent);
+	visitor(unit.m_iExtraOpenRangedAttackMod);
+	visitor(unit.m_iExtraRoughAttackPercent);
+	visitor(unit.m_iExtraRoughRangedAttackMod);
+	visitor(unit.m_iExtraAttackFortifiedMod);
+	visitor(unit.m_iExtraAttackWoundedMod);
+	visitor(unit.m_iExtraFullyHealedMod);
+	visitor(unit.m_iExtraAttackAboveHealthMod);
+	visitor(unit.m_iExtraAttackBelowHealthMod);
+	visitor(unit.m_iFlankAttackModifier);
+	visitor(unit.m_iExtraOpenDefensePercent);
+	visitor(unit.m_iExtraRoughDefensePercent);
+	visitor(unit.m_iExtraOpenFromPercent);
+	visitor(unit.m_iExtraRoughFromPercent);
+	visitor(unit.m_iPillageChange);
+	visitor(unit.m_iUpgradeDiscount);
+	visitor(unit.m_iExperiencePercent);
+	visitor(unit.m_iDropRange);
+	visitor(unit.m_iAirSweepCapableCount);
+	visitor(unit.m_iExtraNavalMoves);
+	visitor(unit.m_iKamikazePercent);
+	visitor(unit.m_eFacingDirection);
+	visitor(unit.m_iIgnoreTerrainCostCount);
+	visitor(unit.m_iIgnoreTerrainDamageCount);
+	visitor(unit.m_iIgnoreFeatureDamageCount);
+	visitor(unit.m_iExtraTerrainDamageCount);
+	visitor(unit.m_iExtraFeatureDamageCount);
+	visitor(unit.m_iNearbyImprovementCombatBonus);
+	visitor(unit.m_iNearbyImprovementBonusRange);
+	visitor(unit.m_eCombatBonusImprovement);
+	visitor(unit.m_iNearbyUnitClassBonus);
+	visitor(unit.m_iNearbyUnitClassBonusRange);
+	visitor(unit.m_iCombatBonusFromNearbyUnitClass);
+	visitor(unit.m_bNearbyPromotion);
+	visitor(unit.m_iNearbyUnitPromotionRange);
+	visitor(unit.m_iNearbyCityCombatMod);
+	visitor(unit.m_iNearbyFriendlyCityCombatMod);
+	visitor(unit.m_iNearbyEnemyCityCombatMod);
+	visitor(unit.m_iPillageBonusStrengthPercent);
+	visitor(unit.m_iStackedGreatGeneralExperience);
+	visitor(unit.m_bIsHighSeaRaider);
+	visitor(unit.m_iWonderProductionModifier);
+	visitor(unit.m_iUnitProductionModifier);
+	visitor(unit.m_iNearbyEnemyDamage);
+	visitor(unit.m_iGGGAXPPercent);
+	visitor(unit.m_iGiveCombatMod);
+	visitor(unit.m_iGiveHPIfEnemyKilled);
+	visitor(unit.m_iGiveExperiencePercent);
+	visitor(unit.m_iGiveOutsideFriendlyLandsModifier);
+	visitor(unit.m_eGiveDomain);
+	visitor(unit.m_iGiveExtraAttacks);
+	visitor(unit.m_iGiveDefenseMod);
+	visitor(unit.m_bGiveInvisibility);
+	visitor(unit.m_bGiveOnlyOnStartingTurn);
+	visitor(unit.m_bConvertUnit);
+	visitor(unit.m_eConvertDomain);
+	visitor(unit.m_eConvertDomainUnit);
+	visitor(unit.m_bConvertEnemyUnitToBarbarian);
+	visitor(unit.m_bConvertOnFullHP);
+	visitor(unit.m_bConvertOnDamage);
+	visitor(unit.m_iDamageThreshold);
+	visitor(unit.m_eConvertDamageOrFullHPUnit);
+	visitor(unit.m_iNumberOfCultureBombs);
+	visitor(unit.m_iNearbyHealEnemyTerritory);
+	visitor(unit.m_iNearbyHealNeutralTerritory);
+	visitor(unit.m_iNearbyHealFriendlyTerritory);
+	visitor(unit.m_iCanCrossMountainsCount);
+	visitor(unit.m_iCanCrossOceansCount);
+	visitor(unit.m_iCanCrossIceCount);
+	visitor(unit.m_iNumTilesRevealedThisTurn);
+	visitor(unit.m_bSpottedEnemy);
+	visitor(unit.m_iGainsXPFromScouting);
+	visitor(unit.m_iGainsXPFromPillaging);
+	visitor(unit.m_iGainsXPFromSpotting);
+	visitor(unit.m_iCaptureDefeatedEnemyChance);
+	visitor(unit.m_iBarbCombatBonus);
+	visitor(unit.m_iAdjacentEnemySapMovement);
+	visitor(unit.m_iGGFromBarbariansCount);
+	visitor(unit.m_iAuraRangeChange);
+	visitor(unit.m_iAuraEffectChange);
+	visitor(unit.m_iNumRepairCharges);
+	visitor(unit.m_iMilitaryCapChange);
+	visitor(unit.m_iRoughTerrainEndsTurnCount);
+	visitor(unit.m_iEmbarkAbilityCount);
+	visitor(unit.m_iHoveringUnitCount);
+	visitor(unit.m_iFlatMovementCostCount);
+	visitor(unit.m_iCanMoveImpassableCount);
+	visitor(unit.m_iOnlyDefensiveCount);
+	visitor(unit.m_iNoDefensiveBonusCount);
+	visitor(unit.m_iNoCaptureCount);
+	visitor(unit.m_iNukeImmuneCount);
+	visitor(unit.m_iHiddenNationalityCount);
+	visitor(unit.m_iAlwaysHostileCount);
+	visitor(unit.m_iNoRevealMapCount);
+	visitor(unit.m_iCanMoveAllTerrainCount);
+	visitor(unit.m_iCanMoveAfterAttackingCount);
+	visitor(unit.m_iFreePillageMoveCount);
+	visitor(unit.m_iHealOnPillageCount);
+	visitor(unit.m_iHPHealedIfDefeatEnemy);
+	visitor(unit.m_iGoldenAgeValueFromKills);
+	visitor(unit.m_iTacticalAIPlotX);
+	visitor(unit.m_iTacticalAIPlotY);
+	visitor(unit.m_iGarrisonCityID);
+	visitor(unit.m_iNumAttacks);
+	visitor(unit.m_iAttacksMade);
+	visitor(unit.m_iGreatGeneralCount);
+	visitor(unit.m_iGreatAdmiralCount);
+	visitor(unit.m_iGreatGeneralModifier);
+	visitor(unit.m_iGreatGeneralReceivesMovementCount);
+	visitor(unit.m_iGreatGeneralCombatModifier);
+	visitor(unit.m_iIgnoreGreatGeneralBenefit);
+	visitor(unit.m_iIgnoreZOC);
+	visitor(unit.m_iNoSupply);
+	visitor(unit.m_iMaxHitPointsChange);
+	visitor(unit.m_iMaxHitPointsModifier);
+	visitor(unit.m_iFriendlyLandsModifier);
+	visitor(unit.m_iFriendlyLandsAttackModifier);
+	visitor(unit.m_iOutsideFriendlyLandsModifier);
+	visitor(unit.m_iHealIfDefeatExcludeBarbariansCount);
+	visitor(unit.m_iNumInterceptions);
+	visitor(unit.m_iExtraAirInterceptRange);
+	visitor(unit.m_iMadeInterceptionCount);
+	visitor(unit.m_iEverSelectedCount);
+	visitor(unit.m_iSapperCount);
+	visitor(unit.m_iCanHeavyCharge);
+	visitor(unit.m_iStrongerDamaged);
+	visitor(unit.m_iFightWellDamaged);
+	visitor(unit.m_iCanMoraleBreak);
+	visitor(unit.m_iDamageAoEFortified);
+	visitor(unit.m_iWorkRateMod);
+	visitor(unit.m_iDamageReductionCityAssault);
+	visitor(unit.m_iGoodyHutYieldBonus);
+	visitor(unit.m_iReligiousPressureModifier);
+	visitor(unit.m_iNumExoticGoods);
+	visitor(unit.m_bPromotionReady);
+	visitor(unit.m_bDeathDelay);
+	visitor(unit.m_bCombatFocus);
+	visitor(unit.m_bInfoBarDirty);
+	visitor(unit.m_bNotConverting);
+	visitor(unit.m_bAirCombat);
+	visitor(unit.m_bSetUpForRangedAttack);
+	visitor(unit.m_bEmbarked);
+	visitor(unit.m_bPromotedFromGoody);
+	visitor(unit.m_bAITurnProcessed);
+	visitor(unit.m_iDamageTakenThisTurn);
+	visitor(unit.m_iDamageTakenLastTurn);
+	visitor(unit.m_eCapturingPlayer);
+	visitor(unit.m_bCapturedAsIs);
+	visitor(unit.m_eLeaderUnitType);
+	visitor(unit.m_eInvisibleType);
+	visitor(unit.m_eSeeInvisibleType);
+	visitor(unit.m_eGreatPeopleDirectiveType);
+	visitor(unit.m_strScriptData);
+	visitor(unit.m_iScenarioData);
+	visitor(unit.m_iBuilderStrength);
+	visitor(unit.m_terrainDoubleMoveCount);
+	visitor(unit.m_featureDoubleMoveCount);
+	visitor(unit.m_terrainHalfMoveCount);
+	visitor(unit.m_featureHalfMoveCount);
+	visitor(unit.m_terrainExtraMoveCount);
+	visitor(unit.m_featureExtraMoveCount);
+	visitor(unit.m_terrainDoubleHeal);
+	visitor(unit.m_featureDoubleHeal);
+	visitor(unit.m_terrainImpassableCount);
+	visitor(unit.m_featureImpassableCount);
+	visitor(unit.m_extraTerrainAttackPercent);
+	visitor(unit.m_extraTerrainDefensePercent);
+	visitor(unit.m_extraFeatureAttackPercent);
+	visitor(unit.m_extraFeatureDefensePercent);
+	visitor(unit.m_extraUnitClassAttackMod);
+	visitor(unit.m_extraUnitClassDefenseMod);
+	visitor(unit.m_aiNumTimesAttackedThisTurn);
+	visitor(unit.m_yieldFromScouting);
+	visitor(unit.m_yieldFromKills);
+	visitor(unit.m_yieldFromBarbarianKills);
+	visitor(unit.m_extraUnitCombatModifier);
+	visitor(unit.m_unitClassModifier);
+	visitor(unit.m_iCombatModPerAdjacentUnitCombatModifier);
+	visitor(unit.m_iCombatModPerAdjacentUnitCombatAttackMod);
+	visitor(unit.m_iCombatModPerAdjacentUnitCombatDefenseMod);
+	visitor(unit.m_iMissionTimer);
+	visitor(unit.m_iMissionAIX);
+	visitor(unit.m_iMissionAIY);
+	visitor(unit.m_eMissionAIType);
+	visitor(unit.m_eActivityType);
+	visitor(unit.m_eAutomateType);
+	visitor(unit.m_eUnitAIType);
+	visitor(unit.m_eCombatType);
+	visitor(unit.m_iEmbarkedAllWaterCount);
+	visitor(unit.m_iEmbarkedDeepWaterCount);
+	visitor(unit.m_iEmbarkExtraVisibility);
+	visitor(unit.m_iEmbarkDefensiveModifier);
+	visitor(unit.m_iCapitalDefenseModifier);
+	visitor(unit.m_iCapitalDefenseFalloff);
+	visitor(unit.m_iCityAttackPlunderModifier);
+	visitor(unit.m_iReligiousStrengthLossRivalTerritory);
+	visitor(unit.m_iTradeMissionInfluenceModifier);
+	visitor(unit.m_iTradeMissionGoldModifier);
+	visitor(unit.m_iDiploMissionInfluence);
+	visitor(unit.m_iMapLayer);
+	visitor(unit.m_iNumGoodyHutsPopped);
+	visitor(unit.m_iTourismBlastStrength);
+	visitor(unit.m_iTourismBlastLength);
+	visitor(unit.m_iHurryStrength);
+	visitor(unit.m_iScienceBlastStrength);
+	visitor(unit.m_iCultureBlastStrength);
+	visitor(unit.m_iGAPBlastStrength);
+	visitor(unit.m_abPromotionEverObtained);
+	visitor(unit.m_eTacticalMove);
+	visitor(unit.m_iTacticalMoveSetTurn);
+	visitor(unit.m_eHomelandMove);
+	visitor(unit.m_iHomelandMoveSetTurn);
+}
+
+//	--------------------------------------------------------------------------------
 void CvUnit::read(FDataStream& kStream)
 {
 	VALIDATE_OBJECT
@@ -26835,13 +27512,14 @@ void CvUnit::read(FDataStream& kStream)
 	kStream >> uiVersion;
 	MOD_SERIALIZE_INIT_READ(kStream);
 
-	// all CvSyncVars in the m_syncArchive marked as SAVE will be read
-	// automagically, no need to explicitly load them here
-	m_syncArchive.read(kStream);
+	// Perform shared serialize
+	CvStreamLoadVisitor serialVisitor(kStream);
+	serialize(*this, serialVisitor);
 
-	// anything not in m_syncArchive needs to be explicitly read
+	// anything not in serialize() needs to be explicitly
+	// read
 
-	// The 'automagic' sync archive saves out the unit type index, which is bad since that can change.
+	// The 'automagic' serialize() saves out the unit type index, which is bad since that can change.
 	// Read in the hash and update the value.
 	{
 		uint idUnitType;
@@ -26936,7 +27614,9 @@ void CvUnit::write(FDataStream& kStream) const
 	kStream << uiVersion;
 	MOD_SERIALIZE_INIT_WRITE(kStream);
 
-	m_syncArchive.write(kStream);
+	// Perform shared serialize
+	CvStreamSaveVisitor serialVisitor(kStream);
+	serialize(*this, serialVisitor);
 
 	// Write out a hash for the unit type, the sync archive saved the index, which is not a good thing to do.
 	if (m_eUnitType != NO_UNIT && m_pUnitInfo)
@@ -27367,7 +28047,7 @@ void CvUnit::ChangeAirSweepCapableCount(int iChange)
 {
 	if(iChange != 0)
 	{
-		m_iAirSweepCapableCount.dirtyGet(m_syncArchive) += iChange;
+		m_iAirSweepCapableCount += iChange;
 	}
 }
 
@@ -27555,7 +28235,7 @@ void CvUnit::changeDropRange(int iChange)
 	VALIDATE_OBJECT
 	if(iChange != 0)
 	{
-		m_iDropRange.dirtyGet(m_syncArchive) += iChange;
+		m_iDropRange += iChange;
 	}
 }
 
@@ -27578,7 +28258,7 @@ int CvUnit::getAlwaysHostileCount() const
 void CvUnit::changeAlwaysHostileCount(int iValue)
 {
 	VALIDATE_OBJECT
-	m_iAlwaysHostileCount.dirtyGet(m_syncArchive) += iValue;
+	m_iAlwaysHostileCount += iValue;
 	CvAssert(getAlwaysHostileCount() >= 0);
 }
 
@@ -27687,7 +28367,7 @@ void CvUnit::IncrementFirstTimeSelected()
 	VALIDATE_OBJECT
 	if(m_iEverSelectedCount < 2)
 	{
-		m_iEverSelectedCount.dirtyGet(m_syncArchive)++;
+		m_iEverSelectedCount++;
 	}
 }
 
@@ -28754,7 +29434,7 @@ const char* CvUnit::GetMissionInfo()
 	else if (m_eGreatPeopleDirectiveType!=NO_GREAT_PEOPLE_DIRECTIVE_TYPE)
 	{
 		m_strMissionInfoString += " // ";
-		m_strMissionInfoString += directiveNames[m_eGreatPeopleDirectiveType.get()];
+		m_strMissionInfoString += directiveNames[m_eGreatPeopleDirectiveType];
 	}
 	else if (isTrade())
 	{
@@ -28788,7 +29468,7 @@ const char* CvUnit::GetMissionInfo()
 		getMissionAIString(strTemp, GetMissionAIType());
 		m_strMissionInfoString += " // ";
 		m_strMissionInfoString += strTemp;
-		strTemp.Format(" target: %d,%d", m_iMissionAIX.get(), m_iMissionAIY.get());
+		strTemp.Format(" target: %d,%d", m_iMissionAIX, m_iMissionAIY);
 		m_strMissionInfoString += strTemp;
 	}
 
@@ -31189,51 +31869,6 @@ std::string CvUnit::debugDump(const FAutoVariableBase& /*var*/) const
 //	--------------------------------------------------------------------------------
 std::string CvUnit::stackTraceRemark(const FAutoVariableBase& /*var*/) const
 {
-	/*
-	std::string result = "Game Turn : ";
-	char gameTurnBuffer[8] = { 0 };
-	int gameTurn = GC.getGame().getGameTurn();
-	sprintf_s(gameTurnBuffer, "%d\0", gameTurn);
-	result += gameTurnBuffer;
-	result += "\nValue Before Change=" + FSerialization::toString(var);
-	if (&var == &m_eActivityType)
-	{
-		result += "\nm_eActivityType changes based on canMove().\n";
-		bool moves = getMoves() > 0;
-		if (canMove())
-		{
-			result += "canMove() returned true because ";
-			if (moves)
-			{
-				result += "getMoves() > 0\n";
-				result += "---- Call Stack for m_iMoves last change: ----\n";
-				result += m_iMoves.getStackTrace();
-				result += "---- END STACK TRACE FOR m_iMoves ----\n";
-			}
-			else
-			{
-				result += "some unknown check was added there but not here in the remark code\n";
-			}
-		}
-		else
-		{
-			result += "\ncanMove() return false because ";
-			if (!moves)
-			{
-				result += "getMoves() == 0\n";
-				result += "---- Call Stack for m_iMoves last change: ----\n";
-				result += m_iMoves.getStackTrace();
-				result += "---- END STACK TRACE FOR m_iMoves ----\n";
-
-			}
-			else
-			{
-				result += "some unknown check was added there but not here in the remark code\n";
-			}
-		}
-	}
-	return result;
-	*/
 	return EmptyString;
 }
 

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -27182,7 +27182,7 @@ CvUnit* CvUnit::GetPotentialUnitToSwapWith(CvPlot & swapPlot) const
 
 //	--------------------------------------------------------------------------------
 template<typename Unit, typename Visitor>
-void CvUnit::serialize(Unit& unit, Visitor& visitor)
+void CvUnit::Serialize(Unit& unit, Visitor& visitor)
 {
 	visitor(unit.m_eOwner);
 	visitor(unit.m_eOriginalOwner);
@@ -27514,7 +27514,7 @@ void CvUnit::read(FDataStream& kStream)
 
 	// Perform shared serialize
 	CvStreamLoadVisitor serialVisitor(kStream);
-	serialize(*this, serialVisitor);
+	Serialize(*this, serialVisitor);
 
 	// anything not in serialize() needs to be explicitly
 	// read
@@ -27616,7 +27616,7 @@ void CvUnit::write(FDataStream& kStream) const
 
 	// Perform shared serialize
 	CvStreamSaveVisitor serialVisitor(kStream);
-	serialize(*this, serialVisitor);
+	Serialize(*this, serialVisitor);
 
 	// Write out a hash for the unit type, the sync archive saved the index, which is not a good thing to do.
 	if (m_eUnitType != NO_UNIT && m_pUnitInfo)

--- a/CvGameCoreDLL_Expansion2/CvUnit.h
+++ b/CvGameCoreDLL_Expansion2/CvUnit.h
@@ -1727,7 +1727,7 @@ public:
 	int CountStackingUnitsAtPlot(const CvPlot* pPlot) const;
 
 	template<typename Unit, typename Visitor>
-	static void serialize(Unit& unit, Visitor& visitor);
+	static void Serialize(Unit& unit, Visitor& visitor);
 	void read(FDataStream& kStream);
 	void write(FDataStream& kStream) const;
 

--- a/CvGameCoreDLL_Expansion2/CvUnit.h
+++ b/CvGameCoreDLL_Expansion2/CvUnit.h
@@ -106,323 +106,6 @@ enum AreaEffectType
 	AE_SIEGETOWER
 };
 
-SYNC_ARCHIVE_BEGIN(CvUnit)
-SYNC_ARCHIVE_VAR(PlayerTypes, m_eOwner, true)
-SYNC_ARCHIVE_VAR(PlayerTypes, m_eOriginalOwner, true)
-SYNC_ARCHIVE_VAR(UnitTypes, m_eUnitType, true)
-SYNC_ARCHIVE_VAR(int, m_iX, true)
-SYNC_ARCHIVE_VAR(int, m_iY, true)
-SYNC_ARCHIVE_VAR(int, m_iID, true)
-SYNC_ARCHIVE_VAR(int, m_iDamage, true)
-SYNC_ARCHIVE_VAR(int, m_iMoves, true)
-SYNC_ARCHIVE_VAR(int, m_iArmyId, true)
-SYNC_ARCHIVE_VAR(int, m_iBaseCombat, true)
-SYNC_ARCHIVE_VAR(int, m_iBaseRangedCombat, true)
-SYNC_ARCHIVE_VAR(int, m_iHotKeyNumber, true)
-SYNC_ARCHIVE_VAR(int, m_iDeployFromOperationTurn, true)
-SYNC_ARCHIVE_VAR(int, m_iLastMoveTurn, true)
-SYNC_ARCHIVE_VAR(int, m_iReconX, true)
-SYNC_ARCHIVE_VAR(int, m_iReconY, true)
-SYNC_ARCHIVE_VAR(int, m_iReconCount, true)
-SYNC_ARCHIVE_VAR(int, m_iGameTurnCreated, true)
-SYNC_ARCHIVE_VAR(bool, m_bImmobile, true)
-SYNC_ARCHIVE_VAR(int, m_iExperienceTimes100, true)
-SYNC_ARCHIVE_VAR(int, m_iLevel, true)
-SYNC_ARCHIVE_VAR(int, m_iCargo, true)
-SYNC_ARCHIVE_VAR(int, m_iCargoCapacity, true)
-SYNC_ARCHIVE_VAR(int, m_iAttackPlotX, true)
-SYNC_ARCHIVE_VAR(int, m_iAttackPlotY, true)
-SYNC_ARCHIVE_VAR(int, m_iCombatTimer, true)
-SYNC_ARCHIVE_VAR(int, m_iCombatFirstStrikes, true)
-SYNC_ARCHIVE_VAR(int, m_iCombatDamage, true)
-SYNC_ARCHIVE_VAR(bool, m_bMovedThisTurn, true)
-SYNC_ARCHIVE_VAR(bool, m_bFortified, true)
-SYNC_ARCHIVE_VAR(int, m_iBlitzCount, true)
-SYNC_ARCHIVE_VAR(int, m_iAmphibCount, true)
-SYNC_ARCHIVE_VAR(int, m_iRiverCrossingNoPenaltyCount, true)
-SYNC_ARCHIVE_VAR(int, m_iEnemyRouteCount, true)
-SYNC_ARCHIVE_VAR(int, m_iRivalTerritoryCount, true)
-SYNC_ARCHIVE_VAR(int, m_iIsSlowInEnemyLandCount, true)
-SYNC_ARCHIVE_VAR(int, m_iRangeAttackIgnoreLOSCount, true)
-SYNC_ARCHIVE_VAR(int, m_iCityAttackOnlyCount, true)
-SYNC_ARCHIVE_VAR(int, m_iCaptureDefeatedEnemyCount, true)
-SYNC_ARCHIVE_VAR(int, m_iOriginCity, true)
-SYNC_ARCHIVE_VAR(int, m_iCannotBeCapturedCount, true)
-SYNC_ARCHIVE_VAR(int, m_iForcedDamage, true)
-SYNC_ARCHIVE_VAR(int, m_iChangeDamage, true)
-SYNC_ARCHIVE_VAR(SYNC_ARCHIVE_VAR_TYPE(std::map<PromotionTypes, int>), m_PromotionDuration, true)
-SYNC_ARCHIVE_VAR(SYNC_ARCHIVE_VAR_TYPE(std::map<PromotionTypes, int>), m_TurnPromotionGained, true)
-SYNC_ARCHIVE_VAR(int, m_iRangedSupportFireCount, true)
-SYNC_ARCHIVE_VAR(int, m_iAlwaysHealCount, true)
-SYNC_ARCHIVE_VAR(int, m_iHealOutsideFriendlyCount, true)
-SYNC_ARCHIVE_VAR(int, m_iHillsDoubleMoveCount, true)
-SYNC_ARCHIVE_VAR(int, m_iMountainsDoubleMoveCount, true)
-SYNC_ARCHIVE_VAR(int, m_iEmbarkFlatCostCount, true)
-SYNC_ARCHIVE_VAR(int, m_iDisembarkFlatCostCount, true)
-SYNC_ARCHIVE_VAR(int, m_iAOEDamageOnKill, true)
-SYNC_ARCHIVE_VAR(int, m_iAoEDamageOnMove, true)
-SYNC_ARCHIVE_VAR(int, m_iSplashDamage, true)
-SYNC_ARCHIVE_VAR(int, m_iMultiAttackBonus, true)
-SYNC_ARCHIVE_VAR(int, m_iLandAirDefenseValue, true)
-SYNC_ARCHIVE_VAR(int, m_iImmuneToFirstStrikesCount, true)
-SYNC_ARCHIVE_VAR(int, m_iExtraVisibilityRange, true)
-SYNC_ARCHIVE_VAR(int, m_iExtraReconRange, true)
-SYNC_ARCHIVE_VAR(int, m_iExtraMoves, true)
-SYNC_ARCHIVE_VAR(int, m_iExtraMoveDiscount, true)
-SYNC_ARCHIVE_VAR(int, m_iExtraRange, true)
-SYNC_ARCHIVE_VAR(int, m_iInterceptChance, true)
-SYNC_ARCHIVE_VAR(int, m_iExtraEvasion, true)
-SYNC_ARCHIVE_VAR(int, m_iExtraFirstStrikes, true)
-SYNC_ARCHIVE_VAR(int, m_iExtraChanceFirstStrikes, true)
-SYNC_ARCHIVE_VAR(int, m_iExtraWithdrawal, true)
-SYNC_ARCHIVE_VAR(int, m_iPlagueChance, true)
-SYNC_ARCHIVE_VAR(int, m_iIsPlagued, true)
-SYNC_ARCHIVE_VAR(int, m_iPlagueID, true)
-SYNC_ARCHIVE_VAR(int, m_iPlaguePriority, true)
-SYNC_ARCHIVE_VAR(int, m_iPlagueIDImmunity, true)
-SYNC_ARCHIVE_VAR(int, m_iPlaguePromotion, true)
-SYNC_ARCHIVE_VAR(ContractTypes, m_eUnitContract, true)
-SYNC_ARCHIVE_VAR(int, m_iNegatorPromotion, true)
-SYNC_ARCHIVE_VAR(bool, m_bIsNoMaintenance, true)
-SYNC_ARCHIVE_VAR(int, m_iExtraEnemyHeal, true)
-SYNC_ARCHIVE_VAR(int, m_iExtraNeutralHeal, true)
-SYNC_ARCHIVE_VAR(int, m_iExtraFriendlyHeal, true)
-SYNC_ARCHIVE_VAR(int, m_iEnemyDamageChance, true)
-SYNC_ARCHIVE_VAR(int, m_iNeutralDamageChance, true)
-SYNC_ARCHIVE_VAR(int, m_iEnemyDamage, true)
-SYNC_ARCHIVE_VAR(int, m_iNeutralDamage, true)
-SYNC_ARCHIVE_VAR(int, m_iNearbyEnemyCombatMod, true)
-SYNC_ARCHIVE_VAR(int, m_iNearbyEnemyCombatRange, true)
-SYNC_ARCHIVE_VAR(int, m_iSameTileHeal, true)
-SYNC_ARCHIVE_VAR(int, m_iAdjacentTileHeal, true)
-SYNC_ARCHIVE_VAR(int, m_iAdjacentModifier, true)
-SYNC_ARCHIVE_VAR(int, m_iRangedAttackModifier, true)
-SYNC_ARCHIVE_VAR(int, m_iInterceptionCombatModifier, true)
-SYNC_ARCHIVE_VAR(int, m_iInterceptionDefenseDamageModifier, true)
-SYNC_ARCHIVE_VAR(int, m_iAirSweepCombatModifier, true)
-SYNC_ARCHIVE_VAR(int, m_iAttackModifier, true)
-SYNC_ARCHIVE_VAR(int, m_iDefenseModifier, true)
-SYNC_ARCHIVE_VAR(int, m_iGroundAttackDamage, true)
-SYNC_ARCHIVE_VAR(int, m_iExtraCombatPercent, true)
-SYNC_ARCHIVE_VAR(int, m_iExtraCityAttackPercent, true)
-SYNC_ARCHIVE_VAR(int, m_iExtraCityDefensePercent, true)
-SYNC_ARCHIVE_VAR(int, m_iExtraRangedDefenseModifier, true)
-SYNC_ARCHIVE_VAR(int, m_iExtraHillsAttackPercent, true)
-SYNC_ARCHIVE_VAR(int, m_iExtraHillsDefensePercent, true)
-SYNC_ARCHIVE_VAR(int, m_iExtraOpenAttackPercent, true)
-SYNC_ARCHIVE_VAR(int, m_iExtraOpenRangedAttackMod, true)
-SYNC_ARCHIVE_VAR(int, m_iExtraRoughAttackPercent, true)
-SYNC_ARCHIVE_VAR(int, m_iExtraRoughRangedAttackMod, true)
-SYNC_ARCHIVE_VAR(int, m_iExtraAttackFortifiedMod, true)
-SYNC_ARCHIVE_VAR(int, m_iExtraAttackWoundedMod, true)
-SYNC_ARCHIVE_VAR(int, m_iExtraFullyHealedMod, true)
-SYNC_ARCHIVE_VAR(int, m_iExtraAttackAboveHealthMod, true)
-SYNC_ARCHIVE_VAR(int, m_iExtraAttackBelowHealthMod, true)
-SYNC_ARCHIVE_VAR(int, m_iFlankAttackModifier, true)
-SYNC_ARCHIVE_VAR(int, m_iExtraOpenDefensePercent, true)
-SYNC_ARCHIVE_VAR(int, m_iExtraRoughDefensePercent, true)
-SYNC_ARCHIVE_VAR(int, m_iExtraOpenFromPercent, true)
-SYNC_ARCHIVE_VAR(int, m_iExtraRoughFromPercent, true)
-SYNC_ARCHIVE_VAR(int, m_iPillageChange, true)
-SYNC_ARCHIVE_VAR(int, m_iUpgradeDiscount, true)
-SYNC_ARCHIVE_VAR(int, m_iExperiencePercent, true)
-SYNC_ARCHIVE_VAR(int, m_iDropRange, true)
-SYNC_ARCHIVE_VAR(int, m_iAirSweepCapableCount, true)
-SYNC_ARCHIVE_VAR(int, m_iExtraNavalMoves, true)
-SYNC_ARCHIVE_VAR(int, m_iKamikazePercent, true)
-SYNC_ARCHIVE_VAR(DirectionTypes, m_eFacingDirection, true)
-SYNC_ARCHIVE_VAR(int, m_iIgnoreTerrainCostCount, true)
-SYNC_ARCHIVE_VAR(int, m_iIgnoreTerrainDamageCount, true)
-SYNC_ARCHIVE_VAR(int, m_iIgnoreFeatureDamageCount, true)
-SYNC_ARCHIVE_VAR(int, m_iExtraTerrainDamageCount, true)
-SYNC_ARCHIVE_VAR(int, m_iExtraFeatureDamageCount, true)
-SYNC_ARCHIVE_VAR(int, m_iNearbyImprovementCombatBonus, true)
-SYNC_ARCHIVE_VAR(int, m_iNearbyImprovementBonusRange, true)
-SYNC_ARCHIVE_VAR(ImprovementTypes, m_eCombatBonusImprovement, true)
-SYNC_ARCHIVE_VAR(int, m_iNearbyUnitClassBonus, true)
-SYNC_ARCHIVE_VAR(int, m_iNearbyUnitClassBonusRange, true)
-SYNC_ARCHIVE_VAR(UnitClassTypes, m_iCombatBonusFromNearbyUnitClass, true)
-SYNC_ARCHIVE_VAR(int, m_bNearbyPromotion, true)
-SYNC_ARCHIVE_VAR(int, m_iNearbyUnitPromotionRange, true)
-SYNC_ARCHIVE_VAR(int, m_iNearbyCityCombatMod, true)
-SYNC_ARCHIVE_VAR(int, m_iNearbyFriendlyCityCombatMod, true)
-SYNC_ARCHIVE_VAR(int, m_iNearbyEnemyCityCombatMod, true)
-SYNC_ARCHIVE_VAR(int, m_iPillageBonusStrengthPercent, true)
-SYNC_ARCHIVE_VAR(int, m_iStackedGreatGeneralExperience, true)
-SYNC_ARCHIVE_VAR(int, m_bIsHighSeaRaider, true)
-SYNC_ARCHIVE_VAR(int, m_iWonderProductionModifier, true)
-SYNC_ARCHIVE_VAR(int, m_iUnitProductionModifier, true)
-SYNC_ARCHIVE_VAR(int, m_iNearbyEnemyDamage, true)
-SYNC_ARCHIVE_VAR(int, m_iGGGAXPPercent, true)
-SYNC_ARCHIVE_VAR(int, m_iGiveCombatMod, true)
-SYNC_ARCHIVE_VAR(int, m_iGiveHPIfEnemyKilled, true)
-SYNC_ARCHIVE_VAR(int, m_iGiveExperiencePercent, true)
-SYNC_ARCHIVE_VAR(int, m_iGiveOutsideFriendlyLandsModifier, true)
-SYNC_ARCHIVE_VAR(int, m_eGiveDomain, true)
-SYNC_ARCHIVE_VAR(int, m_iGiveExtraAttacks, true)
-SYNC_ARCHIVE_VAR(int, m_iGiveDefenseMod, true)
-SYNC_ARCHIVE_VAR(int, m_bGiveInvisibility, true)
-SYNC_ARCHIVE_VAR(int, m_bGiveOnlyOnStartingTurn, true)
-SYNC_ARCHIVE_VAR(int, m_bConvertUnit, true)
-SYNC_ARCHIVE_VAR(int, m_eConvertDomain, true)
-SYNC_ARCHIVE_VAR(UnitTypes, m_eConvertDomainUnit, true)
-SYNC_ARCHIVE_VAR(int, m_bConvertEnemyUnitToBarbarian, true)
-SYNC_ARCHIVE_VAR(int, m_bConvertOnFullHP, true)
-SYNC_ARCHIVE_VAR(int, m_bConvertOnDamage, true)
-SYNC_ARCHIVE_VAR(int, m_iDamageThreshold, true)
-SYNC_ARCHIVE_VAR(UnitTypes, m_eConvertDamageOrFullHPUnit, true)
-SYNC_ARCHIVE_VAR(int, m_iNumberOfCultureBombs, true)
-SYNC_ARCHIVE_VAR(int, m_iNearbyHealEnemyTerritory, true)
-SYNC_ARCHIVE_VAR(int, m_iNearbyHealNeutralTerritory, true)
-SYNC_ARCHIVE_VAR(int, m_iNearbyHealFriendlyTerritory, true)
-SYNC_ARCHIVE_VAR(int, m_iCanCrossMountainsCount, true)
-SYNC_ARCHIVE_VAR(int, m_iCanCrossOceansCount, true)
-SYNC_ARCHIVE_VAR(int, m_iCanCrossIceCount, true)
-SYNC_ARCHIVE_VAR(int, m_iNumTilesRevealedThisTurn, true)
-SYNC_ARCHIVE_VAR(int, m_bSpottedEnemy, true)
-SYNC_ARCHIVE_VAR(int, m_iGainsXPFromScouting, true)
-SYNC_ARCHIVE_VAR(int, m_iGainsXPFromPillaging, true)
-SYNC_ARCHIVE_VAR(int, m_iGainsXPFromSpotting, true)
-SYNC_ARCHIVE_VAR(int, m_iCaptureDefeatedEnemyChance, true)
-SYNC_ARCHIVE_VAR(int, m_iBarbCombatBonus, true)
-SYNC_ARCHIVE_VAR(int, m_iAdjacentEnemySapMovement, true)
-SYNC_ARCHIVE_VAR(int, m_iGGFromBarbariansCount, true)
-SYNC_ARCHIVE_VAR(int, m_iAuraRangeChange, true)
-SYNC_ARCHIVE_VAR(int, m_iAuraEffectChange, true)
-SYNC_ARCHIVE_VAR(int, m_iNumRepairCharges, true)
-SYNC_ARCHIVE_VAR(int, m_iMilitaryCapChange, true)
-SYNC_ARCHIVE_VAR(int, m_iRoughTerrainEndsTurnCount, true)
-SYNC_ARCHIVE_VAR(int, m_iEmbarkAbilityCount, true)
-SYNC_ARCHIVE_VAR(int, m_iHoveringUnitCount, true)
-SYNC_ARCHIVE_VAR(int, m_iFlatMovementCostCount, true)
-SYNC_ARCHIVE_VAR(int, m_iCanMoveImpassableCount, true)
-SYNC_ARCHIVE_VAR(int, m_iOnlyDefensiveCount, true)
-SYNC_ARCHIVE_VAR(int, m_iNoDefensiveBonusCount, true)
-SYNC_ARCHIVE_VAR(int, m_iNoCaptureCount, true)
-SYNC_ARCHIVE_VAR(int, m_iNukeImmuneCount, true)
-SYNC_ARCHIVE_VAR(int, m_iHiddenNationalityCount, true)
-SYNC_ARCHIVE_VAR(int, m_iAlwaysHostileCount, true)
-SYNC_ARCHIVE_VAR(int, m_iNoRevealMapCount, true)
-SYNC_ARCHIVE_VAR(int, m_iCanMoveAllTerrainCount, true)
-SYNC_ARCHIVE_VAR(int, m_iCanMoveAfterAttackingCount, true)
-SYNC_ARCHIVE_VAR(int, m_iFreePillageMoveCount, true)
-SYNC_ARCHIVE_VAR(int, m_iHealOnPillageCount, true)
-SYNC_ARCHIVE_VAR(int, m_iHPHealedIfDefeatEnemy, true)
-SYNC_ARCHIVE_VAR(int, m_iGoldenAgeValueFromKills, true)
-SYNC_ARCHIVE_VAR(int, m_iTacticalAIPlotX, true)
-SYNC_ARCHIVE_VAR(int, m_iTacticalAIPlotY, true)
-SYNC_ARCHIVE_VAR(int, m_iGarrisonCityID, true)
-SYNC_ARCHIVE_VAR(int, m_iNumAttacks, true)
-SYNC_ARCHIVE_VAR(int, m_iAttacksMade, true)
-SYNC_ARCHIVE_VAR(int, m_iGreatGeneralCount, true)
-SYNC_ARCHIVE_VAR(int, m_iGreatAdmiralCount, true)
-SYNC_ARCHIVE_VAR(int, m_iGreatGeneralModifier, true)
-SYNC_ARCHIVE_VAR(int, m_iGreatGeneralReceivesMovementCount, true)
-SYNC_ARCHIVE_VAR(int, m_iGreatGeneralCombatModifier, true)
-SYNC_ARCHIVE_VAR(int, m_iIgnoreGreatGeneralBenefit, true)
-SYNC_ARCHIVE_VAR(int, m_iIgnoreZOC, true)
-SYNC_ARCHIVE_VAR(int, m_iNoSupply, true)
-SYNC_ARCHIVE_VAR(int, m_iMaxHitPointsChange, true)
-SYNC_ARCHIVE_VAR(int, m_iMaxHitPointsModifier, true)
-SYNC_ARCHIVE_VAR(int, m_iFriendlyLandsModifier, true)
-SYNC_ARCHIVE_VAR(int, m_iFriendlyLandsAttackModifier, true)
-SYNC_ARCHIVE_VAR(int, m_iOutsideFriendlyLandsModifier, true)
-SYNC_ARCHIVE_VAR(int, m_iHealIfDefeatExcludeBarbariansCount, true)
-SYNC_ARCHIVE_VAR(int, m_iNumInterceptions, true)
-SYNC_ARCHIVE_VAR(int, m_iExtraAirInterceptRange, true)
-SYNC_ARCHIVE_VAR(int, m_iMadeInterceptionCount, true)
-SYNC_ARCHIVE_VAR(int, m_iEverSelectedCount, true)
-SYNC_ARCHIVE_VAR(int, m_iSapperCount, true)
-SYNC_ARCHIVE_VAR(int, m_iCanHeavyCharge, true)
-SYNC_ARCHIVE_VAR(int, m_iStrongerDamaged, true)
-SYNC_ARCHIVE_VAR(int, m_iFightWellDamaged, true)
-SYNC_ARCHIVE_VAR(int, m_iCanMoraleBreak, true)
-SYNC_ARCHIVE_VAR(int, m_iDamageAoEFortified, true)
-SYNC_ARCHIVE_VAR(int, m_iWorkRateMod, true)
-SYNC_ARCHIVE_VAR(int, m_iDamageReductionCityAssault, true)
-SYNC_ARCHIVE_VAR(int, m_iGoodyHutYieldBonus, true)
-SYNC_ARCHIVE_VAR(int, m_iReligiousPressureModifier, true)
-SYNC_ARCHIVE_VAR(int, m_iNumExoticGoods, true)
-SYNC_ARCHIVE_VAR(bool, m_bPromotionReady, true)
-SYNC_ARCHIVE_VAR(bool, m_bDeathDelay, true)
-SYNC_ARCHIVE_VAR(bool, m_bCombatFocus, true)
-SYNC_ARCHIVE_VAR(bool, m_bInfoBarDirty, true)
-SYNC_ARCHIVE_VAR(bool, m_bNotConverting, true)
-SYNC_ARCHIVE_VAR(bool, m_bAirCombat, true)
-SYNC_ARCHIVE_VAR(bool, m_bSetUpForRangedAttack, true)
-SYNC_ARCHIVE_VAR(bool, m_bEmbarked, true)
-SYNC_ARCHIVE_VAR(bool, m_bPromotedFromGoody, true)
-SYNC_ARCHIVE_VAR(bool, m_bAITurnProcessed, true)
-SYNC_ARCHIVE_VAR(int, m_iDamageTakenThisTurn, true)
-SYNC_ARCHIVE_VAR(int, m_iDamageTakenLastTurn, true)
-SYNC_ARCHIVE_VAR(PlayerTypes, m_eCapturingPlayer, true)
-SYNC_ARCHIVE_VAR(bool, m_bCapturedAsIs, true)
-SYNC_ARCHIVE_VAR(UnitTypes, m_eLeaderUnitType, true)
-SYNC_ARCHIVE_VAR(InvisibleTypes, m_eInvisibleType, true)
-SYNC_ARCHIVE_VAR(InvisibleTypes, m_eSeeInvisibleType, true)
-SYNC_ARCHIVE_VAR(GreatPeopleDirectiveTypes, m_eGreatPeopleDirectiveType, true)
-SYNC_ARCHIVE_VAR(CvString, m_strScriptData, true)
-SYNC_ARCHIVE_VAR(int, m_iScenarioData, true)
-SYNC_ARCHIVE_VAR(int, m_iBuilderStrength, true)
-SYNC_ARCHIVE_VAR(TerrainTypeCounter, m_terrainDoubleMoveCount, true)
-SYNC_ARCHIVE_VAR(FeatureTypeCounter, m_featureDoubleMoveCount, true)
-SYNC_ARCHIVE_VAR(TerrainTypeCounter, m_terrainHalfMoveCount, true)
-SYNC_ARCHIVE_VAR(FeatureTypeCounter, m_featureHalfMoveCount, true)
-SYNC_ARCHIVE_VAR(TerrainTypeCounter, m_terrainExtraMoveCount, true)
-SYNC_ARCHIVE_VAR(FeatureTypeCounter, m_featureExtraMoveCount, true)
-SYNC_ARCHIVE_VAR(TerrainTypeCounter, m_terrainDoubleHeal, true)
-SYNC_ARCHIVE_VAR(FeatureTypeCounter, m_featureDoubleHeal, true)
-SYNC_ARCHIVE_VAR(TerrainTypeCounter, m_terrainImpassableCount, true)
-SYNC_ARCHIVE_VAR(FeatureTypeCounter, m_featureImpassableCount, true)
-SYNC_ARCHIVE_VAR(TerrainTypeCounter, m_extraTerrainAttackPercent, true)
-SYNC_ARCHIVE_VAR(TerrainTypeCounter, m_extraTerrainDefensePercent, true)
-SYNC_ARCHIVE_VAR(FeatureTypeCounter, m_extraFeatureAttackPercent, true)
-SYNC_ARCHIVE_VAR(FeatureTypeCounter, m_extraFeatureDefensePercent, true)
-SYNC_ARCHIVE_VAR(UnitClassCounter, m_extraUnitClassAttackMod, true)
-SYNC_ARCHIVE_VAR(UnitClassCounter, m_extraUnitClassDefenseMod, true)
-SYNC_ARCHIVE_VAR(std::vector<int>, m_aiNumTimesAttackedThisTurn, true)
-SYNC_ARCHIVE_VAR(std::vector<int>, m_yieldFromScouting, true)
-SYNC_ARCHIVE_VAR(std::vector<int>, m_yieldFromKills, true)
-SYNC_ARCHIVE_VAR(std::vector<int>, m_yieldFromBarbarianKills, true)
-SYNC_ARCHIVE_VAR(std::vector<int>, m_extraUnitCombatModifier, true)
-SYNC_ARCHIVE_VAR(std::vector<int>, m_unitClassModifier, true)
-SYNC_ARCHIVE_VAR(std::vector<int>, m_iCombatModPerAdjacentUnitCombatModifier, true)
-SYNC_ARCHIVE_VAR(std::vector<int>, m_iCombatModPerAdjacentUnitCombatAttackMod, true)
-SYNC_ARCHIVE_VAR(std::vector<int>, m_iCombatModPerAdjacentUnitCombatDefenseMod, true)
-SYNC_ARCHIVE_VAR(int, m_iMissionTimer, true)
-SYNC_ARCHIVE_VAR(int, m_iMissionAIX, true)
-SYNC_ARCHIVE_VAR(int, m_iMissionAIY, true)
-SYNC_ARCHIVE_VAR(MissionAITypes, m_eMissionAIType, true)
-SYNC_ARCHIVE_VAR(ActivityTypes, m_eActivityType, true)
-SYNC_ARCHIVE_VAR(AutomateTypes, m_eAutomateType, true)
-SYNC_ARCHIVE_VAR(UnitAITypes, m_eUnitAIType, true)
-SYNC_ARCHIVE_VAR(int, m_eCombatType, true)
-SYNC_ARCHIVE_VAR(int, m_iEmbarkedAllWaterCount, true)
-SYNC_ARCHIVE_VAR(int, m_iEmbarkedDeepWaterCount, true)
-SYNC_ARCHIVE_VAR(int, m_iEmbarkExtraVisibility, true)
-SYNC_ARCHIVE_VAR(int, m_iEmbarkDefensiveModifier, true)
-SYNC_ARCHIVE_VAR(int, m_iCapitalDefenseModifier, true)
-SYNC_ARCHIVE_VAR(int, m_iCapitalDefenseFalloff, true)
-SYNC_ARCHIVE_VAR(int, m_iCityAttackPlunderModifier, true)
-SYNC_ARCHIVE_VAR(int, m_iReligiousStrengthLossRivalTerritory, true)
-SYNC_ARCHIVE_VAR(int, m_iTradeMissionInfluenceModifier, true)
-SYNC_ARCHIVE_VAR(int, m_iTradeMissionGoldModifier, true)
-SYNC_ARCHIVE_VAR(int, m_iDiploMissionInfluence, true)
-SYNC_ARCHIVE_VAR(int, m_iMapLayer, true)
-SYNC_ARCHIVE_VAR(int, m_iNumGoodyHutsPopped, true)
-SYNC_ARCHIVE_VAR(int, m_iTourismBlastStrength, true)
-SYNC_ARCHIVE_VAR(int, m_iTourismBlastLength, true)
-SYNC_ARCHIVE_VAR(int, m_iHurryStrength, true)
-SYNC_ARCHIVE_VAR(int, m_iScienceBlastStrength, true)
-SYNC_ARCHIVE_VAR(int, m_iCultureBlastStrength, true)
-SYNC_ARCHIVE_VAR(int, m_iGAPBlastStrength, true)
-SYNC_ARCHIVE_VAR(std::vector<bool>, m_abPromotionEverObtained, true)
-SYNC_ARCHIVE_VAR(AITacticalMove, m_eTacticalMove, true)
-SYNC_ARCHIVE_VAR(int, m_iTacticalMoveSetTurn, true)
-SYNC_ARCHIVE_VAR(AIHomelandMove, m_eHomelandMove, true)
-SYNC_ARCHIVE_VAR(int, m_iHomelandMoveSetTurn, true)
-SYNC_ARCHIVE_END()
-
 class CvUnit
 {
 	friend class CvUnitMission;
@@ -1275,12 +958,12 @@ public:
 
 	inline int getX() const
 	{
-		return m_iX.get();
+		return m_iX;
 	}
 
 	inline int getY() const
 	{
-		return m_iY.get();
+		return m_iY;
 	}
 
 	void setXY(int iX, int iY, bool bGroup = false, bool bUpdate = true, bool bShow = false, bool bCheckPlotVisible = false, bool bNoMove = false);
@@ -1793,7 +1476,7 @@ public:
 
 	inline PlayerTypes getOwner() const
 	{
-		return m_eOwner.get();
+		return m_eOwner;
 	}
 	PlayerTypes getVisualOwner(TeamTypes eForTeam = NO_TEAM) const;
 	PlayerTypes getCombatOwner(TeamTypes eForTeam, const CvPlot& pPlot) const;
@@ -2043,6 +1726,8 @@ public:
 	bool CanStackUnitAtPlot(const CvPlot* pPlot) const;
 	int CountStackingUnitsAtPlot(const CvPlot* pPlot) const;
 
+	template<typename Unit, typename Visitor>
+	static void serialize(Unit& unit, Visitor& visitor);
 	void read(FDataStream& kStream);
 	void write(FDataStream& kStream) const;
 
@@ -2243,299 +1928,299 @@ protected:
 
 	SYNC_ARCHIVE_MEMBER(CvUnit)
 
-	SYNC_VAR_MEMBER(m_eOwner)
-	SYNC_VAR_MEMBER(m_eOriginalOwner)
-	SYNC_VAR_MEMBER(m_eUnitType)
-	SYNC_VAR_MEMBER(m_iX)
-	SYNC_VAR_MEMBER(m_iY)
-	SYNC_VAR_MEMBER(m_iID)
+	PlayerTypes m_eOwner;
+	PlayerTypes m_eOriginalOwner;
+	UnitTypes m_eUnitType;
+	int m_iX;
+	int m_iY;
+	int m_iID;
 
-	SYNC_VAR_MEMBER(m_iDamage)
-	SYNC_VAR_MEMBER(m_iMoves)
-	SYNC_VAR_MEMBER(m_iArmyId)
-	SYNC_VAR_MEMBER(m_iBaseCombat)
+	int m_iDamage;
+	int m_iMoves;
+	int m_iArmyId;
+	int m_iBaseCombat;
 #if defined(MOD_API_EXTENSIONS)
-	SYNC_VAR_MEMBER(m_iBaseRangedCombat)
+	int m_iBaseRangedCombat;
 #endif
 
-	SYNC_VAR_MEMBER(m_iHotKeyNumber)
-	SYNC_VAR_MEMBER(m_iDeployFromOperationTurn)
-	SYNC_VAR_MEMBER(m_iLastMoveTurn)
-	SYNC_VAR_MEMBER(m_iReconX)
-	SYNC_VAR_MEMBER(m_iReconY)
-	SYNC_VAR_MEMBER(m_iReconCount)
-	SYNC_VAR_MEMBER(m_iGameTurnCreated)
-	SYNC_VAR_MEMBER(m_bImmobile)
-	SYNC_VAR_MEMBER(m_iExperienceTimes100)
-	SYNC_VAR_MEMBER(m_iLevel)
-	SYNC_VAR_MEMBER(m_iCargo)
-	SYNC_VAR_MEMBER(m_iCargoCapacity)
-	SYNC_VAR_MEMBER(m_iAttackPlotX)
-	SYNC_VAR_MEMBER(m_iAttackPlotY)
-	SYNC_VAR_MEMBER(m_iCombatTimer)
-	SYNC_VAR_MEMBER(m_iCombatFirstStrikes)
-	SYNC_VAR_MEMBER(m_iCombatDamage)
-	SYNC_VAR_MEMBER(m_bMovedThisTurn)
-	SYNC_VAR_MEMBER(m_bFortified)
-	SYNC_VAR_MEMBER(m_iBlitzCount)
-	SYNC_VAR_MEMBER(m_iAmphibCount)
-	SYNC_VAR_MEMBER(m_iRiverCrossingNoPenaltyCount)
-	SYNC_VAR_MEMBER(m_iEnemyRouteCount)
-	SYNC_VAR_MEMBER(m_iRivalTerritoryCount)
-	SYNC_VAR_MEMBER(m_iIsSlowInEnemyLandCount)
-	SYNC_VAR_MEMBER(m_iRangeAttackIgnoreLOSCount)
-	SYNC_VAR_MEMBER(m_iCityAttackOnlyCount)
-	SYNC_VAR_MEMBER(m_iCaptureDefeatedEnemyCount)
+	int m_iHotKeyNumber;
+	int m_iDeployFromOperationTurn;
+	int m_iLastMoveTurn;
+	int m_iReconX;
+	int m_iReconY;
+	int m_iReconCount;
+	int m_iGameTurnCreated;
+	bool m_bImmobile;
+	int m_iExperienceTimes100;
+	int m_iLevel;
+	int m_iCargo;
+	int m_iCargoCapacity;
+	int m_iAttackPlotX;
+	int m_iAttackPlotY;
+	int m_iCombatTimer;
+	int m_iCombatFirstStrikes;
+	int m_iCombatDamage;
+	bool m_bMovedThisTurn;
+	bool m_bFortified;
+	int m_iBlitzCount;
+	int m_iAmphibCount;
+	int m_iRiverCrossingNoPenaltyCount;
+	int m_iEnemyRouteCount;
+	int m_iRivalTerritoryCount;
+	int m_iIsSlowInEnemyLandCount;
+	int m_iRangeAttackIgnoreLOSCount;
+	int m_iCityAttackOnlyCount;
+	int m_iCaptureDefeatedEnemyCount;
 #if defined(MOD_BALANCE_CORE)
-	SYNC_VAR_MEMBER(m_iOriginCity)
-	SYNC_VAR_MEMBER(m_iCannotBeCapturedCount)
-	SYNC_VAR_MEMBER(m_iForcedDamage)
-	SYNC_VAR_MEMBER(m_iChangeDamage)
-	SYNC_VAR_MEMBER(m_PromotionDuration)
-	SYNC_VAR_MEMBER(m_TurnPromotionGained)
+	int m_iOriginCity;
+	int m_iCannotBeCapturedCount;
+	int m_iForcedDamage;
+	int m_iChangeDamage;
+	std::map<PromotionTypes, int> m_PromotionDuration;
+	std::map<PromotionTypes, int> m_TurnPromotionGained;
 #endif
-	SYNC_VAR_MEMBER(m_iRangedSupportFireCount)
-	SYNC_VAR_MEMBER(m_iAlwaysHealCount)
-	SYNC_VAR_MEMBER(m_iHealOutsideFriendlyCount)
-	SYNC_VAR_MEMBER(m_iHillsDoubleMoveCount)
+	int m_iRangedSupportFireCount;
+	int m_iAlwaysHealCount;
+	int m_iHealOutsideFriendlyCount;
+	int m_iHillsDoubleMoveCount;
 #if defined(MOD_BALANCE_CORE)
-	SYNC_VAR_MEMBER(m_iMountainsDoubleMoveCount)
-	SYNC_VAR_MEMBER(m_iEmbarkFlatCostCount)
-	SYNC_VAR_MEMBER(m_iDisembarkFlatCostCount)
-	SYNC_VAR_MEMBER(m_iAOEDamageOnKill)
-	SYNC_VAR_MEMBER(m_iAoEDamageOnMove)
-	SYNC_VAR_MEMBER(m_iSplashDamage)
-	SYNC_VAR_MEMBER(m_iMultiAttackBonus)
-	SYNC_VAR_MEMBER(m_iLandAirDefenseValue)
+	int m_iMountainsDoubleMoveCount;
+	int m_iEmbarkFlatCostCount;
+	int m_iDisembarkFlatCostCount;
+	int m_iAOEDamageOnKill;
+	int m_iAoEDamageOnMove;
+	int m_iSplashDamage;
+	int m_iMultiAttackBonus;
+	int m_iLandAirDefenseValue;
 #endif
-	SYNC_VAR_MEMBER(m_iImmuneToFirstStrikesCount)
-	SYNC_VAR_MEMBER(m_iExtraVisibilityRange)
+	int m_iImmuneToFirstStrikesCount;
+	int m_iExtraVisibilityRange;
 #if defined(MOD_PROMOTIONS_VARIABLE_RECON)
-	SYNC_VAR_MEMBER(m_iExtraReconRange)
+	int m_iExtraReconRange;
 #endif
-	SYNC_VAR_MEMBER(m_iExtraMoves)
-	SYNC_VAR_MEMBER(m_iExtraMoveDiscount)
-	SYNC_VAR_MEMBER(m_iExtraRange)
-	SYNC_VAR_MEMBER(m_iInterceptChance)
-	SYNC_VAR_MEMBER(m_iExtraEvasion)
-	SYNC_VAR_MEMBER(m_iExtraFirstStrikes)
-	SYNC_VAR_MEMBER(m_iExtraChanceFirstStrikes)
-	SYNC_VAR_MEMBER(m_iExtraWithdrawal)
+	int m_iExtraMoves;
+	int m_iExtraMoveDiscount;
+	int m_iExtraRange;
+	int m_iInterceptChance;
+	int m_iExtraEvasion;
+	int m_iExtraFirstStrikes;
+	int m_iExtraChanceFirstStrikes;
+	int m_iExtraWithdrawal;
 #if defined(MOD_BALANCE_CORE_JFD)
-	SYNC_VAR_MEMBER(m_iPlagueChance)
-	SYNC_VAR_MEMBER(m_iIsPlagued)
-	SYNC_VAR_MEMBER(m_iPlagueID)
-	SYNC_VAR_MEMBER(m_iPlaguePriority)
-	SYNC_VAR_MEMBER(m_iPlagueIDImmunity)
-	SYNC_VAR_MEMBER(m_iPlaguePromotion)
-	SYNC_VAR_MEMBER(m_eUnitContract)
-	SYNC_VAR_MEMBER(m_iNegatorPromotion)
+	int m_iPlagueChance;
+	int m_iIsPlagued;
+	int m_iPlagueID;
+	int m_iPlaguePriority;
+	int m_iPlagueIDImmunity;
+	int m_iPlaguePromotion;
+	ContractTypes m_eUnitContract;
+	int m_iNegatorPromotion;
 #endif
-	SYNC_VAR_MEMBER(m_bIsNoMaintenance)
-	SYNC_VAR_MEMBER(m_iExtraEnemyHeal)
-	SYNC_VAR_MEMBER(m_iExtraNeutralHeal)
-	SYNC_VAR_MEMBER(m_iExtraFriendlyHeal)
-	SYNC_VAR_MEMBER(m_iEnemyDamageChance)
-	SYNC_VAR_MEMBER(m_iNeutralDamageChance)
-	SYNC_VAR_MEMBER(m_iEnemyDamage)
-	SYNC_VAR_MEMBER(m_iNeutralDamage)
-	SYNC_VAR_MEMBER(m_iNearbyEnemyCombatMod)
-	SYNC_VAR_MEMBER(m_iNearbyEnemyCombatRange)
-	SYNC_VAR_MEMBER(m_iSameTileHeal)
-	SYNC_VAR_MEMBER(m_iAdjacentTileHeal)
-	SYNC_VAR_MEMBER(m_iAdjacentModifier)
-	SYNC_VAR_MEMBER(m_iRangedAttackModifier)
-	SYNC_VAR_MEMBER(m_iInterceptionCombatModifier)
-	SYNC_VAR_MEMBER(m_iInterceptionDefenseDamageModifier)
-	SYNC_VAR_MEMBER(m_iAirSweepCombatModifier)
-	SYNC_VAR_MEMBER(m_iAttackModifier)
-	SYNC_VAR_MEMBER(m_iDefenseModifier)
-	SYNC_VAR_MEMBER(m_iGroundAttackDamage)
-	SYNC_VAR_MEMBER(m_iExtraCombatPercent)
-	SYNC_VAR_MEMBER(m_iExtraCityAttackPercent)
-	SYNC_VAR_MEMBER(m_iExtraCityDefensePercent)
-	SYNC_VAR_MEMBER(m_iExtraRangedDefenseModifier)
-	SYNC_VAR_MEMBER(m_iExtraHillsAttackPercent)
-	SYNC_VAR_MEMBER(m_iExtraHillsDefensePercent)
-	SYNC_VAR_MEMBER(m_iExtraOpenAttackPercent)
-	SYNC_VAR_MEMBER(m_iExtraOpenRangedAttackMod)
-	SYNC_VAR_MEMBER(m_iExtraRoughAttackPercent)
-	SYNC_VAR_MEMBER(m_iExtraRoughRangedAttackMod)
-	SYNC_VAR_MEMBER(m_iExtraAttackFortifiedMod)
-	SYNC_VAR_MEMBER(m_iExtraAttackWoundedMod)
-	SYNC_VAR_MEMBER(m_iExtraFullyHealedMod)
-	SYNC_VAR_MEMBER(m_iExtraAttackAboveHealthMod)
-	SYNC_VAR_MEMBER(m_iExtraAttackBelowHealthMod)
-	SYNC_VAR_MEMBER(m_iFlankAttackModifier)
-	SYNC_VAR_MEMBER(m_iExtraOpenDefensePercent)
-	SYNC_VAR_MEMBER(m_iExtraRoughDefensePercent)
-	SYNC_VAR_MEMBER(m_iExtraOpenFromPercent)
-	SYNC_VAR_MEMBER(m_iExtraRoughFromPercent)
-	SYNC_VAR_MEMBER(m_iPillageChange)
-	SYNC_VAR_MEMBER(m_iUpgradeDiscount)
-	SYNC_VAR_MEMBER(m_iExperiencePercent)
-	SYNC_VAR_MEMBER(m_iDropRange)
-	SYNC_VAR_MEMBER(m_iAirSweepCapableCount)
-	SYNC_VAR_MEMBER(m_iExtraNavalMoves)
-	SYNC_VAR_MEMBER(m_iKamikazePercent)
-	SYNC_VAR_MEMBER(m_eFacingDirection)
-	SYNC_VAR_MEMBER(m_iIgnoreTerrainCostCount)
-	SYNC_VAR_MEMBER(m_iIgnoreTerrainDamageCount)
-	SYNC_VAR_MEMBER(m_iIgnoreFeatureDamageCount)
-	SYNC_VAR_MEMBER(m_iExtraTerrainDamageCount)
-	SYNC_VAR_MEMBER(m_iExtraFeatureDamageCount)
+	bool m_bIsNoMaintenance;
+	int m_iExtraEnemyHeal;
+	int m_iExtraNeutralHeal;
+	int m_iExtraFriendlyHeal;
+	int m_iEnemyDamageChance;
+	int m_iNeutralDamageChance;
+	int m_iEnemyDamage;
+	int m_iNeutralDamage;
+	int m_iNearbyEnemyCombatMod;
+	int m_iNearbyEnemyCombatRange;
+	int m_iSameTileHeal;
+	int m_iAdjacentTileHeal;
+	int m_iAdjacentModifier;
+	int m_iRangedAttackModifier;
+	int m_iInterceptionCombatModifier;
+	int m_iInterceptionDefenseDamageModifier;
+	int m_iAirSweepCombatModifier;
+	int m_iAttackModifier;
+	int m_iDefenseModifier;
+	int m_iGroundAttackDamage;
+	int m_iExtraCombatPercent;
+	int m_iExtraCityAttackPercent;
+	int m_iExtraCityDefensePercent;
+	int m_iExtraRangedDefenseModifier;
+	int m_iExtraHillsAttackPercent;
+	int m_iExtraHillsDefensePercent;
+	int m_iExtraOpenAttackPercent;
+	int m_iExtraOpenRangedAttackMod;
+	int m_iExtraRoughAttackPercent;
+	int m_iExtraRoughRangedAttackMod;
+	int m_iExtraAttackFortifiedMod;
+	int m_iExtraAttackWoundedMod;
+	int m_iExtraFullyHealedMod;
+	int m_iExtraAttackAboveHealthMod;
+	int m_iExtraAttackBelowHealthMod;
+	int m_iFlankAttackModifier;
+	int m_iExtraOpenDefensePercent;
+	int m_iExtraRoughDefensePercent;
+	int m_iExtraOpenFromPercent;
+	int m_iExtraRoughFromPercent;
+	int m_iPillageChange;
+	int m_iUpgradeDiscount;
+	int m_iExperiencePercent;
+	int m_iDropRange;
+	int m_iAirSweepCapableCount;
+	int m_iExtraNavalMoves;
+	int m_iKamikazePercent;
+	DirectionTypes m_eFacingDirection;
+	int m_iIgnoreTerrainCostCount;
+	int m_iIgnoreTerrainDamageCount;
+	int m_iIgnoreFeatureDamageCount;
+	int m_iExtraTerrainDamageCount;
+	int m_iExtraFeatureDamageCount;
 #if defined(MOD_PROMOTIONS_IMPROVEMENT_BONUS)
-	SYNC_VAR_MEMBER(m_iNearbyImprovementCombatBonus)
-	SYNC_VAR_MEMBER(m_iNearbyImprovementBonusRange)
-	SYNC_VAR_MEMBER(m_eCombatBonusImprovement)
+	int m_iNearbyImprovementCombatBonus;
+	int m_iNearbyImprovementBonusRange;
+	ImprovementTypes m_eCombatBonusImprovement;
 #endif
 #if defined(MOD_BALANCE_CORE)
-	SYNC_VAR_MEMBER(m_iNearbyUnitClassBonus)
-	SYNC_VAR_MEMBER(m_iNearbyUnitClassBonusRange)
-	SYNC_VAR_MEMBER(m_iCombatBonusFromNearbyUnitClass)
-	SYNC_VAR_MEMBER(m_bNearbyPromotion)
-	SYNC_VAR_MEMBER(m_iNearbyUnitPromotionRange)
-	SYNC_VAR_MEMBER(m_iNearbyCityCombatMod)
-	SYNC_VAR_MEMBER(m_iNearbyFriendlyCityCombatMod)
-	SYNC_VAR_MEMBER(m_iNearbyEnemyCityCombatMod)
-	SYNC_VAR_MEMBER(m_iPillageBonusStrengthPercent)
-	SYNC_VAR_MEMBER(m_iStackedGreatGeneralExperience)
-	SYNC_VAR_MEMBER(m_bIsHighSeaRaider)
-	SYNC_VAR_MEMBER(m_iWonderProductionModifier)
-	SYNC_VAR_MEMBER(m_iUnitProductionModifier)
-	SYNC_VAR_MEMBER(m_iNearbyEnemyDamage)
-	SYNC_VAR_MEMBER(m_iGGGAXPPercent)
-	SYNC_VAR_MEMBER(m_iGiveCombatMod)
-	SYNC_VAR_MEMBER(m_iGiveHPIfEnemyKilled)
-	SYNC_VAR_MEMBER(m_iGiveExperiencePercent)
-	SYNC_VAR_MEMBER(m_iGiveOutsideFriendlyLandsModifier)
-	SYNC_VAR_MEMBER(m_eGiveDomain)
-	SYNC_VAR_MEMBER(m_iGiveExtraAttacks)
-	SYNC_VAR_MEMBER(m_iGiveDefenseMod)
-	SYNC_VAR_MEMBER(m_bGiveInvisibility)
-	SYNC_VAR_MEMBER(m_bGiveOnlyOnStartingTurn)
-	SYNC_VAR_MEMBER(m_bConvertUnit)
-	SYNC_VAR_MEMBER(m_eConvertDomain)
-	SYNC_VAR_MEMBER(m_eConvertDomainUnit)
-	SYNC_VAR_MEMBER(m_bConvertEnemyUnitToBarbarian)
-	SYNC_VAR_MEMBER(m_bConvertOnFullHP)
-	SYNC_VAR_MEMBER(m_bConvertOnDamage)
-	SYNC_VAR_MEMBER(m_iDamageThreshold)
-	SYNC_VAR_MEMBER(m_eConvertDamageOrFullHPUnit)
-	SYNC_VAR_MEMBER(m_iNumberOfCultureBombs)
-	SYNC_VAR_MEMBER(m_iNearbyHealEnemyTerritory)
-	SYNC_VAR_MEMBER(m_iNearbyHealNeutralTerritory)
-	SYNC_VAR_MEMBER(m_iNearbyHealFriendlyTerritory)
+	int m_iNearbyUnitClassBonus;
+	int m_iNearbyUnitClassBonusRange;
+	UnitClassTypes m_iCombatBonusFromNearbyUnitClass;
+	int m_bNearbyPromotion;
+	int m_iNearbyUnitPromotionRange;
+	int m_iNearbyCityCombatMod;
+	int m_iNearbyFriendlyCityCombatMod;
+	int m_iNearbyEnemyCityCombatMod;
+	int m_iPillageBonusStrengthPercent;
+	int m_iStackedGreatGeneralExperience;
+	int m_bIsHighSeaRaider;
+	int m_iWonderProductionModifier;
+	int m_iUnitProductionModifier;
+	int m_iNearbyEnemyDamage;
+	int m_iGGGAXPPercent;
+	int m_iGiveCombatMod;
+	int m_iGiveHPIfEnemyKilled;
+	int m_iGiveExperiencePercent;
+	int m_iGiveOutsideFriendlyLandsModifier;
+	int m_eGiveDomain;
+	int m_iGiveExtraAttacks;
+	int m_iGiveDefenseMod;
+	int m_bGiveInvisibility;
+	int m_bGiveOnlyOnStartingTurn;
+	int m_bConvertUnit;
+	int m_eConvertDomain;
+	UnitTypes m_eConvertDomainUnit;
+	int m_bConvertEnemyUnitToBarbarian;
+	int m_bConvertOnFullHP;
+	int m_bConvertOnDamage;
+	int m_iDamageThreshold;
+	UnitTypes m_eConvertDamageOrFullHPUnit;
+	int m_iNumberOfCultureBombs;
+	int m_iNearbyHealEnemyTerritory;
+	int m_iNearbyHealNeutralTerritory;
+	int m_iNearbyHealFriendlyTerritory;
 #endif
 #if defined(MOD_PROMOTIONS_CROSS_MOUNTAINS)
-	SYNC_VAR_MEMBER(m_iCanCrossMountainsCount)
+	int m_iCanCrossMountainsCount;
 #endif
 #if defined(MOD_PROMOTIONS_CROSS_OCEANS)
-	SYNC_VAR_MEMBER(m_iCanCrossOceansCount)
+	int m_iCanCrossOceansCount;
 #endif
 #if defined(MOD_PROMOTIONS_CROSS_ICE)
-	SYNC_VAR_MEMBER(m_iCanCrossIceCount)
+	int m_iCanCrossIceCount;
 #endif
 #if defined(MOD_BALANCE_CORE)
-	SYNC_VAR_MEMBER(m_iNumTilesRevealedThisTurn)
-	SYNC_VAR_MEMBER(m_bSpottedEnemy)
-	SYNC_VAR_MEMBER(m_iGainsXPFromScouting)
-	SYNC_VAR_MEMBER(m_iGainsXPFromPillaging)
-	SYNC_VAR_MEMBER(m_iGainsXPFromSpotting)
-	SYNC_VAR_MEMBER(m_iCaptureDefeatedEnemyChance)
-	SYNC_VAR_MEMBER(m_iBarbCombatBonus)
-	SYNC_VAR_MEMBER(m_iAdjacentEnemySapMovement)
+	int m_iNumTilesRevealedThisTurn;
+	int m_bSpottedEnemy;
+	int m_iGainsXPFromScouting;
+	int m_iGainsXPFromPillaging;
+	int m_iGainsXPFromSpotting;
+	int m_iCaptureDefeatedEnemyChance;
+	int m_iBarbCombatBonus;
+	int m_iAdjacentEnemySapMovement;
 #endif
 #if defined(MOD_PROMOTIONS_GG_FROM_BARBARIANS)
-	SYNC_VAR_MEMBER(m_iGGFromBarbariansCount)
+	int m_iGGFromBarbariansCount;
 #endif
 #if defined(MOD_PROMOTIONS_AURA_CHANGE)
-	SYNC_VAR_MEMBER(m_iAuraRangeChange)
-	SYNC_VAR_MEMBER(m_iAuraEffectChange)
-	SYNC_VAR_MEMBER(m_iNumRepairCharges)
-	SYNC_VAR_MEMBER(m_iMilitaryCapChange)
+	int m_iAuraRangeChange;
+	int m_iAuraEffectChange;
+	int m_iNumRepairCharges;
+	int m_iMilitaryCapChange;
 #endif
-	SYNC_VAR_MEMBER(m_iRoughTerrainEndsTurnCount)
-	SYNC_VAR_MEMBER(m_iEmbarkAbilityCount)
-	SYNC_VAR_MEMBER(m_iHoveringUnitCount)
-	SYNC_VAR_MEMBER(m_iFlatMovementCostCount)
-	SYNC_VAR_MEMBER(m_iCanMoveImpassableCount)
-	SYNC_VAR_MEMBER(m_iOnlyDefensiveCount)
-	SYNC_VAR_MEMBER(m_iNoDefensiveBonusCount)
-	SYNC_VAR_MEMBER(m_iNoCaptureCount)
-	SYNC_VAR_MEMBER(m_iNukeImmuneCount)
-	SYNC_VAR_MEMBER(m_iHiddenNationalityCount)
-	SYNC_VAR_MEMBER(m_iAlwaysHostileCount)
-	SYNC_VAR_MEMBER(m_iNoRevealMapCount)
-	SYNC_VAR_MEMBER(m_iCanMoveAllTerrainCount)
-	SYNC_VAR_MEMBER(m_iCanMoveAfterAttackingCount)
-	SYNC_VAR_MEMBER(m_iFreePillageMoveCount)
-	SYNC_VAR_MEMBER(m_iHealOnPillageCount)
-	SYNC_VAR_MEMBER(m_iHPHealedIfDefeatEnemy)
-	SYNC_VAR_MEMBER(m_iGoldenAgeValueFromKills)
-	SYNC_VAR_MEMBER(m_iTacticalAIPlotX)
-	SYNC_VAR_MEMBER(m_iTacticalAIPlotY)
-	SYNC_VAR_MEMBER(m_iGarrisonCityID)
-	SYNC_VAR_MEMBER(m_iNumAttacks)
-	SYNC_VAR_MEMBER(m_iAttacksMade)
-	SYNC_VAR_MEMBER(m_iGreatGeneralCount)
-	SYNC_VAR_MEMBER(m_iGreatAdmiralCount)
-	SYNC_VAR_MEMBER(m_iGreatGeneralModifier)
-	SYNC_VAR_MEMBER(m_iGreatGeneralReceivesMovementCount)
-	SYNC_VAR_MEMBER(m_iGreatGeneralCombatModifier)
-	SYNC_VAR_MEMBER(m_iIgnoreGreatGeneralBenefit)
-	SYNC_VAR_MEMBER(m_iIgnoreZOC)
+	int m_iRoughTerrainEndsTurnCount;
+	int m_iEmbarkAbilityCount;
+	int m_iHoveringUnitCount;
+	int m_iFlatMovementCostCount;
+	int m_iCanMoveImpassableCount;
+	int m_iOnlyDefensiveCount;
+	int m_iNoDefensiveBonusCount;
+	int m_iNoCaptureCount;
+	int m_iNukeImmuneCount;
+	int m_iHiddenNationalityCount;
+	int m_iAlwaysHostileCount;
+	int m_iNoRevealMapCount;
+	int m_iCanMoveAllTerrainCount;
+	int m_iCanMoveAfterAttackingCount;
+	int m_iFreePillageMoveCount;
+	int m_iHealOnPillageCount;
+	int m_iHPHealedIfDefeatEnemy;
+	int m_iGoldenAgeValueFromKills;
+	int m_iTacticalAIPlotX;
+	int m_iTacticalAIPlotY;
+	int m_iGarrisonCityID;
+	int m_iNumAttacks;
+	int m_iAttacksMade;
+	int m_iGreatGeneralCount;
+	int m_iGreatAdmiralCount;
+	int m_iGreatGeneralModifier;
+	int m_iGreatGeneralReceivesMovementCount;
+	int m_iGreatGeneralCombatModifier;
+	int m_iIgnoreGreatGeneralBenefit;
+	int m_iIgnoreZOC;
 #if defined(MOD_UNITS_NO_SUPPLY)
-	SYNC_VAR_MEMBER(m_iNoSupply)
+	int m_iNoSupply;
 #endif
 	int m_iMaxHitPointsBase;
-	SYNC_VAR_MEMBER(m_iMaxHitPointsChange)
-	SYNC_VAR_MEMBER(m_iMaxHitPointsModifier)
-	SYNC_VAR_MEMBER(m_iFriendlyLandsModifier)
-	SYNC_VAR_MEMBER(m_iFriendlyLandsAttackModifier)
-	SYNC_VAR_MEMBER(m_iOutsideFriendlyLandsModifier)
-	SYNC_VAR_MEMBER(m_iHealIfDefeatExcludeBarbariansCount)
-	SYNC_VAR_MEMBER(m_iNumInterceptions)
+	int m_iMaxHitPointsChange;
+	int m_iMaxHitPointsModifier;
+	int m_iFriendlyLandsModifier;
+	int m_iFriendlyLandsAttackModifier;
+	int m_iOutsideFriendlyLandsModifier;
+	int m_iHealIfDefeatExcludeBarbariansCount;
+	int m_iNumInterceptions;
 #if defined(MOD_BALANCE_CORE)
-	SYNC_VAR_MEMBER(m_iExtraAirInterceptRange)
+	int m_iExtraAirInterceptRange;
 #endif
-	SYNC_VAR_MEMBER(m_iMadeInterceptionCount)
-	SYNC_VAR_MEMBER(m_iEverSelectedCount)
-	SYNC_VAR_MEMBER(m_iSapperCount)
-	SYNC_VAR_MEMBER(m_iCanHeavyCharge)
+	int m_iMadeInterceptionCount;
+	int m_iEverSelectedCount;
+	int m_iSapperCount;
+	int m_iCanHeavyCharge;
 #if defined(MOD_BALANCE_CORE)
-	SYNC_VAR_MEMBER(m_iStrongerDamaged)
-	SYNC_VAR_MEMBER(m_iFightWellDamaged)
-	SYNC_VAR_MEMBER(m_iCanMoraleBreak)
-	SYNC_VAR_MEMBER(m_iDamageAoEFortified)
-	SYNC_VAR_MEMBER(m_iWorkRateMod)
-	SYNC_VAR_MEMBER(m_iDamageReductionCityAssault)
-	SYNC_VAR_MEMBER(m_iGoodyHutYieldBonus)
-	SYNC_VAR_MEMBER(m_iReligiousPressureModifier)
+	int m_iStrongerDamaged;
+	int m_iFightWellDamaged;
+	int m_iCanMoraleBreak;
+	int m_iDamageAoEFortified;
+	int m_iWorkRateMod;
+	int m_iDamageReductionCityAssault;
+	int m_iGoodyHutYieldBonus;
+	int m_iReligiousPressureModifier;
 #endif
-	SYNC_VAR_MEMBER(m_iNumExoticGoods)
-	SYNC_VAR_MEMBER(m_bPromotionReady)
-	SYNC_VAR_MEMBER(m_bDeathDelay)
-	SYNC_VAR_MEMBER(m_bCombatFocus)
-	SYNC_VAR_MEMBER(m_bInfoBarDirty)
-	SYNC_VAR_MEMBER(m_bNotConverting)
-	SYNC_VAR_MEMBER(m_bAirCombat)
+	int m_iNumExoticGoods;
+	bool m_bPromotionReady;
+	bool m_bDeathDelay;
+	bool m_bCombatFocus;
+	bool m_bInfoBarDirty;
+	bool m_bNotConverting;
+	bool m_bAirCombat;
 	//to be removed
-		SYNC_VAR_MEMBER(m_bSetUpForRangedAttack)
-	SYNC_VAR_MEMBER(m_bEmbarked)
-	SYNC_VAR_MEMBER(m_bPromotedFromGoody)
-	SYNC_VAR_MEMBER(m_bAITurnProcessed)
+		bool m_bSetUpForRangedAttack;
+	bool m_bEmbarked;
+	bool m_bPromotedFromGoody;
+	bool m_bAITurnProcessed;
 #if defined(MOD_CORE_PER_TURN_DAMAGE)
-	SYNC_VAR_MEMBER(m_iDamageTakenThisTurn)
-	SYNC_VAR_MEMBER(m_iDamageTakenLastTurn)
+	int m_iDamageTakenThisTurn;
+	int m_iDamageTakenLastTurn;
 #endif
 
-	SYNC_VAR_MEMBER(m_eCapturingPlayer)
-	SYNC_VAR_MEMBER(m_bCapturedAsIs)
-	SYNC_VAR_MEMBER(m_eLeaderUnitType)
-	SYNC_VAR_MEMBER(m_eInvisibleType)
-	SYNC_VAR_MEMBER(m_eSeeInvisibleType)
-	SYNC_VAR_MEMBER(m_eGreatPeopleDirectiveType)
+	PlayerTypes m_eCapturingPlayer;
+	bool m_bCapturedAsIs;
+	UnitTypes m_eLeaderUnitType;
+	InvisibleTypes m_eInvisibleType;
+	InvisibleTypes m_eSeeInvisibleType;
+	GreatPeopleDirectiveTypes m_eGreatPeopleDirectiveType;
 	CvUnitEntry* m_pUnitInfo;
 
 	bool m_bWaitingForMove;			///< If true, the unit is busy visualizing its move.
@@ -2550,89 +2235,89 @@ protected:
 	std::vector<int> m_iGarrisonYieldChange;
 	std::vector<int> m_iFortificationYieldChange;
 
-	SYNC_VAR_MEMBER(m_strScriptData)
-	SYNC_VAR_MEMBER(m_iScenarioData)
+	CvString m_strScriptData;
+	int m_iScenarioData;
 
 	CvUnitPromotions  m_Promotions;
 	CvUnitReligion* m_pReligion;
 
 #if defined(MOD_CIV6_WORKER)
-	SYNC_VAR_MEMBER(m_iBuilderStrength)
+	int m_iBuilderStrength;
 #endif
 
-	SYNC_VAR_MEMBER(m_terrainDoubleMoveCount)
-	SYNC_VAR_MEMBER(m_featureDoubleMoveCount)
+	TerrainTypeCounter m_terrainDoubleMoveCount;
+	FeatureTypeCounter m_featureDoubleMoveCount;
 #if defined(MOD_PROMOTIONS_HALF_MOVE)
-	SYNC_VAR_MEMBER(m_terrainHalfMoveCount)
-	SYNC_VAR_MEMBER(m_featureHalfMoveCount)
+	TerrainTypeCounter m_terrainHalfMoveCount;
+	FeatureTypeCounter m_featureHalfMoveCount;
 
-	SYNC_VAR_MEMBER(m_terrainExtraMoveCount)
-	SYNC_VAR_MEMBER(m_featureExtraMoveCount)
+	TerrainTypeCounter m_terrainExtraMoveCount;
+	FeatureTypeCounter m_featureExtraMoveCount;
 #endif
 #if defined(MOD_BALANCE_CORE)
-	SYNC_VAR_MEMBER(m_terrainDoubleHeal)
-	SYNC_VAR_MEMBER(m_featureDoubleHeal)
+	TerrainTypeCounter m_terrainDoubleHeal;
+	FeatureTypeCounter m_featureDoubleHeal;
 #endif
-	SYNC_VAR_MEMBER(m_terrainImpassableCount)
-	SYNC_VAR_MEMBER(m_featureImpassableCount)
-	SYNC_VAR_MEMBER(m_extraTerrainAttackPercent)
-	SYNC_VAR_MEMBER(m_extraTerrainDefensePercent)
-	SYNC_VAR_MEMBER(m_extraFeatureAttackPercent)
-	SYNC_VAR_MEMBER(m_extraFeatureDefensePercent)
+	TerrainTypeCounter m_terrainImpassableCount;
+	FeatureTypeCounter m_featureImpassableCount;
+	TerrainTypeCounter m_extraTerrainAttackPercent;
+	TerrainTypeCounter m_extraTerrainDefensePercent;
+	FeatureTypeCounter m_extraFeatureAttackPercent;
+	FeatureTypeCounter m_extraFeatureDefensePercent;
 
-	SYNC_VAR_MEMBER(m_extraUnitClassAttackMod)
-	SYNC_VAR_MEMBER(m_extraUnitClassDefenseMod)
+	UnitClassCounter m_extraUnitClassAttackMod;
+	UnitClassCounter m_extraUnitClassDefenseMod;
 #if defined(MOD_BALANCE_CORE)
-	SYNC_VAR_MEMBER(m_aiNumTimesAttackedThisTurn)
-	SYNC_VAR_MEMBER(m_yieldFromScouting)
+	std::vector<int> m_aiNumTimesAttackedThisTurn;
+	std::vector<int> m_yieldFromScouting;
 #endif
 #if defined(MOD_API_UNIFIED_YIELDS)
-	SYNC_VAR_MEMBER(m_yieldFromKills)
-	SYNC_VAR_MEMBER(m_yieldFromBarbarianKills)
+	std::vector<int> m_yieldFromKills;
+	std::vector<int> m_yieldFromBarbarianKills;
 #endif
-	SYNC_VAR_MEMBER(m_extraUnitCombatModifier)
-	SYNC_VAR_MEMBER(m_unitClassModifier)
+	std::vector<int> m_extraUnitCombatModifier;
+	std::vector<int> m_unitClassModifier;
 #if defined(MOD_BALANCE_CORE)
-	SYNC_VAR_MEMBER(m_iCombatModPerAdjacentUnitCombatModifier)
-	SYNC_VAR_MEMBER(m_iCombatModPerAdjacentUnitCombatAttackMod)
-	SYNC_VAR_MEMBER(m_iCombatModPerAdjacentUnitCombatDefenseMod)
+	std::vector<int> m_iCombatModPerAdjacentUnitCombatModifier;
+	std::vector<int> m_iCombatModPerAdjacentUnitCombatAttackMod;
+	std::vector<int> m_iCombatModPerAdjacentUnitCombatDefenseMod;
 #endif
-	SYNC_VAR_MEMBER(m_iMissionTimer)
-	SYNC_VAR_MEMBER(m_iMissionAIX)
-	SYNC_VAR_MEMBER(m_iMissionAIY)
-	SYNC_VAR_MEMBER(m_eMissionAIType)
+	int m_iMissionTimer;
+	int m_iMissionAIX;
+	int m_iMissionAIY;
+	MissionAITypes m_eMissionAIType;
 	IDInfo m_missionAIUnit;
-	SYNC_VAR_MEMBER(m_eActivityType)
-	SYNC_VAR_MEMBER(m_eAutomateType)
-	SYNC_VAR_MEMBER(m_eUnitAIType) //current AI type, might be different from default
-	SYNC_VAR_MEMBER(m_eCombatType)
+	ActivityTypes m_eActivityType;
+	AutomateTypes m_eAutomateType;
+	UnitAITypes m_eUnitAIType; //current AI type, might be different from default
+	int m_eCombatType;
 
 	//not serialized
 	std::vector<CvPlot*> m_unitMoveLocs;
 
-	SYNC_VAR_MEMBER(m_iEmbarkedAllWaterCount)
+	int m_iEmbarkedAllWaterCount;
 #if defined(MOD_PROMOTIONS_DEEP_WATER_EMBARKATION)
-	SYNC_VAR_MEMBER(m_iEmbarkedDeepWaterCount)
+	int m_iEmbarkedDeepWaterCount;
 #endif
-	SYNC_VAR_MEMBER(m_iEmbarkExtraVisibility)
-	SYNC_VAR_MEMBER(m_iEmbarkDefensiveModifier)
-	SYNC_VAR_MEMBER(m_iCapitalDefenseModifier)
-	SYNC_VAR_MEMBER(m_iCapitalDefenseFalloff)
-	SYNC_VAR_MEMBER(m_iCityAttackPlunderModifier)
-	SYNC_VAR_MEMBER(m_iReligiousStrengthLossRivalTerritory)
-	SYNC_VAR_MEMBER(m_iTradeMissionInfluenceModifier)
-	SYNC_VAR_MEMBER(m_iTradeMissionGoldModifier)
-	SYNC_VAR_MEMBER(m_iDiploMissionInfluence)
-	SYNC_VAR_MEMBER(m_iMapLayer)		// Which layer does the unit reside on for pathing/stacking/etc.
-	SYNC_VAR_MEMBER(m_iNumGoodyHutsPopped)
-	SYNC_VAR_MEMBER(m_iTourismBlastStrength)
-	SYNC_VAR_MEMBER(m_iTourismBlastLength)
+	int m_iEmbarkExtraVisibility;
+	int m_iEmbarkDefensiveModifier;
+	int m_iCapitalDefenseModifier;
+	int m_iCapitalDefenseFalloff;
+	int m_iCityAttackPlunderModifier;
+	int m_iReligiousStrengthLossRivalTerritory;
+	int m_iTradeMissionInfluenceModifier;
+	int m_iTradeMissionGoldModifier;
+	int m_iDiploMissionInfluence;
+	int m_iMapLayer;		// Which layer does the unit reside on for pathing/stacking/etc.
+	int m_iNumGoodyHutsPopped;
+	int m_iTourismBlastStrength;
+	int m_iTourismBlastLength;
 #if defined(MOD_BALANCE_CORE)
-	SYNC_VAR_MEMBER(m_iHurryStrength)
-	SYNC_VAR_MEMBER(m_iScienceBlastStrength)
-	SYNC_VAR_MEMBER(m_iCultureBlastStrength)
-	SYNC_VAR_MEMBER(m_iGAPBlastStrength)
-	SYNC_VAR_MEMBER(m_abPromotionEverObtained)
+	int m_iHurryStrength;
+	int m_iScienceBlastStrength;
+	int m_iCultureBlastStrength;
+	int m_iGAPBlastStrength;
+	std::vector<bool> m_abPromotionEverObtained;
 #endif
 		
 #if defined(MOD_PROMOTIONS_UNIT_NAMING)
@@ -2672,10 +2357,10 @@ private:
 #if defined(MOD_BALANCE_CORE_MILITARY)
 	// for debugging
 	CvString m_strMissionInfoString;
-	SYNC_VAR_MEMBER(m_eTacticalMove)
-	SYNC_VAR_MEMBER(m_iTacticalMoveSetTurn)
-	SYNC_VAR_MEMBER(m_eHomelandMove)
-	SYNC_VAR_MEMBER(m_iHomelandMoveSetTurn)
+	AITacticalMove m_eTacticalMove;
+	int m_iTacticalMoveSetTurn;
+	AIHomelandMove m_eHomelandMove;
+	int m_iHomelandMoveSetTurn;
 #endif
 
 	friend class CvLuaUnit;
@@ -2689,5 +2374,322 @@ namespace FSerialization
 void SyncUnits();
 void ClearUnitDeltas();
 }
+
+SYNC_ARCHIVE_BEGIN(CvUnit)
+SYNC_ARCHIVE_VAR(PlayerTypes, m_eOwner)
+SYNC_ARCHIVE_VAR(PlayerTypes, m_eOriginalOwner)
+SYNC_ARCHIVE_VAR(UnitTypes, m_eUnitType)
+SYNC_ARCHIVE_VAR(int, m_iX)
+SYNC_ARCHIVE_VAR(int, m_iY)
+SYNC_ARCHIVE_VAR(int, m_iID)
+SYNC_ARCHIVE_VAR(int, m_iDamage)
+SYNC_ARCHIVE_VAR(int, m_iMoves)
+SYNC_ARCHIVE_VAR(int, m_iArmyId)
+SYNC_ARCHIVE_VAR(int, m_iBaseCombat)
+SYNC_ARCHIVE_VAR(int, m_iBaseRangedCombat)
+SYNC_ARCHIVE_VAR(int, m_iHotKeyNumber)
+SYNC_ARCHIVE_VAR(int, m_iDeployFromOperationTurn)
+SYNC_ARCHIVE_VAR(int, m_iLastMoveTurn)
+SYNC_ARCHIVE_VAR(int, m_iReconX)
+SYNC_ARCHIVE_VAR(int, m_iReconY)
+SYNC_ARCHIVE_VAR(int, m_iReconCount)
+SYNC_ARCHIVE_VAR(int, m_iGameTurnCreated)
+SYNC_ARCHIVE_VAR(bool, m_bImmobile)
+SYNC_ARCHIVE_VAR(int, m_iExperienceTimes100)
+SYNC_ARCHIVE_VAR(int, m_iLevel)
+SYNC_ARCHIVE_VAR(int, m_iCargo)
+SYNC_ARCHIVE_VAR(int, m_iCargoCapacity)
+SYNC_ARCHIVE_VAR(int, m_iAttackPlotX)
+SYNC_ARCHIVE_VAR(int, m_iAttackPlotY)
+SYNC_ARCHIVE_VAR(int, m_iCombatTimer)
+SYNC_ARCHIVE_VAR(int, m_iCombatFirstStrikes)
+SYNC_ARCHIVE_VAR(int, m_iCombatDamage)
+SYNC_ARCHIVE_VAR(bool, m_bMovedThisTurn)
+SYNC_ARCHIVE_VAR(bool, m_bFortified)
+SYNC_ARCHIVE_VAR(int, m_iBlitzCount)
+SYNC_ARCHIVE_VAR(int, m_iAmphibCount)
+SYNC_ARCHIVE_VAR(int, m_iRiverCrossingNoPenaltyCount)
+SYNC_ARCHIVE_VAR(int, m_iEnemyRouteCount)
+SYNC_ARCHIVE_VAR(int, m_iRivalTerritoryCount)
+SYNC_ARCHIVE_VAR(int, m_iIsSlowInEnemyLandCount)
+SYNC_ARCHIVE_VAR(int, m_iRangeAttackIgnoreLOSCount)
+SYNC_ARCHIVE_VAR(int, m_iCityAttackOnlyCount)
+SYNC_ARCHIVE_VAR(int, m_iCaptureDefeatedEnemyCount)
+SYNC_ARCHIVE_VAR(int, m_iOriginCity)
+SYNC_ARCHIVE_VAR(int, m_iCannotBeCapturedCount)
+SYNC_ARCHIVE_VAR(int, m_iForcedDamage)
+SYNC_ARCHIVE_VAR(int, m_iChangeDamage)
+SYNC_ARCHIVE_VAR(SYNC_ARCHIVE_VAR_TYPE(std::map<PromotionTypes, int>), m_PromotionDuration)
+SYNC_ARCHIVE_VAR(SYNC_ARCHIVE_VAR_TYPE(std::map<PromotionTypes, int>), m_TurnPromotionGained)
+SYNC_ARCHIVE_VAR(int, m_iRangedSupportFireCount)
+SYNC_ARCHIVE_VAR(int, m_iAlwaysHealCount)
+SYNC_ARCHIVE_VAR(int, m_iHealOutsideFriendlyCount)
+SYNC_ARCHIVE_VAR(int, m_iHillsDoubleMoveCount)
+SYNC_ARCHIVE_VAR(int, m_iMountainsDoubleMoveCount)
+SYNC_ARCHIVE_VAR(int, m_iEmbarkFlatCostCount)
+SYNC_ARCHIVE_VAR(int, m_iDisembarkFlatCostCount)
+SYNC_ARCHIVE_VAR(int, m_iAOEDamageOnKill)
+SYNC_ARCHIVE_VAR(int, m_iAoEDamageOnMove)
+SYNC_ARCHIVE_VAR(int, m_iSplashDamage)
+SYNC_ARCHIVE_VAR(int, m_iMultiAttackBonus)
+SYNC_ARCHIVE_VAR(int, m_iLandAirDefenseValue)
+SYNC_ARCHIVE_VAR(int, m_iImmuneToFirstStrikesCount)
+SYNC_ARCHIVE_VAR(int, m_iExtraVisibilityRange)
+SYNC_ARCHIVE_VAR(int, m_iExtraReconRange)
+SYNC_ARCHIVE_VAR(int, m_iExtraMoves)
+SYNC_ARCHIVE_VAR(int, m_iExtraMoveDiscount)
+SYNC_ARCHIVE_VAR(int, m_iExtraRange)
+SYNC_ARCHIVE_VAR(int, m_iInterceptChance)
+SYNC_ARCHIVE_VAR(int, m_iExtraEvasion)
+SYNC_ARCHIVE_VAR(int, m_iExtraFirstStrikes)
+SYNC_ARCHIVE_VAR(int, m_iExtraChanceFirstStrikes)
+SYNC_ARCHIVE_VAR(int, m_iExtraWithdrawal)
+SYNC_ARCHIVE_VAR(int, m_iPlagueChance)
+SYNC_ARCHIVE_VAR(int, m_iIsPlagued)
+SYNC_ARCHIVE_VAR(int, m_iPlagueID)
+SYNC_ARCHIVE_VAR(int, m_iPlaguePriority)
+SYNC_ARCHIVE_VAR(int, m_iPlagueIDImmunity)
+SYNC_ARCHIVE_VAR(int, m_iPlaguePromotion)
+SYNC_ARCHIVE_VAR(ContractTypes, m_eUnitContract)
+SYNC_ARCHIVE_VAR(int, m_iNegatorPromotion)
+SYNC_ARCHIVE_VAR(bool, m_bIsNoMaintenance)
+SYNC_ARCHIVE_VAR(int, m_iExtraEnemyHeal)
+SYNC_ARCHIVE_VAR(int, m_iExtraNeutralHeal)
+SYNC_ARCHIVE_VAR(int, m_iExtraFriendlyHeal)
+SYNC_ARCHIVE_VAR(int, m_iEnemyDamageChance)
+SYNC_ARCHIVE_VAR(int, m_iNeutralDamageChance)
+SYNC_ARCHIVE_VAR(int, m_iEnemyDamage)
+SYNC_ARCHIVE_VAR(int, m_iNeutralDamage)
+SYNC_ARCHIVE_VAR(int, m_iNearbyEnemyCombatMod)
+SYNC_ARCHIVE_VAR(int, m_iNearbyEnemyCombatRange)
+SYNC_ARCHIVE_VAR(int, m_iSameTileHeal)
+SYNC_ARCHIVE_VAR(int, m_iAdjacentTileHeal)
+SYNC_ARCHIVE_VAR(int, m_iAdjacentModifier)
+SYNC_ARCHIVE_VAR(int, m_iRangedAttackModifier)
+SYNC_ARCHIVE_VAR(int, m_iInterceptionCombatModifier)
+SYNC_ARCHIVE_VAR(int, m_iInterceptionDefenseDamageModifier)
+SYNC_ARCHIVE_VAR(int, m_iAirSweepCombatModifier)
+SYNC_ARCHIVE_VAR(int, m_iAttackModifier)
+SYNC_ARCHIVE_VAR(int, m_iDefenseModifier)
+SYNC_ARCHIVE_VAR(int, m_iGroundAttackDamage)
+SYNC_ARCHIVE_VAR(int, m_iExtraCombatPercent)
+SYNC_ARCHIVE_VAR(int, m_iExtraCityAttackPercent)
+SYNC_ARCHIVE_VAR(int, m_iExtraCityDefensePercent)
+SYNC_ARCHIVE_VAR(int, m_iExtraRangedDefenseModifier)
+SYNC_ARCHIVE_VAR(int, m_iExtraHillsAttackPercent)
+SYNC_ARCHIVE_VAR(int, m_iExtraHillsDefensePercent)
+SYNC_ARCHIVE_VAR(int, m_iExtraOpenAttackPercent)
+SYNC_ARCHIVE_VAR(int, m_iExtraOpenRangedAttackMod)
+SYNC_ARCHIVE_VAR(int, m_iExtraRoughAttackPercent)
+SYNC_ARCHIVE_VAR(int, m_iExtraRoughRangedAttackMod)
+SYNC_ARCHIVE_VAR(int, m_iExtraAttackFortifiedMod)
+SYNC_ARCHIVE_VAR(int, m_iExtraAttackWoundedMod)
+SYNC_ARCHIVE_VAR(int, m_iExtraFullyHealedMod)
+SYNC_ARCHIVE_VAR(int, m_iExtraAttackAboveHealthMod)
+SYNC_ARCHIVE_VAR(int, m_iExtraAttackBelowHealthMod)
+SYNC_ARCHIVE_VAR(int, m_iFlankAttackModifier)
+SYNC_ARCHIVE_VAR(int, m_iExtraOpenDefensePercent)
+SYNC_ARCHIVE_VAR(int, m_iExtraRoughDefensePercent)
+SYNC_ARCHIVE_VAR(int, m_iExtraOpenFromPercent)
+SYNC_ARCHIVE_VAR(int, m_iExtraRoughFromPercent)
+SYNC_ARCHIVE_VAR(int, m_iPillageChange)
+SYNC_ARCHIVE_VAR(int, m_iUpgradeDiscount)
+SYNC_ARCHIVE_VAR(int, m_iExperiencePercent)
+SYNC_ARCHIVE_VAR(int, m_iDropRange)
+SYNC_ARCHIVE_VAR(int, m_iAirSweepCapableCount)
+SYNC_ARCHIVE_VAR(int, m_iExtraNavalMoves)
+SYNC_ARCHIVE_VAR(int, m_iKamikazePercent)
+SYNC_ARCHIVE_VAR(DirectionTypes, m_eFacingDirection)
+SYNC_ARCHIVE_VAR(int, m_iIgnoreTerrainCostCount)
+SYNC_ARCHIVE_VAR(int, m_iIgnoreTerrainDamageCount)
+SYNC_ARCHIVE_VAR(int, m_iIgnoreFeatureDamageCount)
+SYNC_ARCHIVE_VAR(int, m_iExtraTerrainDamageCount)
+SYNC_ARCHIVE_VAR(int, m_iExtraFeatureDamageCount)
+SYNC_ARCHIVE_VAR(int, m_iNearbyImprovementCombatBonus)
+SYNC_ARCHIVE_VAR(int, m_iNearbyImprovementBonusRange)
+SYNC_ARCHIVE_VAR(ImprovementTypes, m_eCombatBonusImprovement)
+SYNC_ARCHIVE_VAR(int, m_iNearbyUnitClassBonus)
+SYNC_ARCHIVE_VAR(int, m_iNearbyUnitClassBonusRange)
+SYNC_ARCHIVE_VAR(UnitClassTypes, m_iCombatBonusFromNearbyUnitClass)
+SYNC_ARCHIVE_VAR(int, m_bNearbyPromotion)
+SYNC_ARCHIVE_VAR(int, m_iNearbyUnitPromotionRange)
+SYNC_ARCHIVE_VAR(int, m_iNearbyCityCombatMod)
+SYNC_ARCHIVE_VAR(int, m_iNearbyFriendlyCityCombatMod)
+SYNC_ARCHIVE_VAR(int, m_iNearbyEnemyCityCombatMod)
+SYNC_ARCHIVE_VAR(int, m_iPillageBonusStrengthPercent)
+SYNC_ARCHIVE_VAR(int, m_iStackedGreatGeneralExperience)
+SYNC_ARCHIVE_VAR(int, m_bIsHighSeaRaider)
+SYNC_ARCHIVE_VAR(int, m_iWonderProductionModifier)
+SYNC_ARCHIVE_VAR(int, m_iUnitProductionModifier)
+SYNC_ARCHIVE_VAR(int, m_iNearbyEnemyDamage)
+SYNC_ARCHIVE_VAR(int, m_iGGGAXPPercent)
+SYNC_ARCHIVE_VAR(int, m_iGiveCombatMod)
+SYNC_ARCHIVE_VAR(int, m_iGiveHPIfEnemyKilled)
+SYNC_ARCHIVE_VAR(int, m_iGiveExperiencePercent)
+SYNC_ARCHIVE_VAR(int, m_iGiveOutsideFriendlyLandsModifier)
+SYNC_ARCHIVE_VAR(int, m_eGiveDomain)
+SYNC_ARCHIVE_VAR(int, m_iGiveExtraAttacks)
+SYNC_ARCHIVE_VAR(int, m_iGiveDefenseMod)
+SYNC_ARCHIVE_VAR(int, m_bGiveInvisibility)
+SYNC_ARCHIVE_VAR(int, m_bGiveOnlyOnStartingTurn)
+SYNC_ARCHIVE_VAR(int, m_bConvertUnit)
+SYNC_ARCHIVE_VAR(int, m_eConvertDomain)
+SYNC_ARCHIVE_VAR(UnitTypes, m_eConvertDomainUnit)
+SYNC_ARCHIVE_VAR(int, m_bConvertEnemyUnitToBarbarian)
+SYNC_ARCHIVE_VAR(int, m_bConvertOnFullHP)
+SYNC_ARCHIVE_VAR(int, m_bConvertOnDamage)
+SYNC_ARCHIVE_VAR(int, m_iDamageThreshold)
+SYNC_ARCHIVE_VAR(UnitTypes, m_eConvertDamageOrFullHPUnit)
+SYNC_ARCHIVE_VAR(int, m_iNumberOfCultureBombs)
+SYNC_ARCHIVE_VAR(int, m_iNearbyHealEnemyTerritory)
+SYNC_ARCHIVE_VAR(int, m_iNearbyHealNeutralTerritory)
+SYNC_ARCHIVE_VAR(int, m_iNearbyHealFriendlyTerritory)
+SYNC_ARCHIVE_VAR(int, m_iCanCrossMountainsCount)
+SYNC_ARCHIVE_VAR(int, m_iCanCrossOceansCount)
+SYNC_ARCHIVE_VAR(int, m_iCanCrossIceCount)
+SYNC_ARCHIVE_VAR(int, m_iNumTilesRevealedThisTurn)
+SYNC_ARCHIVE_VAR(int, m_bSpottedEnemy)
+SYNC_ARCHIVE_VAR(int, m_iGainsXPFromScouting)
+SYNC_ARCHIVE_VAR(int, m_iGainsXPFromPillaging)
+SYNC_ARCHIVE_VAR(int, m_iGainsXPFromSpotting)
+SYNC_ARCHIVE_VAR(int, m_iCaptureDefeatedEnemyChance)
+SYNC_ARCHIVE_VAR(int, m_iBarbCombatBonus)
+SYNC_ARCHIVE_VAR(int, m_iAdjacentEnemySapMovement)
+SYNC_ARCHIVE_VAR(int, m_iGGFromBarbariansCount)
+SYNC_ARCHIVE_VAR(int, m_iAuraRangeChange)
+SYNC_ARCHIVE_VAR(int, m_iAuraEffectChange)
+SYNC_ARCHIVE_VAR(int, m_iNumRepairCharges)
+SYNC_ARCHIVE_VAR(int, m_iMilitaryCapChange)
+SYNC_ARCHIVE_VAR(int, m_iRoughTerrainEndsTurnCount)
+SYNC_ARCHIVE_VAR(int, m_iEmbarkAbilityCount)
+SYNC_ARCHIVE_VAR(int, m_iHoveringUnitCount)
+SYNC_ARCHIVE_VAR(int, m_iFlatMovementCostCount)
+SYNC_ARCHIVE_VAR(int, m_iCanMoveImpassableCount)
+SYNC_ARCHIVE_VAR(int, m_iOnlyDefensiveCount)
+SYNC_ARCHIVE_VAR(int, m_iNoDefensiveBonusCount)
+SYNC_ARCHIVE_VAR(int, m_iNoCaptureCount)
+SYNC_ARCHIVE_VAR(int, m_iNukeImmuneCount)
+SYNC_ARCHIVE_VAR(int, m_iHiddenNationalityCount)
+SYNC_ARCHIVE_VAR(int, m_iAlwaysHostileCount)
+SYNC_ARCHIVE_VAR(int, m_iNoRevealMapCount)
+SYNC_ARCHIVE_VAR(int, m_iCanMoveAllTerrainCount)
+SYNC_ARCHIVE_VAR(int, m_iCanMoveAfterAttackingCount)
+SYNC_ARCHIVE_VAR(int, m_iFreePillageMoveCount)
+SYNC_ARCHIVE_VAR(int, m_iHealOnPillageCount)
+SYNC_ARCHIVE_VAR(int, m_iHPHealedIfDefeatEnemy)
+SYNC_ARCHIVE_VAR(int, m_iGoldenAgeValueFromKills)
+SYNC_ARCHIVE_VAR(int, m_iTacticalAIPlotX)
+SYNC_ARCHIVE_VAR(int, m_iTacticalAIPlotY)
+SYNC_ARCHIVE_VAR(int, m_iGarrisonCityID)
+SYNC_ARCHIVE_VAR(int, m_iNumAttacks)
+SYNC_ARCHIVE_VAR(int, m_iAttacksMade)
+SYNC_ARCHIVE_VAR(int, m_iGreatGeneralCount)
+SYNC_ARCHIVE_VAR(int, m_iGreatAdmiralCount)
+SYNC_ARCHIVE_VAR(int, m_iGreatGeneralModifier)
+SYNC_ARCHIVE_VAR(int, m_iGreatGeneralReceivesMovementCount)
+SYNC_ARCHIVE_VAR(int, m_iGreatGeneralCombatModifier)
+SYNC_ARCHIVE_VAR(int, m_iIgnoreGreatGeneralBenefit)
+SYNC_ARCHIVE_VAR(int, m_iIgnoreZOC)
+SYNC_ARCHIVE_VAR(int, m_iNoSupply)
+SYNC_ARCHIVE_VAR(int, m_iMaxHitPointsChange)
+SYNC_ARCHIVE_VAR(int, m_iMaxHitPointsModifier)
+SYNC_ARCHIVE_VAR(int, m_iFriendlyLandsModifier)
+SYNC_ARCHIVE_VAR(int, m_iFriendlyLandsAttackModifier)
+SYNC_ARCHIVE_VAR(int, m_iOutsideFriendlyLandsModifier)
+SYNC_ARCHIVE_VAR(int, m_iHealIfDefeatExcludeBarbariansCount)
+SYNC_ARCHIVE_VAR(int, m_iNumInterceptions)
+SYNC_ARCHIVE_VAR(int, m_iExtraAirInterceptRange)
+SYNC_ARCHIVE_VAR(int, m_iMadeInterceptionCount)
+SYNC_ARCHIVE_VAR(int, m_iEverSelectedCount)
+SYNC_ARCHIVE_VAR(int, m_iSapperCount)
+SYNC_ARCHIVE_VAR(int, m_iCanHeavyCharge)
+SYNC_ARCHIVE_VAR(int, m_iStrongerDamaged)
+SYNC_ARCHIVE_VAR(int, m_iFightWellDamaged)
+SYNC_ARCHIVE_VAR(int, m_iCanMoraleBreak)
+SYNC_ARCHIVE_VAR(int, m_iDamageAoEFortified)
+SYNC_ARCHIVE_VAR(int, m_iWorkRateMod)
+SYNC_ARCHIVE_VAR(int, m_iDamageReductionCityAssault)
+SYNC_ARCHIVE_VAR(int, m_iGoodyHutYieldBonus)
+SYNC_ARCHIVE_VAR(int, m_iReligiousPressureModifier)
+SYNC_ARCHIVE_VAR(int, m_iNumExoticGoods)
+SYNC_ARCHIVE_VAR(bool, m_bPromotionReady)
+SYNC_ARCHIVE_VAR(bool, m_bDeathDelay)
+SYNC_ARCHIVE_VAR(bool, m_bCombatFocus)
+SYNC_ARCHIVE_VAR(bool, m_bInfoBarDirty)
+SYNC_ARCHIVE_VAR(bool, m_bNotConverting)
+SYNC_ARCHIVE_VAR(bool, m_bAirCombat)
+SYNC_ARCHIVE_VAR(bool, m_bSetUpForRangedAttack)
+SYNC_ARCHIVE_VAR(bool, m_bEmbarked)
+SYNC_ARCHIVE_VAR(bool, m_bPromotedFromGoody)
+SYNC_ARCHIVE_VAR(bool, m_bAITurnProcessed)
+SYNC_ARCHIVE_VAR(int, m_iDamageTakenThisTurn)
+SYNC_ARCHIVE_VAR(int, m_iDamageTakenLastTurn)
+SYNC_ARCHIVE_VAR(PlayerTypes, m_eCapturingPlayer)
+SYNC_ARCHIVE_VAR(bool, m_bCapturedAsIs)
+SYNC_ARCHIVE_VAR(UnitTypes, m_eLeaderUnitType)
+SYNC_ARCHIVE_VAR(InvisibleTypes, m_eInvisibleType)
+SYNC_ARCHIVE_VAR(InvisibleTypes, m_eSeeInvisibleType)
+SYNC_ARCHIVE_VAR(GreatPeopleDirectiveTypes, m_eGreatPeopleDirectiveType)
+SYNC_ARCHIVE_VAR(CvString, m_strScriptData)
+SYNC_ARCHIVE_VAR(int, m_iScenarioData)
+SYNC_ARCHIVE_VAR(int, m_iBuilderStrength)
+SYNC_ARCHIVE_VAR(TerrainTypeCounter, m_terrainDoubleMoveCount)
+SYNC_ARCHIVE_VAR(FeatureTypeCounter, m_featureDoubleMoveCount)
+SYNC_ARCHIVE_VAR(TerrainTypeCounter, m_terrainHalfMoveCount)
+SYNC_ARCHIVE_VAR(FeatureTypeCounter, m_featureHalfMoveCount)
+SYNC_ARCHIVE_VAR(TerrainTypeCounter, m_terrainExtraMoveCount)
+SYNC_ARCHIVE_VAR(FeatureTypeCounter, m_featureExtraMoveCount)
+SYNC_ARCHIVE_VAR(TerrainTypeCounter, m_terrainDoubleHeal)
+SYNC_ARCHIVE_VAR(FeatureTypeCounter, m_featureDoubleHeal)
+SYNC_ARCHIVE_VAR(TerrainTypeCounter, m_terrainImpassableCount)
+SYNC_ARCHIVE_VAR(FeatureTypeCounter, m_featureImpassableCount)
+SYNC_ARCHIVE_VAR(TerrainTypeCounter, m_extraTerrainAttackPercent)
+SYNC_ARCHIVE_VAR(TerrainTypeCounter, m_extraTerrainDefensePercent)
+SYNC_ARCHIVE_VAR(FeatureTypeCounter, m_extraFeatureAttackPercent)
+SYNC_ARCHIVE_VAR(FeatureTypeCounter, m_extraFeatureDefensePercent)
+SYNC_ARCHIVE_VAR(UnitClassCounter, m_extraUnitClassAttackMod)
+SYNC_ARCHIVE_VAR(UnitClassCounter, m_extraUnitClassDefenseMod)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiNumTimesAttackedThisTurn)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_yieldFromScouting)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_yieldFromKills)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_yieldFromBarbarianKills)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_extraUnitCombatModifier)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_unitClassModifier)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_iCombatModPerAdjacentUnitCombatModifier)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_iCombatModPerAdjacentUnitCombatAttackMod)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_iCombatModPerAdjacentUnitCombatDefenseMod)
+SYNC_ARCHIVE_VAR(int, m_iMissionTimer)
+SYNC_ARCHIVE_VAR(int, m_iMissionAIX)
+SYNC_ARCHIVE_VAR(int, m_iMissionAIY)
+SYNC_ARCHIVE_VAR(MissionAITypes, m_eMissionAIType)
+SYNC_ARCHIVE_VAR(ActivityTypes, m_eActivityType)
+SYNC_ARCHIVE_VAR(AutomateTypes, m_eAutomateType)
+SYNC_ARCHIVE_VAR(UnitAITypes, m_eUnitAIType)
+SYNC_ARCHIVE_VAR(int, m_eCombatType)
+SYNC_ARCHIVE_VAR(int, m_iEmbarkedAllWaterCount)
+SYNC_ARCHIVE_VAR(int, m_iEmbarkedDeepWaterCount)
+SYNC_ARCHIVE_VAR(int, m_iEmbarkExtraVisibility)
+SYNC_ARCHIVE_VAR(int, m_iEmbarkDefensiveModifier)
+SYNC_ARCHIVE_VAR(int, m_iCapitalDefenseModifier)
+SYNC_ARCHIVE_VAR(int, m_iCapitalDefenseFalloff)
+SYNC_ARCHIVE_VAR(int, m_iCityAttackPlunderModifier)
+SYNC_ARCHIVE_VAR(int, m_iReligiousStrengthLossRivalTerritory)
+SYNC_ARCHIVE_VAR(int, m_iTradeMissionInfluenceModifier)
+SYNC_ARCHIVE_VAR(int, m_iTradeMissionGoldModifier)
+SYNC_ARCHIVE_VAR(int, m_iDiploMissionInfluence)
+SYNC_ARCHIVE_VAR(int, m_iMapLayer)
+SYNC_ARCHIVE_VAR(int, m_iNumGoodyHutsPopped)
+SYNC_ARCHIVE_VAR(int, m_iTourismBlastStrength)
+SYNC_ARCHIVE_VAR(int, m_iTourismBlastLength)
+SYNC_ARCHIVE_VAR(int, m_iHurryStrength)
+SYNC_ARCHIVE_VAR(int, m_iScienceBlastStrength)
+SYNC_ARCHIVE_VAR(int, m_iCultureBlastStrength)
+SYNC_ARCHIVE_VAR(int, m_iGAPBlastStrength)
+SYNC_ARCHIVE_VAR(std::vector<bool>, m_abPromotionEverObtained)
+SYNC_ARCHIVE_VAR(AITacticalMove, m_eTacticalMove)
+SYNC_ARCHIVE_VAR(int, m_iTacticalMoveSetTurn)
+SYNC_ARCHIVE_VAR(AIHomelandMove, m_eHomelandMove)
+SYNC_ARCHIVE_VAR(int, m_iHomelandMoveSetTurn)
+SYNC_ARCHIVE_END()
 
 #endif


### PR DESCRIPTION
I've rewritten much of the code related to sync variables after realizing that a lot of performance was being lost due to variable state tracking.

This new code completely decouples the sync system from member declarations which is about as good as it's going to get in terms of singleplayer performance. Sync related code should have zero cost outside of checking if the game is multiplayer when an object is created. The trade-off is that the state of each variable between syncs must be stored somewhere in order to know what has changed between turns and each variable must be checked at the end of a turn.

Because of this multiplayer memory usage will see an increase and the CPU will spend more cycles at the end of a turn gathering sync delta information. The gathering of sync delta information is actually a pretty good contender for multi-threading so there is room for more optimization there.

Additionally I've begun working on creating a shared serialization path for both saving and loading in order to simplify writing code for it and reduce the chance of making mistakes (see CvUnit::Serialize).