### PR TITLE
Defer database processing to engine load

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvDllDatabaseUtility.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDllDatabaseUtility.cpp
@@ -275,6 +275,8 @@ bool CvDllDatabaseUtility::PerformDatabasePostProcessing()
 
 	db->EndTransaction();
 
+	GC.GameDataPostProcess();
+
 	return true;
 }
 //------------------------------------------------------------------------------

--- a/CvGameCoreDLL_Expansion2/CvGlobals.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGlobals.cpp
@@ -2756,16 +2756,6 @@ void CvGlobals::init()
 	m_pContracts = FNEW(CvContractXMLEntries, c_eCiv5GameplayDLL, 0);
 #endif
 
-	auto_ptr<ICvDLLDatabaseUtility1> pkLoader(getDatabaseLoadUtility());
-
-	Database::Connection* pDB = GetGameDatabase();
-	pDB->Execute(m_kGlobalDefinesLookup, "SELECT Value from Defines where Name = ? LIMIT 1");
-
-	pkLoader->PerformDatabasePostProcessing();
-	pkLoader->CacheGameDatabaseData();
-
-	GameDataPostProcess();
-
 	CvPlayerAI::initStatics();
 	CvTeam::initStatics();
 
@@ -4871,6 +4861,9 @@ bool CvGlobals::GetHexDebugLayerString(CvPlot* pkPlot, const char* szLayerName, 
 
 void CvGlobals::cacheGlobals()
 {
+	Database::Connection* pDB = GetGameDatabase();
+	pDB->Execute(m_kGlobalDefinesLookup, "SELECT Value from Defines where Name = ? LIMIT 1");
+
 	// -- ints --
 
 	getDatabaseValue("AI_ATTEMPT_RUSH_OVER_X_TURNS_TO_BUILD",m_iAI_ATTEMPT_RUSH_OVER_X_TURNS_TO_BUILD);


### PR DESCRIPTION
CvGlobals::init() currently caches and processes the game database, but this operation appears to be unnecessary and serves to make startup times worse.

Immediately after CvGlobals::init() is invoked the engine retrieves and requests a flush of the database and then performs the cache and process operations a second time.

This reorders some operations in order to try and make the cache that the engine performs the only time the database gets cached and subsequently processed.

I haven't observed anything unusual from these changes and I see no reason why this would cause problems. I've tested this as both a standard mod installation and as a modpack; **however if you do believe this might cause problems let me know and I'll do more testing in any areas requested.**