### PR TITLE
Normalize unit gifting behavior

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvAIOperation.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAIOperation.cpp
@@ -3317,7 +3317,7 @@ CvPlot* OperationalAIHelpers::FindEnemiesNearHomelandPlot(PlayerTypes ePlayer, P
 }
 
 /// Find our port operation operations against this enemy should leave from
-CvCity* OperationalAIHelpers::GetClosestFriendlyCoastalCity(PlayerTypes ePlayer, CvPlot* pRefPlot)
+CvCity* OperationalAIHelpers::GetClosestFriendlyCoastalCity(PlayerTypes ePlayer, const CvPlot* pRefPlot)
 {
 	if (ePlayer==NO_PLAYER || !pRefPlot)
 		return NULL;

--- a/CvGameCoreDLL_Expansion2/CvAIOperation.h
+++ b/CvGameCoreDLL_Expansion2/CvAIOperation.h
@@ -584,7 +584,7 @@ namespace OperationalAIHelpers
 	CvPlot* FindEnemiesNearHomelandPlot(PlayerTypes ePlayer, PlayerTypes eEnemy, DomainTypes eDomain, CvPlot* pRefPlot);
 	bool IsSlotRequired(PlayerTypes ePlayer, const OperationSlot& thisOperationSlot);
 	int IsUnitSuitableForRecruitment(CvUnit* pLoopUnit, const ReachablePlots& turnsFromMuster, 	bool bMustEmbark, bool bMustBeDeepWaterNaval, const vector<pair<size_t,CvFormationSlotEntry>>& availableSlots);
-	CvCity* GetClosestFriendlyCoastalCity(PlayerTypes ePlayer, CvPlot* pRefPlot);
+	CvCity* GetClosestFriendlyCoastalCity(PlayerTypes ePlayer, const CvPlot* pRefPlot);
 	pair<CvCity*, CvCity*> GetClosestCoastalCityPair(PlayerTypes ePlayerA, PlayerTypes ePlayerB);
 }
 

--- a/CvGameCoreDLL_Expansion2/CvMinorCivAI.h
+++ b/CvGameCoreDLL_Expansion2/CvMinorCivAI.h
@@ -237,26 +237,53 @@ public:
 
 	int getArrivalCountdown() const;
 	UnitTypes getUnitType() const;
+	PlayerTypes getOriginalOwner() const;
+	int getGameTurnCreated() const;
 	bool isHasPromotion(PromotionTypes ePromotion) const;
 	int getPromotionDuration(PromotionTypes ePromotion) const;
 	int getTurnPromotionGained(PromotionTypes ePromotion) const;
+	bool isHasBeenPromotedFromGoody() const;
+	int getExperienceTimes100() const;
+	int getLevel() const;
+	int getOriginCity() const;
+	UnitTypes getLeaderUnitType() const;
+	int getNumGoodyHutsPopped() const;
+	const CvString& getName() const;
 
 	void setArrivalCountdown(int iNewCountdown);
 	void changeArrivalCountdown(int iChangeCountdown);
 	void setUnitType(UnitTypes eNewUnitType);
+	void setOriginalOwner(PlayerTypes eNewOriginalOwner);
+	void setGameTurnCreated(int iNewValue);
 	void setHasPromotion(PromotionTypes ePromotion, bool bNewValue);
 	void setPromotionDuration(PromotionTypes ePromotion, int iNewValue);
 	void setTurnPromotionGained(PromotionTypes ePromotion, int iNewValue);
+	void setHasBeenPromotedFromGoody(bool bPromotedFromGoody);
+	void setExperienceTimes100(int iNewValueTimes100);
+	void setLevel(int iNewLevel);
+	void setOriginCity(int iNewOriginCity);
+	void setLeaderUnitType(UnitTypes eNewLeaderUnitType);
+	void setNumGoodyHutsPopped(int iNewNumGoodyHutsPopped);
+	void setName(const CvString& strNewName);
 
-	void applyToUnit(CvUnit& destUnit) const;
+	void applyToUnit(PlayerTypes eFromPlayer, CvUnit& destUnit) const;
 	void reset();
 
 private:
 	int m_iArrivalCountdown;
 	UnitTypes m_eUnitType;
+	PlayerTypes m_eOriginalOwner;
+	int m_iGameTurnCreated;
 	CvBitfield m_HasPromotions;
 	std::map<PromotionTypes, int> m_PromotionDuration;
 	std::map<PromotionTypes, int> m_TurnPromotionGained;
+	bool m_bPromotedFromGoody;
+	int m_iExperienceTimes100;
+	int m_iLevel;
+	int m_iOriginCity;
+	UnitTypes m_eLeaderUnitType;
+	int m_iNumGoodyHutsPopped;
+	CvString m_strName;
 };
 FDataStream& operator>>(FDataStream&, CvMinorCivIncomingUnitGift&);
 FDataStream& operator<<(FDataStream&, const CvMinorCivIncomingUnitGift&);

--- a/CvGameCoreDLL_Expansion2/CvMinorCivAI.h
+++ b/CvGameCoreDLL_Expansion2/CvMinorCivAI.h
@@ -237,6 +237,7 @@ public:
 
 	int getArrivalCountdown() const;
 	UnitTypes getUnitType() const;
