### PR TITLE
Golden Ages

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -6733,7 +6733,8 @@ void CvCity::DoEventChoice(CityEventChoiceTypes eEventChoice, CityEventTypes eCi
 				}
 				else
 				{
-					GET_PLAYER(eSpyOwner).changeGoldenAgeTurns(pkEventChoiceInfo->getForgeGW() * 10);
+					int iGoldenAgeTurns = GET_PLAYER(eSpyOwner).getGoldenAgeLength(pkEventChoiceInfo->getForgeGW() * 10);
+					GET_PLAYER(eSpyOwner).changeGoldenAgeTurns(iGoldenAgeTurns);
 				}
 			}
 
@@ -6757,7 +6758,8 @@ void CvCity::DoEventChoice(CityEventChoiceTypes eEventChoice, CityEventTypes eCi
 				}
 				else
 				{
-					GET_PLAYER(eSpyOwner).changeGoldenAgeTurns(pkEventChoiceInfo->getForgeGW() * 10);
+					int iGoldenAgeTurns = GET_PLAYER(eSpyOwner).getGoldenAgeLength(pkEventChoiceInfo->getForgeGW() * 10);
+					GET_PLAYER(eSpyOwner).changeGoldenAgeTurns(iGoldenAgeTurns);
 				}
 			}
 
@@ -10417,7 +10419,7 @@ void CvCity::DoTestResourceDemanded()
 				iWLTKD *= GC.getGame().getGameSpeedInfo().getTrainPercent();
 				iWLTKD /= 100;
 
-				ChangeWeLoveTheKingDayCounter(/*20*/ iWLTKD);
+				ChangeWeLoveTheKingDayCounter(iWLTKD);
 
 				CvNotifications* pNotifications = GET_PLAYER(getOwner()).GetNotifications();
 				if (pNotifications)
