### PR TITLE
Desired vote commitment fix

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvDealAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDealAI.cpp
@@ -1429,7 +1429,7 @@ int CvDealAI::GetGPTforForValueExchange(int iGPTorValue, bool bNumGPTFromValue, 
 	if(bNumGPTFromValue)
 	{
 		//let's assume an interest rate of 0.5% per turn, no compounding
-		int iInterestPercent = min(50, 100 * (iNumTurns * /*5*/ GC.getEACH_GOLD_PER_TURN_VALUE_PERCENT()) / 1000);
+		int iInterestPercent = (5 * /*5*/ GC.getEACH_GOLD_PER_TURN_VALUE_PERCENT() * iNumTurns) / max(1, GC.getGame().getGameSpeedInfo().GetDealDuration());
 
 		//add interest. 100 gold now is better than 100 gold in the future
 		iGPTorValue += (iGPTorValue*iInterestPercent) / 100;
@@ -1456,10 +1456,11 @@ int CvDealAI::GetGPTforForValueExchange(int iGPTorValue, bool bNumGPTFromValue, 
 		iValueTimes100 = (iGPTorValue * iNumTurns);
 
 		//let's assume an interest rate of 0.5% per turn, no compounding
-		int iInterestPercent = min(50, 100 * (iNumTurns * /*5*/ GC.getEACH_GOLD_PER_TURN_VALUE_PERCENT()) / 1000);
+		int iInterestPercent = (5 * /*5*/ GC.getEACH_GOLD_PER_TURN_VALUE_PERCENT() * iNumTurns) / max(1,GC.getGame().getGameSpeedInfo().GetDealDuration());
 
 		//subtract interest. 100 gold now is better than 100 gold in the future
-		iValueTimes100 -= (iValueTimes100*iInterestPercent) / 100;
+		iValueTimes100 *= 100;
+		iValueTimes100 /= max(1,100 + iInterestPercent);
 
 		// Sometimes we want to round up. Let's say the AI offers a deal to the human. We have to ensure that the human can also offer that deal back and the AI will accept (and vice versa)
 		if (bRoundUp)

--- a/CvGameCoreDLL_Expansion2/CvDealAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDealAI.cpp
@@ -3770,7 +3770,6 @@ void CvDealAI::DoAddVoteCommitmentToUs(CvDeal* pDeal, PlayerTypes eThem, int& iT
 			{
 				//reverse!
 				for (int iRanking = viTradeValues.size() - 1; iRanking >= 0; iRanking--)
-					////**** I think this is the wrong way around, it currently counts from lowest to highest value
 				{
 					int iWeight = viTradeValues.GetWeight(iRanking);
 					if (iWeight != 0)

--- a/CvGameCoreDLL_Expansion2/CvDealAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDealAI.cpp
@@ -3741,14 +3741,8 @@ void CvDealAI::DoAddVoteCommitmentToUs(CvDeal* pDeal, PlayerTypes eThem, int& iT
 				return;
 			}
 			CvLeagueAI::VoteCommitmentList vDesiredCommitments;
-			if (GET_PLAYER(eThem).isHuman())
-			{
-				vDesiredCommitments = GetPlayer()->GetLeagueAI()->GetDesiredVoteCommitments(eThem, true);
-			}
-			else
-			{
-				vDesiredCommitments = GET_PLAYER(eThem).GetLeagueAI()->GetDesiredVoteCommitments(eMyPlayer);
-			}
+			vDesiredCommitments = GET_PLAYER(eThem).GetLeagueAI()->GetDesiredVoteCommitments(eMyPlayer);
+			
 			CvWeightedVector<int> viTradeValues;
 			for (CvLeagueAI::VoteCommitmentList::iterator it = vDesiredCommitments.begin(); it != vDesiredCommitments.end(); ++it)
 			{
@@ -3776,6 +3770,7 @@ void CvDealAI::DoAddVoteCommitmentToUs(CvDeal* pDeal, PlayerTypes eThem, int& iT
 			{
 				//reverse!
 				for (int iRanking = viTradeValues.size() - 1; iRanking >= 0; iRanking--)
+					////**** I think this is the wrong way around, it currently counts from lowest to highest value
 				{
 					int iWeight = viTradeValues.GetWeight(iRanking);
 					if (iWeight != 0)

--- a/CvGameCoreDLL_Expansion2/CvVotingClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvVotingClasses.cpp
@@ -9473,7 +9473,7 @@ void CvLeagueAI::DoProposals(CvLeague* pLeague)
 	}
 }
 
-CvLeagueAI::VoteCommitmentList CvLeagueAI::GetDesiredVoteCommitments(PlayerTypes eFromPlayer, bool bFlippedLogic)
+CvLeagueAI::VoteCommitmentList CvLeagueAI::GetDesiredVoteCommitments(PlayerTypes eFromPlayer)
 {
 	VoteCommitmentList vDesired;
 
@@ -9497,9 +9497,13 @@ CvLeagueAI::VoteCommitmentList CvLeagueAI::GetDesiredVoteCommitments(PlayerTypes
 						{
 							iDesiredChoice = LeagueHelpers::CHOICE_YES;
 						}
-						if (it->GetEffects()->bEmbargoPlayer && it->GetProposerDecision()->GetDecision() == GetPlayer()->GetID())
+						else
 						{
-							iDesiredChoice = LeagueHelpers::CHOICE_NO;
+							DesireLevels eDesire = EvaluateDesire(ScoreVoteChoiceYesNo(&(*it), 1,/*bEnact*/ true,/*bConsiderGlobal*/false));
+							if (eDesire > DESIRE_NEUTRAL)
+								iDesiredChoice = LeagueHelpers::CHOICE_YES;
+							else if (eDesire < DESIRE_NEUTRAL)
+								iDesiredChoice = LeagueHelpers::CHOICE_NO;
 						}
 					}
 					// Proposals voting on a player
@@ -9526,14 +9530,7 @@ CvLeagueAI::VoteCommitmentList CvLeagueAI::GetDesiredVoteCommitments(PlayerTypes
 						VoteCommitment temp;
 						temp.iResolutionID = it->GetID();
 						int iVotes = 0;
-						if (bFlippedLogic)
-						{
-							iVotes =pLeague->GetPotentialVotesForMember(eFromPlayer, GetPlayer()->GetID());
-						}
-						else
-						{
-							iVotes = pLeague->GetPotentialVotesForMember(GetPlayer()->GetID(), eFromPlayer);
-						}	
+						iVotes = pLeague->GetPotentialVotesForMember(GetPlayer()->GetID(), eFromPlayer);
 						temp.iNumVotes = iVotes;
 						temp.iVoteChoice = iDesiredChoice;
 						temp.bEnact = true;
@@ -9553,9 +9550,13 @@ CvLeagueAI::VoteCommitmentList CvLeagueAI::GetDesiredVoteCommitments(PlayerTypes
 						{
 							iDesiredChoice = LeagueHelpers::CHOICE_YES;
 						}
-						if (it->GetEffects()->bEmbargoPlayer && it->GetProposerDecision()->GetDecision() == GetPlayer()->GetID())
+						else
 						{
-							iDesiredChoice = LeagueHelpers::CHOICE_YES;
+							DesireLevels eDesire = EvaluateDesire(ScoreVoteChoiceYesNo(&(*it), 1,/*bEnact*/ false,/*bConsiderGlobal*/false));
+							if (eDesire > DESIRE_NEUTRAL)
+								iDesiredChoice = LeagueHelpers::CHOICE_YES;
+							else if (eDesire < DESIRE_NEUTRAL)
+								iDesiredChoice = LeagueHelpers::CHOICE_NO;
 						}
 					}
 					else
@@ -9568,14 +9569,7 @@ CvLeagueAI::VoteCommitmentList CvLeagueAI::GetDesiredVoteCommitments(PlayerTypes
 						VoteCommitment temp;
 						temp.iResolutionID = it->GetID();
 						int iVotes = 0;
-						if (bFlippedLogic)
-						{
-							iVotes = pLeague->GetPotentialVotesForMember(eFromPlayer, GetPlayer()->GetID());
-						}
-						else
-						{
-							iVotes = pLeague->GetPotentialVotesForMember(GetPlayer()->GetID(), eFromPlayer);
-						}
+						iVotes = pLeague->GetPotentialVotesForMember(GetPlayer()->GetID(), eFromPlayer);
 						temp.iNumVotes = iVotes;
 						temp.iVoteChoice = iDesiredChoice;
 						temp.bEnact = false;
@@ -9596,14 +9590,7 @@ CvLeagueAI::VoteCommitmentList CvLeagueAI::GetDesiredVoteCommitments(PlayerTypes
 					{
 						int iChoice = vChoices[i];
 						int iVotes = 0;
-						if (bFlippedLogic)
-						{
-							iVotes = pLeague->GetPotentialVotesForMember(eFromPlayer, GetPlayer()->GetID());
-						}
-						else
-						{
-							iVotes = pLeague->GetPotentialVotesForMember(GetPlayer()->GetID(), eFromPlayer);
-						}
+						iVotes = pLeague->GetPotentialVotesForMember(GetPlayer()->GetID(), eFromPlayer);
 						DesireLevels eDesire = EvaluateVoteForTrade(it->GetID(), iChoice, iVotes, /*bRepeal*/false);
 
 						if (eDesire > eHighestDesire)
@@ -9618,14 +9605,7 @@ CvLeagueAI::VoteCommitmentList CvLeagueAI::GetDesiredVoteCommitments(PlayerTypes
 						VoteCommitment temp;
 						temp.iResolutionID = it->GetID();
 						int iVotes = 0;
-						if (bFlippedLogic)
-						{
-							iVotes = pLeague->GetPotentialVotesForMember(eFromPlayer, GetPlayer()->GetID());
-						}
-						else
-						{
-							iVotes = pLeague->GetPotentialVotesForMember(GetPlayer()->GetID(), eFromPlayer);
-						}
+						iVotes = pLeague->GetPotentialVotesForMember(GetPlayer()->GetID(), eFromPlayer);
 						temp.iNumVotes = iVotes;
 						temp.iVoteChoice = iDesiredChoice;
 						temp.bEnact = true;
@@ -9643,14 +9623,7 @@ CvLeagueAI::VoteCommitmentList CvLeagueAI::GetDesiredVoteCommitments(PlayerTypes
 					{
 						int iChoice = vChoices[i];
 						int iVotes = 0;
-						if (bFlippedLogic)
-						{
-							iVotes = pLeague->GetPotentialVotesForMember(eFromPlayer, GetPlayer()->GetID());
-						}
-						else
-						{
-							iVotes = pLeague->GetPotentialVotesForMember(GetPlayer()->GetID(), eFromPlayer);
-						}
+						iVotes = pLeague->GetPotentialVotesForMember(GetPlayer()->GetID(), eFromPlayer);
 						DesireLevels eDesire = EvaluateVoteForTrade(it->GetID(), iChoice, iVotes, /*bRepeal*/true);
 
 						if (eDesire > eHighestDesire)
@@ -9666,14 +9639,7 @@ CvLeagueAI::VoteCommitmentList CvLeagueAI::GetDesiredVoteCommitments(PlayerTypes
 						temp.iResolutionID = it->GetID();
 
 						int iVotes = 0;
-						if (bFlippedLogic)
-						{
-							iVotes = pLeague->GetPotentialVotesForMember(eFromPlayer, GetPlayer()->GetID());
-						}
-						else
-						{
-							iVotes = pLeague->GetPotentialVotesForMember(GetPlayer()->GetID(), eFromPlayer);
-						}
+						iVotes = pLeague->GetPotentialVotesForMember(GetPlayer()->GetID(), eFromPlayer);
 						temp.iNumVotes = iVotes;
 						temp.iVoteChoice = iDesiredChoice;
 						temp.bEnact = false;

--- a/CvGameCoreDLL_Expansion2/CvVotingClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvVotingClasses.h
@@ -994,7 +994,7 @@ public:
 	void DoProposals(CvLeague* pLeague);
 
 	// Deals for votes
-	VoteCommitmentList GetDesiredVoteCommitments(PlayerTypes eFromPlayer, bool bFlippedLogic = false);
+	VoteCommitmentList GetDesiredVoteCommitments(PlayerTypes eFromPlayer);
 	bool HasVoteCommitment() const;
 	int GetVoteCommitment(PlayerTypes eToPlayer, int iResolutionID, int iVoteChoice, bool bRepeal);
 	bool CanCommitVote(PlayerTypes eToPlayer, CvString* sTooltipSink = NULL);


### PR DESCRIPTION
- bFlippedLogic removed in CvLeagueAI::GetDesiredVoteCommitments
- human desired commitments based on  'yay' if they proposed it or their vote score with bConsiderGlobal 'false'
Fixes #8371 
- **Interest rate change for deal equilization**

@LoneGazebo You may want to increase the EACH_GOLD_PER_TURN_VALUE_PERCENT to 6 to maintain the same feel of interest rate as before.