### PR TITLE
Quests now cancelled when City-State killed

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
@@ -1908,6 +1908,11 @@ bool CvMinorCivQuest::IsExpired()
 		return true;
 	}
 
+	if (!GET_PLAYER(m_eMinor).isAlive())
+	{
+		return true;
+	}
+
 	// Build a Route
 	if(m_eType == MINOR_CIV_QUEST_ROUTE)
 	{


### PR DESCRIPTION
- This is necessary because you can only have one quest of each type at once. So if a city-state was killed with an active quest it was never getting returned to the pool and you would never get that quest again.