### PR TITLE
Linked & Group movement, DLL functions

### DIFF
--- a/(2) Vox Populi/Core Files/CoreLua/WorldView.lua
+++ b/(2) Vox Populi/Core Files/CoreLua/WorldView.lua
@@ -116,8 +116,7 @@ function ShowMovementRangeIndicator()
 
 	if bAlt then 
 		print ("displaying linked movement range")
---		Events.ShowMovementRange( iPlayerID, unit:GetSlowestUnitIDOnPlot() );
-		Events.ShowMovementRange( iPlayerID, unit:GetID() );
+		Events.ShowMovementRange( iPlayerID, unit:GetSlowestUnitIDOnPlot() );
 	else
 		Events.ShowMovementRange( iPlayerID, unit:GetID() );
 	end
@@ -808,12 +807,10 @@ function MovementRButtonUp()
 			
 			elseif bAlt and not bCtrl and not bShift then
 			-- alt + rclick moves all units on the tile together / call normal movement thing for the unit, followed by DoLinkedMovement()
---				Game.SelectionListGameNetMessage(GameMessageTypes.GAMEMESSAGE_PUSH_MISSION, MissionTypes.MISSION_LINKED_MOVEMENT, plotX, plotY, 0, false, true);				
 				print("TRYING LINKED MOVEMENT")
 				pHeadSelectedUnit:DoLinkedMovement(plot)
 			elseif bAlt and bCtrl and not bShift then
 				-- alt + ctrl + rclick moves units adjacent to this tile in formation / call normal movement thing for the unit, followed by DoGroupMovement()
---				Game.SelectionListGameNetMessage(GameMessageTypes.GAMEMESSAGE_PUSH_MISSION, MissionTypes.MISSION_GROUP_MOVEMENT, plotX, plotY, 0, false, true);				
 				print("TRYING GROUP MOVEMENT")
 				pHeadSelectedUnit:DoGroupMovement(plot)
 			elseif bShift and not bCtrl and not bAlt then -- VP/bal: holding down shift queues move orders

--- a/(2) Vox Populi/Core Files/CoreLua/WorldView.lua
+++ b/(2) Vox Populi/Core Files/CoreLua/WorldView.lua
@@ -115,7 +115,7 @@ function ShowMovementRangeIndicator()
 	local iPlayerID = Game.GetActivePlayer();
 
 	if bAlt then 
-		print ("displaying linked movement range")
+--		print ("displaying linked movement range")
 		Events.ShowMovementRange( iPlayerID, unit:GetSlowestUnitIDOnPlot() );
 	else
 		Events.ShowMovementRange( iPlayerID, unit:GetID() );
@@ -807,11 +807,11 @@ function MovementRButtonUp()
 			
 			elseif bAlt and not bCtrl and not bShift then
 			-- alt + rclick moves all units on the tile together / call normal movement thing for the unit, followed by DoLinkedMovement()
-				print("TRYING LINKED MOVEMENT")
+--				print("TRYING LINKED MOVEMENT")
 				pHeadSelectedUnit:DoLinkedMovement(plot)
 			elseif bAlt and bCtrl and not bShift then
 				-- alt + ctrl + rclick moves units adjacent to this tile in formation / call normal movement thing for the unit, followed by DoGroupMovement()
-				print("TRYING GROUP MOVEMENT")
+--				print("TRYING GROUP MOVEMENT")
 				pHeadSelectedUnit:DoGroupMovement(plot)
 			elseif bShift and not bCtrl and not bAlt then -- VP/bal: holding down shift queues move orders
 				Game.SelectionListGameNetMessage(GameMessageTypes.GAMEMESSAGE_PUSH_MISSION, MissionTypes.MISSION_MOVE_TO, plotX, plotY, 0, false, true);				
@@ -874,7 +874,7 @@ function MovementRButtonUp()
 
 			else--if plot == UI.GetGotoPlot() then
 				--print("Game.SelectionListMove(plot,  bAlt, bShift, bCtrl);");
