### PR TITLE
Fix CvLuaArgs::toValue usage with CvLuaScopedInstance<> types

### DIFF
--- a/CvGameCoreDLLUtil/include/CvLuaArgTemplates.h
+++ b/CvGameCoreDLLUtil/include/CvLuaArgTemplates.h
@@ -7,26 +7,26 @@ namespace CvLuaArgs
 {
 	//To
 	template<typename T>
-	static T toValue(lua_State* L, int idx)
+	inline T toValue(lua_State* L, int idx)
 	{
 		//This is pretty unsafe, but common.
 		//Assume T is a poorly designed enum =(
 		return (T)lua_tointeger(L, idx);
 	}
 
-	template<> static int toValue(lua_State* L, int idx)
+	template<> inline int toValue(lua_State* L, int idx)
 	{
 		return lua_tointeger(L, idx);
 	}
 
-	template<> static bool toValue(lua_State* L, int idx)
+	template<> inline bool toValue(lua_State* L, int idx)
 	{
 		return lua_toboolean(L, idx) != 0;
 	}
 
 	//Push
 	template<typename T>
-	static void pushValue(lua_State* L, T t)
+	inline void pushValue(lua_State* L, T t)
 	{
 		//This is pretty unsafe, but common.
 		//Assume T is a poorly designed enum =(
@@ -34,13 +34,13 @@ namespace CvLuaArgs
 	}
 
 	template<>
-	static void pushValue(lua_State* L, int t)
+	inline void pushValue(lua_State* L, int t)
 	{
 		lua_pushinteger(L, t);
 	}
 
 	template<>
-	static void pushValue(lua_State* L, bool t)
+	inline void pushValue(lua_State* L, bool t)
 	{
 		lua_pushboolean(L, t);
 	}

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaArea.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaArea.h
@@ -69,13 +69,22 @@ namespace CvLuaArgs
 	{
 		return CvLuaArea::GetInstance(L, idx);
 	}
+	template<> inline const CvArea& toValue(lua_State* L, int idx)
+	{
+		return *CvLuaArea::GetInstance(L, idx);
+	}
 	template<> inline CvArea& toValue(lua_State* L, int idx)
 	{
 		return *CvLuaArea::GetInstance(L, idx);
 	}
-	template<> inline const CvArea& toValue(lua_State* L, int idx)
+
+	template<> inline void pushValue(lua_State* L, CvArea* p)
 	{
-		return *CvLuaArea::GetInstance(L, idx);
+		CvLuaArea::Push(L, p);
+	}
+	template<> inline void pushValue(lua_State* L, CvArea& r)
+	{
+		CvLuaArea::Push(L, &r);
 	}
 }
 

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaArea.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaArea.h
@@ -59,4 +59,24 @@ protected:
 	static int lGetNumImprovements(lua_State* L);
 };
 
+namespace CvLuaArgs
+{
+	template<> inline const CvArea* toValue(lua_State* L, int idx)
+	{
+		return CvLuaArea::GetInstance(L, idx);
+	}
+	template<> inline CvArea* toValue(lua_State* L, int idx)
+	{
+		return CvLuaArea::GetInstance(L, idx);
+	}
+	template<> inline CvArea& toValue(lua_State* L, int idx)
+	{
+		return *CvLuaArea::GetInstance(L, idx);
+	}
+	template<> inline const CvArea& toValue(lua_State* L, int idx)
+	{
+		return *CvLuaArea::GetInstance(L, idx);
+	}
+}
+
 #endif //CVLUAAREA_H

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaCity.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaCity.h
@@ -835,13 +835,22 @@ namespace CvLuaArgs
 	{
 		return CvLuaCity::GetInstance(L, idx);
 	}
+	template<> inline const CvCity& toValue(lua_State* L, int idx)
+	{
+		return *CvLuaCity::GetInstance(L, idx);
+	}
 	template<> inline CvCity& toValue(lua_State* L, int idx)
 	{
 		return *CvLuaCity::GetInstance(L, idx);
 	}
-	template<> inline const CvCity& toValue(lua_State* L, int idx)
+
+	template<> inline void pushValue(lua_State* L, CvCity* p)
 	{
-		return *CvLuaCity::GetInstance(L, idx);
+		CvLuaCity::Push(L, p);
+	}
+	template<> inline void pushValue(lua_State* L, CvCity& r)
+	{
+		CvLuaCity::Push(L, &r);
 	}
 }
 

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaCity.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaCity.h
@@ -825,4 +825,24 @@ protected:
 #endif
 };
 
