### PR TITLE
Remove default unit name when unit has custom name

### DIFF
--- a/(3a) EUI Compatibility Files/LUA/UnitPanel.lua
+++ b/(3a) EUI Compatibility Files/LUA/UnitPanel.lua
@@ -1167,7 +1167,7 @@ local nullOffset = { x=0, y=0 }
 local function UpdateUnitPortrait( unit )
 
 	local name
-	if unit:IsGreatPerson() then
+	if unit:HasName() or unit:IsGreatPerson() then
 		name = unit:GetNameNoDesc()
 		if not name or #name == 0 then
 			name = unit:GetName()


### PR DESCRIPTION
Currently, if the name of a unit is edited the normal name of the unit still appears in parentheses, such as:

SCREAMING EAGLES (PARATROOPER)

This change makes it appear as:

SCREAMING EAGLES

This is the same change I make every time I download a new version