-				print("STANDARD MOVEMENT")
+--				print("STANDARD MOVEMENT")
 				Game.SelectionListMove(plot,  bAlt, bShift, bCtrl);
 				--UI.SetGotoPlot(nil);
 			end

--- a/(2) Vox Populi/Core Files/CoreLua/WorldView.lua
+++ b/(2) Vox Populi/Core Files/CoreLua/WorldView.lua
@@ -106,13 +106,21 @@ end
 
 function ShowMovementRangeIndicator()
 	local unit = UI.GetHeadSelectedUnit();
+	local bAlt = UIManager:GetAlt();
+
 	if not unit then
 		return;
 	end
 
 	local iPlayerID = Game.GetActivePlayer();
 
-	Events.ShowMovementRange( iPlayerID, unit:GetID() );
+	if bAlt then 
+		print ("displaying linked movement range")
+--		Events.ShowMovementRange( iPlayerID, unit:GetSlowestUnitIDOnPlot() );
+		Events.ShowMovementRange( iPlayerID, unit:GetID() );
+	else
+		Events.ShowMovementRange( iPlayerID, unit:GetID() );
+	end
 end
 
 -- Add any interface modes that need special processing to this table
@@ -661,6 +669,7 @@ end
 InterfaceModeMessageHandler[InterfaceModeTypes.INTERFACEMODE_SELECTION][MouseEvents.RButtonDown] =
 function()
 	local bShift = UIManager:GetShift();
+	local bAlt = UIManager:GetAlt();
 	ShowMovementRangeIndicator();
 	UI.SendPathfinderUpdate();
 	if bShift then
@@ -795,11 +804,22 @@ function MovementRButtonUp()
 				--print("Game.SelectionListGameNetMessage(GameMessageTypes.GAMEMESSAGE_DO_COMMAND, CommandTypes.COMMAND_CANCEL_ALL);");
 				Game.SelectionListGameNetMessage(GameMessageTypes.GAMEMESSAGE_DO_COMMAND, CommandTypes.COMMAND_CANCEL_ALL);
 
-			-- VP: QoL key+click combinations 
-			elseif bShift and not bCtrl then -- VP/bal: holding down shift queues move orders
+			-- VP: QoL key+click combinations (could do these in dll by modifying selectionListMove / or not since that also sends selectionlistgamemessage :P)
+			
+			elseif bAlt and not bCtrl and not bShift then
+			-- alt + rclick moves all units on the tile together / call normal movement thing for the unit, followed by DoLinkedMovement()
+--				Game.SelectionListGameNetMessage(GameMessageTypes.GAMEMESSAGE_PUSH_MISSION, MissionTypes.MISSION_LINKED_MOVEMENT, plotX, plotY, 0, false, true);				
+				print("TRYING LINKED MOVEMENT")
+				pHeadSelectedUnit:DoLinkedMovement(plot)
+			elseif bAlt and bCtrl and not bShift then
+				-- alt + ctrl + rclick moves units adjacent to this tile in formation / call normal movement thing for the unit, followed by DoGroupMovement()
+--				Game.SelectionListGameNetMessage(GameMessageTypes.GAMEMESSAGE_PUSH_MISSION, MissionTypes.MISSION_GROUP_MOVEMENT, plotX, plotY, 0, false, true);				
+				print("TRYING GROUP MOVEMENT")
+				pHeadSelectedUnit:DoGroupMovement(plot)
+			elseif bShift and not bCtrl and not bAlt then -- VP/bal: holding down shift queues move orders
 				Game.SelectionListGameNetMessage(GameMessageTypes.GAMEMESSAGE_PUSH_MISSION, MissionTypes.MISSION_MOVE_TO, plotX, plotY, 0, false, true);				
 
