### PR TITLE
'Bonus vs. Armored Units (50)' instead of 'Anti-Tank Rounds'

### DIFF
--- a/Community Balance Overhaul/Balance Changes/Text/en_US/PromotionText.sql
+++ b/Community Balance Overhaul/Balance Changes/Text/en_US/PromotionText.sql
@@ -238,7 +238,7 @@
 
 -- Adjust Anti-Tank
 	UPDATE Language_en_US
-	SET Text = 'Anti-Tank Rounds.'
+	SET Text = 'Bonus vs. Armored Units (50)'
 	WHERE Tag = 'TXT_KEY_PROMOTION_ANTI_TANK';
 
 	UPDATE Language_en_US


### PR DESCRIPTION
'TXT_KEY_PROMOTION_ANTI_TANK_HELP' doesn't exist in the database, without it Anti-Tank Rounds promotion isn't really descriptive. I tried inserting the help key, but couldn't do it for some reason, so I just changed the title to a format used by many promotions. I don't think this needs a help text anyway. Stackedpromotions also prevent duplicate texts from being shown in the unitpanel when title = help, so it doesn't look bad either.

https://github.com/LoneGazebo/Community-Patch-DLL/issues/8675