### PR TITLE
DB Text Cleaning

### DIFF
--- a/Community Balance Overhaul/Balance Changes/Text/en_US/PromotionText.sql
+++ b/Community Balance Overhaul/Balance Changes/Text/en_US/PromotionText.sql
@@ -525,9 +525,8 @@
 	WHERE Tag = 'TXT_KEY_PROMOTION_ANTI_AIR_II';
 
 	-- Second Attack Explanations
-	UPDATE Language_en_US
-	SET Text = '-20% [ICON_STRENGTH] Combat Strength.[NEWLINE]May [COLOR_POSITIVE_TEXT]Attack Twice[ENDCOLOR].'
-	WHERE Tag = 'TXT_KEY_PROMOTION_SECOND_ATTACK_HELP';
+	INSERT INTO Language_en_US (Tag, Text)
+	VALUES ('TXT_KEY_PROMOTION_SECOND_ATTACK_HELP', '-20% [ICON_STRENGTH] Combat Strength.[NEWLINE]May [COLOR_POSITIVE_TEXT]Attack Twice[ENDCOLOR].');
 
 	UPDATE Language_en_US
 	SET Text = '-30% [ICON_RANGE_STRENGTH] Ranged Combat Strength when attacking.[NEWLINE]May [COLOR_POSITIVE_TEXT]Attack Twice[ENDCOLOR].'

--- a/Community Balance Overhaul/Balance Changes/Text/en_US/PromotionText.sql
+++ b/Community Balance Overhaul/Balance Changes/Text/en_US/PromotionText.sql
@@ -490,7 +490,7 @@
 	-- Amphibious Change
 
 	UPDATE Language_en_US
-	SET Text = 'Eliminates combat penalties for attacking from the sea or over a river, and crossing a river costs only 1 [ICON_MOVES] Movement.'
+	SET Text = 'Eliminates combat penalties for attacking from the sea or over a river. Crossing a river costs only 1 [ICON_MOVES] Movement.'
 	WHERE Tag = 'TXT_KEY_PROMOTION_AMPHIBIOUS_HELP';
 
 	-- Medic I/II

--- a/Community Balance Overhaul/Balance Changes/Text/en_US/PromotionText.sql
+++ b/Community Balance Overhaul/Balance Changes/Text/en_US/PromotionText.sql
@@ -490,7 +490,7 @@
 	-- Amphibious Change
 
 	UPDATE Language_en_US
-	SET Text = 'Eliminates combat penalties for attacking from the sea or over a river, and grants a movement bonus when moving across rivers.'
+	SET Text = 'Eliminates combat penalties for attacking from the sea or over a river, and crossing a river costs only 1 [ICON_MOVES] Movement.'
 	WHERE Tag = 'TXT_KEY_PROMOTION_AMPHIBIOUS_HELP';
 
 	-- Medic I/II
@@ -537,15 +537,14 @@
 	SET Text = 'May [COLOR_POSITIVE_TEXT]Attack Twice[ENDCOLOR].[NEWLINE]+1 [ICON_MOVES] Movement.'
 	WHERE Tag = 'TXT_KEY_PROMOTION_RESTLESSNESS_HELP';
 
-	-- Indirect Fire, Blitz, Range Combat Strength Reductions
+	UPDATE Language_en_US
+	SET Text = 'May [COLOR_POSITIVE_TEXT]Attack Twice[ENDCOLOR], and can move after attacking.'
+	WHERE Tag = 'TXT_KEY_PROMOTION_BLITZ_HELP';
 
+	-- Indirect Fire, Range Combat Strength Reductions
 	UPDATE Language_en_US
 	SET Text = '-10% [ICON_RANGE_STRENGTH] Ranged Combat Strength when attacking.[NEWLINE]Ranged attacks may be performed over obstacles (as long as other friendly Units can see the target).'
 	WHERE Tag = 'TXT_KEY_PROMOTION_INDIRECT_FIRE_HELP';
-
-	UPDATE Language_en_US
-	SET Text = 'Unit may Attack [COLOR_POSITIVE_TEXT]twice[ENDCOLOR] per turn, and can move after attacking.'
-	WHERE Tag = 'TXT_KEY_PROMOTION_BLITZ_HELP';
 
 	UPDATE Language_en_US
 	SET Text = '-20% [ICON_RANGE_STRENGTH] Ranged Combat Strength when attacking.[NEWLINE]+1 Range.'
@@ -553,7 +552,7 @@
 
 	-- Changed English UA
 	UPDATE Language_en_US
-	SET Text = '1 Extra Movement for Naval Units.'
+	SET Text = '+1 [ICON_MOVES] Movement for Naval Units.'
 	WHERE Tag = 'TXT_KEY_PROMOTION_OCEAN_MOVEMENT_HELP';
 
 	-- Bonus vs Naval


### PR DESCRIPTION
Updated the text for Amphibious, England's UA promotion.
Moved Blitz into the correct section.

TXT_KEY_PROMOTION_SECOND_ATTACK_HELP didn't exist in the BNW database, so it needs to be inserted.

Everything looks good in game.