### PR TITLE
RSI Fixes & Improvements

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.h
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.h
@@ -352,7 +352,7 @@ public:
 	bool IsLockedIntoCoopWar(PlayerTypes ePlayer) const;
 
 	CoopWarStates GetGlobalCoopWarAgainstState(PlayerTypes ePlayer) const;
-	CoopWarStates GetGlobalCoopWarWithState(PlayerTypes ePlayer) const;
+	CoopWarStates GetGlobalCoopWarWithState(PlayerTypes ePlayer, bool bExcludeOngoing = false) const;
 	int GetNumCoopWarTargets();
 
 	int GetCoopWarStateChangeTurn(PlayerTypes eAllyPlayer, PlayerTypes eTargetPlayer) const;

--- a/ISSUE_TEMPLATE
+++ b/ISSUE_TEMPLATE
@@ -1,4 +1,4 @@
-_1. Mod version (i.e Date - 8/19):_
+_1. Mod version (X.Y.Z, e.g. 1.0.0):_
 
 
 _2. Mod list (if using Vox Populi only, leave blank):_


### PR DESCRIPTION
Add recent assist bonus for agreeing to a coop war
No positive recent assist decay during the waiting period for a coop war to begin