### PR TITLE
Reintroduce base game global defines 

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvDllDatabaseUtility.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDllDatabaseUtility.cpp
@@ -269,8 +269,12 @@ bool CvDllDatabaseUtility::PerformDatabasePostProcessing()
 		InsertGameDefine(kInsertDefine, "MIN_CITY_RADIUS", MIN_CITY_RADIUS);
 		InsertGameDefine(kInsertDefine, "MAX_CITY_RADIUS", MAX_CITY_RADIUS);
 		InsertGameDefine(kInsertDefine, "CITY_HOME_PLOT", CITY_HOME_PLOT);
-		InsertGameDefine(kInsertDefine, "MAX_CITY_RADIUS", MAX_CITY_RADIUS);
 		InsertGameDefine(kInsertDefine, "MAX_CITY_DIAMETER", (2*MAX_CITY_RADIUS+1));
+
+		// These values are present in the base game but we don't have them here which would not be a problem
+		// if not for mods possibly relying on them; PlotHelpManager for instance references CITY_PLOTS_RADIUS
+		InsertGameDefine(kInsertDefine, "CITY_PLOTS_RADIUS", 3);
+		InsertGameDefine(kInsertDefine, "CITY_PLOTS_DIAMETER", 7);
 	}
 
 	db->EndTransaction();


### PR DESCRIPTION
I've found that without this little fix PlotHelpManager from EUI fails to properly populate plot tool-tips when a civilian is selected and a tile is moused over because it relies on the ``CITY_PLOTS_RADIUS`` define. FireTuner will even report these errors constantly.

Was this ever reported? I can't be the only person who has experienced this, right?

Interestingly this only happens with standard mod installs and not with mod-packs created by the Multiplayer Mod-Pack Maker. This appears to be because the tool uses a standalone DLL which does insert these defines. Since the DLL inserts them they end up being dumped into the override XML file it produces. Since they're now in the XML database they are later available when the CBP DLL is loaded.

Edit - I should have mentioned that I play with my tool-tip delays at the minimum values which probably helps reproduce this.