### PR TITLE
Fix WB scenarios never loading in modpack installations

### DIFF
--- a/UI_bc1/GameSetup/GameSetupScreen.lua
+++ b/UI_bc1/GameSetup/GameSetupScreen.lua
@@ -36,7 +36,7 @@ Controls.StartButton:RegisterCallback( Mouse.eLClick,
 function()
 	PreGame.SetPersistSettings( not bIsModding ); -- Whether or not to save settings for the "Play Now" option.
 
-	if bIsModding and isWBMap( PreGame.GetMapScript() ) then
+	if isWBMap( PreGame.GetMapScript() ) then
 		PreGame.SetRandomMapScript(false);
 		PreGame.SetLoadWBScenario(PreGame.GetLoadWBScenario());
 		PreGame.SetOverrideScenarioHandicap(true);


### PR DESCRIPTION
**This only fixes the bug if a user installs EUI**
**An identical bug exists in the vanilla GameSetupScreen**

When loading a world-builder map, there is a tick box that is meant to control whether or not the associated scenario script should be loaded. For some reason someone decided to override the behavior of this tick box (among other wack things I can't begin to comprehend) when no mods are loaded. This means that if a player uses a modpackesque install, world-builder scenarios cannot be loaded.

This removes the erroneous check for mods being loaded from the EUI GameSetupScreen so that world-builder scenarios will actually load! Hooray! \o/