### PR TITLE
allow negative growth boon

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -10098,7 +10098,7 @@ void CvCity::DoPickResourceDemanded(bool bCurrentResourceInvalid)
 	{
 #if defined(MOD_BALANCE_CORE)
 
-		if (GET_PLAYER(getOwner()).GetPlayerTraits()->GetGrowthBoon() > 0)
+		if (GET_PLAYER(getOwner()).GetPlayerTraits()->GetGrowthBoon() != 0)
 		{
 			Localization::String strText = Localization::Lookup("TXT_KEY_NOTIFICATION_CITY_RESOURCE_DEMAND_UA");
 			strText << getNameKey() << GC.getResourceInfo(eResource)->GetTextKey();
@@ -10185,7 +10185,7 @@ void CvCity::DoTestResourceDemanded()
 				if (pNotifications)
 				{
 #if defined(MOD_BALANCE_CORE)
-					if (GET_PLAYER(getOwner()).GetPlayerTraits()->GetGrowthBoon() > 0)
+					if (GET_PLAYER(getOwner()).GetPlayerTraits()->GetGrowthBoon() != 0)
 					{
 						Localization::String strText = Localization::Lookup("TXT_KEY_NOTIFICATION_CITY_WLTKD_UA_RESOURCE");
 						strText << GC.getResourceInfo(eResource)->GetTextKey() << getNameKey() << iWLTKD << GET_PLAYER(getOwner()).GetPlayerTraits()->GetGrowthBoon();
@@ -24401,7 +24401,7 @@ int CvCity::getBaseYieldRateModifier(YieldTypes eIndex, int iExtra, CvString* to
 		if (toolTipSink)
 			GC.getGame().BuildProdModHelpText(toolTipSink, "TXT_KEY_PRODMOD_CORPORATION", iTempMod);
 	}
-	if (eIndex == YIELD_FOOD && GetWeLoveTheKingDayCounter() > 0 && GET_PLAYER(getOwner()).GetPlayerTraits()->GetGrowthBoon() > 0)
+	if (eIndex == YIELD_FOOD && GetWeLoveTheKingDayCounter() > 0 && GET_PLAYER(getOwner()).GetPlayerTraits()->GetGrowthBoon() != 0)
 	{
 		iTempMod = GET_PLAYER(getOwner()).GetPlayerTraits()->GetGrowthBoon();
 		iModifier += iTempMod;

--- a/CvGameCoreDLL_Expansion2/CvTraitClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTraitClasses.cpp
@@ -4112,7 +4112,7 @@ void CvPlayerTraits::SetIsExpansionist()
 		GetNaturalWonderSubsequentFinderGold() != 0 ||
 		GetNaturalWonderYieldModifier() != 0 ||
 		GetNaturalWonderHappinessModifier() != 0 ||
-		GetGrowthBoon() != 0 ||
+		GetGrowthBoon() > 0 ||
 		GetGAUnhappinesNeedMod() != 0 ||
 		GetUniqueLuxuryCities() != 0 ||
 		GetExtraFoundedCityTerritoryClaimRange() != 0 ||


### PR DESCRIPTION
so a civ can have an ability to have negative growth during WLTKD.

Expansionist civs will no longer be defined as a civ with any growth boon but only ones with a positive growth boon. (seems to be a specific case for china?)