### PR TITLE
Retreat Updates

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -30061,7 +30061,9 @@ bool CvUnit::DoFallBack(const CvUnit& attacker)
 
 		if(pDestPlot && canMoveInto(*pDestPlot, MOVEFLAG_DESTINATION|MOVEFLAG_NO_EMBARK) && isNativeDomain(pDestPlot))
 		{
-			setXY(pDestPlot->getX(), pDestPlot->getY(), false, false, true, false);
+			setXY(pDestPlot->getX(), pDestPlot->getY(), true, true, true, true);
+			PublishQueuedVisualizationMoves();
+
 			return true;
 		}
 	}

--- a/CvGameCoreDLL_Expansion2/CvUnitCombat.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnitCombat.cpp
@@ -649,7 +649,7 @@ void CvUnitCombat::ResolveMeleeCombat(const CvCombatInfo& kCombatInfo, uint uiPa
 
 					pkAttacker->PublishQueuedVisualizationMoves();
 #if defined(MOD_BALANCE_CORE)
-					if (pkAttacker->getAOEDamageOnKill() != 0)
+					if (pkAttacker->getAOEDamageOnKill() != 0 && bDefenderDead)
 					{
 						CvPlot* pAdjacentPlot = NULL;
 						CvPlot* pPlot = GC.getMap().plot(pkAttacker->getX(), pkAttacker->getY());
@@ -3790,7 +3790,8 @@ CvUnitCombat::ATTACK_RESULT CvUnitCombat::Attack(CvUnit& kAttacker, CvPlot& targ
 		}
 
 		// Move forward
-		if(targetPlot.getNumVisibleEnemyDefenders(&kAttacker) == 0)
+		bool bCanAdvance = kCombatInfo.getAttackerAdvances() && targetPlot.getNumVisibleEnemyDefenders(&kAttacker) == 0;
+		if(bCanAdvance)
 		{
 			kAttacker.UnitMove(&targetPlot, true, &kAttacker);
 		}

--- a/CvGameCoreDLL_Expansion2/CvUnitCombat.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnitCombat.cpp
@@ -3789,11 +3789,15 @@ CvUnitCombat::ATTACK_RESULT CvUnitCombat::Attack(CvUnit& kAttacker, CvPlot& targ
 				MILITARYLOG(pDefender->getOwner(), strBuffer.c_str(), pDefender->plot(), kAttacker.getOwner());
 		}
 
-		// Move forward
+		// Move forward if able
+		CvPlot* pFromPlot = kAttacker.plot();
+		kAttacker.UnitMove(&targetPlot, true, &kAttacker);
 		bool bCanAdvance = kCombatInfo.getAttackerAdvances() && targetPlot.getNumVisibleEnemyDefenders(&kAttacker) == 0;
-		if(bCanAdvance)
+		if (!bCanAdvance)
 		{
-			kAttacker.UnitMove(&targetPlot, true, &kAttacker);
+			kAttacker.ClearMissionQueue(false, GetPostCombatDelay());
+			kAttacker.setXY(pFromPlot->getX(), pFromPlot->getY(), true, true, true, true);
+			kAttacker.PublishQueuedVisualizationMoves();
 		}
 
 //		kAttacker.setMadeAttack(true);   /* EFB: Doesn't work, causes tactical AI to not dequeue this attack; but we've decided you don't lose your attack anyway */


### PR DESCRIPTION
Some weird interactions that I noticed while I was checking the Withdrawal Chance changes.  For your consideration:

- Winged Hussars (HeavyCharge) can no longer deal AoEOn**Kill** damage when they force an enemy to retreat after dealing damage (without killing).
- Units with Withdrawal chance no longer bait attackers out of their fortifications (cities, forts, etc.) upon a successful withdrawal.
- Falling back is now animated.

![Normal Retreat](https://user-images.githubusercontent.com/34615525/149016211-03deedce-724f-4b6d-91fc-34fd248e2466.gif)
![Retreat with Attacker](https://user-images.githubusercontent.com/34615525/149016246-49ef78a3-9753-4df3-8219-155f47de2808.gif)
![Heavy Charge](https://user-images.githubusercontent.com/34615525/149016270-c8dbc538-3f15-4b10-bece-53f2bf35a846.gif)