-			elseif bCtrl then --VP/bal: ctrl+click gives move&activate orders (e.g. move&alert, move&improve resource). ctrl+shift+click queues 
+			elseif bCtrl and not bAlt then --VP/bal: ctrl+click gives move&activate orders (e.g. move&alert, move&improve resource). ctrl+shift+click queues 
 				if pHeadSelectedUnit:IsCanAttack() then
 					Game.SelectionListGameNetMessage(GameMessageTypes.GAMEMESSAGE_PUSH_MISSION, MissionTypes.MISSION_MOVE_TO, plotX, plotY, 0, false, bShift);				
 					Game.SelectionListGameNetMessage(GameMessageTypes.GAMEMESSAGE_PUSH_MISSION, MissionTypes.MISSION_ALERT, plotX, plotY, 0, false, true);				
@@ -857,6 +877,7 @@ function MovementRButtonUp()
 
 			else--if plot == UI.GetGotoPlot() then
 				--print("Game.SelectionListMove(plot,  bAlt, bShift, bCtrl);");
+				print("STANDARD MOVEMENT")
 				Game.SelectionListMove(plot,  bAlt, bShift, bCtrl);
 				--UI.SetGotoPlot(nil);
 			end

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -145,6 +145,7 @@ CvUnit::CvUnit() :
 	, m_bIsGrouped()
 	, m_iLinkedMaxMoves()
 	, m_LinkedUnitIDs()
+	, m_LinkedLeaderUnit()
 	, m_bImmobile()
 	, m_iExperienceTimes100()
 	, m_iLevel()
@@ -4688,6 +4689,8 @@ void CvUnit::doCommand(CommandTypes eCommand, int iData1, int iData2)
 
 		case COMMAND_CANCEL_ALL:
 			ClearMissionQueue();
+			if (IsLinked())
+				SetIsLinked(false);
 			break;
 
 		case COMMAND_STOP_AUTOMATION:

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -5456,13 +5456,13 @@ void CvUnit::move(CvPlot& targetPlot, bool bShow)
 		}
 		if (bCanDoLinkedMove)
 		{
+			setXY(targetPlot.getX(), targetPlot.getY(), true, true, bShow && targetPlot.isVisibleToWatchingHuman(), bShow);
+
 			for (int iI = 0; iI < (int)LinkedUnits.size(); iI++)
 			{
 				CvUnit* pLinkedUnit = LinkedUnits[iI];
-				pLinkedUnit->move(targetPlot, true);
+				pLinkedUnit->move(targetPlot, false);
 			}
-
-			setXY(targetPlot.getX(), targetPlot.getY(), true, true, bShow && targetPlot.isVisibleToWatchingHuman(), bShow);
 		}
 	}
 	//important, first do the move, then subtract the cost
