### PR TITLE
Unique National Wonder Population Requirements

### DIFF
--- a/Community Balance Overhaul/Balance Changes/Buildings/NationalWonderChanges.sql
+++ b/Community Balance Overhaul/Balance Changes/Buildings/NationalWonderChanges.sql
@@ -215,7 +215,7 @@ SET NationalPopRequired = '25'
 WHERE Type = 'BUILDING_CIRCUS_MAXIMUS';
 
 UPDATE Buildings
-SET NationalPopRequired = '40'
+SET NationalPopRequired = '35'
 WHERE Type = 'BUILDING_NATIONAL_TREASURY';
 
 UPDATE Buildings
@@ -223,11 +223,11 @@ SET NationalPopRequired = '25'
 WHERE Type = 'BUILDING_NATIONAL_COLLEGE';
 
 UPDATE Buildings
-SET NationalPopRequired = '40'
+SET NationalPopRequired = '35'
 WHERE Type = 'BUILDING_IRONWORKS';
 
 UPDATE Buildings
-SET NationalPopRequired = '35'
+SET NationalPopRequired = '30'
 WHERE Type = 'BUILDING_OXFORD_UNIVERSITY';
 
 UPDATE Buildings


### PR DESCRIPTION
```
NW            Tech Tier        Pop Notes
Heroic Epic   4  (1 Classical) 20
Piazza San Ma 4  (1 Classical) 10  <> (UNW)
Royal Library 4  (1 Classical) 15  <> (UNW)
National Epic 5  (2 Classical) 25
Circus Maximu 5  (2 Classical) 25
School of Phi 5  (2 Classical) 25
Great Cothon  5  (2 Classical) 20  <> (UNW)
Oxford Univer 6  (1 Medieval)  35  <<<<<<<<
Grand Temple  6  (1 Medieval)  30
East India Co 7  (2 Medieval)  40  <<<<<<<<
White Tower   7  (2 Medieval)  30  <> (UNW)
Ironworks     7  (2 Medieval)  40  <<<<<<<<
Independenc H 9  (2 Renaissan) 40  <> (UNW)
Hermitage     9  (2 Renaissan) 45
National Inte 15 (2 Atomic)    70  <>
National Visi 16 (1 Informati) 70  <>
The majority of default NWs follow 5 pop required per tech tier.
<<<<<<<< more expensive than default
<>       less expensive than default
(UNW)    civilization unique
```

So, what we see here is that Unique National Wonders are always 5 pop cheaper than their contemporary tier would suggest, true for both wide and tall civilizations. I assume Venice gets a larger discount because their ability to settle cities to lower the requirement is greatly hampered compared to other civs. That the last two wonders are cheaper than their tier suggests that the national pop curve should be logarithmic or nth root, but the majority of wonders appear at the beginning of the curve, so it looks linear.

Lowered Ironworks, East India Company, Oxford by 5 to put them in line with the rest of the early national wonders.