+namespace CvLuaArgs
+{
+	template<> inline const CvCity* toValue(lua_State* L, int idx)
+	{
+		return CvLuaCity::GetInstance(L, idx);
+	}
+	template<> inline CvCity* toValue(lua_State* L, int idx)
+	{
+		return CvLuaCity::GetInstance(L, idx);
+	}
+	template<> inline CvCity& toValue(lua_State* L, int idx)
+	{
+		return *CvLuaCity::GetInstance(L, idx);
+	}
+	template<> inline const CvCity& toValue(lua_State* L, int idx)
+	{
+		return *CvLuaCity::GetInstance(L, idx);
+	}
+}
+
 #endif //CVLUACITY_H

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaDeal.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaDeal.h
@@ -232,13 +232,22 @@ namespace CvLuaArgs
 	{
 		return CvLuaDeal::GetInstance(L, idx);
 	}
+	template<> inline const CvDeal& toValue(lua_State* L, int idx)
+	{
+		return *CvLuaDeal::GetInstance(L, idx);
+	}
 	template<> inline CvDeal& toValue(lua_State* L, int idx)
 	{
 		return *CvLuaDeal::GetInstance(L, idx);
 	}
-	template<> inline const CvDeal& toValue(lua_State* L, int idx)
+
+	template<> inline void pushValue(lua_State* L, CvDeal* p)
 	{
-		return *CvLuaDeal::GetInstance(L, idx);
+		CvLuaDeal::Push(L, p);
+	}
+	template<> inline void pushValue(lua_State* L, CvDeal& r)
+	{
+		CvLuaDeal::Push(L, &r);
 	}
 }
 

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaDeal.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaDeal.h
@@ -222,4 +222,24 @@ protected:
 #endif
 };
 
+namespace CvLuaArgs
+{
+	template<> inline const CvDeal* toValue(lua_State* L, int idx)
+	{
+		return CvLuaDeal::GetInstance(L, idx);
+	}
+	template<> inline CvDeal* toValue(lua_State* L, int idx)
+	{
+		return CvLuaDeal::GetInstance(L, idx);
+	}
+	template<> inline CvDeal& toValue(lua_State* L, int idx)
+	{
+		return *CvLuaDeal::GetInstance(L, idx);
+	}
+	template<> inline const CvDeal& toValue(lua_State* L, int idx)
+	{
+		return *CvLuaDeal::GetInstance(L, idx);
+	}
+}
+
 #endif //CVLUADEAL_H

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaLeague.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaLeague.h
@@ -108,5 +108,24 @@ protected:
 	static int lProposalTableHelper(lua_State* L, const int iTop, CvProposal &proposal);
 };
 
+namespace CvLuaArgs
+{
+	template<> inline const CvLeague* toValue(lua_State* L, int idx)
+	{
+		return CvLuaLeague::GetInstance(L, idx);
+	}
+	template<> inline CvLeague* toValue(lua_State* L, int idx)
+	{
+		return CvLuaLeague::GetInstance(L, idx);
+	}
+	template<> inline CvLeague& toValue(lua_State* L, int idx)
+	{
+		return *CvLuaLeague::GetInstance(L, idx);
+	}
+	template<> inline const CvLeague& toValue(lua_State* L, int idx)
+	{
+		return *CvLuaLeague::GetInstance(L, idx);
+	}
+}
 
 #endif //CVLUALEAGUE_H

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaLeague.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaLeague.h
@@ -118,13 +118,22 @@ namespace CvLuaArgs
 	{
 		return CvLuaLeague::GetInstance(L, idx);
 	}
+	template<> inline const CvLeague& toValue(lua_State* L, int idx)
+	{
+		return *CvLuaLeague::GetInstance(L, idx);
+	}
 	template<> inline CvLeague& toValue(lua_State* L, int idx)
 	{
 		return *CvLuaLeague::GetInstance(L, idx);
 	}
