### PR TITLE
Use static_cast in CvLuaArgs::toValue instead of C-style cast

### DIFF
--- a/CvGameCoreDLLUtil/include/CvLuaArgTemplates.h
+++ b/CvGameCoreDLLUtil/include/CvLuaArgTemplates.h
@@ -11,7 +11,7 @@ namespace CvLuaArgs
 	{
 		//This is pretty unsafe, but common.
 		//Assume T is a poorly designed enum =(
-		return (T)lua_tointeger(L, idx);
+		return static_cast<T>(lua_tointeger(L, idx));
 	}
 
 	template<> inline int toValue(lua_State* L, int idx)
@@ -22,6 +22,11 @@ namespace CvLuaArgs
 	template<> inline bool toValue(lua_State* L, int idx)
 	{
 		return lua_toboolean(L, idx) != 0;
+	}
+
+	template<> inline const char* toValue(lua_State* L, int idx)
+	{
+		return lua_tostring(L, idx);
 	}
 
 	//Push

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaCity.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaCity.cpp
@@ -1547,7 +1547,10 @@ int CvLuaCity::lCanJoin(lua_State* L)
 //bool IsBuildingLocalResourceValid(BuildingTypes eBuilding, bool bCheckForImprovement);
 int CvLuaCity::lIsBuildingLocalResourceValid(lua_State* L)
 {
-	return BasicLuaMethod(L, &CvCity::IsBuildingLocalResourceValid);
+	CvCity* pkCity = GetInstance(L);
+
+	lua_pushboolean(L, pkCity->IsBuildingLocalResourceValid(static_cast<BuildingTypes>(lua_tointeger(L, 2)), lua_toboolean(L, 3)));
+	return 1;
 }
 //------------------------------------------------------------------------------
 //bool GetResourceDemanded();
@@ -3762,7 +3765,10 @@ int CvLuaCity::lChangeWonderProductionModifier(lua_State* L)
 //int GetLocalResourceWonderProductionMod(BuildingTypes eBuilding);
 int CvLuaCity::lGetLocalResourceWonderProductionMod(lua_State* L)
 {
-	return BasicLuaMethod(L, &CvCity::GetLocalResourceWonderProductionMod);
+	CvCity* pkCity = GetInstance(L);
+
+	lua_pushinteger(L, pkCity->GetLocalResourceWonderProductionMod(static_cast<BuildingTypes>(lua_tointeger(L, 2))));
+	return 1;
 }
 
 #if defined(MOD_API_LUA_EXTENSIONS)

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaTeam.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaTeam.cpp
@@ -18,6 +18,7 @@
 #include "CvLuaSupport.h"
 #include "CvLuaTeam.h"
 #include "CvLuaTeamTech.h"
+#include "CvLuaArea.h"
 
 //Utility macro for registering methods
 #define Method(Name)			\


### PR DESCRIPTION
Fix bugs revealed by using static_cast in CvLuaArgs::toValue

It should be noted that some of these errors ~~could have been~~ **are** security risks since we are accepting arbitrary pointers from lua and working on them. Gotta be careful with this.