### PR TITLE
use 1 bit per custom mod boolean instead of 1 byte

### DIFF
--- a/CvGameCoreDLL_Expansion2/CustomMods.h
+++ b/CvGameCoreDLL_Expansion2/CustomMods.h
@@ -1210,7 +1210,7 @@ void CheckSentinel(uint);
 
 
 // CustomMod option wrappers
-#define MOD_OPT_DECL(name)  protected: bool m_b##name; public: inline bool is##name() { return m_b##name; }
+#define MOD_OPT_DECL(name)  protected: bool m_b##name:1; public: inline bool is##name() { return m_b##name; }
 #define MOD_OPT_CACHE(name) m_b##name = (m_options[string(#name)] == 1);
 
 


### PR DESCRIPTION
Because why not? Reduces size of the CustomMods struct from 280 bytes to 48 bytes.