### PR TITLE
ATTRITION, CIVILIANS_RETREAT_WITH_MILITARY modmods

### DIFF
--- a/(1) Community Patch/Core Files/Core Tables/CustomModOptions.xml
+++ b/(1) Community Patch/Core Files/Core Tables/CustomModOptions.xml
@@ -445,6 +445,8 @@
    <Row Class="4" Name="ADJACENT_BLOCKADE" Value="0"/>
     <!-- Units take damage when moving through enemy lands -->
    <Row Class="4" Name="ATTRITION" Value="0"/>
+    <!-- When a military unit retreats, civilians units on the same tile also retreat -->
+   <Row Class="4" Name="CIVILIANS_RETREAT_WITH_MILITARY" Value="0"/>
 	  
     <!-- Events sent when terraforming occurs (v33) -->
     <!--   GameEvents.TerraformingMap.Add(function(iEvent, iLoad) end) -->

--- a/(1) Community Patch/Core Files/Core Tables/CustomModOptions.xml
+++ b/(1) Community Patch/Core Files/Core Tables/CustomModOptions.xml
@@ -443,6 +443,8 @@
     <Row Class="5" Name="AI_UNIT_PRODUCTION" Value="0"/>
     <!-- Land units blockade undefended adjacent tiles -->
    <Row Class="4" Name="ADJACENT_BLOCKADE" Value="0"/>
+    <!-- Units take damage when moving through enemy lands -->
+   <Row Class="4" Name="ATTRITION" Value="0"/>
 	  
     <!-- Events sent when terraforming occurs (v33) -->
     <!--   GameEvents.TerraformingMap.Add(function(iEvent, iLoad) end) -->

--- a/CvGameCoreDLL_Expansion2/CustomMods.cpp
+++ b/CvGameCoreDLL_Expansion2/CustomMods.cpp
@@ -558,6 +558,7 @@ int CustomMods::getOption(string sOption, int defValue) {
 
 		MOD_OPT_CACHE(AI_UNIT_PRODUCTION);
 		MOD_OPT_CACHE(ADJACENT_BLOCKADE);
+		MOD_OPT_CACHE(ATTRITION);
 
 		m_bInit = true;
 	}

--- a/CvGameCoreDLL_Expansion2/CustomMods.cpp
+++ b/CvGameCoreDLL_Expansion2/CustomMods.cpp
@@ -559,7 +559,8 @@ int CustomMods::getOption(string sOption, int defValue) {
 		MOD_OPT_CACHE(AI_UNIT_PRODUCTION);
 		MOD_OPT_CACHE(ADJACENT_BLOCKADE);
 		MOD_OPT_CACHE(ATTRITION);
-
+		MOD_OPT_CACHE(CIVILIANS_RETREAT_WITH_MILITARY);
+		
 		m_bInit = true;
 	}
 

--- a/CvGameCoreDLL_Expansion2/CustomMods.h
+++ b/CvGameCoreDLL_Expansion2/CustomMods.h
@@ -465,7 +465,8 @@
 #define MOD_ADJACENT_BLOCKADE						gCustomMods.isADJACENT_BLOCKADE()
 // Units take damage in enemy lands
 #define MOD_ATTRITION								gCustomMods.isATTRITION()
-
+// When a military unit retreats, civilians units on the same tile also retreat
+#define MOD_CIVILIANS_RETREAT_WITH_MILITARY			gCustomMods.isCIVILIANS_RETREAT_WITH_MILITARY()
 
 //
 //	 GameEvents.TradeRouteCompleted.Add(function( iOriginOwner, iOriginCity, iDestOwner, iDestCity, eDomain, eConnectionTradeType) end)
@@ -1538,6 +1539,7 @@ public:
 	MOD_OPT_DECL(AI_UNIT_PRODUCTION);
 	MOD_OPT_DECL(ADJACENT_BLOCKADE);
 	MOD_OPT_DECL(ATTRITION);
+	MOD_OPT_DECL(CIVILIANS_RETREAT_WITH_MILITARY);
 
 protected:
 	bool m_bInit;

