### PR TITLE
Syncretism modification

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -24580,9 +24580,10 @@ void CvCity::UpdateSpecialReligionYields(YieldTypes eYield)
 				{
 					if (pLoopCity != NULL)
 					{
-						iYieldValue += (pLoopCity->GetCityReligions()->GetFollowersOtherReligions(eReligion) / iYieldPerXNonFollowers);
+						iYieldValue += (pLoopCity->GetCityReligions()->GetFollowersOtherReligions(eReligion));
 					}
 				}
+				iYieldValue /= iYieldPerXNonFollowers;
 			}
 
 			// This came from CvTreasury::GetGoldPerTurnFromReligion()


### PR DESCRIPTION
yields from foreign followers no longer added up per city; sum all of the followers first, then divide by the divisor.