-	template<> inline const CvLeague& toValue(lua_State* L, int idx)
+
+	template<> inline void pushValue(lua_State* L, CvLeague* p)
 	{
-		return *CvLuaLeague::GetInstance(L, idx);
+		CvLuaLeague::Push(L, p);
+	}
+	template<> inline void pushValue(lua_State* L, CvLeague& r)
+	{
+		CvLuaLeague::Push(L, &r);
 	}
 }
 

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.h
@@ -1511,6 +1511,23 @@ protected:
 
 namespace CvLuaArgs
 {
+	template<> inline const CvPlayerAI* toValue(lua_State* L, int idx)
+	{
+		return CvLuaPlayer::GetInstance(L, idx);
+	}
+	template<> inline CvPlayerAI* toValue(lua_State* L, int idx)
+	{
+		return CvLuaPlayer::GetInstance(L, idx);
+	}
+	template<> inline const CvPlayerAI& toValue(lua_State* L, int idx)
+	{
+		return *CvLuaPlayer::GetInstance(L, idx);
+	}
+	template<> inline CvPlayerAI& toValue(lua_State* L, int idx)
+	{
+		return *CvLuaPlayer::GetInstance(L, idx);
+	}
+
 	template<> inline const CvPlayer* toValue(lua_State* L, int idx)
 	{
 		return CvLuaPlayer::GetInstance(L, idx);
@@ -1519,13 +1536,31 @@ namespace CvLuaArgs
 	{
 		return CvLuaPlayer::GetInstance(L, idx);
 	}
+	template<> inline const CvPlayer& toValue(lua_State* L, int idx)
+	{
+		return *CvLuaPlayer::GetInstance(L, idx);
+	}
 	template<> inline CvPlayer& toValue(lua_State* L, int idx)
 	{
 		return *CvLuaPlayer::GetInstance(L, idx);
 	}
-	template<> inline const CvPlayer& toValue(lua_State* L, int idx)
+
+	template<> inline void pushValue(lua_State* L, CvPlayerAI* p)
 	{
-		return *CvLuaPlayer::GetInstance(L, idx);
+		CvLuaPlayer::Push(L, p);
+	}
+	template<> inline void pushValue(lua_State* L, CvPlayerAI& r)
+	{
+		CvLuaPlayer::Push(L, &r);
+	}
+
+	template<> inline void pushValue(lua_State* L, CvPlayer* p)
+	{
+		CvLuaPlayer::Push(L, static_cast<CvPlayerAI*>(p));
+	}
+	template<> inline void pushValue(lua_State* L, CvPlayer& r)
+	{
+		CvLuaPlayer::Push(L, static_cast<CvPlayerAI*>(&r));
 	}
 }
 

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.h
@@ -1509,4 +1509,24 @@ protected:
 #endif
 };
 
+namespace CvLuaArgs
+{
+	template<> inline const CvPlayer* toValue(lua_State* L, int idx)
+	{
+		return CvLuaPlayer::GetInstance(L, idx);
+	}
+	template<> inline CvPlayer* toValue(lua_State* L, int idx)
+	{
+		return CvLuaPlayer::GetInstance(L, idx);
+	}
+	template<> inline CvPlayer& toValue(lua_State* L, int idx)
+	{
+		return *CvLuaPlayer::GetInstance(L, idx);
+	}
+	template<> inline const CvPlayer& toValue(lua_State* L, int idx)
+	{
+		return *CvLuaPlayer::GetInstance(L, idx);
+	}
+}
+
 #endif //CVLUAPLAYER_H

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlot.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlot.h
@@ -408,13 +408,22 @@ namespace CvLuaArgs
 	{
 		return CvLuaPlot::GetInstance(L, idx);
 	}
+	template<> inline const CvPlot& toValue(lua_State* L, int idx)
+	{
+		return *CvLuaPlot::GetInstance(L, idx);
+	}
 	template<> inline CvPlot& toValue(lua_State* L, int idx)
 	{
 		return *CvLuaPlot::GetInstance(L, idx);
 	}
-	template<> inline const CvPlot& toValue(lua_State* L, int idx)
+
+	template<> inline void pushValue(lua_State* L, CvPlot* p)
 	{
-		return *CvLuaPlot::GetInstance(L, idx);
+		CvLuaPlot::Push(L, p);
+	}
+	template<> inline void pushValue(lua_State* L, CvPlot& r)
+	{
+		CvLuaPlot::Push(L, &r);
 	}
 }
 

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlot.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlot.h
@@ -397,4 +397,25 @@ protected:
 
 #endif
 };
+
+namespace CvLuaArgs
+{
+	template<> inline const CvPlot* toValue(lua_State* L, int idx)
+	{
+		return CvLuaPlot::GetInstance(L, idx);
+	}
+	template<> inline CvPlot* toValue(lua_State* L, int idx)
+	{
+		return CvLuaPlot::GetInstance(L, idx);
+	}
+	template<> inline CvPlot& toValue(lua_State* L, int idx)
+	{
+		return *CvLuaPlot::GetInstance(L, idx);
+	}
+	template<> inline const CvPlot& toValue(lua_State* L, int idx)
+	{
+		return *CvLuaPlot::GetInstance(L, idx);
+	}
+}
+
 #endif

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaTeam.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaTeam.h
@@ -263,4 +263,24 @@ protected:
 #endif
 };
 
+namespace CvLuaArgs
+{
+	template<> inline const CvTeam* toValue(lua_State* L, int idx)
+	{
+		return CvLuaTeam::GetInstance(L, idx);
+	}
+	template<> inline CvTeam* toValue(lua_State* L, int idx)
+	{
+		return CvLuaTeam::GetInstance(L, idx);
+	}
+	template<> inline CvTeam& toValue(lua_State* L, int idx)
+	{
+		return *CvLuaTeam::GetInstance(L, idx);
+	}
+	template<> inline const CvTeam& toValue(lua_State* L, int idx)
+	{
+		return *CvLuaTeam::GetInstance(L, idx);
+	}
+}
+
 #endif //CVLUATEAM_H

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaTeam.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaTeam.h
@@ -273,13 +273,22 @@ namespace CvLuaArgs
 	{
 		return CvLuaTeam::GetInstance(L, idx);
 	}
