### PR TITLE
Disable project upgrade

### DIFF
--- a/CvGameCoreDLL_Expansion2/VoxPopuli.vcxproj
+++ b/CvGameCoreDLL_Expansion2/VoxPopuli.vcxproj
@@ -13,6 +13,9 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{2D4B6CDC-0887-4EE1-97B9-0865CC82FAF3}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
+  <PropertyGroup>
+    <VCProjectUpgraderObjectName>NoUpgrade</VCProjectUpgraderObjectName>
+  </PropertyGroup>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">


### PR DESCRIPTION
Adding field to disable the upgrade prompt. Available from 2017 to 2022. Tested on Visual Studio 2019.

https://docs.microsoft.com/en-us/visualstudio/extensibility/visual-cpp-project-extensibility?view=vs-2017#disable-project-upgrade