### PR TITLE
 Fix to wonders disappearing from automated city lists

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -8817,8 +8817,8 @@ bool CvCity::canConstruct(BuildingTypes eBuilding, const std::vector<int>& vPreE
 		return false;
 	}
 
-	//no wonders in puppets or automated cities (also affects venice)
-	if (IsPuppet() || isHumanAutomated())
+	//no wonders in puppets (also affects venice)
+	if (IsPuppet())
 	{
 		if (isWorldWonderClass(pkBuildingInfo->GetBuildingClassInfo()) || isNationalWonderClass(pkBuildingInfo->GetBuildingClassInfo()))
 		{

--- a/CvGameCoreDLL_Expansion2/CvCityStrategyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCityStrategyAI.cpp
@@ -833,6 +833,12 @@ void CvCityStrategyAI::ChooseProduction(BuildingTypes eIgnoreBldg, UnitTypes eIg
 				if (pkBuildingInfo->GetGoldMaintenance() > 0 && GET_PLAYER(m_pCity->getOwner()).GetEconomicAI()->IsUsingStrategy(eStrategyLosingMoney))
 					continue;
 			}
+
+		// no wonders in automated human cities
+			const CvBuildingClassInfo& kBuildingClassInfo = pkBuildingInfo->GetBuildingClassInfo();
+			if (isWorldWonderClass(kBuildingClassInfo) || isTeamWonderClass(kBuildingClassInfo) || isNationalWonderClass(kBuildingClassInfo) || isLimitedWonderClass(kBuildingClassInfo))
+				continue;
+
 		}
 
 		// Make sure this building can be built now


### PR DESCRIPTION
Moved the check from CvCity to CvCityStrategy, so wonders will appear on the lists but won't be picked by the AI governor