@@ -29325,7 +29325,7 @@ bool CvUnit::CanDoInterfaceMode(InterfaceModeTypes eInterfaceMode, bool bTestVis
 		break;
 
 	case INTERFACEMODE_MOVE_TO_ALL:
-		if (GetNumOwningPlayerUnitsAdjacent() > 0)
+		if (IsCombatUnit() && getDomainType() != DOMAIN_AIR && GetNumOwningPlayerUnitsAdjacent() > 0)
 		{
 			return true;
 		}

--- a/CvGameCoreDLL_Expansion2/CvUnit.h
+++ b/CvGameCoreDLL_Expansion2/CvUnit.h
@@ -617,6 +617,7 @@ public:
 	UnitIdContainer GetLinkedUnits();
 	int GetLinkedMaxMoves() const;
 	void SetLinkedMaxMoves(int iValue);
+	int GetSlowestUnitIDOnPlot() const;
 	void DoLinkedMovement(CvPlot* pDestPlot);
 	void DoGroupMovement(CvPlot* pDestPlot);
 

--- a/CvGameCoreDLL_Expansion2/CvUnit.h
+++ b/CvGameCoreDLL_Expansion2/CvUnit.h
@@ -609,16 +609,17 @@ public:
 	void SetIsLinked(bool bValue);
 	bool IsLinkedLeader() const;
 	void SetIsLinkedLeader(bool bValue);
-	void GetLinkedLeader(CvUnit* pLinkedLeader);
-	void SetLinkedLeader(CvUnit* pLinkedLeader);
+	int GetLinkedLeaderID() const;
+	void SetLinkedLeaderID(int iLinkedLeaderID);
 	bool IsGrouped() const;
 	void SetIsGrouped(bool bValue);
 	void SetLinkedUnits(UnitIdContainer LinkedUnits);
 	UnitIdContainer GetLinkedUnits();
 	int GetLinkedMaxMoves() const;
 	void SetLinkedMaxMoves(int iValue);
-	int GetSlowestUnitIDOnPlot() const;
-	void DoLinkedMovement(CvPlot* pDestPlot);
+	void LinkUnits();
+	void UnlinkUnits();
+	void MoveLinkedLeader(CvPlot* pDestPlot);
 	void DoGroupMovement(CvPlot* pDestPlot);
 
 	int GetRange() const;
@@ -1997,6 +1998,7 @@ protected:
 	bool m_bIsGrouped;
 	int m_iLinkedMaxMoves;
 	UnitIdContainer m_LinkedUnitIDs;
+	int m_iLinkedLeaderID;
 	int m_iArmyId;
 	int m_iBaseCombat;
 	int m_iBaseRangedCombat;
@@ -2441,6 +2443,7 @@ SYNC_ARCHIVE_VAR(bool, m_bIsLinkedLeader)
 SYNC_ARCHIVE_VAR(bool, m_bIsGrouped)
 SYNC_ARCHIVE_VAR(int, m_iLinkedMaxMoves)
 SYNC_ARCHIVE_VAR(UnitIdContainer, m_LinkedUnitIDs)
+SYNC_ARCHIVE_VAR(int, m_iLinkedLeaderID)
 SYNC_ARCHIVE_VAR(int, m_iArmyId)
 SYNC_ARCHIVE_VAR(int, m_iBaseCombat)
 SYNC_ARCHIVE_VAR(int, m_iBaseRangedCombat)

--- a/CvGameCoreDLL_Expansion2/CvUnit.h
+++ b/CvGameCoreDLL_Expansion2/CvUnit.h
@@ -609,6 +609,8 @@ public:
 	void SetIsLinked(bool bValue);
 	bool IsLinkedLeader() const;
 	void SetIsLinkedLeader(bool bValue);
+	void GetLinkedLeader(CvUnit* pLinkedLeader);
+	void SetLinkedLeader(CvUnit* pLinkedLeader);
 	bool IsGrouped() const;
 	void SetIsGrouped(bool bValue);
 	void SetLinkedUnits(UnitIdContainer LinkedUnits);

--- a/CvGameCoreDLL_Expansion2/CvUnit.h
+++ b/CvGameCoreDLL_Expansion2/CvUnit.h
@@ -604,6 +604,20 @@ public:
 	bool canMove() const;
 	bool hasMoved() const;
 
+	// VP - Linked & Group Movement 
+	bool IsLinked() const;
+	void SetIsLinked(bool bValue);
+	bool IsLinkedLeader() const;
+	void SetIsLinkedLeader(bool bValue);
+	bool IsGrouped() const;
+	void SetIsGrouped(bool bValue);
+	void SetLinkedUnits(UnitIdContainer LinkedUnits);
+	UnitIdContainer GetLinkedUnits();
+	int GetLinkedMaxMoves() const;
+	void SetLinkedMaxMoves(int iValue);
+	void DoLinkedMovement(CvPlot* pDestPlot);
+	void DoGroupMovement(CvPlot* pDestPlot);
+
 	int GetRange() const;
 	int GetNukeDamageLevel() const;
 
@@ -1975,6 +1989,11 @@ protected:
 
 	int m_iDamage;
 	int m_iMoves;
+	bool m_bIsLinked;
+	bool m_bIsLinkedLeader;
+	bool m_bIsGrouped;
+	int m_iLinkedMaxMoves;
+	UnitIdContainer m_LinkedUnitIDs;
 	int m_iArmyId;
 	int m_iBaseCombat;
 	int m_iBaseRangedCombat;
@@ -2414,6 +2433,11 @@ SYNC_ARCHIVE_VAR(int, m_iY)
 SYNC_ARCHIVE_VAR(int, m_iID)
 SYNC_ARCHIVE_VAR(int, m_iDamage)
 SYNC_ARCHIVE_VAR(int, m_iMoves)
+SYNC_ARCHIVE_VAR(bool, m_bIsLinked)
+SYNC_ARCHIVE_VAR(bool, m_bIsLinkedLeader)
+SYNC_ARCHIVE_VAR(bool, m_bIsGrouped)
+SYNC_ARCHIVE_VAR(int, m_iLinkedMaxMoves)
+SYNC_ARCHIVE_VAR(UnitIdContainer, m_LinkedUnitIDs)
 SYNC_ARCHIVE_VAR(int, m_iArmyId)
 SYNC_ARCHIVE_VAR(int, m_iBaseCombat)
 SYNC_ARCHIVE_VAR(int, m_iBaseRangedCombat)

--- a/CvGameCoreDLL_Expansion2/CvUnitMission.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnitMission.cpp
@@ -543,8 +543,7 @@ void CvUnitMission::ContinueMission(CvUnit* hUnit, int iSteps)
 						else //cannot move or no need to move
 						{
 							bDone = true;
-							if (hUnit->IsGrouped() || hUnit->IsLinkedLeader()) {
-								hUnit->SetIsLinkedLeader(false);
+							if (hUnit->IsGrouped()) {
 								hUnit->SetIsGrouped(false);
 							}
 						}

--- a/CvGameCoreDLL_Expansion2/CvUnitMission.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnitMission.cpp
@@ -543,6 +543,10 @@ void CvUnitMission::ContinueMission(CvUnit* hUnit, int iSteps)
 						else //cannot move or no need to move
 						{
 							bDone = true;
+							if (hUnit->IsGrouped() || hUnit->IsLinkedLeader()) {
+								hUnit->SetIsLinkedLeader(false);
+								hUnit->SetIsGrouped(false);
+							}
 						}
 					}
 					else if (iResult == CvUnit::MOVE_RESULT_ATTACK)

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.cpp
@@ -192,6 +192,7 @@ void CvLuaUnit::PushMethods(lua_State* L, int t)
 
 	Method(IsLinked);
 	Method(IsGrouped);
+	Method(GetSlowestUnitIDOnPlot);
 	Method(DoLinkedMovement);
 	Method(DoGroupMovement);
 
@@ -2429,6 +2430,16 @@ int CvLuaUnit::lIsGrouped(lua_State* L)
 	return 1;
 }
 //------------------------------------------------------------------------------