--- a/CvGameCoreDLL_Expansion2/CustomMods.h
+++ b/CvGameCoreDLL_Expansion2/CustomMods.h
@@ -463,6 +463,8 @@
 
 // Land units blockade undefended adjacent tiles
 #define MOD_ADJACENT_BLOCKADE						gCustomMods.isADJACENT_BLOCKADE()
+// Units take damage in enemy lands
+#define MOD_ATTRITION								gCustomMods.isATTRITION()
 
 
 //
@@ -1535,7 +1537,8 @@ public:
 
 	MOD_OPT_DECL(AI_UNIT_PRODUCTION);
 	MOD_OPT_DECL(ADJACENT_BLOCKADE);
-	
+	MOD_OPT_DECL(ATTRITION);
+
 protected:
 	bool m_bInit;
 	std::map<std::string, int> m_options;

--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -4088,7 +4088,6 @@ bool CvPlot::isFortification(TeamTypes eDefenderTeam) const
 	if (isCity())
 		return true;
 
-#if defined(MOD_GLOBAL_NO_FOLLOWUP_FROM_CITIES)
 	if (MOD_GLOBAL_NO_FOLLOWUP_FROM_CITIES)
 	{
 		// If the attacker is in a fort or citadel or other improvement with NoFollowUp, don't advance
@@ -4100,7 +4099,6 @@ bool CvPlot::isFortification(TeamTypes eDefenderTeam) const
 				return true;
 		}
 	}
-#endif
 
 	return false;
 }

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -1219,7 +1219,7 @@ void CvUnit::initWithNameOffset(int iID, UnitTypes eUnit, int iNameOffset, UnitA
 		{
 			GET_PLAYER(getOwner()).doInstantYield(INSTANT_YIELD_TYPE_GP_BORN, false, eGreatPerson, NO_BUILDING, 0, true, NO_PLAYER, NULL, false, GET_PLAYER(getOwner()).getCapitalCity());
 		}
-		GET_PLAYER(getOwner()).doInstantGWAM(eGreatPerson, getUnitName());
+		GET_PLAYER(getOwner()).doInstantGWAM(eGreatPerson, getGreatName());
 	}
 #endif
 	// Update UI