+	template<> inline const CvTeam& toValue(lua_State* L, int idx)
+	{
+		return *CvLuaTeam::GetInstance(L, idx);
+	}
 	template<> inline CvTeam& toValue(lua_State* L, int idx)
 	{
 		return *CvLuaTeam::GetInstance(L, idx);
 	}
-	template<> inline const CvTeam& toValue(lua_State* L, int idx)
+
+	template<> inline void pushValue(lua_State* L, CvTeam* p)
 	{
-		return *CvLuaTeam::GetInstance(L, idx);
+		CvLuaTeam::Push(L, p);
+	}
+	template<> inline void pushValue(lua_State* L, CvTeam& r)
+	{
+		CvLuaTeam::Push(L, &r);
 	}
 }
 

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaTeamTech.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaTeamTech.h
@@ -72,13 +72,22 @@ namespace CvLuaArgs
 	{
 		return CvLuaTeamTech::GetInstance(L, idx);
 	}
+	template<> inline const CvTeamTechs& toValue(lua_State* L, int idx)
+	{
+		return *CvLuaTeamTech::GetInstance(L, idx);
+	}
 	template<> inline CvTeamTechs& toValue(lua_State* L, int idx)
 	{
 		return *CvLuaTeamTech::GetInstance(L, idx);
 	}
-	template<> inline const CvTeamTechs& toValue(lua_State* L, int idx)
+
+	template<> inline void pushValue(lua_State* L, CvTeamTechs* p)
 	{
-		return *CvLuaTeamTech::GetInstance(L, idx);
+		CvLuaTeamTech::Push(L, p);
+	}
+	template<> inline void pushValue(lua_State* L, CvTeamTechs& r)
+	{
+		CvLuaTeamTech::Push(L, &r);
 	}
 }
 

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaTeamTech.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaTeamTech.h
@@ -62,4 +62,24 @@ protected:
 
 };
 
+namespace CvLuaArgs
+{
+	template<> inline const CvTeamTechs* toValue(lua_State* L, int idx)
+	{
+		return CvLuaTeamTech::GetInstance(L, idx);
+	}
+	template<> inline CvTeamTechs* toValue(lua_State* L, int idx)
+	{
+		return CvLuaTeamTech::GetInstance(L, idx);
+	}
+	template<> inline CvTeamTechs& toValue(lua_State* L, int idx)
+	{
+		return *CvLuaTeamTech::GetInstance(L, idx);
+	}
+	template<> inline const CvTeamTechs& toValue(lua_State* L, int idx)
+	{
+		return *CvLuaTeamTech::GetInstance(L, idx);
+	}
+}
+
 #endif //CVLUATEAMTECH_H

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.h
@@ -697,13 +697,22 @@ namespace CvLuaArgs
 	{
 		return CvLuaUnit::GetInstance(L, idx);
 	}
+	template<> inline const CvUnit& toValue(lua_State* L, int idx)
+	{
+		return *CvLuaUnit::GetInstance(L, idx);
+	}
 	template<> inline CvUnit& toValue(lua_State* L, int idx)
 	{
 		return *CvLuaUnit::GetInstance(L, idx);
 	}
-	template<> inline const CvUnit& toValue(lua_State* L, int idx)
+
+	template<> inline void pushValue(lua_State* L, CvUnit* p)
 	{
-		return *CvLuaUnit::GetInstance(L, idx);
+		CvLuaUnit::Push(L, p);
+	}
+	template<> inline void pushValue(lua_State* L, CvUnit& r)
+	{
+		CvLuaUnit::Push(L, &r);
 	}
 }
 

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.h
@@ -687,5 +687,24 @@ protected:
 #endif
 };
 
+namespace CvLuaArgs
+{
+	template<> inline const CvUnit* toValue(lua_State* L, int idx)
+	{
+		return CvLuaUnit::GetInstance(L, idx);
+	}
+	template<> inline CvUnit* toValue(lua_State* L, int idx)
+	{
+		return CvLuaUnit::GetInstance(L, idx);
+	}
+	template<> inline CvUnit& toValue(lua_State* L, int idx)
+	{
+		return *CvLuaUnit::GetInstance(L, idx);
+	}
+	template<> inline const CvUnit& toValue(lua_State* L, int idx)
+	{
+		return *CvLuaUnit::GetInstance(L, idx);
+	}
+}
 
 #endif //CVLUAUNIT_H


### PR DESCRIPTION
Also declare CvLuaArgs helpers inline instead of static

Fixes #7947