+//int GetSlowestUnitIDOnPlot();
+int CvLuaUnit::lGetSlowestUnitIDOnPlot(lua_State* L)
+{
+	CvUnit* pkUnit = GetInstance(L);
+	const int iResult = pkUnit->GetSlowestUnitIDOnPlot();
+
+	lua_pushinteger(L, iResult);
+	return 1;
+}
+//------------------------------------------------------------------------------ 
 //void DoLinkedMovement();
 int CvLuaUnit::lDoLinkedMovement(lua_State* L)
 {

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.cpp
@@ -191,9 +191,11 @@ void CvLuaUnit::PushMethods(lua_State* L, int t)
 	Method(HasMoved);
 
 	Method(IsLinked);
+	Method(IsLinkedLeader);
 	Method(IsGrouped);
-	Method(GetSlowestUnitIDOnPlot);
-	Method(DoLinkedMovement);
+	Method(LinkUnits);
+	Method(UnlinkUnits);
+	Method(MoveLinkedLeader);
 	Method(DoGroupMovement);
 
 	Method(Range);
@@ -2420,6 +2422,16 @@ int CvLuaUnit::lIsLinked(lua_State* L)
 	return 1;
 }
 //------------------------------------------------------------------------------
+//bool IsLinkedLeader();
+int CvLuaUnit::lIsLinkedLeader(lua_State* L)
+{
+	CvUnit* pkUnit = GetInstance(L);
+	const bool bResult = pkUnit->IsLinkedLeader();
+
+	lua_pushboolean(L, bResult);
+	return 1;
+}
+//------------------------------------------------------------------------------
 //bool IsGrouped();
 int CvLuaUnit::lIsGrouped(lua_State* L)
 {
@@ -2429,24 +2441,31 @@ int CvLuaUnit::lIsGrouped(lua_State* L)
 	lua_pushboolean(L, bResult);
 	return 1;
 }