+	CvPlot* getFromPlot() const;
 	PlayerTypes getOriginalOwner() const;
 	int getGameTurnCreated() const;
 	bool isHasPromotion(PromotionTypes ePromotion) const;
@@ -250,9 +251,13 @@ public:
 	int getNumGoodyHutsPopped() const;
 	const CvString& getName() const;
 
+private:
 	void setArrivalCountdown(int iNewCountdown);
+
+public:
 	void changeArrivalCountdown(int iChangeCountdown);
 	void setUnitType(UnitTypes eNewUnitType);
+	void setFromXY(int iFromX, int iFromY);
 	void setOriginalOwner(PlayerTypes eNewOriginalOwner);
 	void setGameTurnCreated(int iNewValue);
 	void setHasPromotion(PromotionTypes ePromotion, bool bNewValue);
@@ -266,12 +271,16 @@ public:
 	void setNumGoodyHutsPopped(int iNewNumGoodyHutsPopped);
 	void setName(const CvString& strNewName);
 
+	bool hasIncomingUnit() const;
+
 	void applyToUnit(PlayerTypes eFromPlayer, CvUnit& destUnit) const;
 	void reset();
 
 private:
 	int m_iArrivalCountdown;
 	UnitTypes m_eUnitType;
+	int m_iFromX;
+	int m_iFromY;
 	PlayerTypes m_eOriginalOwner;
 	int m_iGameTurnCreated;
 	CvBitfield m_HasPromotions;
@@ -800,6 +809,7 @@ public:
 	CvMinorCivIncomingUnitGift& getIncomingUnitGift(PlayerTypes eMajor);
 
 	void doIncomingUnitGifts();
+	void returnIncomingUnitGift(PlayerTypes eMajor);
 
 	// ******************************
 	// ***** Misc Helper Functions *****

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -4582,7 +4582,7 @@ CvCity* CvPlayer::acquireCity(CvCity* pCity, bool bConquest, bool bGift)
 					if (!pNewUnit)
 						continue;
 
-					unitGift.applyToUnit(*pNewUnit);
+					unitGift.applyToUnit(eMajor, *pNewUnit);
 
 					if (pNewUnit->getDomainType() != DOMAIN_AIR && !pNewUnit->jumpToNearestValidPlot())
 					{
@@ -14447,7 +14447,7 @@ void CvPlayer::doGoody(CvPlot* pPlot, CvUnit* pUnit)
 #if defined(MOD_API_ACHIEVEMENTS)
 				if (pUnit && isHuman() && !GC.getGame().isGameMultiPlayer())
 				{
-					pUnit->ChangeNumGoodyHutsPopped(pUnit->GetNumGoodyHutsPopped() + 1);
+					pUnit->SetNumGoodyHutsPopped(pUnit->GetNumGoodyHutsPopped() + 1);
 					if (pUnit->isHasPromotion((PromotionTypes)GD_INT_GET(PROMOTION_GOODY_HUT_PICKER)) && pUnit->GetNumGoodyHutsPopped() >= 5)
 					{
 						gDLL->UnlockAchievement(ACHIEVEMENT_XP2_25);

--- a/CvGameCoreDLL_Expansion2/CvSerialize.h
+++ b/CvGameCoreDLL_Expansion2/CvSerialize.h
@@ -112,7 +112,7 @@ public:
 	template<typename T>
 	inline CvStreamLoadVisitor& operator<<(const T& value)
 	{
-		CvAssertMsg(false, "CvStreamSaveVisitor is not meant for saving");
+		CvAssertMsg(false, "CvStreamLoadVisitor is not meant for saving");
 		return *this;
 	}
 

--- a/CvGameCoreDLL_Expansion2/CvUnit.h
+++ b/CvGameCoreDLL_Expansion2/CvUnit.h
@@ -241,6 +241,10 @@ public:
 
 	void uninitInfos();  // used to uninit arrays that may be reset due to mod changes
 
+	static bool IsRetainablePromotion(PromotionTypes ePromotion);
+	static int CalcExperienceTimes100ForConvert(PlayerTypes eFromPlayer, PlayerTypes eToPlayer, int iExperienceTimes100);
+	void grantExperienceFromLostPromotions(int iNumLost);
+
 #if defined(MOD_BALANCE_CORE)
 	void convert(CvUnit* pUnit, bool bIsUpgrade);
 #else
@@ -1885,7 +1889,7 @@ public:
 	bool IsLargerCivThan(const CvUnit* pOtherUnit) const;
 
 	int GetNumGoodyHutsPopped() const;
-	void ChangeNumGoodyHutsPopped(int iValue);
+	void SetNumGoodyHutsPopped(int iValue);
 
 	const CvUnitReligion* GetReligionData() const { return &m_Religion; }
 	CvUnitReligion* GetReligionDataMutable() { return &m_Religion; }


### PR DESCRIPTION
This should give distance gifts near parity with normal unit gifts as well as prevent them from receiving AI bonus exp.
Also attempts to fix units not receiving refund exp for promotions lost during upgrade.