### PR TITLE
Function Optimizations

### DIFF
--- a/(2) Vox Populi/Balance Changes/Text/en_US/ReligionText.sql
+++ b/(2) Vox Populi/Balance Changes/Text/en_US/ReligionText.sql
@@ -635,7 +635,7 @@ SET Text = 'Holy Land'
 WHERE Tag = 'TXT_KEY_BELIEF_RELIGIOUS_FERVOR_SHORT';
 
 UPDATE Language_en_US
-SET Text = 'Receive 1 additional [ICON_DIPLOMAT] Delegate in the World Congress for every 2 [ICON_RELIGION] Holy Sites or 2 [ICON_TOURISM] Landmarks you own. +50% Yields from Friendly/Allied [ICON_CITY_STATE] City-States following this Religion.'
+SET Text = 'Receive 1 additional [ICON_DIPLOMAT] Delegate in the World Congress for every 2 [ICON_RELIGION] Holy Sites and [ICON_TOURISM] Landmarks you own. +50% Yields from Friendly/Allied [ICON_CITY_STATE] City-States following this Religion.'
 WHERE Tag = 'TXT_KEY_BELIEF_RELIGIOUS_FERVOR';
 
 

--- a/CvGameCoreDLL_Expansion2/CvBeliefClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBeliefClasses.cpp
@@ -1,5 +1,5 @@
 /*	-------------------------------------------------------------------------------------------------------
-	© 1991-2012 Take-Two Interactive Software and its subsidiaries.  Developed by Firaxis Games.  
+	Â© 1991-2012 Take-Two Interactive Software and its subsidiaries.  Developed by Firaxis Games.  
 	Sid Meier's Civilization V, Civ, Civilization, 2K Games, Firaxis Games, Take-Two Interactive Software 
 	and their respective logos are all trademarks of Take-Two interactive Software, Inc.  
 	All other marks and trademarks are the property of their respective owners.  
@@ -4685,22 +4685,25 @@ int CvReligionBeliefs::GetCSYieldBonus(PlayerTypes ePlayer, const CvCity* pCity,
 	return rtnValue;
 }
 
-
-int CvReligionBeliefs::GetVoteFromOwnedImprovement(ImprovementTypes eImprovement, PlayerTypes ePlayer, const CvCity* pCity, bool bHolyCityOnly) const
+/// Get votes per improvement (fractional) from belief
+std::pair<int, int> CvReligionBeliefs::GetVoteFromOwnedImprovement(ImprovementTypes eImprovement, PlayerTypes ePlayer, const CvCity* pCity, bool bHolyCityOnly) const
 {
 	CvBeliefXMLEntries* pBeliefs = GC.GetGameBeliefs();
-	int rtnValue = 0;
-
+	
+	std::pair<int, int> fVotes = std::make_pair(0, 1);
+	
+	// if two beliefs give fractional votes for the same improvement, then the fractional vote gets larger (1/2 + 1/3 = 5/6)
 	for (BeliefList::const_iterator it = m_ReligionBeliefs.begin(); it != m_ReligionBeliefs.end(); ++it)
 	{
+		/// GetImprovementVoteChange() returns the number of improvements required for each vote
 		int iValue = pBeliefs->GetEntry(*it)->GetImprovementVoteChange(eImprovement);
 		if (iValue != 0 && IsBeliefValid((BeliefTypes)*it, GetReligion(), ePlayer, pCity, bHolyCityOnly))
 		{
-			rtnValue += iValue;
-		}
+			AddFractionToReference(fVotes, std::make_pair(1, iValue));
+   		}
 	}
 
-	return rtnValue;
+	return fVotes;
 }
 
 

--- a/CvGameCoreDLL_Expansion2/CvBeliefClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvBeliefClasses.h
@@ -1,5 +1,5 @@
 /*	-------------------------------------------------------------------------------------------------------
-	© 1991-2012 Take-Two Interactive Software and its subsidiaries.  Developed by Firaxis Games.  
+	Â© 1991-2012 Take-Two Interactive Software and its subsidiaries.  Developed by Firaxis Games.  
 	Sid Meier's Civilization V, Civ, Civilization, 2K Games, Firaxis Games, Take-Two Interactive Software 
 	and their respective logos are all trademarks of Take-Two interactive Software, Inc.  
 	All other marks and trademarks are the property of their respective owners.  
@@ -582,7 +582,7 @@ public:
 	CivilizationTypes GetUniqueCiv(PlayerTypes ePlayer = NO_PLAYER, bool bHolyCityOnly = false) const;
 	int GetIgnorePolicyRequirementsAmount(EraTypes eEra, PlayerTypes ePlayer = NO_PLAYER, const CvCity* pCity = NULL, bool bHolyCityOnly = false) const;
 	int GetCSYieldBonus(PlayerTypes ePlayer = NO_PLAYER, const CvCity* pCity = NULL, bool bHolyCityOnly = false) const;
-	int GetVoteFromOwnedImprovement(ImprovementTypes eImprovement, PlayerTypes ePlayer = NO_PLAYER, const CvCity* pCity = NULL, bool bHolyCityOnly = false) const;
+	std::pair<int, int> GetVoteFromOwnedImprovement(ImprovementTypes eImprovement, PlayerTypes ePlayer = NO_PLAYER, const CvCity* pCity = NULL, bool bHolyCityOnly = false) const;
 #endif
 
 	// Serialization

--- a/CvGameCoreDLL_Expansion2/CvCorporationClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCorporationClasses.cpp
@@ -880,7 +880,7 @@ void CvPlayerCorporations::RecalculateNumFranchises()
 	{
 		if (GetFranchisesPerImprovement((ImprovementTypes)iI) > 0)
 		{
-			iFranchises += (m_pPlayer->CountAllImprovement((ImprovementTypes)iI, true) * GetFranchisesPerImprovement((ImprovementTypes)iI));
+			iFranchises += (m_pPlayer->getImprovementCount((ImprovementTypes)iI, true) * GetFranchisesPerImprovement((ImprovementTypes)iI));
 		}
 	}
 
@@ -1357,7 +1357,7 @@ int CvPlayerCorporations::GetMaxNumFranchises() const
 	{
 		if (GetFranchisesPerImprovement((ImprovementTypes)iI) > 0)
 		{
-			iReturnValue += (m_pPlayer->CountAllImprovement((ImprovementTypes)iI, true) * GetFranchisesPerImprovement((ImprovementTypes)iI));
+			iReturnValue += (m_pPlayer->getImprovementCount((ImprovementTypes)iI, true) * GetFranchisesPerImprovement((ImprovementTypes)iI));
 		}
 	}
 

--- a/CvGameCoreDLL_Expansion2/CvGameCoreUtils.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGameCoreUtils.cpp
@@ -1666,4 +1666,52 @@ int MapToPercent(int iValue, int iZeroAt, int iHundredAt)
 	else
 		return 50;
 }
+
+// add a fraction to a referenced fraction without losing information; the referenced fraction is assumed to have the larger dividend & divisor
+void AddFractionToReference(pair<int,int>& A, const pair<int,int>& B)
+{
+	// protect from integer overflow (safe, simple max that will probably never be hit)
+	if (A.first >= (INT_MAX / B.first / B.second) - A.second)
+	{
+		// Divisor or Dividend is too large! Start fresh
+		if (A.first > A.second)
+		{
+			A.first /= A.second;
+			A.second = 1;
+		}
+		else
+		{
+			A.second /= A.first;
+			A.first = 1;
+		}
+	}
+
+	// N / D = nA / dA + nB / dB
+	//       = (nA*dB + nB*dA) / (dB*dA)
+	A.first *= B.second;
+	A.first += B.first * A.second;
+
+	A.second *= B.second;
+}
+
+// add two fractions together without losing information; A is assumed to have the larger dividend & divisor
+pair<int,int> AddFractions(pair<int,int>& A, pair<int,int>& B)
+{
+	AddFractionToReference(A, B);
+	return A;
+}
+
+// add a list of fractions together (separated numerators and denominators)
+pair<int,int> AddFractions(vector<int>& aDividendList, vector<int>& aDivisorList)
+{
+	CvAssert(aDividendList.size() == aDivisorList.size());
+
+	pair<int,int> result = make_pair(0, 1);
+
+	for (size_t jJ = 0, jlen = aDividendList.size(); jJ < jlen; ++jJ)
+	{
+		AddFractionToReference(result, make_pair(aDividendList[jJ], aDivisorList[jJ]));
+	}
+	return result;
+}
 #endif

--- a/CvGameCoreDLL_Expansion2/CvGameCoreUtils.h
+++ b/CvGameCoreDLL_Expansion2/CvGameCoreUtils.h
@@ -461,4 +461,8 @@ T PseudoRandomChoiceByWeight(vector<OptionWithScore<T>>& candidates, const T& de
 	return defaultChoice;
 }
 
+void AddFractionToReference(pair<int,int>& A, const pair<int,int>& B);
+pair<int,int> AddFractions(pair<int,int>& A, pair<int,int>& B);
+pair<int,int> AddFractions(vector<int>& dividendList, vector<int>& divisorList);
+
 #endif

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -23543,14 +23543,14 @@ int CvPlayer::TestCapitalsToVotes(int iChange)
 }
 
 //	--------------------------------------------------------------------------------
-/// Extra league votes from DoF
+/// Extra league votes from Declarations of Friendship
 int CvPlayer::GetDoFToVotes() const
 {
 	return m_iDoFToVotes;
 }
 
 //	--------------------------------------------------------------------------------
-/// Extra league votes from DoF
+/// Extra league votes from Declarations of Friendship
 void CvPlayer::ChangeDoFToVotes(int iChange)
 {
 	m_iDoFToVotes = iChange;
@@ -23562,7 +23562,7 @@ void CvPlayer::ChangeDoFToVotes(int iChange)
 }
 
 //	--------------------------------------------------------------------------------
-/// Extra league votes from DoF
+/// Extra league votes from Declarations of Friendship
 int CvPlayer::TestDoFToVotes(int iChange)
 {
 	int iDoFToVotes = 0;
@@ -23577,14 +23577,14 @@ int CvPlayer::TestDoFToVotes(int iChange)
 }
 
 //	--------------------------------------------------------------------------------
-/// Extra league votes from RA
+/// Extra league votes from Research Agreements
 int CvPlayer::GetRAToVotes() const
 {
 	return m_iRAToVotes;
 }
 
 //	--------------------------------------------------------------------------------
-/// Extra league votes from RA
+/// Extra league votes from Research Agreements
 void CvPlayer::ChangeRAToVotes(int iChange)
 {
 	m_iRAToVotes = iChange;
@@ -23596,7 +23596,7 @@ void CvPlayer::ChangeRAToVotes(int iChange)
 }
 
 //	--------------------------------------------------------------------------------
-/// Extra league votes from RA
+/// Extra league votes from Research Agreements
 int CvPlayer::TestRAToVotes(int iChange)
 {
 	int iRAToVotes = 0;
@@ -23609,14 +23609,14 @@ int CvPlayer::TestRAToVotes(int iChange)
 	return iRAToVotes;
 }
 //	--------------------------------------------------------------------------------
-/// Extra league votes from RA
+/// Extra league votes from Defense Pacts
 int CvPlayer::GetDefensePactsToVotes() const
 {
 	return m_iDefensePactsToVotes;
 }
 
 //	--------------------------------------------------------------------------------
-/// Extra league votes from RA
+/// Extra league votes from Defense Pacts
 void CvPlayer::ChangeDefensePactsToVotes(int iChange)
 {
 	m_iDefensePactsToVotes = iChange;
@@ -23644,6 +23644,57 @@ int CvPlayer::TestDefensePactsToVotes(int iChange)
 	}
 	
 	return iDefensePactsToVotes;
+}
+
+/// Extra league votes from Religion
+int CvPlayer::GetReligionVotes() const
+{
+	int iVotes = 0;
+	const CvReligion* pReligion = GC.getGame().GetGameReligions()->GetReligion(GetReligions()->GetStateReligion(false), m_eID);
+	if (pReligion)
+	{
+		iVotes += CalculateReligionExtraVotes(pReligion);
+
+		iVotes += CalculateReligionVotesFromImprovements(pReligion);
+	}
+	return iVotes;
+}
+// Religion gives extra votes based on the number of Minor Civs
+int CvPlayer::CalculateReligionExtraVotes(const CvReligion *pReligion) const
+{
+	int iExtraVotes = pReligion->m_Beliefs.GetExtraVotes(m_eID);
+	if (iExtraVotes > 0)
+	{
+		int iNumMinor = (GC.getGame().GetNumMinorCivsEver(true) / 8);
+		if (iNumMinor > 0)
+		{
+			return (iExtraVotes * iNumMinor);
+		}
+	}
+	return 0;
+}
+
+// Religion gives extra votes based on the number of certain improvements
+int CvPlayer::CalculateReligionVotesFromImprovements(const CvReligion *pReligion) const
+{
+	int iNumImprovementInfos = GC.getNumImprovementInfos();
+	
+	std::pair<int, int> fTotalVotes = std::make_pair(0, 1);
+	
+	for (int jJ = 0; jJ < iNumImprovementInfos; jJ++)
+	{
+		int iNumImprovements = getImprovementCount((ImprovementTypes)jJ); // less expensive function call
+		if (iNumImprovements > 0)
+		{
+			// number of votes per improvement (a fraction less than one)
+			std::pair<int, int> fPotentialVotes = pReligion->m_Beliefs.GetVoteFromOwnedImprovement((ImprovementTypes)jJ, m_eID); // more likely to be zero
+			if (fPotentialVotes.first > 0)
+			{
+				AddFractionToReference(fTotalVotes, std::make_pair(iNumImprovements * fPotentialVotes.first, fPotentialVotes.second));
+			}
+		}
+	}
+	return fTotalVotes.first / fTotalVotes.second;
 }
 
 //	--------------------------------------------------------------------------------
@@ -39271,7 +39322,7 @@ void CvPlayer::changeFreeBuildingCount(BuildingTypes eIndex, int iChange)
 }
 
 //	--------------------------------------------------------------------------------
-/// Is ePromotion a free promotion?
+/// How many sources have added ePromotion as a free promotion?
 int CvPlayer::GetFreePromotionCount(PromotionTypes ePromotion) const
 {
 	CvAssertMsg(ePromotion >= 0, "ePromotion is expected to be non-negative (invalid Index)");
@@ -39287,7 +39338,7 @@ bool CvPlayer::IsFreePromotion(PromotionTypes ePromotion)	const
 }
 
 //	--------------------------------------------------------------------------------
-/// Is ePromotion a free promotion?
+/// Add another source of ePromotion to the free promotion list
 void CvPlayer::ChangeFreePromotionCount(PromotionTypes ePromotion, int iChange)
 {
 	CvAssertMsg(ePromotion >= 0, "ePromotion is expected to be non-negative (invalid Index)");

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -408,6 +408,7 @@ CvPlayer::CvPlayer() :
 	, m_paiResourcesSiphoned()
 	, m_aiNumResourceFromGP()
 	, m_paiImprovementCount()
+	, m_paiImprovementBuiltCount()
 #if defined(MOD_BALANCE_CORE)
 	, m_paiTotalImprovementsBuilt()
 #endif
@@ -1109,6 +1110,7 @@ void CvPlayer::uninit()
 	m_paiResourcesSiphoned.clear();
 	m_aiNumResourceFromGP.clear();
 	m_paiImprovementCount.clear();
+	m_paiImprovementBuiltCount.clear();
 #if defined(MOD_BALANCE_CORE)
 	m_paiTotalImprovementsBuilt.clear();
 #endif
@@ -2012,9 +2014,9 @@ void CvPlayer::reset(PlayerTypes eID, bool bConstructorCall)
 		CvAssertMsg(0 < GC.getNumImprovementInfos(), "GC.getNumImprovementInfos() is not greater than zero but it is used to allocate memory in CvPlayer::reset");
 		m_paiImprovementCount.clear();
 		m_paiImprovementCount.resize(GC.getNumImprovementInfos(), 0);
-
+		m_paiImprovementBuiltCount.clear();
+		m_paiImprovementBuiltCount.resize(GC.getNumImprovementInfos(), 0);
 #if defined(MOD_BALANCE_CORE)
-		CvAssertMsg(0 < GC.getNumImprovementInfos(), "GC.getNumImprovementInfos() is not greater than zero but it is used to allocate memory in CvPlayer::reset");
 		m_paiTotalImprovementsBuilt.clear();
 		m_paiTotalImprovementsBuilt.resize(GC.getNumImprovementInfos(), 0);
 #endif
@@ -39085,21 +39087,31 @@ void CvPlayer::changeTotalImprovementsBuilt(int iChange)
 
 
 //	--------------------------------------------------------------------------------
-int CvPlayer::getImprovementCount(ImprovementTypes eIndex) const
+int CvPlayer::getImprovementCount(ImprovementTypes eIndex, bool bBuiltOnly) const
 {
 	CvAssertMsg(eIndex >= 0, "eIndex is expected to be non-negative (invalid Index)");
 	CvAssertMsg(eIndex < GC.getNumImprovementInfos(), "eIndex is expected to be within maximum bounds (invalid Index)");
-	return m_paiImprovementCount[eIndex];
+	if (bBuiltOnly)
+		return m_paiImprovementBuiltCount[eIndex];
+	else
+		return m_paiImprovementCount[eIndex];
 }
 
 
 //	--------------------------------------------------------------------------------
-void CvPlayer::changeImprovementCount(ImprovementTypes eIndex, int iChange)
+void CvPlayer::changeImprovementCount(ImprovementTypes eIndex, int iChange, bool bBuilt)
 {
 	CvAssertMsg(eIndex >= 0, "eIndex is expected to be non-negative (invalid Index)");
 	CvAssertMsg(eIndex < GC.getNumImprovementInfos(), "eIndex is expected to be within maximum bounds (invalid Index)");
-	m_paiImprovementCount[eIndex] = m_paiImprovementCount[eIndex] + iChange;
+	
+	m_paiImprovementCount[eIndex] += iChange;
 	CvAssert(getImprovementCount(eIndex) >= 0);
+
+	if (bBuilt)
+	{
+		m_paiImprovementBuiltCount[eIndex] += iChange;
+		CvAssert(getImprovementCount(eIndex, true) >= 0);
+	}
 }
 
 #if defined(MOD_BALANCE_CORE)
@@ -46446,6 +46458,7 @@ void CvPlayer::Serialize(Player& player, Visitor& visitor)
 	visitor(player.m_paiResourcesSiphoned);
 	visitor(player.m_aiNumResourceFromGP);
 	visitor(player.m_paiImprovementCount);
+	visitor(player.m_paiImprovementBuiltCount);
 	visitor(player.m_paiTotalImprovementsBuilt);
 	visitor(player.m_paiBuildingChainSteps);
 	visitor(player.m_paiFreeBuildingCount);

--- a/CvGameCoreDLL_Expansion2/CvPlayer.h
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.h
@@ -802,6 +802,10 @@ public:
 	void ChangeDefensePactsToVotes(int iChange);
 	int TestDefensePactsToVotes(int iChange);
 
+	int GetReligionVotes() const;
+	int CalculateReligionExtraVotes(const CvReligion *pReligion) const;
+	int CalculateReligionVotesFromImprovements(const CvReligion *pReligion) const;
+
 	int GetGPExpendInfluence() const;
 	void ChangeGPExpendInfluence(int iChange);
 	

--- a/CvGameCoreDLL_Expansion2/CvPlayer.h
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.h
@@ -1,5 +1,5 @@
 /*	-------------------------------------------------------------------------------------------------------
-	© 1991-2012 Take-Two Interactive Software and its subsidiaries.  Developed by Firaxis Games.  
+	Â© 1991-2012 Take-Two Interactive Software and its subsidiaries.  Developed by Firaxis Games.  
 	Sid Meier's Civilization V, Civ, Civilization, 2K Games, Firaxis Games, Take-Two Interactive Software 
 	and their respective logos are all trademarks of Take-Two interactive Software, Inc.  
 	All other marks and trademarks are the property of their respective owners.  
@@ -2191,8 +2191,8 @@ public:
 
 	int getTotalImprovementsBuilt() const;
 	void changeTotalImprovementsBuilt(int iChange);
-	int getImprovementCount(ImprovementTypes eIndex) const;
-	void changeImprovementCount(ImprovementTypes eIndex, int iChange);
+	int getImprovementCount(ImprovementTypes eIndex, bool bBuiltOnly = false) const;
+	void changeImprovementCount(ImprovementTypes eIndex, int iChange, bool bBuilt = false);
 
 #if defined(MOD_BALANCE_CORE)
 	int getTotalImprovementsBuilt(ImprovementTypes eIndex) const;
@@ -3537,6 +3537,7 @@ protected:
 	std::vector<int> m_paiResourcesSiphoned;
 	std::vector<byte> m_aiNumResourceFromGP;
 	std::vector<int> m_paiImprovementCount;
+	std::vector<int> m_paiImprovementBuiltCount;
 #if defined(MOD_BALANCE_CORE)
 	std::vector<int> m_paiTotalImprovementsBuilt;
 #endif
@@ -4297,6 +4298,7 @@ SYNC_ARCHIVE_VAR(std::vector<int>, m_paiResourceFromMinors)
 SYNC_ARCHIVE_VAR(std::vector<int>, m_paiResourcesSiphoned)
 SYNC_ARCHIVE_VAR(std::vector<byte>, m_aiNumResourceFromGP)
 SYNC_ARCHIVE_VAR(std::vector<int>, m_paiImprovementCount)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiImprovementBuiltCount)
 SYNC_ARCHIVE_VAR(std::vector<int>, m_paiTotalImprovementsBuilt)
 SYNC_ARCHIVE_VAR(std::vector<int>, m_paiBuildingChainSteps)
 SYNC_ARCHIVE_VAR(std::vector<int>, m_paiFreeBuildingCount)

--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -14321,27 +14321,19 @@ bool CvPlot::IsAdjacentToUnitPromotion(PlayerTypes ePlayer, PromotionTypes eUnit
 				pLoopUnit = pLoopPlot->getUnitByIndex(iI);
 				if(pLoopUnit != NULL)
 				{
-					for(int iPromotionLoop = 0; iPromotionLoop < GC.getNumPromotionInfos(); iPromotionLoop++)
+					if(pLoopUnit->isHasPromotion(eUnitPromotion))
 					{
-						const PromotionTypes ePromotion = (PromotionTypes) iPromotionLoop;
-						CvPromotionEntry* pkPromotionInfo = GC.getPromotionInfo(ePromotion);
-						if(pkPromotionInfo)
+						if(bIsFriendly && GET_PLAYER(pLoopUnit->getOwner()).getTeam() == GET_PLAYER(ePlayer).getTeam())
 						{
-							if(pLoopUnit->isHasPromotion(ePromotion) && ePromotion == eUnitPromotion)
-							{
-								if(bIsFriendly && GET_PLAYER(pLoopUnit->getOwner()).getTeam() == GET_PLAYER(ePlayer).getTeam())
-								{
-									return true;
-								}
-								else if(bIsEnemy && GET_TEAM(GET_PLAYER(pLoopUnit->getOwner()).getTeam()).isAtWar(GET_PLAYER(ePlayer).getTeam()))
-								{
-									return true;
-								}
-								else if(!bIsFriendly && !bIsEnemy)
-								{
-									return true;
-								}
-							}
+							return true;
+						}
+						else if(bIsEnemy && GET_TEAM(GET_PLAYER(pLoopUnit->getOwner()).getTeam()).isAtWar(GET_PLAYER(ePlayer).getTeam()))
+						{
+							return true;
+						}
+						else if(!bIsFriendly && !bIsEnemy)
+						{
+							return true;
 						}
 					}
 				}

--- a/CvGameCoreDLL_Expansion2/CvReligionClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvReligionClasses.cpp
@@ -9554,14 +9554,6 @@ int CvReligionAI::ScoreBeliefForPlayer(CvBeliefEntry* pEntry, bool bReturnConque
 			}
 		}
 
-		for (int iJ = 0; iJ < GC.getNumImprovementInfos(); iJ++)
-		{
-			if (pEntry->GetImprovementVoteChange((ImprovementTypes)iJ) > 0)
-			{
-				iDiploTemp += (pEntry->GetImprovementVoteChange((ImprovementTypes)iJ) * max(5, m_pPlayer->CountAllImprovement((ImprovementTypes)iJ)));
-			}
-		}
-
 		iDiploTemp += (pEntry->GetCityStateMinimumInfluence() * GC.getGame().GetNumMinorCivsAlive()) / 10;
 
 		iDiploTemp += pEntry->GetHappinessFromForeignSpies() * max(2, m_pPlayer->GetEspionage()->GetNumSpies() * 25);

--- a/CvGameCoreDLL_Expansion2/CvReligionClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvReligionClasses.cpp
@@ -9609,16 +9609,18 @@ int CvReligionAI::ScoreBeliefForPlayer(CvBeliefEntry* pEntry, bool bReturnConque
 		}
 
 		int iNumImprovementInfos = GC.getNumImprovementInfos();
+		pair<int, int> fVoteRatio = make_pair(0, 1);
 		for (int jJ = 0; jJ < iNumImprovementInfos; jJ++)
 		{
 			int potentialVotes = pEntry->GetImprovementVoteChange((ImprovementTypes)jJ);
 			if (potentialVotes > 0)
 			{
-				int numImprovements = m_pPlayer->getImprovementCount((ImprovementTypes)jJ);
-				iDiploTemp += potentialVotes * (max(1, numImprovements) * 20);
+				int numImprovements = max(m_pPlayer->getImprovementCount((ImprovementTypes)jJ), 1);
+				AddFractionToReference(fVoteRatio, make_pair(numImprovements, potentialVotes));
 			}
 		}
-
+		iDiploTemp += 80 * fVoteRatio.first / fVoteRatio.second;
+		
 		if (pEntry->GetCityStateInfluenceModifier() > 0)
 		{
 			iDiploTemp += (pEntry->GetCityStateInfluenceModifier() * m_pPlayer->GetNumCSFriends()) / 2;

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -16530,45 +16530,40 @@ int CvUnit::GetMaxRangedCombatStrength(const CvUnit* pOtherUnit, const CvCity* p
 		iModifier += GetUnhappinessCombatPenalty();
 	}
 
-	// Siege bonus
-	if (bAttacking)
-	{
-		iModifier += GetNearbyCityBonusCombatMod(pMyPlot);
-	}
-
-	// Great General nearby
-	if (!bIgnoreUnitAdjacencyBoni && !IsIgnoreGreatGeneralBenefit())
-	{
-		iModifier += kPlayer.GetAreaEffectModifier(AE_GREAT_GENERAL, getDomainType(), pMyPlot);
-	}
-
-	if (!bIgnoreUnitAdjacencyBoni && GetAdjacentModifier() != 0)
-	{
-		// Adjacent Friendly military Unit?
-		if (pMyPlot->IsFriendlyUnitAdjacent(getTeam(), /*bCombatUnit*/ true))
-		{
-			iModifier += GetAdjacentModifier();
-			for (int iI = 0; iI < GC.getNumUnitCombatClassInfos(); iI++) // Stuff for per adjacent unit combat
-			{
-				const UnitCombatTypes eUnitCombat = static_cast<UnitCombatTypes>(iI);
-				int iModPerAdjacent = getCombatModPerAdjacentUnitCombatModifier(eUnitCombat);
-				if (iModPerAdjacent != 0)
-				{
-					int iNumFriendliesAdjacent = pMyPlot->GetNumSpecificFriendlyUnitCombatsAdjacent(getTeam(), eUnitCombat, NULL);
-					iModifier += (iNumFriendliesAdjacent * iModPerAdjacent);
-				}
-			}
-		}
-	}
-
 	// sometimes we want to ignore the finer points
 	if (!bQuickAndDirty)
 	{
-		// Reverse Great General nearby
-		int iReverseGGModifier = GetReverseGreatGeneralModifier(pMyPlot);
-		if (iReverseGGModifier != 0)
+		if (!bIgnoreUnitAdjacencyBoni)
 		{
-			iModifier += iReverseGGModifier;
+			// Adjacent Friendly military Unit?
+			if (pMyPlot->IsFriendlyUnitAdjacent(getTeam(), /*bCombatUnit*/ true))
+			{
+				iModifier += GetAdjacentModifier();
+				for (int iI = 0; iI < GC.getNumUnitCombatClassInfos(); iI++) // Stuff for per adjacent unit combat
+				{
+					const UnitCombatTypes eUnitCombat = static_cast<UnitCombatTypes>(iI);
+					int iModPerAdjacent = getCombatModPerAdjacentUnitCombatModifier(eUnitCombat);
+					iModPerAdjacent += bAttacking ? getCombatModPerAdjacentUnitCombatAttackMod(eUnitCombat) : getCombatModPerAdjacentUnitCombatDefenseMod(eUnitCombat);
+					if (iModPerAdjacent != 0)
+					{
+						int iNumFriendliesAdjacent = pMyPlot->GetNumSpecificFriendlyUnitCombatsAdjacent(getTeam(), eUnitCombat, NULL);
+						iModifier += (iNumFriendliesAdjacent * iModPerAdjacent);
+					}
+				}
+			}
+
+			// Great General nearby
+			if (!IsIgnoreGreatGeneralBenefit())
+			{
+				iModifier += kPlayer.GetAreaEffectModifier(AE_GREAT_GENERAL, getDomainType(), pMyPlot);
+			}
+
+			// Reverse Great General nearby
+			int iReverseGGModifier = GetReverseGreatGeneralModifier(pMyPlot);
+			if (iReverseGGModifier != 0)
+			{
+				iModifier += iReverseGGModifier;
+			}
 		}
 
 		// Improvement with combat bonus (from trait) nearby
@@ -16824,6 +16819,7 @@ int CvUnit::GetMaxRangedCombatStrength(const CvUnit* pOtherUnit, const CvCity* p
 	// Ranged attack mod
 	if(bAttacking)
 	{
+		iModifier += GetNearbyCityBonusCombatMod(pMyPlot);
 		iModifier += GetRangedAttackModifier();
 		iModifier += getAttackModifier();
 	}

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -11677,7 +11677,7 @@ int CvUnit::GetScaleAmount(int iAmountToScale) const
 		if (iScaleAmount <= 0)
 			continue;
 
-		int iOwned = GET_PLAYER(getOwner()).CountAllImprovement(eImprovement, true);
+		int iOwned = GET_PLAYER(getOwner()).getImprovementCount(eImprovement, true);
 		iExtra = (iOwned * iScaleAmount) * iAmountToScale;
 		iExtra /= 100;
 
@@ -11705,7 +11705,7 @@ int CvUnit::getDiscoverAmount()
 			iValue = pPlayer->getYieldPerTurnHistory(YIELD_SCIENCE, iPreviousTurnsToCount);
 
 #if defined(MOD_BALANCE_CORE_NEW_GP_ATTRIBUTES)
-			//Let's make the GM a little more flexible.
+			//Let's make the GS a little more flexible.
 			if (MOD_BALANCE_CORE_NEW_GP_ATTRIBUTES)
 			{
 				//scale up our value
@@ -12225,18 +12225,13 @@ bool CvUnit::trade()
 		if(m_pUnitInfo->GetNumGoldPerEra() > 0)
 		{
 			int iCap = 5;
-#if defined(MOD_BALANCE_CORE_NEW_GP_ATTRIBUTES)
 			//Let's make the GM a little more flexible.
-			if (MOD_BALANCE_CORE_NEW_GP_ATTRIBUTES)
-			{
-				iCap = GetScaleAmount(iCap);
-			}
-#endif
+			iCap = GetScaleAmount(iCap);
 			iCap *= GC.getGame().getGameSpeedInfo().getInstantYieldPercent();
 			iCap /= 100;
+
 			CvCity* pLoopCity;
 			int iCityLoop;
-
 			// Loop through owner's cities.
 			for(pLoopCity = GET_PLAYER(getOwner()).firstCity(&iCityLoop); pLoopCity != NULL; pLoopCity = GET_PLAYER(getOwner()).nextCity(&iCityLoop))
 			{

--- a/CvGameCoreDLL_Expansion2/CvUnit.h
+++ b/CvGameCoreDLL_Expansion2/CvUnit.h
@@ -1,5 +1,5 @@
 /*	-------------------------------------------------------------------------------------------------------
-	© 1991-2012 Take-Two Interactive Software and its subsidiaries.  Developed by Firaxis Games.  
+	Â© 1991-2012 Take-Two Interactive Software and its subsidiaries.  Developed by Firaxis Games.  
 	Sid Meier's Civilization V, Civ, Civilization, 2K Games, Firaxis Games, Take-Two Interactive Software 
 	and their respective logos are all trademarks of Take-Two interactive Software, Inc.  
 	All other marks and trademarks are the property of their respective owners.  

--- a/CvGameCoreDLL_Expansion2/CvUnit.h
+++ b/CvGameCoreDLL_Expansion2/CvUnit.h
@@ -1486,7 +1486,7 @@ public:
 	int getDropRange() const;
 	void changeDropRange(int iChange);
 
-	bool isOutOfAttacks() const;
+	bool isOutOfAttacks(bool bIgnoreMoves = false) const;
 	void setMadeAttack(bool bNewValue);
 
 	int GetNumInterceptions() const;

--- a/CvGameCoreDLL_Expansion2/CvVotingClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvVotingClasses.cpp
@@ -4286,50 +4286,11 @@ int CvLeague::CalculateStartingVotesForMember(PlayerTypes ePlayer, bool bFakeUN,
 	int iReligionVotes = 0;
 	if (!GC.getGame().isOption(GAMEOPTION_NO_RELIGION))
 	{
-		ReligionTypes eReligion = GET_PLAYER(ePlayer).GetReligions()->GetOwnedReligion();
-		bool bOwned = eReligion != NO_RELIGION;
-		if (!bOwned)
-		{
-			eReligion = GET_PLAYER(ePlayer).GetReligions()->GetStateReligion(false);
-		}
-		if (eReligion != NO_RELIGION)
-		{
-			const CvReligion* pReligion = GC.getGame().GetGameReligions()->GetReligion(eReligion, ePlayer);
-			if (pReligion)
-			{
-				CvCity* pHolyCity = bOwned ? pReligion->GetHolyCity() : GET_PLAYER(ePlayer).getCapitalCity();
-				if (pHolyCity != NULL)
-				{
-					int iExtraVotes = pReligion->m_Beliefs.GetExtraVotes(ePlayer, pHolyCity, true);
-					if (iExtraVotes > 0)
-					{
-						int iNumMinor = (GC.getGame().GetNumMinorCivsEver(true) / 8);
-						if (iNumMinor > 0)
-						{
-							iReligionVotes = (iExtraVotes * iNumMinor);
-						}
-						iVotes += iReligionVotes;
-					}
-
-					int iNumImprovementInfos = GC.getNumImprovementInfos();
-					for (int jJ = 0; jJ < iNumImprovementInfos; jJ++)
-					{
-						int iPotentialVotes = pReligion->m_Beliefs.GetVoteFromOwnedImprovement((ImprovementTypes)jJ);
-						if (iPotentialVotes > 0)
-						{
-							int numImprovements = GET_PLAYER(ePlayer).getImprovementCount((ImprovementTypes)jJ);
-							int iTempVotes = numImprovements / iPotentialVotes;
-							iReligionVotes += iTempVotes;
-							iVotes += iTempVotes;
-						}
-					}
-				}
-			}
-		}
+		iReligionVotes += GET_PLAYER(ePlayer).GetReligionVotes();
+		iVotes += iReligionVotes;
 	}
 
 	int iPolicyVotes = 0;
-
 	iPolicyVotes = GET_PLAYER(ePlayer).GetFreeWCVotes();
 	if (iPolicyVotes > 0)
 	{


### PR DESCRIPTION
Spend less time calculating, more time playing!

balance changes:
- Improvements that scale GEMS expend abilities + Transnationalism Franchises no longer need to be within workable distance of an owned city (still needs to be in owned territory and built by the player).
- The Holy Land reformation belief now works for any combination of 2 Holy Sites and Landmarks (instead of requiring exactly 2 Holy Sites or 2 Landmarks).
- Combat Strength PER UnitCombat modifiers from Promotions should now work for all Ranged Units.