-//------------------------------------------------------------------------------
-//int GetSlowestUnitIDOnPlot();
-int CvLuaUnit::lGetSlowestUnitIDOnPlot(lua_State* L)
+//------------------------------------------------------------------------------ 
+//void LinkUnits();
+int CvLuaUnit::lLinkUnits(lua_State* L)
 {
 	CvUnit* pkUnit = GetInstance(L);
-	const int iResult = pkUnit->GetSlowestUnitIDOnPlot();
 
-	lua_pushinteger(L, iResult);
-	return 1;
+	pkUnit->LinkUnits();
+	return 0;
 }
-//------------------------------------------------------------------------------ 
-//void DoLinkedMovement();
-int CvLuaUnit::lDoLinkedMovement(lua_State* L)
+//------------------------------------------------------------------------------
+//void UnlinkUnits();
+int CvLuaUnit::lUnlinkUnits(lua_State* L)
+{
+	CvUnit* pkUnit = GetInstance(L);
+	pkUnit->UnlinkUnits();
+
+	return 0;
+}
+//------------------------------------------------------------------------------
+int CvLuaUnit::lMoveLinkedLeader(lua_State* L)
 {
 	CvUnit* pkUnit = GetInstance(L);
 	CvPlot* pkDestPlot = CvLuaPlot::GetInstance(L, 2);
 
-	pkUnit->DoLinkedMovement(pkDestPlot);
+	pkUnit->MoveLinkedLeader(pkDestPlot);
 	return 0;
 }
 //------------------------------------------------------------------------------

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.cpp
@@ -189,6 +189,12 @@ void CvLuaUnit::PushMethods(lua_State* L, int t)
 
 	Method(CanMove);
 	Method(HasMoved);
+
+	Method(IsLinked);
+	Method(IsGrouped);
+	Method(DoLinkedMovement);
+	Method(DoGroupMovement);
+
 	Method(Range);
 	Method(NukeDamageLevel);
 
@@ -2401,6 +2407,46 @@ int CvLuaUnit::lHasMoved(lua_State* L)
 
 	lua_pushboolean(L, bResult);
 	return 1;
+}
+//------------------------------------------------------------------------------
+//bool IsLinked();
+int CvLuaUnit::lIsLinked(lua_State* L)
+{
+	CvUnit* pkUnit = GetInstance(L);
+	const bool bResult = pkUnit->IsLinked();
+
+	lua_pushboolean(L, bResult);
+	return 1;
+}
+//------------------------------------------------------------------------------
+//bool IsGrouped();
+int CvLuaUnit::lIsGrouped(lua_State* L)
+{
+	CvUnit* pkUnit = GetInstance(L);
+	const bool bResult = pkUnit->IsGrouped();
+
+	lua_pushboolean(L, bResult);
+	return 1;
+}
+//------------------------------------------------------------------------------
+//void DoLinkedMovement();
+int CvLuaUnit::lDoLinkedMovement(lua_State* L)
+{
+	CvUnit* pkUnit = GetInstance(L);
+	CvPlot* pkDestPlot = CvLuaPlot::GetInstance(L, 2);
+
+	pkUnit->DoLinkedMovement(pkDestPlot);
+	return 0;
+}
+//------------------------------------------------------------------------------
+//void DoGroupMovement();
+int CvLuaUnit::lDoGroupMovement(lua_State* L)
+{
+	CvUnit* pkUnit = GetInstance(L);
+	CvPlot* pkDestPlot = CvLuaPlot::GetInstance(L, 2);
+
+	pkUnit->DoGroupMovement(pkDestPlot);
+	return 0;
 }
 //------------------------------------------------------------------------------
 //int GetRange();

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.h
@@ -191,6 +191,12 @@ protected:
 
 	static int lCanMove(lua_State* L);
 	static int lHasMoved(lua_State* L);