@@ -8042,7 +8042,7 @@ void CvUnit::DoAttrition()
 
 	if (!pPlot->IsFriendlyTerritory(getOwner()))
 	{
-		if (MOD_ATTRITION && !isBarbarian() && isEnemy(pPlot->getTeam(), pPlot) && (GC.getGame().getGameTurn() - getLastMoveTurn() < 2) && !isHasPromotion((PromotionTypes)GC.getInfoTypeForString("PROMOTION_ATTRITION_IMMUNITY", true)))
+		if (MOD_ATTRITION && !isBarbarian() && !IsCivilianUnit() && isEnemy(pPlot->getTeam(), pPlot) && (GC.getGame().getGameTurn() - getLastMoveTurn() < 2) && !isHasPromotion((PromotionTypes)GC.getInfoTypeForString("PROMOTION_ATTRITION_IMMUNITY", true)))
 		{
 			strAppendText = GetLocalizedText("TXT_KEY_MISC_YOU_UNIT_WAS_DAMAGED_ATTRITION");
 			changeDamage(5, NO_PLAYER, 0.0, &strAppendText);
@@ -29984,9 +29984,27 @@ bool CvUnit::DoFallBack(const CvUnit& attacker)
 
 		if(pDestPlot && canMoveInto(*pDestPlot, MOVEFLAG_DESTINATION|MOVEFLAG_NO_EMBARK) && isNativeDomain(pDestPlot))
 		{
+
+			if (MOD_CIVILIANS_RETREAT_WITH_MILITARY) // civilian units also retreat
+			{
+				CvPlot* pUnitPlot = plot();
+				IDInfoVector currentUnits;
+				if (pUnitPlot->getUnits(&currentUnits) > 0)
+				{
+					for (IDInfoVector::const_iterator itr = currentUnits.begin(); itr != currentUnits.end(); ++itr)
+					{
+						CvUnit* pLoopUnit = (CvUnit*)GetPlayerUnit(*itr);
+
+						if (pLoopUnit)
+						{
+							pLoopUnit->setXY(pDestPlot->getX(), pDestPlot->getY(), true, true, true, true);
+						}
+					}
+				}
+			}
+
 			setXY(pDestPlot->getX(), pDestPlot->getY(), true, true, true, true);
 			PublishQueuedVisualizationMoves();
-
 			return true;
 		}
 	}

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -8042,6 +8042,12 @@ void CvUnit::DoAttrition()
 
 	if (!pPlot->IsFriendlyTerritory(getOwner()))
 	{
+		if (MOD_ATTRITION && !isBarbarian() && isEnemy(pPlot->getTeam(), pPlot) && (GC.getGame().getGameTurn() - getLastMoveTurn() < 2) && !isHasPromotion((PromotionTypes)GC.getInfoTypeForString("PROMOTION_ATTRITION_IMMUNITY", true)))
+		{
+			strAppendText = GetLocalizedText("TXT_KEY_MISC_YOU_UNIT_WAS_DAMAGED_ATTRITION");
+			changeDamage(5, NO_PLAYER, 0.0, &strAppendText);
+		}
+
 		if (isEnemy(pPlot->getTeam(), pPlot) && getEnemyDamageChance() > 0 && getEnemyDamage() > 0)
 		{
 			if (GC.getGame().getSmallFakeRandNum(100, *pPlot) < getEnemyDamageChance())
@@ -16253,8 +16259,12 @@ int CvUnit::GetMaxAttackStrength(const CvPlot* pFromPlot, const CvPlot* pToPlot,
 
 		//Heavy charge without escape
 		if (IsCanHeavyCharge() && !pDefender->CanFallBack(*this, false))
-			iModifier += 50;
-
+		{
+			if (MOD_ATTRITION)
+				iModifier += 25;
+			else
+				iModifier += 50;
+		}
 		//bonus for attacking same unit over and over in a turn?
 		int iTempModifier = getMultiAttackBonus() + GET_PLAYER(getOwner()).GetPlayerTraits()->GetMultipleAttackBonus();
 		if (iTempModifier != 0)

--- a/CvGameCoreDLL_Expansion2/CvUnitCombat.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnitCombat.cpp
@@ -620,7 +620,7 @@ void CvUnitCombat::ResolveMeleeCombat(const CvCombatInfo& kCombatInfo, uint uiPa
 			{
 				if (pkAttacker->IsCanHeavyCharge() && !pkDefender->isDelayedDeath() && bAttackerDidMoreDamage)
 				{
-					if (MOD_ATTRITION && pkDefender->plot()->isFortification(pkDefender->getTeam()))
+					if (MOD_ATTRITION && (pkDefender->plot()->isFortification(pkDefender->getTeam()) || pkDefender->plot()->HasBarbarianCamp()))
 					{ }
 					else
 						pkDefender->DoFallBack(*pkAttacker);

--- a/CvGameCoreDLL_Expansion2/CvUnitCombat.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnitCombat.cpp
@@ -620,7 +620,10 @@ void CvUnitCombat::ResolveMeleeCombat(const CvCombatInfo& kCombatInfo, uint uiPa
 			{
 				if (pkAttacker->IsCanHeavyCharge() && !pkDefender->isDelayedDeath() && bAttackerDidMoreDamage)
 				{
-					pkDefender->DoFallBack(*pkAttacker);
+					if (MOD_ATTRITION && pkDefender->plot()->isFortification(pkDefender->getTeam()))
+					{ }
+					else
+						pkDefender->DoFallBack(*pkAttacker);
 					//no notifications?
 				}
 


### PR DESCRIPTION
MOD_CIVILIANS_RETREAT_WITH_MILITARY: Makes civilians units retreat with the military units when the latter gets heavy charged, could also affect the cases where the defending unit withdraws but haven't specifically checked for that. Separated this into a different modmod in case VP decides to implement this.

MOD_ATTRITION: Units take 5 damage per turn if they move in enemy lands, barbarian units, civilian units, scouts and submarines are immune. Also modifies heavy charge.