### PR TITLE
Unit Upgrade Priority

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
@@ -1314,10 +1314,10 @@ void CvHomelandAI::ExecutePatrolMoves()
 void CvHomelandAI::PlotUpgradeMoves()
 {
 	ClearCurrentMoveUnits(AI_HOMELAND_MOVE_UPGRADE);
-	for(list<int>::iterator it = m_CurrentTurnUnits.begin(); it != m_CurrentTurnUnits.end(); ++it)
+	int iLoop;
+	for (CvUnit* pUnit = m_pPlayer->firstUnit(&iLoop); pUnit != NULL; pUnit = m_pPlayer->nextUnit(&iLoop))
 	{
 		// Don't try and upgrade a human player's unit or one already recruited for an operation
-		CvUnit* pUnit = m_pPlayer->getUnit(*it);
 
 		if(pUnit && !pUnit->isHuman() && pUnit->getArmyID() == -1)
 		{


### PR DESCRIPTION
- All units now checked to see if they can be upgraded each turn instead of only those recruited by homelandAI

I have used this in my own games and AIs will upgrade their units much faster and I haven't noticed any visible downsides. This could potentially have issues with cancelling units' current orders though I'm not exactly sure how troop movements work.

@ilteroi 
Up to you whether you think this is a good idea or not but could solve #8307 