### PR TITLE
Multiplicative Pressure Erosion Resistance

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvReligionClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvReligionClasses.cpp
@@ -5126,7 +5126,8 @@ void CvCityReligions::ErodeOtherReligiousPressure(CvReligiousFollowChangeReason 
 			if(pReligion)
 			{
 				int iRetentionPercent = pReligion->m_Beliefs.GetInquisitorPressureRetention(m_pCity->getOwner());  // Normally 0
-				iReductionPercent = max(0, iReductionPercent - iRetentionPercent);
+				iReductionPercent = iReductionPercent * (100 - iRetentionPercent) / 100;
+				iReductionPercent = max(0, iReductionPercent);
 			}
 		}
 


### PR DESCRIPTION
When Retention is additive with Reduction, retention percentages higher than reduction completely negate Reduction; this can result in Religions that are completely immune to inquisitors without saying so in the help text.