### PR TITLE
Allow oversupply production for hoomans

### DIFF
--- a/Community Patch/Core Files/Text/CoreText_en_US.xml
+++ b/Community Patch/Core Files/Text/CoreText_en_US.xml
@@ -2896,10 +2896,10 @@
 
 		<!-- No Supply -->
 		<Row Tag="TXT_KEY_NO_ACTION_NO_SUPPLY">
-			<Text>[NEWLINE]Cannot [ICON_PRODUCTION] Train this unit, as you are at your Supply cap!</Text>
+			<Text>[NEWLINE]Cannot [ICON_PRODUCTION] Train this unit, as you are at your maximum Supply cap!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NO_ACTION_NO_SUPPLY_PURCHASE">
-			<Text>[NEWLINE]Cannot [ICON_GOLD] Purchase this unit, as you are at your Supply cap!</Text>
+			<Text>[NEWLINE]Cannot [ICON_GOLD] Purchase this unit, as you are at your maximum Supply cap!</Text>
 		</Row>
 		
 		<!-- Lack of gross resource (before deductions) -->

--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -8633,8 +8633,7 @@ bool CvCity::canTrain(UnitTypes eUnit, bool bContinue, bool bTestVisible, bool b
 
 		if (MOD_BALANCE_CORE_MILITARY && !pUnitInfo.IsNoSupply())
 		{
-			bool bCanSupply = GET_PLAYER(getOwner()).GetNumUnitsToSupply() < GET_PLAYER(getOwner()).GetNumUnitsSupplied(); // this works when we're at the limit
-			if (!bCanSupply && !isBarbarian() && (pUnitInfo.GetCombat() > 0 || pUnitInfo.GetRangedCombat() > 0))
+			if (GET_PLAYER(getOwner()).GetNumUnitsOutOfSupply() > 13 && !isBarbarian() && (pUnitInfo.GetCombat() > 0 || pUnitInfo.GetRangedCombat() > 0))
 			{
 				GC.getGame().BuildCannotPerformActionHelpText(toolTipSink, "TXT_KEY_NO_ACTION_NO_SUPPLY");
 				if (toolTipSink == NULL)


### PR DESCRIPTION
Allows oversupply production until the maximum penalty is hit (14 units)