### PR TITLE
Workboats in Ocean

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
@@ -7409,8 +7409,9 @@ bool CvMinorCivAI::IsValidQuestForPlayer(PlayerTypes ePlayer, MinorCivQuestTypes
 			return false;
 		}
 
-		//Give this quest out once the player can cross oceans.
-		if (!GET_TEAM(GET_PLAYER(ePlayer).getTeam()).GetTeamTechs()->HasTech(GC.getGame().getOceanPassableTech()))
+		//Give this quest out once the player can embark across oceans (Traits not included).
+		if (!GET_TEAM(GET_PLAYER(ePlayer).getTeam()).canEmbarkAllWaterPassage())
+		//if (!GET_PLAYER(ePlayer).CanCrossOcean())
 		{
 			return false;
 		}

--- a/CvGameCoreDLL_Expansion2/CvPromotionClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPromotionClasses.cpp
@@ -3180,7 +3180,9 @@ void CvUnitPromotions::SetPromotion(PromotionTypes eIndex, bool bValue)
 void CvUnitPromotions::UpdateCache()
 {
 	m_terrainPassableCache.clear();
+	m_bTerrainPassable = false;
 	m_featurePassableCache.clear();
+	m_bFeaturePassable = false;
 
 	for(int iTerrain = 0; iTerrain < GC.getNumTerrainInfos(); iTerrain++)
 	{
@@ -3194,11 +3196,14 @@ void CvUnitPromotions::UpdateCache()
 				{
 					TechTypes eTech = (TechTypes) promotion->GetTerrainPassableTech(iTerrain);
 					if(eTech != NO_TECH)
+					{
 						reqTechs.push_back(eTech);
+						m_bTerrainPassable = true;
+					}
 				}
 			}
 		}
-
+		
 		m_terrainPassableCache.push_back( reqTechs );
 	}
 
@@ -3213,8 +3218,11 @@ void CvUnitPromotions::UpdateCache()
 				if(promotion)
 				{
 					TechTypes eTech = (TechTypes) promotion->GetFeaturePassableTech(iFeature);
-					if(eTech != NO_TECH)
+					if (eTech != NO_TECH)
+					{
 						reqTechs.push_back(eTech);
+						m_bFeaturePassable = true;
+					}
 				}
 			}
 		}
@@ -3226,7 +3234,7 @@ void CvUnitPromotions::UpdateCache()
 /// determines if the unit has a promotion that makes a feature passable
 bool CvUnitPromotions::HasAllowFeaturePassable() const
 {
-	return m_featurePassableCache.size() > 0;
+	return m_bFeaturePassable;
 }
 
 /// determines if the feature is passable given the unit's current promotions and tech level
@@ -3248,7 +3256,7 @@ bool CvUnitPromotions::GetAllowFeaturePassable(FeatureTypes eFeatureType, TeamTy
 /// determines if the unit has a promotion that makes a terrain passable
 bool CvUnitPromotions::HasAllowTerrainPassable() const
 {
-	return m_terrainPassableCache.size() > 0;
+	return m_bTerrainPassable;
 }
 /// determines if the terrain is passable given the unit's current promotions and tech level
 bool CvUnitPromotions::GetAllowTerrainPassable(TerrainTypes eTerrainType, TeamTypes eTeam) const

--- a/CvGameCoreDLL_Expansion2/CvPromotionClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvPromotionClasses.h
@@ -717,7 +717,9 @@ public:
 	bool HasPromotion(PromotionTypes eIndex) const;
 	void SetPromotion(PromotionTypes eIndex, bool bValue);
 
+	bool HasAllowFeaturePassable() const;
 	bool GetAllowFeaturePassable(FeatureTypes eFeatureType, TeamTypes eTeam) const;
+	bool HasAllowTerrainPassable() const;
 	bool GetAllowTerrainPassable(TerrainTypes eTerrainType, TeamTypes eTeam) const;
 
 	int GetUnitClassAttackMod(UnitClassTypes eUnitClass) const;
@@ -728,13 +730,11 @@ public:
 private:
 	bool IsInUseByPlayer(PromotionTypes eIndex, PlayerTypes ePlayer); 
 
-#if defined(MOD_BALANCE_CORE)
 	void UpdateCache();
 	std::vector<std::vector<TechTypes>> m_terrainPassableCache;
 	std::vector<std::vector<TechTypes>> m_featurePassableCache;
 	std::vector<int> m_unitClassDefenseMod;
 	std::vector<int> m_unitClassAttackMod;
-#endif
 
 	CvBitfield m_kHasPromotion;
 };

--- a/CvGameCoreDLL_Expansion2/CvPromotionClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvPromotionClasses.h
@@ -731,6 +731,8 @@ private:
 	bool IsInUseByPlayer(PromotionTypes eIndex, PlayerTypes ePlayer); 
 
 	void UpdateCache();
+	bool m_bTerrainPassable;
+	bool m_bFeaturePassable;
 	std::vector<std::vector<TechTypes>> m_terrainPassableCache;
 	std::vector<std::vector<TechTypes>> m_featurePassableCache;
 	std::vector<int> m_unitClassDefenseMod;

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -4849,15 +4849,11 @@ bool CvUnit::canEnterTerrain(const CvPlot& enterPlot, int iMoveFlags) const
 		}
 
 		// general promotions ---------------------------------------------------
