### PR TITLE
Clicking on Unit Promoted opens the promo tree, clicking on promotion…

### DIFF
--- a/EUI Compatibility Files/LUA/UnitPanel.lua
+++ b/EUI Compatibility Files/LUA/UnitPanel.lua
@@ -312,6 +312,24 @@ self = {
 	return self
 end
 
+function IsModActive(sModID, iModMinVersion)
+	for _, mod in pairs(Modding.GetActivatedMods()) do
+		if (mod.ID == sModID) then
+			return (mod.Version >= iModMinVersion)
+		end
+	end
+end  
+
+function OnPromotionTreeButton()
+	LuaEvents.PromotionTreeDisplay(UI.GetHeadSelectedUnit():GetID())
+end
+
+if (IsModActive("1f0a153b-26ae-4496-a2c0-a106d9b43c95", 3)) then
+	Controls.PromotionText:RegisterCallback(Mouse.eLClick, OnPromotionTreeButton)
+else
+	Controls.PromotionText:SetToolTipString(nil)
+end
+
 -------------------------------------------------
 -- Item Functions
 -------------------------------------------------
@@ -1279,6 +1297,11 @@ local UpdateUnitPromotions = EUI.UpdateUnitPromotions or function(unit)
 				sDurationTip = " (" .. Locale.ConvertTextKey("TXT_KEY_STR_TURNS", unit:GetPromotionDuration(unitPromotionID) - (Game.GetGameTurn() - unit:GetTurnPromotionGained(unitPromotionID))) .. ")"
 			end
 			controlTable.EarnedPromotion:SetToolTipString( L(unitPromotion.Description) .. sDurationTip .. "[NEWLINE][NEWLINE]" .. L(unitPromotion.Help) )
+			controlTable.UnitPromoButton:RegisterCallback( Mouse.eRClick, 
+			function()
+				Events.SearchForPediaEntry(unitPromotion.Description)
+			end
+			);
 		end
 	end
 	g_EarnedPromotionIM:Commit()

--- a/EUI Compatibility Files/LUA/UnitPanel.xml
+++ b/EUI Compatibility Files/LUA/UnitPanel.xml
@@ -24,7 +24,7 @@
 			<!-- Worker Action Panel -->
 			<Grid ID="WorkerActionPanel" Anchor="L,B" Offset="517,-39" Size="290,210" Style="Grid9DetailFive140" ConsumeMouse="1">
 				<Label ID="WorkerText" Anchor="C,T" Offset="0,18" Font="TwCenMT20" FontStyle="Shadow" String="TXT_KEY_WORKERACTION_TEXT"/>
-				<Label ID="PromotionText" Anchor="L,T" Offset="60,18" Font="TwCenMT20" String="TXT_KEY_UPANEL_UNIT_PROMOTED" FontStyle="Shadow"/>
+				<TextButton Anchor="L,T" Offset="60,18" Font="TwCenMT20" String="TXT_KEY_UPANEL_UNIT_PROMOTED" ToolTip ="TXT_KEY_PROMO_OPEN_TREE_FOR_UNIT_TT" FontStyle="Shadow" MouseOverStyle="SoftShadow" ConsumeMouse="1" ID="PromotionText" />
 
 				<FlipAnim ID="PromotionAnimation" Size="64,64" Offset="12,-12" Anchor="L,T" Columns="4" Speed="10" Pause=".5" StepSize="64,64" FrameCount="8" Texture="PromotionAnimation.dds"/>
 
@@ -200,6 +200,7 @@
 	<Instance Name="EarnedPromotionInstance">
 		<Container ID="EarnedPromotion" Size="26,26">
 			<Image ID="UnitPromotionImage" Anchor="C,C" Size="32,32" Texture="Promotions256.dds"/>
+			<Button ID="UnitPromoButton" Anchor="C,C" Size="32,32" Hidden="0" Disabled="0"/>
 		</Container>
 	</Instance>
 

--- a/EUI Compatibility Files/LUA/UnitPanel_small.xml
+++ b/EUI Compatibility Files/LUA/UnitPanel_small.xml
@@ -24,7 +24,7 @@
 			<!-- Worker Action Panel -->
 			<Grid ID="WorkerActionPanel" Anchor="L,B" Offset="370,-39" Size="290,210" Style="Grid9DetailFive140" ConsumeMouse="1">
 				<Label ID="WorkerText" Anchor="C,T" Offset="0,18" Font="TwCenMT20" FontStyle="Shadow" String="TXT_KEY_WORKERACTION_TEXT"/>
-				<Label ID="PromotionText" Anchor="L,T" Offset="60,18" Font="TwCenMT20" String="TXT_KEY_UPANEL_UNIT_PROMOTED" FontStyle="Shadow"/>
+				<TextButton Anchor="L,T" Offset="60,18" Font="TwCenMT20" String="TXT_KEY_UPANEL_UNIT_PROMOTED" ToolTip ="TXT_KEY_PROMO_OPEN_TREE_FOR_UNIT_TT" FontStyle="Shadow" MouseOverStyle="SoftShadow" ConsumeMouse="1" ID="PromotionText" />
 
 				<FlipAnim ID="PromotionAnimation" Size="64,64" Offset="12,-12" Anchor="L,T" Columns="4" Speed="10" Pause=".5" StepSize="64,64" FrameCount="8" Texture="PromotionAnimation.dds"/>
 
@@ -200,6 +200,7 @@
 	<Instance Name="EarnedPromotionInstance">
 		<Container ID="EarnedPromotion" Size="26,26">
 			<Image ID="UnitPromotionImage" Anchor="C,C" Size="32,32" Texture="Promotions256.dds"/>
+			<Button ID="UnitPromoButton" Anchor="C,C" Size="32,32" Hidden="0" Disabled="0"/>
 		</Container>
 	</Instance>
 


### PR DESCRIPTION
…s opens their pedia

pressing screenshot removes my mouse but my mouse is on the text that says "Unit Promoted", and left clicking it opens the Promotion Tree if that mod is enabled.
![image](https://user-images.githubusercontent.com/80181074/147896387-d0ff23c4-02b7-43b8-9ead-b4cc23fd3b14.png)

Right clicking on a unit's promotions opens the pedia for that promotion