+
+	static int lIsLinked(lua_State* L);
+	static int lIsGrouped(lua_State* L);
+	static int lDoLinkedMovement(lua_State* L);
+	static int lDoGroupMovement(lua_State* L);
+
 	static int lRange(lua_State* L);
 	static int lNukeDamageLevel(lua_State* L);
 

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.h
@@ -194,6 +194,7 @@ protected:
 
 	static int lIsLinked(lua_State* L);
 	static int lIsGrouped(lua_State* L);
+	static int lGetSlowestUnitIDOnPlot(lua_State* L);
 	static int lDoLinkedMovement(lua_State* L);
 	static int lDoGroupMovement(lua_State* L);
 

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.h
@@ -193,9 +193,11 @@ protected:
 	static int lHasMoved(lua_State* L);
 
 	static int lIsLinked(lua_State* L);
+	static int lIsLinkedLeader(lua_State* L);
 	static int lIsGrouped(lua_State* L);
-	static int lGetSlowestUnitIDOnPlot(lua_State* L);
-	static int lDoLinkedMovement(lua_State* L);
+	static int lLinkUnits(lua_State* L);
+	static int lUnlinkUnits(lua_State* L);
+	static int lMoveLinkedLeader(lua_State* L);
 	static int lDoGroupMovement(lua_State* L);
 
 	static int lRange(lua_State* L);


### PR DESCRIPTION
I won't be able to mod for a while, but fundamentals are there and features are fully functional, only need some checks for edge cases & indicators on the UI. This is the most c++ intensive stuff I've ever done, so I'd appreciate if anyone could take a look at this, to see whether the code could be optimized better. I couldn't manage to use pointers or references for UnitIdContainer, maybe that's one area worth checking.

Linked Movement: Moves all units on the tile together, by calling DoLinkedMovement() on ALT+RCLICK. The function runs two loops, first a loop to get the movable units, their maximum and current movement points. The units are stored in a temporary vector for easier recall on the next loop. The second loop sets the units as IsLinked, and assigns the lowest max&current movement to all linked units. The ordering unit is designated as the LinkedLeader, and gets a standard move mission. The other unit IDs are stored on the Leader unit. The mission calls move() on the Leader, and every move() call made by the mission (i.e. one for each plot on the path) checks whether all the linked units can move. If so, everyone moves, if not, no-one. Upon finishing each move order, ContinueMission is called automatically, if the original move mission is completed, IsGrouped and IsLinkedLeader are reset, and units get back their maxMoves, and their current moves are also updated accordingly.

While plot by plot check is cumbersome, I couldn't think of another way. The problem lies with unit promotions affecting movement costs and the generated path. Ideally all movement promotions of the linked units would be temporarily disabled (unless the promotion is shared by all), but that seems like a costly computation.

Group Movement: Moves all units adjacent to the selected tile, in formation, by calling DoGroupMovement() on ALT+CTRL+RCLICK. The function is very similar to LinkedMovement, but it also loops through adjacent plots (only for the "get units&movement loop"). Another difference is that no unit IDs are stored here, as we just care about the end result, it doesn't matter if unit paths diverge from the formation during movement. Instead of only the leading unit getting a move mission, each unit gets one (non-leading units use approximate_target_ring1 flag).

I thought about creating a new class (i.e. CvUnitGroups), storing UnitIDs, base & group movement points etc. working similar to ArmyAI, but much more limited. That seemed like more work, and I guess would consume more memory. In the current version mostly a few booleans are stored, and units in linkedmovement also store a few integers. Since the latter gets reset after each order, majority of the time it would be empty.