@@ -14383,9 +14385,7 @@ void CvCity::processBuilding(BuildingTypes eBuilding, int iChange, bool bFirst, 
 									}
 									if (pFreeUnit->isGoldenAgeOnBirth())
 									{
-										int iGoldenAgeTurns = owningPlayer.getGoldenAgeLength();
-										int iValue = owningPlayer.GetGoldenAgeProgressMeter();
-										owningPlayer.changeGoldenAgeTurns(iGoldenAgeTurns, iValue);
+										owningPlayer.changeGoldenAgeTurns(owningPlayer.getGoldenAgeLength());
 									}
 									if (pFreeUnit->isCultureBoost())
 									{
@@ -14707,9 +14707,7 @@ void CvCity::processBuilding(BuildingTypes eBuilding, int iChange, bool bFirst, 
 									}
 									if (pFreeUnit->isGoldenAgeOnBirth())
 									{
-										int iGoldenAgeTurns = owningPlayer.getGoldenAgeLength();
-										int iValue = owningPlayer.GetGoldenAgeProgressMeter();
-										owningPlayer.changeGoldenAgeTurns(iGoldenAgeTurns, iValue);
+										owningPlayer.changeGoldenAgeTurns(owningPlayer.getGoldenAgeLength());
 									}
 									if (pFreeUnit->isCultureBoost())
 									{

--- a/CvGameCoreDLL_Expansion2/CvCityCitizens.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCityCitizens.cpp
@@ -1,5 +1,5 @@
 /*	-------------------------------------------------------------------------------------------------------
-© 1991-2012 Take-Two Interactive Software and its subsidiaries.  Developed by Firaxis Games.
+Â© 1991-2012 Take-Two Interactive Software and its subsidiaries.  Developed by Firaxis Games.
 Sid Meier's Civilization V, Civ, Civilization, 2K Games, Firaxis Games, Take-Two Interactive Software
 and their respective logos are all trademarks of Take-Two interactive Software, Inc.
 All other marks and trademarks are the property of their respective owners.
@@ -3214,9 +3214,7 @@ void CvCityCitizens::DoSpawnGreatPerson(UnitTypes eUnit, bool bIncrementCount, b
 		}
 		if (newUnit->isGoldenAgeOnBirth())
 		{
-			int iGoldenAgeTurns = kPlayer.getGoldenAgeLength();
-			int iValue = kPlayer.GetGoldenAgeProgressMeter();
-			kPlayer.changeGoldenAgeTurns(iGoldenAgeTurns, iValue);
+			kPlayer.changeGoldenAgeTurns(kPlayer.getGoldenAgeLength());
 		}
 		if (newUnit->isCultureBoost())
 		{
@@ -3426,9 +3424,7 @@ void CvCityCitizens::DoSpawnGreatPerson(UnitTypes eUnit, bool bIncrementCount, b
 		}
 		if (newUnit->isGoldenAgeOnBirth())
 		{
-			int iGoldenAgeTurns = kPlayer.getGoldenAgeLength();
-			int iValue = kPlayer.GetGoldenAgeProgressMeter();
-			kPlayer.changeGoldenAgeTurns(iGoldenAgeTurns, iValue);
+			kPlayer.changeGoldenAgeTurns(kPlayer.getGoldenAgeLength());
 		}
 		if (newUnit->isCultureBoost())
 		{

--- a/CvGameCoreDLL_Expansion2/CvGame.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGame.cpp
@@ -4248,11 +4248,19 @@ int CvGame::countKnownTechNumTeams(TechTypes eTech)
 }
 
 //	--------------------------------------------------------------------------------
-int CvGame::goldenAgeLength() const
+int CvGame::goldenAgeLength(int iManualLength) const
 {
 	int iLength;
-
-	iLength = /*10*/ GD_INT_GET(GOLDEN_AGE_LENGTH);
+	
+	// Sometimes we need to alter a manual number of golden age turns by the game speed
+	if (iManualLength >= 0)
+	{
+		iLength = iManualLength;
+	}
+	else
+	{
+		iLength = /*10*/ GD_INT_GET(GOLDEN_AGE_LENGTH);
+	}
 
 	iLength *= getGameSpeedInfo().getGoldenAgePercent();
 	iLength /= 100;

--- a/CvGameCoreDLL_Expansion2/CvGame.h
+++ b/CvGameCoreDLL_Expansion2/CvGame.h
@@ -1,5 +1,5 @@
 /*	-------------------------------------------------------------------------------------------------------
-	© 1991-2012 Take-Two Interactive Software and its subsidiaries.  Developed by Firaxis Games.  
+	Â© 1991-2012 Take-Two Interactive Software and its subsidiaries.  Developed by Firaxis Games.  
 	Sid Meier's Civilization V, Civ, Civilization, 2K Games, Firaxis Games, Take-Two Interactive Software 
 	and their respective logos are all trademarks of Take-Two interactive Software, Inc.  
 	All other marks and trademarks are the property of their respective owners.  
@@ -122,7 +122,7 @@ public:
 	int countTotalNukeUnits();
 	int countKnownTechNumTeams(TechTypes eTech);
 
-	int goldenAgeLength() const;
+	int goldenAgeLength(int iManualLength = -1) const;
 	int victoryDelay(VictoryTypes eVictory) const;
 
 	int getImprovementUpgradeTimeMod(ImprovementTypes eImprovement, const CvPlot* pPlot = NULL) const;

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -2846,9 +2846,7 @@ CvPlot* CvPlayer::addFreeUnit(UnitTypes eUnit, UnitAITypes eUnitAI)
 		}
 		if(pNewUnit->isGoldenAgeOnBirth())
 		{
-			int iGoldenAgeTurns = getGoldenAgeLength();
-			int iValue = GetGoldenAgeProgressMeter();
-			changeGoldenAgeTurns(iGoldenAgeTurns, iValue);
+			changeGoldenAgeTurns(getGoldenAgeLength());
 		}
 		if(pNewUnit->isCultureBoost())
 		{
@@ -3400,9 +3398,9 @@ CvCity* CvPlayer::acquireCity(CvCity* pCity, bool bConquest, bool bGift)
 			if (GetPlayerTraits()->IsConquestOfTheWorld())
 			{
 				if (isGoldenAge())
-					changeGoldenAgeTurns(3, GetGoldenAgeProgressMeter());
+					changeGoldenAgeTurns(getGoldenAgeLength(3));
 				else
-					changeGoldenAgeTurns(5, GetGoldenAgeProgressMeter());
+					changeGoldenAgeTurns(getGoldenAgeLength(5));
 			}
 
 			// Culture bonus turns from conquering a city?
@@ -9207,9 +9205,8 @@ void CvPlayer::DoEventChoice(EventChoiceTypes eEventChoice, EventTypes eEvent, b
 			if(pkEventChoiceInfo->getGoldenAgeTurns() > 0)
 			{
 				int iTurns = pkEventChoiceInfo->getGoldenAgeTurns();
-				iTurns *= GC.getGame().getGameSpeedInfo().getTrainPercent();
-				iTurns /= 100;
-				changeGoldenAgeTurns(max(1, iTurns), true);
+				iTurns = iTurns * GC.getGame().getGameSpeedInfo().getTrainPercent() / 100;
+				changeGoldenAgeTurns(getGoldenAgeLength(max(1, iTurns)), true);
 			}
 			if(pkEventChoiceInfo->getNumFreeGreatPeople() > 0)
 			{
@@ -16962,13 +16959,7 @@ void CvPlayer::processBuilding(BuildingTypes eBuilding, int iChange, bool bFirst
 		// Golden Age
 		if(pBuildingInfo->IsGoldenAge())
 		{
-			int iGoldenAgeTurns = getGoldenAgeLength();
-#if defined(MOD_BALANCE_CORE)
-			int iValue = GetGoldenAgeProgressMeter();
-			changeGoldenAgeTurns(iGoldenAgeTurns, iValue, true);
-#else
-			changeGoldenAgeTurns(iGoldenAgeTurns);
-#endif
+			changeGoldenAgeTurns(getGoldenAgeLength(), true);
 		}
 
 		// Global Pop change
@@ -19766,19 +19757,7 @@ void CvPlayer::DoWarVictoryBonuses()
 	int iTurns = GetPlayerTraits()->GetGoldenAgeFromVictory();
 	if(iTurns > 0)
 	{
-		if(iTurns < GC.getGame().goldenAgeLength())
-		{
-			iTurns = GC.getGame().goldenAgeLength();
-		}
-		// Player modifier
-		int iLengthModifier = getGoldenAgeModifier();
-
-		if(iLengthModifier != 0)
-		{
-			iTurns = iTurns * (100 + iLengthModifier) / 100;
-		}
-		int iValue = GetGoldenAgeProgressMeter();
-		changeGoldenAgeTurns(iTurns, iValue, true);
+		changeGoldenAgeTurns(getGoldenAgeLength(iTurns), true);
 	}
 
 	int iTourism = GetHistoricEventTourism(HISTORIC_EVENT_WAR);
@@ -24964,16 +24943,10 @@ void CvPlayer::DoProcessGoldenAge()
 			{
 				int iOverflow = GetGoldenAgeProgressMeter() - GetGoldenAgeProgressThreshold();
 #if defined(MOD_BALANCE_CORE)
-				int iValue = GetGoldenAgeProgressMeter();
 #endif
 				SetGoldenAgeProgressMeter(iOverflow);
 				
-				int iLength = getGoldenAgeLength();
-#if defined(MOD_BALANCE_CORE)
-				changeGoldenAgeTurns(iLength, iValue);
-#else
-				changeGoldenAgeTurns(iLength);
-#endif
+				changeGoldenAgeTurns(getGoldenAgeLength());
 
 				// If it's the active player then show the popup
 				if(GetID() == GC.getGame().getActivePlayer())
@@ -25203,20 +25176,15 @@ bool CvPlayer::isGoldenAge() const
 }
 
 //	--------------------------------------------------------------------------------
-#if defined(MOD_BALANCE_CORE)
-void CvPlayer::changeGoldenAgeTurns(int iChange, int iValue, bool bFree)
-#else
-void CvPlayer::changeGoldenAgeTurns(int iChange)
-#endif
+void CvPlayer::changeGoldenAgeTurns(int iChange, bool bFree)
 {
 	Localization::String locString;
 	Localization::String locSummaryString;
 
-	bool bOldGoldenAge;
-
 	if(iChange != 0)
 	{
-		bOldGoldenAge = isGoldenAge();
+		bool bOldGoldenAge = isGoldenAge();
+		int iThreshold = GetGoldenAgeProgressThreshold();
 
 		m_iGoldenAgeTurns = (m_iGoldenAgeTurns + iChange);
 		CvAssert(getGoldenAgeTurns() >= 0);
@@ -25225,22 +25193,13 @@ void CvPlayer::changeGoldenAgeTurns(int iChange)
 		{
 			GC.getMap().updateYield();	// Do the entire map, so that any potential golden age bonus is reflected in the yield icons.
 
-			if(isGoldenAge())
-			{
-				if (!bFree)
-				{
-					ChangeNumGoldenAges(1);
-				}
-			}
-			else
+			if(!isGoldenAge())
 			{
 				gDLL->GameplayGoldenAgeEnded();
 
-#if defined(MOD_EVENTS_GOLDEN_AGE)
 				if (MOD_EVENTS_GOLDEN_AGE) {
 					GAMEEVENTINVOKE_HOOK(GAMEEVENT_PlayerGoldenAge, GetID(), false, 0);
 				}
-#endif
 #if defined(MOD_BALANCE_CORE)
 				int iLoop;
 				for(CvCity* pLoopCity = firstCity(&iLoop); pLoopCity != NULL; pLoopCity = nextCity(&iLoop))
@@ -25276,16 +25235,18 @@ void CvPlayer::changeGoldenAgeTurns(int iChange)
 
 		if (iChange > 0)
 		{
+			if (!(bFree && MOD_BALANCE_CORE))
+			{
+				ChangeNumGoldenAges(1);
+			}
 #if defined(MOD_BALANCE_CORE)
 			//Instant Boost
 			CvCity* pCapitalCity = getCapitalCity();
 			if (pCapitalCity != NULL)
 			{
-				doInstantYield(INSTANT_YIELD_TYPE_INSTANT, false, NO_GREATPERSON, NO_BUILDING, iValue, false, NO_PLAYER, NULL, false, pCapitalCity);
+				doInstantYield(INSTANT_YIELD_TYPE_INSTANT, false, NO_GREATPERSON, NO_BUILDING, iThreshold, false, NO_PLAYER, NULL, false, pCapitalCity);
 			}
-#endif
-
-#if defined(MOD_BALANCE_CORE)
+			
 			if (GetGoldenAgeTourism() > 0)
 			{
 				int iTourism = GetHistoricEventTourism(HISTORIC_EVENT_GA);
@@ -25324,15 +25285,15 @@ void CvPlayer::changeGoldenAgeTurns(int iChange)
 
 			if (GetPlayerTraits()->GetWLTKDGATimer() > 0)
 			{
-				int iValue2 = GetPlayerTraits()->GetWLTKDGATimer();
-				iValue2 *= GC.getGame().getGameSpeedInfo().getTrainPercent();
-				iValue2 /= 100;
+				int iValue = GetPlayerTraits()->GetWLTKDGATimer();
+				iValue *= GC.getGame().getGameSpeedInfo().getTrainPercent();
+				iValue /= 100;
 				int iLoop;
 				for (CvCity* pLoopCity = firstCity(&iLoop); pLoopCity != NULL; pLoopCity = nextCity(&iLoop))
 				{
 					if (pLoopCity != NULL)
 					{
-						pLoopCity->ChangeWeLoveTheKingDayCounter(iValue2);
+						pLoopCity->ChangeWeLoveTheKingDayCounter(iValue);
 					}
 				}
 				CvNotifications* pNotification = GetNotifications();
@@ -25340,7 +25301,7 @@ void CvPlayer::changeGoldenAgeTurns(int iChange)
 				{
 					CvString strMessage;
 					CvString strSummary;
-					strMessage = GetLocalizedText("TXT_KEY_CARNAVAL_WLTKD", iValue2);
+					strMessage = GetLocalizedText("TXT_KEY_CARNAVAL_WLTKD", iValue);
 					strSummary = GetLocalizedText("TXT_KEY_CARNAVAL_WLTKD_S");
 					pNotification->Add(NOTIFICATION_GENERIC, strMessage, strSummary, -1, -1, GetID());
 				}
@@ -25357,11 +25318,9 @@ void CvPlayer::changeGoldenAgeTurns(int iChange)
 
 			gDLL->GameplayGoldenAgeStarted();
 
-#if defined(MOD_EVENTS_GOLDEN_AGE)
 			if (MOD_EVENTS_GOLDEN_AGE) {
 				GAMEEVENTINVOKE_HOOK(GAMEEVENT_PlayerGoldenAge, GetID(), true, iChange);
 			}
-#endif
 #if defined(MOD_BALANCE_CORE)
 			int iLoop;
 			for (CvCity* pLoopCity = firstCity(&iLoop); pLoopCity != NULL; pLoopCity = nextCity(&iLoop))
@@ -25380,18 +25339,16 @@ void CvPlayer::changeGoldenAgeTurns(int iChange)
 }
 
 //	--------------------------------------------------------------------------------
-int CvPlayer::getGoldenAgeLength() const
+// get the number of turns this Golden Age will occur over
+// (optional input allows manually sets the length with included length modifiers)
+int CvPlayer::getGoldenAgeLength(int iManualLength) const
 {
-	int iTurns = GC.getGame().goldenAgeLength();
+	int iTurns = GC.getGame().goldenAgeLength(iManualLength);
 
 	// Player modifier
 	int iLengthModifier = getGoldenAgeModifier();
 
-#if defined(MOD_BALANCE_CORE)
 	if(iLengthModifier != 0)
-#else
-	if(iLengthModifier > 0)
-#endif
 	{
 		iTurns = iTurns * (100 + iLengthModifier) / 100;
 	}
@@ -29195,9 +29152,7 @@ void CvPlayer::DoSpawnGreatPerson(PlayerTypes eMinor)
 			}
 			if(pNewGreatPeople->isGoldenAgeOnBirth())
 			{
-				int iGoldenAgeTurns = getGoldenAgeLength();
-				int iValue = GetGoldenAgeProgressMeter();
-				changeGoldenAgeTurns(iGoldenAgeTurns, iValue);
+				changeGoldenAgeTurns(getGoldenAgeLength());
 			}
 			if(pNewGreatPeople->isCultureBoost())
 			{
@@ -44838,23 +44793,7 @@ void CvPlayer::processPolicies(PolicyTypes ePolicy, int iChange)
 	int iGoldenAgeTurns = pPolicy->GetGoldenAgeTurns() * iChange;
 	if(iGoldenAgeTurns > 0)
 	{
-		// Player modifier
-		int iLengthModifier = getGoldenAgeModifier();
-
-		if(iLengthModifier > 0)
-		{
-			iGoldenAgeTurns = iGoldenAgeTurns * (100 + iLengthModifier) / 100;
-		}
-
-		// Game Speed mod
-		iGoldenAgeTurns *= GC.getGame().getGameSpeedInfo().getGoldenAgePercent();
-		iGoldenAgeTurns /= 100;
-#if defined(MOD_BALANCE_CORE)
-		int iValue = GetGoldenAgeProgressMeter();
-		changeGoldenAgeTurns(iGoldenAgeTurns, iValue);
-#else
-		changeGoldenAgeTurns(iGoldenAgeTurns);
-#endif
+		changeGoldenAgeTurns(getGoldenAgeLength(iGoldenAgeTurns));
 	}
 
 	// Free Techs
@@ -44982,9 +44921,7 @@ void CvPlayer::processPolicies(PolicyTypes ePolicy, int iChange)
 									}
 									if(pNewUnit->isGoldenAgeOnBirth())
 									{
-										int iGoldenAgeTurns = getGoldenAgeLength();
-										int iValue = GetGoldenAgeProgressMeter();
-										changeGoldenAgeTurns(iGoldenAgeTurns, iValue);
+										changeGoldenAgeTurns(getGoldenAgeLength());
 									}
 									if(pNewUnit->isCultureBoost())
 									{
@@ -46898,9 +46835,7 @@ void CvPlayer::createGreatGeneral(UnitTypes eGreatPersonUnit, int iX, int iY)
 	}
 	if(pGreatPeopleUnit->isGoldenAgeOnBirth())
 	{
-		int iGoldenAgeTurns = getGoldenAgeLength();
-		int iValue = GetGoldenAgeProgressMeter();
-		changeGoldenAgeTurns(iGoldenAgeTurns, iValue);
+		changeGoldenAgeTurns(getGoldenAgeLength());
 	}
 	if(pGreatPeopleUnit->isCultureBoost())
 	{
@@ -47055,9 +46990,7 @@ void CvPlayer::createGreatAdmiral(UnitTypes eGreatPersonUnit, int iX, int iY)
 	}
 	if(pGreatPeopleUnit->isGoldenAgeOnBirth())
 	{
-		int iGoldenAgeTurns = getGoldenAgeLength();
-		int iValue = GetGoldenAgeProgressMeter();
-		changeGoldenAgeTurns(iGoldenAgeTurns, iValue);
+		changeGoldenAgeTurns(getGoldenAgeLength());
 	}
 	if(pGreatPeopleUnit->isCultureBoost())
 	{

--- a/CvGameCoreDLL_Expansion2/CvPlayer.h
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.h
@@ -939,12 +939,8 @@ public:
 
 	int getGoldenAgeTurns() const;
 	bool isGoldenAge() const;
-#if defined(MOD_BALANCE_CORE)
-	void changeGoldenAgeTurns(int iChange, int iValue = 0, bool bFree = false);
-#else
-	void changeGoldenAgeTurns(int iChange);
-#endif
-	int getGoldenAgeLength() const;
+	void changeGoldenAgeTurns(int iChange, bool bFree = false);
+	int getGoldenAgeLength(int iManualLength = -1) const;
 
 	int getNumUnitGoldenAges() const;
 	void changeNumUnitGoldenAges(int iChange);

--- a/CvGameCoreDLL_Expansion2/CvTeam.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTeam.cpp
@@ -1665,11 +1665,11 @@ void CvTeam::DoDeclareWar(PlayerTypes eOriginatingPlayer, bool bAggressor, TeamT
 					//Do a golden age on war if we can
 					if(kAttackingPlayer.GetPlayerTraits()->IsGoldenAgeOnWar())
 					{
-						kAttackingPlayer.changeGoldenAgeTurns(kAttackingPlayer.getGoldenAgeLength(), kAttackingPlayer.GetGoldenAgeProgressMeter());
+						kAttackingPlayer.changeGoldenAgeTurns(kAttackingPlayer.getGoldenAgeLength());
 					}
 					if(kDefendingPlayer.GetPlayerTraits()->IsGoldenAgeOnWar())
 					{
-						kDefendingPlayer.changeGoldenAgeTurns(kDefendingPlayer.getGoldenAgeLength(), kDefendingPlayer.GetGoldenAgeProgressMeter());
+						kDefendingPlayer.changeGoldenAgeTurns(kDefendingPlayer.getGoldenAgeLength());
 					}
 					// Best unit on an improvement DOW?
 					if(kAttackingPlayer.GetPlayerTraits()->IsBestUnitSpawnOnImprovementDOW())

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -1299,12 +1299,7 @@ void CvUnit::initWithNameOffset(int iID, UnitTypes eUnit, int iNameOffset, UnitA
 			int iGATurnsfromGPBirth = pPlayer->GetPlayerTraits()->GetGoldenAgeFromGreatPersonBirth(GetGreatPersonFromUnitClass(getUnitClassType())); // Get number of GA turns as defined in table Trait_GoldenAgeFromGreatPersonBirth for this GP type
 			if (iGATurnsfromGPBirth > 0) // If someone defined a positive value (no such thing as negative GA turns!)
 			{
-				iGATurnsfromGPBirth = iGATurnsfromGPBirth * (100 + pPlayer->getGoldenAgeModifier()) / 100; // Adjust for in-game modifiers (eg Persia, GA monopoly, etc)
-				iGATurnsfromGPBirth *= GC.getGame().getGameSpeedInfo().getGoldenAgePercent(); // Adjust for game speed
-				iGATurnsfromGPBirth /= 100;
-				int iValue = pPlayer->GetGoldenAgeProgressMeter();
-				// Do not increase the cost of the next GA
-				pPlayer->changeGoldenAgeTurns(iGATurnsfromGPBirth, iValue, true);
+				pPlayer->changeGoldenAgeTurns(pPlayer->getGoldenAgeLength(iGATurnsfromGPBirth), true);
 			}
 		}
 	}
@@ -12992,13 +12987,7 @@ bool CvUnit::goldenAge()
 	int iGoldenAgeTurns = GetGoldenAgeTurns();
 	if (iGoldenAgeTurns > 0)
 	{
-
-#if defined(MOD_BALANCE_CORE)
-		int iValue = kPlayer.GetGoldenAgeProgressMeter();
-		kPlayer.changeGoldenAgeTurns(iGoldenAgeTurns, iValue, true);
-#else
-		kPlayer.changeGoldenAgeTurns(iGoldenAgeTurns);
-#endif
+		kPlayer.changeGoldenAgeTurns(iGoldenAgeTurns, true);
 		kPlayer.changeNumUnitGoldenAges(1);
 	}
 
@@ -13064,9 +13053,7 @@ int CvUnit::GetGoldenAgeTurns() const
 	}
 #endif
 	// Game Speed mod
-
-	iGoldenAgeTurns *= GC.getGame().getGameSpeedInfo().getGoldenAgePercent();
-	iGoldenAgeTurns /= 100;
+	iGoldenAgeTurns = GC.getGame().goldenAgeLength(iGoldenAgeTurns);
 
 	if(iGoldenAgeTurns < 1)
 		iGoldenAgeTurns = 1;

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
@@ -7177,7 +7177,8 @@ int CvLuaPlayer::lGetGoldenAgeLength(lua_State* L)
 	CvPlayerAI* pkPlayer = GetInstance(L);
 	const int iManualTurns = luaL_optint(L, 2, -1);
 
-	pkPlayer->getGoldenAgeLength(iManualTurns);
+	const int iResult = pkPlayer->getGoldenAgeLength(iManualTurns);
+	lua_pushinteger(L, iResult);
 	return 1;
 }
 //------------------------------------------------------------------------------
@@ -7195,7 +7196,7 @@ int CvLuaPlayer::lChangeGoldenAgeTurns(lua_State* L)
 	const bool bFree = luaL_optbool(L, 3, false);
 
 	pkPlayer->changeGoldenAgeTurns(pkPlayer->getGoldenAgeLength(iTurns), bFree);
-	return 1;
+	return 0;
 }
 //------------------------------------------------------------------------------
 //int getNumUnitGoldenAges();

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
@@ -7171,10 +7171,14 @@ int CvLuaPlayer::lGetGoldenAgeTurns(lua_State* L)
 	return BasicLuaMethod(L, &CvPlayerAI::getGoldenAgeTurns);
 }
 //------------------------------------------------------------------------------
-//int getGoldenAgeLength();
+//int getGoldenAgeLength(int iManualTurns);
 int CvLuaPlayer::lGetGoldenAgeLength(lua_State* L)
 {
-	return BasicLuaMethod(L, &CvPlayerAI::getGoldenAgeLength);
+	CvPlayerAI* pkPlayer = GetInstance(L);
+	const int iManualTurns = luaL_optint(L, 2, -1);
+
+	pkPlayer->getGoldenAgeLength(iManualTurns);
+	return 1;
 }
 //------------------------------------------------------------------------------
 //bool isGoldenAge();
@@ -7183,10 +7187,15 @@ int CvLuaPlayer::lIsGoldenAge(lua_State* L)
 	return BasicLuaMethod(L, &CvPlayerAI::isGoldenAge);
 }
 //------------------------------------------------------------------------------
-//void changeGoldenAgeTurns(int iChange);
+//void changeGoldenAgeTurns(int iChange, bool bFree);
 int CvLuaPlayer::lChangeGoldenAgeTurns(lua_State* L)
 {
-	return BasicLuaMethod(L, &CvPlayerAI::changeGoldenAgeTurns);
+	CvPlayerAI* pkPlayer = GetInstance(L);
+	const int iTurns = lua_tointeger(L, 2);
+	const bool bFree = luaL_optbool(L, 3, false);
+
+	pkPlayer->changeGoldenAgeTurns(pkPlayer->getGoldenAgeLength(iTurns), bFree);
+	return 1;
 }
 //------------------------------------------------------------------------------
 //int getNumUnitGoldenAges();


### PR DESCRIPTION
CvPlayer::changeGoldenAgeTurns :
 - iValue has only been used for Brazil's gain yields on golden age. Every passed parameter is the current turn's Golden Age Points.  This is a hidden exploit that gives you many more yields if you can trigger a golden age while currently overflowing in GAP.  I've changed it so that it only gives the current GA threshold in yields. The iValue parameter is now unnecessary.
 - bug: if you gain a Golden Age that isn't free (eg the old Great Artist expend ability, or Spy Tech Steal when there are no techs to steal) while you are currently in a Golden Age, you don't cause the threshold to go up (ie. it's free).  FIXED

CvPlayer::getGoldenAgeLength :
CvGame::getGoldenAgeLength :
 - now take a manual number of turns as an optional parameter to replace the default (10) turns; it returns this value after modification by player and game speed.