### PR TITLE
fix Non-Specialist yields being 100x smaller

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -24839,7 +24839,6 @@ int CvCity::getBasicYieldRateTimes100(YieldTypes eIndex) const
 	if (iNonSpecialist != 0)
 	{
 		int iBonusTimes100 = (iNonSpecialist * (getPopulation() - GetCityCitizens()->GetTotalSpecialistCount()));
-		iBonusTimes100 /= 100;
 		iBaseYield += iBonusTimes100;
 	}
 


### PR DESCRIPTION
The code was copied from getJONSCulture and they left it as divided by 100 but the var is later divided by 100 again..