### PR TITLE
Prevent Triremes and Lighthouses in Lakes

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -33206,7 +33206,7 @@ bool CvCity::isValidBuildingLocation(BuildingTypes eBuilding) const
 	if (pkBuildingInfo->IsWater())
 	{
 		//-1 is ocean (fast check)
-		if (!isCoastal(-1) && !isCoastal(pkBuildingInfo->GetMinAreaSize()))
+		if (!isCoastal(-1) || !isCoastal(pkBuildingInfo->GetMinAreaSize()))
 			return false;
 	}
 

--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -13186,8 +13186,8 @@ bool CvPlot::canTrain(UnitTypes eUnit, bool, bool) const
 	{
 		if(thisUnitDomain == DOMAIN_SEA)
 		{
-			//fast check for ocean (-1) or any lake (1) allows building ships
-			if(!isWater() && !isCoastalLand(-1) && !isCoastalLand(1))
+			//fast check for ocean (-1)
+			if(!isCoastalLand(-1) || !isCoastalLand(thisUnitEntry.GetMinAreaSize()))
 			{
 				return false;
 			}


### PR DESCRIPTION
Fix for issue #8512 .

Explanation: It should be "or" instead of "and" in the if-clause: A trireme/lighthouse is buildable if the city is next to water (isCoastal(-1)) **and** the body of water is large enough (isCoastal(pkBuildingInfo->GetMinAreaSize()). The negated condition must use **or** then.

Additionally, for coastal units the check of GetMinAreaSize (10 for all ships, -1 for work boats) was missing, so ships could be build in any city next to water.