### PR TITLE
Make modular NoFollowUp for improvements

### DIFF
--- a/Community Patch/Core Files/Core Tables/CoreTableEntries.sql
+++ b/Community Patch/Core Files/Core Tables/CoreTableEntries.sql
@@ -1363,6 +1363,9 @@ ALTER TABLE Improvements ADD COLUMN 'RandResourceChance' INTEGER DEFAULT 0;
 -- Removes the improvement when built. Useful in combination with CreatesFeature.
 ALTER TABLE Improvements ADD COLUMN 'RemoveWhenComplete' BOOLEAN DEFAULT 0;
 
+-- Units that stand on this improvement don't leave it when they attack (like from a city)
+ALTER TABLE Improvements ADD COLUMN 'NoFollowUp' BOOLEAN DEFAULT 0;
+
 -- Start a WLTKD when this unit is born or gained. GP's only.
 ALTER TABLE Units ADD COLUMN 'WLTKDFromBirth' BOOLEAN DEFAULT 0;
 

--- a/Community Patch/Core Files/Core Values/CoreValues.xml
+++ b/Community Patch/Core Files/Core Values/CoreValues.xml
@@ -315,4 +315,18 @@
 			<Description>TXT_KEY_REPLAY_VIEWER_GRAPHBY_GAP</Description>
 		</Row>
 	</ReplayDataSets>
+	<Improvements>
+		<Update>
+			<Where Type="IMPROVEMENT_CITADEL" />
+			<Set NoFollowUp="1" />
+		</Update>
+		<Update>
+			<Where Type="IMPROVEMENT_FORT" />
+			<Set NoFollowUp="1" />
+		</Update>
+		<Update>
+			<Where Type="IMPROVEMENT_BARBARIAN_CAMP" />
+			<Set NoFollowUp="1" />
+		</Update>
+	</Improvements>
 </GameData>

--- a/CvGameCoreDLL_Expansion2/CvImprovementClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvImprovementClasses.cpp
@@ -70,6 +70,9 @@ CvImprovementEntry::CvImprovementEntry(void):
 #if defined(MOD_API_EXTENSIONS)
 	m_iRequiresXAdjacentWater(-1),
 #endif
+#if defined(MOD_GLOBAL_NO_FOLLOWUP_FROM_CITIES)
+	m_bNoFollowUp(false),
+#endif
 #if defined(MOD_GLOBAL_STACKING_RULES)
 	m_iAdditionalUnits(0),
 #endif
@@ -272,6 +275,9 @@ bool CvImprovementEntry::CacheResults(Database::Results& kResults, CvDatabaseUti
 	m_iRequiresXAdjacentLand = kResults.GetInt("RequiresXAdjacentLand");
 #if defined(MOD_API_EXTENSIONS)
 	m_iRequiresXAdjacentWater = kResults.GetInt("RequiresXAdjacentWater");
+#endif
+#if defined(MOD_GLOBAL_NO_FOLLOWUP_FROM_CITIES)
+	m_bNoFollowUp = kResults.GetBool("NoFollowUp");
 #endif
 #if defined(MOD_GLOBAL_STACKING_RULES)
 	m_iAdditionalUnits = kResults.GetInt("AdditionalUnits");
@@ -793,6 +799,14 @@ int CvImprovementEntry::GetRequiresXAdjacentLand() const
 int CvImprovementEntry::GetRequiresXAdjacentWater() const
 {
 	return m_iRequiresXAdjacentWater;
+}
+#endif
+
+#if defined(MOD_GLOBAL_NO_FOLLOWUP_FROM_CITIES)
+/// Units that stand on this improvement don't leave it when they attack (like from a city)
+bool CvImprovementEntry::IsNoFollowUp() const
+{
+	return m_bNoFollowUp;
 }
 #endif
 

--- a/CvGameCoreDLL_Expansion2/CvImprovementClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvImprovementClasses.h
@@ -105,6 +105,10 @@ public:
 	int GetRequiresXAdjacentWater() const;
 #endif
 
+#if defined(MOD_GLOBAL_NO_FOLLOWUP_FROM_CITIES)
+	bool IsNoFollowUp() const;
+#endif
+
 #if defined(MOD_GLOBAL_RELOCATION)
 	bool IsAllowsRebaseTo() const;
 	bool IsAllowsAirliftFrom() const;
@@ -279,6 +283,9 @@ protected:
 	int m_iRequiresXAdjacentLand;
 #if defined(MOD_API_EXTENSIONS)
 	int m_iRequiresXAdjacentWater;
+#endif
+#if defined(MOD_GLOBAL_NO_FOLLOWUP_FROM_CITIES)
+	bool m_bNoFollowUp;
 #endif
 
 #if defined(MOD_GLOBAL_RELOCATION)

--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -4239,15 +4239,12 @@ bool CvPlot::isFortification(TeamTypes eDefenderTeam) const
 #if defined(MOD_GLOBAL_NO_FOLLOWUP_FROM_CITIES)
 	if (MOD_GLOBAL_NO_FOLLOWUP_FROM_CITIES)
 	{
-		// If the attacker is in a city, fort or citadel, don't advance
-		static const  ImprovementTypes eImprovementFort = (ImprovementTypes)GC.getInfoTypeForString("IMPROVEMENT_FORT");
-		static const  ImprovementTypes eImprovementCitadel = (ImprovementTypes)GC.getInfoTypeForString("IMPROVEMENT_CITADEL");
-		static const  ImprovementTypes eImprovementCamp = (ImprovementTypes)GC.getBARBARIAN_CAMP_IMPROVEMENT();
+		// If the attacker is in a fort or citadel or other improvement with NoFollowUp, don't advance
 
 		if (getTeam() == eDefenderTeam && !IsImprovementPillaged())
 		{
-			ImprovementTypes eImprovement = getImprovementType();
-			if (eImprovement == eImprovementFort || eImprovement == eImprovementCitadel || eImprovement == eImprovementCamp)
+			CvImprovementEntry* pImprovementInfo = GC.getImprovementInfo(getImprovementType());
+			if (pImprovementInfo && pImprovementInfo->IsNoFollowUp())
 				return true;
 		}
 	}


### PR DESCRIPTION
Forts, Citadels, and Barbarian Camps have it set to 1,  setting it on another improvement means units won't leave it when they attack like cities.