### PR TITLE
Allow governor to select neighbor cities' unreachable plots

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvCityCitizens.h
+++ b/CvGameCoreDLL_Expansion2/CvCityCitizens.h
@@ -110,7 +110,7 @@ public:
 	int GetNumForcedWorkingPlots() const;
 	void ChangeNumForcedWorkingPlots(int iChange);
 
-	bool IsCanWork(CvPlot* pPlot) const;
+	bool IsCanWork(CvPlot* pPlot, bool bAllowFromOtherCities = false) const;
 	bool IsBlockaded(CvPlot* pPlot) const;
 	void SetBlockaded(CvPlot* pPlot);
 	void ClearBlockades();


### PR DESCRIPTION
I've played a bit with this without encountering anything unusual. It wont make governors intelligently work together to optimize overlapping plots; However, it is good enough to prevent scenarios where rapidly expanding cities begins to starve surrounding puppets of workable plots, which is a particularly common occurrence for Venice.

It should also prevent annoying scenarios where players learns late that a city has been unable to work a high value plot because a neighbor city that cannot work the plot had expanded to it.

Only plots that are out of working range are candidates for use by neighbors and once a neighbor's governor selects a neighboring plot it stays under that city control until the player manually intervenes.

Also included is the removal of some redundant checks.

@ilteroi please review. You've recently worked on code related to this and I don't want to step on any toes.