### PR TITLE
Prevent City States from building Settlers

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -14871,6 +14871,15 @@ bool CvPlayer::canTrainUnit(UnitTypes eUnit, bool bContinue, bool bTestVisible, 
 			return false;
 		}
 	}
+
+	// No Settlers for City States
+	if (pUnitInfo.IsFound() || pUnitInfo.IsFoundAbroad())
+	{
+		if (isMinorCiv())
+		{
+			return false;
+		}
+	}
 	
 	//Policy Requirement
 	PolicyTypes ePolicy = (PolicyTypes)pUnitInfo.GetPolicyType();


### PR DESCRIPTION
Fix for #8660 and #8058.

I tested it for Community Patch, but since I don't know much about the changes in Community Balance Overhaul, I don't know if there under some occasion City States should be allowed to build units for which "(pUnitInfo.IsFound() || pUnitInfo.IsFoundAbroad())" is true. If so, please reject this request.