### PR TITLE
Withdrawal Chance change

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -30027,10 +30027,11 @@ bool CvUnit::CanFallBack(const CvUnit& attacker, bool bCheckChances) const
 	if(bCheckChances)
 	{
 		int iWithdrawChance = getExtraWithdrawal();
-		// Does attacker have a speed greater than 1?
+		// Does attacker have a greater speed than defender? Reduce withdrawal chance for each point the attacker is faster
+		int iDefenderMovementRange = baseMoves(isEmbarked());
 		int iAttackerMovementRange = attacker.baseMoves(attacker.isEmbarked());
-		if(iAttackerMovementRange > 2)
-			iWithdrawChance += (/*-20*/ GD_INT_GET(WITHDRAW_MOD_ENEMY_MOVES) * (iAttackerMovementRange - 2));
+		if(iAttackerMovementRange > iDefenderMovementRange)
+			iWithdrawChance += (/*-20*/ GD_INT_GET(WITHDRAW_MOD_ENEMY_MOVES) * (iAttackerMovementRange - iDefenderMovementRange));
 
 		iWithdrawChance += (/*-20*/ GD_INT_GET(WITHDRAW_MOD_BLOCKED_TILE) * iBlockedHexes);
 


### PR DESCRIPTION
Withdrawal chance reduction is now based on the difference between attacker speed and defender speed instead of solely dependent on attacker speed. This makes withdrawal chance actually do something on naval units.  Fast units (eg mounted) are still good at catching slower units (eg commando).