### PR TITLE
Follower Assignment Hotfix

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvReligionClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvReligionClasses.cpp
@@ -5853,7 +5853,10 @@ void CvCityReligions::SimulateFollowers()
 		}
 
 		if (iLargestRemainder > 0)
+		{	
 			m_SimulatedStatus[iNextRecipient].m_iFollowers++;
+			remainders[iNextRecipient] = 0;
+		}
 	}
 }
 

--- a/CvGameCoreDLL_Expansion2/CvReligionClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvReligionClasses.cpp
@@ -5776,8 +5776,10 @@ void CvCityReligions::RecomputeFollowers(CvReligiousFollowChangeReason eReason, 
 		}
 
 		if (iLargestRemainder > 0)
+		{
 			m_ReligionStatus[iNextRecipient].m_iFollowers++;
 			remainders[iNextRecipient] = 0;
+		}
 	}
 
 	ComputeReligiousMajority(true);

--- a/CvGameCoreDLL_Expansion2/CvReligionClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvReligionClasses.cpp
@@ -5777,6 +5777,7 @@ void CvCityReligions::RecomputeFollowers(CvReligiousFollowChangeReason eReason, 
 
 		if (iLargestRemainder > 0)
 			m_ReligionStatus[iNextRecipient].m_iFollowers++;
+			remainders[iNextRecipient] = 0;
 	}
 
 	ComputeReligiousMajority(true);


### PR DESCRIPTION
Remainders, when chosen, were no longer getting zeroed out, so the religion with the highest remainder would get **all** of the remaining unassigned followers instead of 1. The bug shows itself when there is more than one unassigned follower (common) and/or a religion with low pressure has a high remainder (also common).

Given that a remainder represents a fraction of a follower, no religion should get more than one additional follower from the remainder; instead, given X unassigned followers, the X religions with the highest remainder should each get **one**.