+		if(enterPlot.getFeatureType() != NO_FEATURE && m_Promotions.HasAllowFeaturePassable() && m_Promotions.GetAllowFeaturePassable(enterPlot.getFeatureType(), getTeam()))
+			return true;
 
-		if(enterPlot.getFeatureType() != NO_FEATURE && m_Promotions.HasAllowFeaturePassable())
-		{
-			return m_Promotions.GetAllowFeaturePassable(enterPlot.getFeatureType(), getTeam());
-		}	
 		else if(enterPlot.getTerrainType() != NO_TERRAIN && m_Promotions.HasAllowTerrainPassable())
-		{
 			return m_Promotions.GetAllowTerrainPassable(enterPlot.getTerrainType(), getTeam());
-		}	
 
 		//ok, seems we ran out of jokers. no pasaran!
 		return false;
@@ -4885,11 +4881,8 @@ bool CvUnit::canEnterTerrain(const CvPlot& enterPlot, int iMoveFlags) const
 					return m_Promotions.GetAllowTerrainPassable(enterPlot.getTerrainType(), getTeam());
 
 				// tech limited embarkation
-				if (eDomain==DOMAIN_LAND && !IsEmbarkDeepWater() && !IsEmbarkAllWater() && !kPlayer.CanCrossOcean())
-				{
-					CvTeam& kTeam = GET_TEAM(getTeam());
-					return kTeam.canEmbarkAllWaterPassage();
-				}
+				if (eDomain == DOMAIN_LAND)
+					return IsEmbarkDeepWater() || IsEmbarkAllWater() || kPlayer.CanCrossOcean();
 			}
 		}
 		else if(enterPlot.getFeatureType() != NO_FEATURE && isFeatureImpassable(enterPlot.getFeatureType()))

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -4880,14 +4880,15 @@ bool CvUnit::canEnterTerrain(const CvPlot& enterPlot, int iMoveFlags) const
 				if (canCrossOceans())
 					return true;
 
-				PromotionTypes ePromotionOceanImpassableUntilAstronomy = (PromotionTypes)GD_INT_GET(PROMOTION_OCEAN_IMPASSABLE_UNTIL_ASTRONOMY);
-				bool bOceanImpassableUntilAstronomy = isHasPromotion(ePromotionOceanImpassableUntilAstronomy) || 
-					(eDomain==DOMAIN_LAND && !IsEmbarkDeepWater() && !IsEmbarkAllWater() && !kPlayer.CanCrossOcean());
+				// tech-locked promotion
+				if (m_Promotions.GetAllowTerrainPassable(enterPlot.getTerrainType(),getTeam()))
+					return true;
 
-				if(bOceanImpassableUntilAstronomy )
+				// tech limited embarkation
+				if (eDomain==DOMAIN_LAND && !IsEmbarkDeepWater() && !IsEmbarkAllWater() && !kPlayer.CanCrossOcean())
 				{
 					CvTeam& kTeam = GET_TEAM(getTeam());
-					return kTeam.GetTeamTechs()->HasTech( GC.getGame().getOceanPassableTech() );
+					return kTeam.canEmbarkAllWaterPassage();
 				}
 			}
 		}

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -4850,13 +4850,13 @@ bool CvUnit::canEnterTerrain(const CvPlot& enterPlot, int iMoveFlags) const
 
 		// general promotions ---------------------------------------------------
 
-		if(enterPlot.getFeatureType() != NO_FEATURE && m_Promotions.GetAllowFeaturePassable(enterPlot.getFeatureType(),getTeam()))
+		if(enterPlot.getFeatureType() != NO_FEATURE && m_Promotions.HasAllowFeaturePassable())
 		{
-			return true;
+			return m_Promotions.GetAllowFeaturePassable(enterPlot.getFeatureType(), getTeam());
 		}	
-		else if(enterPlot.getTerrainType() != NO_TERRAIN && m_Promotions.GetAllowTerrainPassable(enterPlot.getTerrainType(),getTeam()))
+		else if(enterPlot.getTerrainType() != NO_TERRAIN && m_Promotions.HasAllowTerrainPassable())
 		{
-			return true;
+			return m_Promotions.GetAllowTerrainPassable(enterPlot.getTerrainType(), getTeam());
 		}	
 
 		//ok, seems we ran out of jokers. no pasaran!
@@ -4881,8 +4881,8 @@ bool CvUnit::canEnterTerrain(const CvPlot& enterPlot, int iMoveFlags) const
 					return true;
 
 				// tech-locked promotion
-				if (m_Promotions.GetAllowTerrainPassable(enterPlot.getTerrainType(),getTeam()))
-					return true;
+				if (m_Promotions.HasAllowTerrainPassable())
+					return m_Promotions.GetAllowTerrainPassable(enterPlot.getTerrainType(), getTeam());
 
 				// tech limited embarkation
 				if (eDomain==DOMAIN_LAND && !IsEmbarkDeepWater() && !IsEmbarkAllWater() && !kPlayer.CanCrossOcean())


### PR DESCRIPTION
After much finagling, Workboats can now enter the Ocean at compass like their promotion says.

Also speeds up calculations for "Terrain Passable with Tech" and "Feature Passable with Tech" Promotions in the general case.

