### PR TITLE
Game_Era Serialised

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvGame.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGame.cpp
@@ -807,6 +807,7 @@ void CvGame::setInitialItems(CvGameInitialItemsOverrides& kInitialItemOverrides)
 
 	m_iEarliestBarbarianReleaseTurn = getHandicapInfo().getEarliestBarbarianReleaseTurn() + GC.getGame().getJonRandNum(GC.getAI_TACTICAL_BARBARIAN_RELEASE_VARIATION(), "barb release");
 
+	UpdateGameEra();
 	// What route type forms an industrial connection
 	DoUpdateIndustrialRoute();
 
@@ -1164,6 +1165,7 @@ void CvGame::uninit()
 	m_eBestGreatPeoplePlayer = NO_PLAYER;
 	m_eReligionTech = NO_TECH;
 	m_eIndustrialRoute = NO_ROUTE;
+	m_eGameEra = NO_ERA;
 #if defined(MOD_DIPLOMACY_CITYSTATES_QUESTS)
 	m_eTeamThatCircumnavigated = NO_TEAM;
 #endif
@@ -4384,25 +4386,31 @@ bool CvGame::canTrainNukes() const
 //	--------------------------------------------------------------------------------
 EraTypes CvGame::getCurrentEra() const
 {
+	{
+		return m_eGameEra;
+	}
+}
+
+void CvGame::UpdateGameEra()
+{
 	float fEra = 0;
 	int iCount = 0;
-
-	for(int iI = 0; iI < MAX_TEAMS; iI++)
+	for (int iI = 0; iI < MAX_TEAMS; iI++)
 	{
 		if (GET_TEAM((TeamTypes)iI).isAlive() && GET_TEAM((TeamTypes)iI).isMajorCiv())
 		{
-			fEra += GET_TEAM((TeamTypes)iI).GetCurrentEra();
 			iCount++;
 		}
 	}
-
-	if(iCount > 0)
+	if (iCount >= 0)
 	{
-		int iRoundedEra = int(fEra / iCount + 0.5f);
-		return ((EraTypes)iRoundedEra);
+		int iRoundedEra = int(fEra / (max(1, iCount)) + 0.5f);
+		m_eGameEra = (EraTypes)iRoundedEra;
 	}
-
-	return NO_ERA;
+	else
+	{
+		m_eGameEra = NO_ERA;
+	}
 }
 
 
@@ -11834,6 +11842,7 @@ void CvGame::Serialize(Game& game, Visitor& visitor)
 	visitor(game.m_eBestGreatPeoplePlayer);
 	visitor(game.m_eReligionTech);
 	visitor(game.m_eIndustrialRoute);
+	visitor(game.m_eGameEra);
 
 	visitor(game.m_eTeamThatCircumnavigated);
 	visitor(game.m_bVictoryRandomization);

--- a/CvGameCoreDLL_Expansion2/CvGame.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGame.cpp
@@ -4399,6 +4399,7 @@ void CvGame::UpdateGameEra()
 	{
 		if (GET_TEAM((TeamTypes)iI).isAlive() && GET_TEAM((TeamTypes)iI).isMajorCiv())
 		{
+			fEra += GET_TEAM((TeamTypes)iI).GetCurrentEra();
 			iCount++;
 		}
 	}

--- a/CvGameCoreDLL_Expansion2/CvGame.h
+++ b/CvGameCoreDLL_Expansion2/CvGame.h
@@ -130,6 +130,7 @@ public:
 
 	bool canTrainNukes() const;
 	EraTypes getCurrentEra() const;
+	void CvGame::UpdateGameEra();
 
 	TeamTypes getActiveTeam();
 	CivilizationTypes getActiveCivilizationType();
@@ -841,6 +842,7 @@ protected:
 	PlayerTypes m_eBestGreatPeoplePlayer;
 	TechTypes m_eReligionTech;
 	RouteTypes m_eIndustrialRoute;
+	EraTypes m_eGameEra;
 	bool m_bArchaeologyTriggered;
 
 #if defined(MOD_DIPLOMACY_CITYSTATES_QUESTS)

--- a/CvGameCoreDLL_Expansion2/CvTeam.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTeam.cpp
@@ -6700,6 +6700,10 @@ void CvTeam::setHasTech(TechTypes eIndex, bool bNewValue, PlayerTypes ePlayer, b
 				EraTypes eNewEra = (EraTypes) pkTechInfo->GetEra();
 
 				SetCurrentEra(eNewEra);
+				if (isMajorCiv())
+				{
+					GC.getGame().UpdateGameEra();
+				}
 #if defined(MOD_BALANCE_CORE)
 				if(!bNoBonus)
 				{
@@ -6854,6 +6858,10 @@ void CvTeam::setHasTech(TechTypes eIndex, bool bNewValue, PlayerTypes ePlayer, b
 						if(pkEraInfo != NULL)
 						{
 							SetCurrentEra(nextEra);
+							if (isMajorCiv())
+							{
+								GC.getGame().UpdateGameEra();
+							}
 #if defined(MOD_BALANCE_CORE)
 							if(!bNoBonus)
 							{


### PR DESCRIPTION
- Use a serialised m_eGameEra to allow m_eGameEra to be accessed without need for calculation from CvGame::getCurrentEra()
- m_eGameEra changed in CvGame::UpdateGameEra() which is called whenever a major civ reaches a new era.

I've used this in my mod for a while and it works well. It reduces calculations for quite a few calls to CvGame::getCurrentEra() and I used CvGame::getCurrentEra() instead of CvPlayer::GetCurrentEra() in some cases to stop the civs which are already further ahead getting even more bonuses than the rest.