### PR TITLE
Dirty closest city map upon new game start

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvGame.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGame.cpp
@@ -223,6 +223,8 @@ void CvGame::init(HandicapTypes eHandicap)
 	m_mapRand.init(CvPreGame::mapRandomSeed() % 73637381);
 	m_jonRand.init(CvPreGame::syncRandomSeed() % 52319761);
 
+	SetClosestCityMapDirty();
+
 	//--------------------------------
 	// Verify pregame data
 


### PR DESCRIPTION
Should fix the player occasionally being unable to found their first city when starting a new game.

No issue exists for this but I've encountered it myself and only decided to look into it because of this post
https://forums.civfanatics.com/threads/quick-questions-quick-answers.573489/page-379#post-16105713

Edit - Forced push to fix branch mixup