### PR TITLE
Loading screen tips for VP

### DIFF
--- a/(3a) EUI Compatibility Files/LUA/LoadScreen.lua
+++ b/(3a) EUI Compatibility Files/LUA/LoadScreen.lua
@@ -1,0 +1,145 @@
+-------------------------------------------------
+-- Game Loading Screen
+-- modified by bc1 from 1.0.3.144 code
+-------------------------------------------------
+include( "EUI_utilities" )
+local IconHookup = EUI.IconHookup
+local CivIconHookup = EUI.CivIconHookup
+local SimpleCivIconHookup = EUI.SimpleCivIconHookup
+include( "PopulateUniques" )
+local InitializePopulateUniques = InitializePopulateUniques
+local PopulateUniquesForGameLoad = PopulateUniquesForGameLoad
+local math_min = math.min
+local math_max = math.max
+
+local g_civID = -1;
+local g_isLoadComplete = false;
+
+include( "ContentSwitch" )
+
+Controls.ProgressBar:SetPercent( 1 );
+
+ContextPtr:SetShowHideHandler( 
+function( isHide, isInit )
+	if not isHide then
+		UI.SetDontShowPopups(true);
+		if not isInit then
+			UIManager:SetUICursor( 1 );
+			g_isLoadComplete = false;
+
+			Controls.AlphaAnim:SetToBeginning();
+--			Controls.SlideAnim:SetToBeginning();
+			Controls.ActivateButton:SetHide(true);
+
+			-- Force some settings off when loading a HotSeat game.
+			if not PreGame.IsMultiplayerGame() then
+				PreGame.SetGameOption("GAMEOPTION_DYNAMIC_TURNS", false);
+				PreGame.SetGameOption("GAMEOPTION_SIMULTANEOUS_TURNS", false);
+				PreGame.SetGameOption("GAMEOPTION_PITBOSS", false);
+			end
+
+			-- Sets up Selected Civ Slot
+			local civ = GameInfo.Civilizations[ PreGame.GetCivilization( Game:GetActivePlayer() ) ];
+			if civ then
+				g_civID = civ.ID;
+				-- Use the Civilization_Leaders table to cross reference from this civ to the Leaders table
+				local leader = GameInfo.Leaders[ GameInfo.Civilization_Leaders{ CivilizationType = civ.Type }().LeaderheadType ];
+
+				-- Set Leader & Civ Text
+				Controls.Civilization:LocalizeAndSetText( civ.Description );
+				Controls.Leader:LocalizeAndSetText( leader.Description );
+				-- Set Civ Leader Icon
+-- there is no Portrait!!!	IconHookup( leader.PortraitIndex, 128, leader.IconAtlas, Controls.Portrait );
+
+				-- Set Civ Icon
+				SimpleCivIconHookup( Game.GetActivePlayer(), 80, Controls.IconShadow );
+
+				-- Sets Trait bonus Text
+				local trait = GameInfo.Traits[ GameInfo.Leader_Traits{ LeaderType = leader.Type }().TraitType ];
+				Controls.BonusTitle:LocalizeAndSetText( trait.ShortDescription );
+				Controls.BonusDescription:LocalizeAndSetText( trait.Description );
+				Controls.Tips:SetText("Tip: "..getVPTip())
+				-- Sets Bonus Icons
+				InitializePopulateUniques();
+				Controls.SubStack:DestroyAllChildren();
+				PopulateUniquesForGameLoad( Controls.SubStack, civ.Type );
+
+				-- Sets Dawn of Man Quote
+				Controls.Quote:LocalizeAndSetText( civ.DawnOfManQuote or "" );
+
+				-- Sets Dawn of Man Image
+				Controls.Image:SetTexture(civ.DawnOfManImage);
+				local x, y = UIManager:GetScreenSizeVal()
+				local a = math_min( x-500, y/0.75 )
+				local b = math_max( 500, x-a )
+				Controls.Image:Resize( a, 0.75*a )
+				Controls.Details:SetSizeX( b )
+--				Controls.BonusDescription:SetWrapWidth( b*0.9 )
+--				Controls.Quote:SetWrapWidth( b*0.9 )
+				Controls.Details:ReprocessAnchoring();
+			else
+				g_civID = -1;
+				PreGame.SetCivilization( 0, -1 );
+			end
+			if g_civID ~= -1 then
+				Events.SerialEventDawnOfManShow(g_civID);
+			end
+		end
+	elseif not isInit then
+		UIManager:SetUICursor( 0 );
+		Controls.Image:UnloadTexture();
+		--print("Texture is unloaded");
+		if g_civID ~= -1 then
+			Events.SerialEventDawnOfManHide(g_civID);
+		end
+	end
+end );
+-------------
+-- Start Game
+-------------
+local function OnActivateButtonClicked ()
+	--print("Activate button clicked!");
+	Events.LoadScreenClose();
+	if not PreGame.IsMultiplayerGame() and not PreGame.IsHotSeatGame() then
+		Game.SetPausePlayer( -1 );
+	end
+
+	UI.SetDontShowPopups( false );
+
+	--UI.SetNextGameState( GameStates.MainGameView, g_iAIPlayer );
+end
+Controls.ActivateButton:RegisterCallback( Mouse.eLClick, OnActivateButtonClicked );
+
+
+----------------------
+-- Key Down Processing
+----------------------
+ContextPtr:SetInputHandler(
+function( uiMsg, wParam, lParam )
+	if g_isLoadComplete
+		and uiMsg == KeyEvents.KeyDown
+		and ( wParam == Keys.VK_ESCAPE or wParam == Keys.VK_RETURN )
+	then
+		OnActivateButtonClicked();
+	end
+	return true;
+end );
+
+---------------------
+-- Game Init complete
+---------------------
+Events.SequenceGameInitComplete.Add(
+function()
+	g_isLoadComplete = true;
+
+	if PreGame.IsMultiplayerGame() or PreGame.IsHotSeatGame() then
+		OnActivateButtonClicked();
+	else
+		Game.SetPausePlayer( Game.GetActivePlayer() );
+		Controls.ActivateButtonText:LocalizeAndSetText( UI:IsLoadedGame() and "TXT_KEY_BEGIN_GAME_BUTTON_CONTINUE" or "TXT_KEY_BEGIN_GAME_BUTTON" );
+		Controls.ActivateButton:SetHide(false);
+		Controls.AlphaAnim:Play();
+--		Controls.SlideAnim:Play();
+		UIManager:SetUICursor( 0 );
+	end
+end );

--- a/(3a) EUI Compatibility Files/LUA/LoadScreen.xml
+++ b/(3a) EUI Compatibility Files/LUA/LoadScreen.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- edited with XMLSPY v2004 rel. 2 U (http://www.xmlspy.com) by Scott Lewis (Firaxis Games) -->
+<Context>
+	<!-- NEED TO HIDE-->
+
+	<AlphaAnim ID="AlphaAnim" Stopped="1" AlphaStart="1" Pause="1" AlphaEnd="0.36" Speed=".5" Cycle="Once" >
+		<!-- NEED TO HIDE-->
+		<Box ID="BG0" Size="Full,Full" Color="Black.255">
+			<Image ID="Image" Anchor="L,C" Size="1024,768" Sampler="Linear" >
+				<Box Anchor="R,T" AnchorSide="i.o" Size="Full,Full" Color="Black.100" />
+				<Box Anchor="R,B" AnchorSide="i.o" Size="Full,Full" Color="Black.100" />
+			</Image>
+		</Box>
+	</AlphaAnim>
+
+	<Box ID="Details" Anchor="R.T" Color="Black.36" Size="500,Full" >
+		<Stack ID="MainStack" Anchor="C,C" Size="128,128" StackGrowth="Bottom" Padding="12" >
+			<Image Anchor="C,T" AnchorSide="i.o" Size="80,80" Texture="NotificationFrameBase.dds">
+				<Image ID="IconShadow" Anchor="C,C" Offset="0,-1" Size="80,80" Texture="CivSymbolsColor640.dds"/>
+			</Image>
+			<Label ID="Leader" Anchor="C,C" ColorSet="Beige_Black_Alpha" Font="TwCenMT24" FontStyle="Shadow"/>
+			<Label ID="Civilization" Anchor="C,C" ColorSet="Beige_Black_Alpha" Font="TwCenMT20" FontStyle="Shadow"/>
+			<Image Anchor="C,C" Texture="bar340x2.dds" Size="340.1"/>
+			<Label ID="Quote" Anchor="C,C" WrapWidth="460" LeadingOffset="-4" ColorSet="Beige_Black_Alpha" Font="TwCenMT16" FontStyle="Shadow"/>
+			<Container Size="6,6"/>
+			<Image Anchor="C,C" Texture="bar340x2.dds" Size="340.1"/>
+			<Label ID="BonusTitle" Anchor="C,C" ColorSet="Beige_Black_Alpha" Font="TwCenMT24" FontStyle="Shadow"/>
+			<Label ID="BonusDescription" Anchor="C,C" WrapWidth="460" LeadingOffset="-4" ColorSet="Beige_Black_Alpha" Font="TwCenMT16" FontStyle="Shadow"/>
+			<Image Anchor="C,C" Texture="bar340x2.dds" Size="340.1"/>
+
+			<Stack ID="SubStack" Anchor="C,C" StackGrowth="Right" WrapGrowth="Down" WrapWidth="460" />
+
+			<Image Anchor="C,B" Texture="Assets/UI/Art/Civilopedia/LoadingMeterTrim.dds" Size="300,64">
+				<AlphaAnim Anchor="C,C" Pause="0" Cycle="Bounce" Speed=".5" AlphaStart="1" AlphaEnd=".3">
+					<TextureBar ID="ProgressBar" Anchor="C,C" Size="277.36" Texture="Assets/UI/Art/Civilopedia/LoadingMeterHL.dds" Direction="Right" Hidden="0"/>
+				</AlphaAnim>
+				<Label Anchor="C,C" Offset="0,-1" String="TXT_KEY_GAME_LOADING" Color0="255.255.200.255" Color1="5.10.10.255" Color2="5.10.10.255" Font="TwCenMT20" FontStyle="SoftShadow"/>
+				<GridButton ID="ActivateButton" Style="SmallButton2" Anchor="C,C" Size="300,32" Hidden="1">
+					<Label ID="ActivateButtonText" Anchor="C,C" String="TXT_KEY_BEGIN_GAME_BUTTON" ColorSet="Beige_Black_Alpha" Font="TwCenMT18" FontStyle="Shadow"/>
+				</GridButton>
+			</Image>
+
+			<Container Size="6,6"/>
+			<Label ID="Tips" Anchor="L,C" WrapWidth="460" BranchAlpha="1.5" LeadingOffset="-4" Color0="Production,255" Color1="0,0,0,200" Font="TwCenMT16" FontStyle="Shadow"/>
+		</Stack>
+	</Box>
+
+	<Instance Name="IconInstance" >
+		<Container Anchor="L,T" Size="225,64" >
+			<Image Anchor="L,C" Texture="IconFrame64.dds" Size="64.64">
+				<Button ID="Portrait" Anchor="C,C" Size="64,64" NoStateChange="1" />
+				<Label ID="Text" Anchor="R,C" AnchorSide="O.I" WrapWidth="150" ColorSet="Beige_Black_Alpha" Font="TwCenMT16" FontStyle="Shadow"/>
+			</Image>
+		</Container>
+	</Instance>
+</Context>

--- a/(3a) EUI Compatibility Files/VP EUI Compatibility.civ5proj
+++ b/(3a) EUI Compatibility Files/VP EUI Compatibility.civ5proj
@@ -177,10 +177,6 @@
       <SubType>Lua</SubType>
       <ImportIntoVFS>True</ImportIntoVFS>
     </Content>
-    <Content Include="LUA\LoadingScreen.xml">
-      <SubType>Lua</SubType>
-      <ImportIntoVFS>True</ImportIntoVFS>
-    </Content>
     <Content Include="LUA\MonopoliesInfo.lua">
       <SubType>Lua</SubType>
       <ImportIntoVFS>True</ImportIntoVFS>

--- a/(3a) EUI Compatibility Files/VP EUI Compatibility.civ5proj
+++ b/(3a) EUI Compatibility Files/VP EUI Compatibility.civ5proj
@@ -165,6 +165,10 @@
       <SubType>Lua</SubType>
       <ImportIntoVFS>True</ImportIntoVFS>
     </Content>
+    <Content Include="LUA\LeaderHeadRoot.xml">
+      <SubType>Lua</SubType>
+      <ImportIntoVFS>True</ImportIntoVFS>
+    </Content>
     <Content Include="LUA\LoadScreen.xml">
       <SubType>Lua</SubType>
       <ImportIntoVFS>True</ImportIntoVFS>

--- a/(3a) EUI Compatibility Files/VP EUI Compatibility.civ5proj
+++ b/(3a) EUI Compatibility Files/VP EUI Compatibility.civ5proj
@@ -165,7 +165,15 @@
       <SubType>Lua</SubType>
       <ImportIntoVFS>True</ImportIntoVFS>
     </Content>
-    <Content Include="LUA\LeaderHeadRoot.xml">
+    <Content Include="LUA\LoadScreen.xml">
+      <SubType>Lua</SubType>
+      <ImportIntoVFS>True</ImportIntoVFS>
+    </Content>
+    <Content Include="LUA\LoadScreen.lua">
+      <SubType>Lua</SubType>
+      <ImportIntoVFS>True</ImportIntoVFS>
+    </Content>
+    <Content Include="LUA\LoadingScreen.xml">
       <SubType>Lua</SubType>
       <ImportIntoVFS>True</ImportIntoVFS>
     </Content>

--- a/Vox Populi Installer Files/CPPSetupData.iss
+++ b/Vox Populi Installer Files/CPPSetupData.iss
@@ -57,6 +57,7 @@ Source: "(4b) UI - Promotion Tree for VP\*"; DestDir: "{app}\(4b) UI - Promotion
 Source: "LUA for (1) CP\LUA\*"; DestDir: "{app}\(1) Community Patch\LUA"; Flags: ignoreversion createallsubdirs recursesubdirs; Components: Core Civ43CPOnly     
 Source: "LUA for (2) VP\LUA\*"; DestDir: "{app}\(2) Vox Populi\LUA"; Flags: ignoreversion createallsubdirs recursesubdirs; Components: FullNoEUI Civ43NoEUI
 Source: "UI_bc1\*"; DestDir: "{code:GetCIVDir}\Assets\DLC\UI_bc1"; Flags: ignoreversion createallsubdirs recursesubdirs; Components: FullEUI Civ43EUI
+Source: "VPUI\*"; DestDir: "{code:GetCIVDir}\Assets\DLC\VPUI"; Flags: ignoreversion createallsubdirs recursesubdirs; Components: FullEUI Civ43EUI FullNoEUI Civ43NoEUI
 
 [Components]
 Name: "FullEUI"; Description: "Full Version (EUI)"; Types: FullEUI; Flags: exclusive disablenouninstallwarning
@@ -76,6 +77,7 @@ Name: "43CivEUI"; Description: "43 Civ Vox Populi (with EUI)"
 
 [InstallDelete]
 Type: filesandordirs; Name: "{code:GetCIVDir}\Assets\DLC\UI_bc1"
+Type: filesandordirs; Name: "{code:GetCIVDir}\Assets\DLC\VPUI"
 Type: filesandordirs; Name: "{userdocs}\My Games\Sid Meier's Civilization 5\cache"
 Type: filesandordirs; Name: "{userdocs}\My Games\Sid Meier's Civilization 5\MODS\(1) Community Patch"
 Type: filesandordirs; Name: "{userdocs}\My Games\Sid Meier's Civilization 5\MODS\(2) Vox Populi"
@@ -104,11 +106,11 @@ var
 
 procedure InitializeWizard;
 begin
-  // Create the EUI path page
+  // Create the DLC path page
 
   CIVDirPage := CreateInputDirPage(wpSelectComponents,
-    'Select the Civilization V path', 'Where should EUI files be installed?',
-    'Select the Civilization V folder in which the Setup should install EUI files, then click Next. If the installer does not select the correct folder by default, please click Browse and choose the right folder ',
+    'Select the Civilization V folder', 'Where should the UI files be installed?',
+    'Select the Civilization V folder in which the Setup will install the UI files, then click Next. If the installer does not select the correct folder by default, please click Browse and choose the correct folder ',
     False, '');
   CIVDirPage.Add('');
 
@@ -138,7 +140,7 @@ begin
   S := '';
 
   S := S + MemoDirInfo + NewLine + NewLine;
-  if WizardIsComponentSelected('FullEUI') or WizardIsComponentSelected('Civ43EUI') then
+  if WizardIsComponentSelected('FullEUI') or WizardIsComponentSelected('Civ43EUI') or WizardIsComponentSelected('FullNoEUI') or WizardIsComponentSelected('Civ43NoEUI') then
   begin
    S := S + 'Civilization V path' + NewLine;
    S := S + Space + CIVDirPage.Values[0] + NewLine + NewLine;
@@ -154,9 +156,9 @@ begin
   Result := CIVDirPage.Values[0];
 end;
 
-function IsEUI: Boolean;
+function IsUI: Boolean;
 begin
-  Result := WizardIsComponentSelected('FullEUI') or WizardIsComponentSelected('Civ43EUI');
+  Result := WizardIsComponentSelected('FullEUI') or WizardIsComponentSelected('Civ43EUI') or WizardIsComponentSelected('FullNoEUI') or WizardIsComponentSelected('Civ43NoEUI');
 end;
 
 function ShouldSkipPage(CIVDirPageID: Integer): Boolean;
@@ -164,6 +166,6 @@ begin
   Result := False;
   if CIVDirPageID = CIVDirPage.ID then
   begin
-    Result := not IsEUI;
+    Result := not IsUI;
   end;
 end;

--- a/Vox Populi Installer Files/VPUI/FrontEnd/ContentSwitch.lua
+++ b/Vox Populi Installer Files/VPUI/FrontEnd/ContentSwitch.lua
@@ -32,7 +32,7 @@ function getVPTip()
 	math.randomseed(os.time()) -- random initialize
 	math.random(); math.random(); math.random() -- warming up
 
-	value = math.random(16)
+	value = math.random(26)
 	print(value)
 	return g_VPTipTable[value]
 end

--- a/Vox Populi Installer Files/VPUI/FrontEnd/ContentSwitch.lua
+++ b/Vox Populi Installer Files/VPUI/FrontEnd/ContentSwitch.lua
@@ -1,0 +1,55 @@
+-- Table of Vox Populi tips
+local g_VPTipTable = {
+"Great Person yields are fixed at the moment they are created.", 
+"Unhappiness from needs caps at city population.", 
+"A large standing army costs less than losing half your empire to an opportunistic neighbor. The AI knows exactly how big your military is, so make sure it's never small.", 
+"Roads and forts can help immensely in both offensive and defensive wars, but be wary of the maintenance cost.",
+"To deal with a snowballing civilization, isolate it diplomatically and weaken it one step at a time. Light a thousand fires.",
+"Against an aggressive warmonger, value defensive positions for your frontier cities instead of good economic output: a lost city will grant you no reward.",
+"Tourism is more than a victory condition: it also helps your trade routes and preserves the buildings and population of conquered cities.",
+"Internal trade routes can be reliable ways to preserve your economy when barbarians and aggressive neighbors roam around.",
+"Never let a settler or great person unguarded.",
+"Your recon units are most vulnerable near coastal or mountainous tiles, where barbarians can often surprise and trap them.",
+"Founding a religion isn't crucial if you know you can take the Holy City of your neighbor.",
+"Even if you aren't aiming for a diplomatic victory, Great Diplomats are critical to not to be left at the mercy of more influential civilizations after the World Congress is founded.",
+"Offense is often the best defense, particularly against warmongers whose power spikes later in the game.",
+"Combat strength allows you to win battles, healing allows you to win wars.",
+ "If you don't have any gold and have negative income, your science will be reduced, and some units will be disbanded.",
+ "Technologies have their cost lowered when other players have researched them.",
+ "Always check your faith and gold stockpile before clicking 'Next Turn.' It's easy to forget you were saving them for a unit.",
+ "Units suffer a 0.3% combat strength penalty in melee combat and when attacking for every 1 damage taken. Soften your enemy's units with ranged attacks before attacking with your melee units.",
+ "Melee units garrisoning a city, fort, or citadel don't move to the tile of the unit they kill when ordered to attack. You can use those to keep your units from overextending.", 
+"Unhappiness from needs grows rather exponentially with the number of non-puppeted cities you own. Don't expand your empire without sizable surplus happiness.",
+ "Cities, forts, and citadels on a coastal tile count as a canal for your naval units and sea trade routes.",
+ "Missionaries lose strength if they end a turn on a tile belonging to another civilization that you do not have Open Borders. Try to end their turn just outside their borders.",
+ "When you expend a Great Writer, make sure you do it in a city where you want to grab new tiles from border growth.",
+"Issue move orders with SHIFT+RCLICK to create waypoints.",
+"CTRL+RCLICK issues a 'Move and Act' order. 'Act' depends on the unit: Workers repair tiles and improve resources, missionaries spread religion, diplomatic units spread influence, archaeologists dig, and combat units go into fortify or alert mode.",
+"When voting for resolutions, right-click to assign all delegates and middle click to assign ten."
+ }
+
+function getVPTip()
+	math.randomseed(os.time()) -- random initialize
+	math.random(); math.random(); math.random() -- warming up
+
+	value = math.random(16)
+	print(value)
+	return g_VPTipTable[value]
+end
+
+-------------------------------------------------
+-- ContentSwitch
+-------------------------------------------------
+
+----------------------------------------------------------------  
+----------------------------------------------------------------        
+function OnShowHide( isHide, isInit )
+	
+	if(not isHide) then
+		
+	end	
+	Controls.Tips:SetText("Tip: "..getVPTip())
+
+end
+ContextPtr:SetShowHideHandler( OnShowHide );
+

--- a/Vox Populi Installer Files/VPUI/FrontEnd/ContentSwitch.xml
+++ b/Vox Populi Installer Files/VPUI/FrontEnd/ContentSwitch.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Context ColorSet="Beige_Black_Alpha" Font="TwCenMT22" FontStyle="Shadow" Name="ContentSwitch" >
+
+    <Box Color="Black.128" Size="Full.Full" ID="ContentSwitchBox" ConsumeMouseOver="1" >
+        <Grid Size="500,284" Anchor="C,C" Offset="0,0" Padding="0,20" Style="Grid9DetailFive140"  Hidden="0" >
+
+			<!-- Side treatments -->
+			<Box Style="PopupLeftSideTreatment"/>
+			<Box Style="PopupRightSideTreatment"/>
+			<Box Style="PopupNotificationTopTreatment"/>
+			
+			<Label ID="Message" Anchor="C,C"  Offset="0,-24"  WrapWidth="440" String="TXT_KEY_UPDATING_GAME_DATA" Font="TwCenMT22" ColorSet="Beige_Black_Alpha" FontStyle="Shadow"  />
+			<!-- Vox Populi Tips --> 
+			<Label ID="Tips" Anchor="C,C" WrapWidth="440" Offset= "0,24" Color0="Production,255" Color1="0,0,0,200" Font="TwCenMT16" FontStyle="Shadow"/>
+        </Grid>
+    </Box>
+</Context>

--- a/Vox Populi Installer Files/VPUI/FrontEnd/EULA.lua
+++ b/Vox Populi Installer Files/VPUI/FrontEnd/EULA.lua
@@ -1,0 +1,61 @@
+-- modified by Temudjin from 1.0.3.142 code
+-------------------------------------------------
+-- EULA Screen
+-------------------------------------------------
+
+---------- Temudjin START
+g_HasAcceptedEULA = true;
+---------- Temudjin END
+
+
+function OnAccept()
+	g_HasAcceptedEULA = true;
+	NavigateForward();
+end
+
+--------------------------------------------------
+-- Navigation Routines
+--------------------------------------------------
+function NavigateBack()
+	UIManager:DequeuePopup( ContextPtr );
+end
+
+function NavigateForward()
+	UIManager:DequeuePopup(	ContextPtr );
+	UIManager:QueuePopup( Controls.ModsBrowser, PopupPriority.ModsBrowserScreen );
+end
+
+--------------------------------------------------
+-- Explicit Event Handlers
+--------------------------------------------------
+ContextPtr:SetInputHandler(function(uiMsg, wParam, lParam)
+
+	if uiMsg == KeyEvents.KeyDown then
+		if wParam == Keys.VK_ESCAPE then
+			NavigateBack();
+		end
+	end
+
+	return true;
+end);
+
+ContextPtr:SetShowHideHandler(function(isHide)
+    --UNCOMMENT THIS BLOCK IF YOU WISH TO ONLY 
+    --SHOW THE EULA ONCE PER APPLICATION RUN
+    --if not isHide and g_HasAcceptedEULA then
+	--	NavigateForward();
+	--end
+	
+	--if not isHide and g_QueueEulaToHide then
+	--	NavigateBack();
+	--end
+	---------- Temudjin START
+	if not isHide then
+		NavigateForward();
+	end
+	---------- Temudjin END
+end);
+
+-- For now, we don't need to track any sort of acknowledgement of the policy.
+Controls.AcceptButton:RegisterCallback( Mouse.eLClick, OnAccept);
+Controls.DeclineButton:RegisterCallback( Mouse.eLClick, NavigateBack);

--- a/Vox Populi Installer Files/VPUI/FrontEnd/FrontEnd.lua
+++ b/Vox Populi Installer Files/VPUI/FrontEnd/FrontEnd.lua
@@ -1,0 +1,26 @@
+-- modified by Temudjin from 1.0.3.142 code
+-------------------------------------------------
+-- FrontEnd
+-------------------------------------------------
+
+function ShowHideHandler( bIsHide, bIsInit )
+
+		-- Check for game invites first.  If we have a game invite, we will have flipped 
+		-- the Civ5App::eHasShownLegal and not show the legal/touch screens.
+		UI:CheckForCommandLineInvitation();
+
+---------- Temudjin START
+--    if not UI:HasShownLegal() then
+--        UIManager:QueuePopup( Controls.LegalScreen, PopupPriority.LegalScreen );
+--    end
+---------- Temudjin END
+
+    if not bIsHide then
+        Controls.AtlasLogo:SetTexture( "CivilzationVAtlas.dds" );
+    	UIManager:SetUICursor( 0 );
+        UIManager:QueuePopup( Controls.MainMenu, PopupPriority.MainMenu );
+    else
+        Controls.AtlasLogo:UnloadTexture();
+    end
+end
+ContextPtr:SetShowHideHandler( ShowHideHandler );

--- a/Vox Populi Installer Files/VPUI/GameSetup/LoadScreen.lua
+++ b/Vox Populi Installer Files/VPUI/GameSetup/LoadScreen.lua
@@ -1,0 +1,170 @@
+include( "IconSupport" );
+include( "UniqueBonuses" );
+include( "ContentSwitch" ); -- Includes tips for Vox Populi
+
+local iCivID = -1;
+local g_bLoadComplete;
+
+function ShowHide( isHide, isInit )
+	if ( not isInit ) then
+		if ( isHide == true ) then
+			UIManager:SetUICursor( 0 );
+			Controls.Image:UnloadTexture();
+			--print("Texture is unloaded");
+			if (iCivID ~= -1) then
+				Events.SerialEventDawnOfManHide(iCivID);
+			end
+		else
+			OnInitScreen();
+			UIManager:SetUICursor( 1 );
+			if (iCivID ~= -1) then
+				Events.SerialEventDawnOfManShow(iCivID);        
+			end
+		end
+	end
+	
+	if(not isHide) then
+		UI.SetDontShowPopups(true);
+	end
+end
+ContextPtr:SetShowHideHandler( ShowHide );
+
+Controls.ProgressBar:SetPercent( 1 );
+
+function OnInitScreen()
+	
+	g_bLoadComplete = false;
+	
+    Controls.AlphaAnim:SetToBeginning();
+    Controls.SlideAnim:SetToBeginning();
+	Controls.ActivateButton:SetHide(true);
+	
+	local civIndex = PreGame.GetCivilization( Game:GetActivePlayer() );
+    
+    local civ = GameInfo.Civilizations[civIndex];
+    
+    if(civ == nil) then
+		PreGame.SetCivilization(0, -1);
+	end
+	
+    if ( not PreGame.IsMultiplayerGame() ) then
+		-- Force some settings off when loading a HotSeat game.
+        PreGame.SetGameOption("GAMEOPTION_DYNAMIC_TURNS", false);
+        PreGame.SetGameOption("GAMEOPTION_SIMULTANEOUS_TURNS", false);
+        PreGame.SetGameOption("GAMEOPTION_PITBOSS", false);
+    end	
+    
+    -- Sets up Selected Civ Slot
+    if( civ ~= nil ) then
+		
+        -- Use the Civilization_Leaders table to cross reference from this civ to the Leaders table
+        local leader = GameInfo.Leaders[GameInfo.Civilization_Leaders( "CivilizationType = '" .. civ.Type .. "'" )().LeaderheadType];
+        local leaderDescription = leader.Description;
+
+		-- Set Leader & Civ Text
+		Controls.Civilization:LocalizeAndSetText( civ.Description );
+		Controls.Leader:LocalizeAndSetText( leaderDescription );
+        
+        -- Set Civ Leader Icon
+		IconHookup( leader.PortraitIndex, 128, leader.IconAtlas, Controls.Portrait );
+		
+		-- Set Civ Icon
+		SimpleCivIconHookup( Game.GetActivePlayer(), 80, Controls.IconShadow );
+		
+		-- Sets Trait bonus Text
+        local leaderTrait = GameInfo.Leader_Traits("LeaderType ='" .. leader.Type .. "'")();
+        local trait = leaderTrait.TraitType;
+        Controls.BonusTitle:SetText( Locale.ConvertTextKey( GameInfo.Traits[trait].ShortDescription ));
+        Controls.BonusDescription:SetText( Locale.ConvertTextKey( GameInfo.Traits[trait].Description ));
+		Controls.Tips:SetText("Tip: "..getVPTip()); -- Vox Populi tips
+
+         -- Sets Bonus Icons
+        local bonusText = PopulateUniqueBonuses( Controls, civ, leader, false, true);
+        
+        Controls.BonusUnit:LocalizeAndSetText( bonusText[1] or "" );
+        Controls.BonusBuilding:LocalizeAndSetText( bonusText[2] or "" );
+        
+        -- Sets Dawn of Man Quote
+        Controls.Quote:LocalizeAndSetText(civ.DawnOfManQuote or "");
+        
+        -- Sets Dawn of Man Image
+        Controls.Image:SetTexture(civ.DawnOfManImage);
+		iCivID = civ.ID;
+        --print("iCivID: " .. iCivID);
+	end
+	
+	
+end      
+
+function OnActivateButtonClicked ()
+	--print("Activate button clicked!");
+	Events.LoadScreenClose();
+	if (not PreGame.IsMultiplayerGame() and not PreGame.IsHotSeatGame()) then
+		Game.SetPausePlayer(-1);
+	end
+	
+	UI.SetDontShowPopups(false);
+	
+	--UI.SetNextGameState( GameStates.MainGameView, g_iAIPlayer );
+end
+Controls.ActivateButton:RegisterCallback( Mouse.eLClick, OnActivateButtonClicked );
+
+
+----------------------------------------------------------------        
+-- Key Down Processing
+----------------------------------------------------------------        
+function InputHandler( uiMsg, wParam, lParam )
+    if( uiMsg == KeyEvents.KeyDown )
+    then
+        if( wParam == Keys.VK_ESCAPE or wParam == Keys.VK_RETURN ) then
+			if (g_bLoadComplete) then
+				OnActivateButtonClicked();
+			end
+        end
+    end
+    return true;
+end
+ContextPtr:SetInputHandler( InputHandler );
+
+function HideBackgrounds ()
+	Controls.AlphaAnim:Play();
+	Controls.SlideAnim:Play();
+end
+
+function OnSequenceGameInitComplete ()
+	
+	g_bLoadComplete = true;	
+	
+	if (PreGame.IsMultiplayerGame() or PreGame.IsHotSeatGame()) then
+		OnActivateButtonClicked();
+	else
+		Game.SetPausePlayer(Game.GetActivePlayer());
+		local strGameButtonName;
+		if (not UI:IsLoadedGame()) then
+			strGameButtonName = Locale.ConvertTextKey("TXT_KEY_BEGIN_GAME_BUTTON");
+		else
+			strGameButtonName = Locale.ConvertTextKey("TXT_KEY_BEGIN_GAME_BUTTON_CONTINUE");
+		end
+	
+		Controls.ActivateButtonText:SetText(strGameButtonName);
+		Controls.ActivateButton:SetHide(false);
+		HideBackgrounds();
+        UIManager:SetUICursor( 0 );	
+        
+        -- Update Icons to now have tooltips.
+        local civIndex = PreGame.GetCivilization( Game:GetActivePlayer() );
+        local civ = GameInfo.Civilizations[civIndex];
+    
+		-- Sets up Selected Civ Slot
+		if( civ ~= nil ) then
+			
+			-- Use the Civilization_Leaders table to cross reference from this civ to the Leaders table
+			local leader = GameInfo.Leaders[GameInfo.Civilization_Leaders( "CivilizationType = '" .. civ.Type .. "'" )().LeaderheadType];
+
+			 -- Sets Bonus Icons
+			local bonusText = PopulateUniqueBonuses( Controls, civ, leader, true, false);
+		end
+	end
+end
+
+Events.SequenceGameInitComplete.Add( OnSequenceGameInitComplete );

--- a/Vox Populi Installer Files/VPUI/GameSetup/LoadScreen.xml
+++ b/Vox Populi Installer Files/VPUI/GameSetup/LoadScreen.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- edited with XMLSPY v2004 rel. 2 U (http://www.xmlspy.com) by Scott Lewis (Firaxis Games) -->
+<Context>
+    <!-- NEED TO HIDE-->
+
+
+    <Box Anchor="C.C" Offset="0,0" Size="1024,768" Color="Black.0" Hidden="0">
+
+        <AlphaAnim Anchor="c,c" Stopped="1" AlphaStart="1" Pause="1" AlphaEnd="0" Speed=".5" Cycle="Once" ID="AlphaAnim" >
+            <!-- NEED TO HIDE-->
+            <Box ID="BG0" Anchor="C,C" Size="Full,Full" Color="Black" />
+            <Image ID="Image" Anchor="C,C" Offset="0,0" Size="1024,768" />
+        </AlphaAnim>
+
+
+
+        <SlideAnim Anchor="C,C" Size="1024,768" Start="226,0" End="0,0" Cycle="Once" Speed=".5" Stopped="1" Pause="1" ID="SlideAnim" Function="Root" >
+            <Grid Anchor="C.T" Offset="0,36" Size="500,668" Style="GridBlackIndent8" ID="BlackGrid" >
+                <Grid Anchor="R.T" Offset="0,0" Size="502,670" Style="Grid9Frame" ID="BlackGridFrame" />
+                <Image Anchor="L,T" Size="80,80" Offset="24,16" Texture="assets\UI\Art\Notification\NotificationFrameBase.dds">
+                    <Image Anchor="C,C" ID="IconShadow" Offset="0,-1" Size="80,80" Texture="assets\UI\Art\Notification\CivSymbolsColor640.dds"/>
+                </Image>
+                <Stack Anchor="C,T" Offset="0,36" Size="128,128" StackGrowth="Bottom" Padding="12" ID="MainStack" >
+                    <Label Anchor="C,C" Offset="0,0" ID="Leader" ColorSet="Beige_Black_Alpha" Font="TwCenMT24" FontStyle="Shadow"/>
+                    <Label Anchor="C,C" Offset="0,0" ID="Civilization" ColorSet="Beige_Black_Alpha" Font="TwCenMT20" FontStyle="Shadow"/>
+                    <Image Anchor="C,C" Offset="0,0" Texture="bar340x2.dds" Size="340.1"/>
+                    <Label Anchor="C,C" WrapWidth="460" ID="Quote" LeadingOffset="-4" Offset="0,0" ColorSet="Beige_Black_Alpha" Font="TwCenMT14" FontStyle="Shadow"/>
+                    <Box Anchor="C.C" Offset="0,0" Size="400,6" Color="White.0"/>
+                    <Image Anchor="C,C" Offset="0,0" Texture="bar340x2.dds" Size="340.1"/>
+                    <Label Anchor="C,C" Offset="0,0" ID="BonusTitle" String="BONUS LABEL" ColorSet="Beige_Black_Alpha" Font="TwCenMT24" FontStyle="Shadow"/>
+                    <Label Anchor="C,C" WrapWidth="460" ID="BonusDescription" LeadingOffset="-4" Offset="0,0" ColorSet="Beige_Black_Alpha" Font="TwCenMT16" FontStyle="Shadow"/>
+                    <Image Anchor="C,C" Offset="0,0" Texture="bar340x2.dds" Size="340.1"/>
+                    <Stack Anchor="C,C" Offset="0,0" StackGrowth="Right" Padding="0" ID="SubStack" >
+                        <Box Anchor="C.C" Offset="0,0" Size="225,48" Color="White.0">
+                            <Image Anchor="L,C" Offset="0,0" Texture="IconFrame64.dds" Size="64.64" Hidden="0" ID="BF1">
+                                <Image Anchor="C,C" Size="64,64" Texture="WonderAtlas512.dds" ID="B1"/>
+                                <Label Anchor="R,T" AnchorSide="O.I" Offset="0,22" ID="BonusUnit" WrapWidth="150" ColorSet="Beige_Black_Alpha" Font="TwCenMT16" FontStyle="Shadow">
+                                </Label>
+                            </Image>
+                        </Box>
+                        <Box Anchor="C.C" Offset="0,0" Size="225,48" Color="White.0">
+                            <Image Anchor="L,C" Offset="0,0" Texture="IconFrame64.dds" Size="64.64" ID="BF2">
+                                <Image Anchor="C,C" Size="64,64" Texture="WonderAtlas512.dds" ID="B2"/>
+                                <Label Anchor="R,T" AnchorSide="O.I" Offset="0,22" ID="BonusBuilding" WrapWidth="150" ColorSet="Beige_Black_Alpha" Font="TwCenMT16" FontStyle="Shadow">
+                                </Label>
+                            </Image>
+                        </Box>
+                    </Stack>
+                    <Image Anchor="C,C" Offset="0,0" Texture="bar340x2.dds" Size="340.1"/>
+					<Container Size="6,6"/>
+					<Label ID="Tips" Anchor="C,C" WrapWidth="460" BranchAlpha="1.5" LeadingOffset="-4" Color0="Production,255" Color1="0,0,0,200" Font="TwCenMT16" FontStyle="Shadow"/>
+                </Stack>
+            </Grid>
+        </SlideAnim>
+		<!-- Vox Populi Tips -->
+        <Image Anchor="C,B" Offset="0,0" Texture="Assets/UI/Art/Civilopedia/LoadingMeterTrim.dds" Size="300,64">
+            <AlphaAnim Anchor="C,C" Offset="0,0" Pause="0" Cycle="Bounce" Speed=".5" AlphaStart="1" AlphaEnd=".3">
+                <TextureBar Anchor="C,C" Offset="0,0" Size="277.36" Texture="Assets/UI/Art/Civilopedia/LoadingMeterHL.dds" Direction="Right" ID="ProgressBar" Hidden="0"/>
+            </AlphaAnim>
+            <Label Anchor="C,C" Offset="0,-1" String="TXT_KEY_GAME_LOADING" Color0="255.255.200.255" Color1="5.10.10.255" Color2="5.10.10.255" Font="TwCenMT20" FontStyle="SoftShadow"/>
+        </Image>
+        <GridButton ID="ActivateButton" Style="SmallButton2" Anchor="C,B" Offset="0,16" Size="300,32" Hidden="1">
+            <Label ID="ActivateButtonText" Anchor="C,C" String="TXT_KEY_BEGIN_GAME_BUTTON" Offset="0,0" ColorSet="Beige_Black_Alpha" Font="TwCenMT18" FontStyle="Shadow"/>
+        </GridButton>
+    </Box>
+</Context>

--- a/Vox Populi Installer Files/VPUI/VPUI_0.Civ5Pkg
+++ b/Vox Populi Installer Files/VPUI/VPUI_0.Civ5Pkg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Civ5Package>
+	<GUID>{570f793e-fc33-417f-ae18-7cecccdd5f85}</GUID>
+	<Version>1</Version>
+	<Priority>050</Priority>
+	<PTags>
+		<Tag>Version</Tag>
+	</PTags>
+	<Name>
+		<Value language="en_US">Vox Populi UI Additions</Value>
+	</Name>
+	<Description>
+		<Value language="en_US">Vox Populi UI Additions</Value>
+	</Description>
+
+	<UISkin name="BaseGame" set="BaseGame" platform="Common">
+		<Skin>
+			<Directory>FrontEnd</Directory>
+			<Directory>GameSetup</Directory>
+		</Skin>
+	</UISkin>
+
+</Civ5Package>

--- a/Vox Populi Installer Files/VPUI/VPUI_1.Civ5Pkg
+++ b/Vox Populi Installer Files/VPUI/VPUI_1.Civ5Pkg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Civ5Package>
+	<GUID>{570f793e-fc33-417f-ae18-7cecccdd5f85}</GUID>
+	<Version>1</Version>
+	<Priority>150</Priority>
+	<PTags>
+		<Tag>Version</Tag>
+	</PTags>
+	<Name>
+		<Value language="en_US">Vox Populi UI Additions</Value>
+	</Name>
+	<Description>
+		<Value language="en_US">Vox Populi UI Additions</Value>
+	</Description>
+
+	<UISkin name="Expansion1Primary" set="Expansion1" platform="Common">
+		<Skin>
+			<Directory>FrontEnd</Directory>
+			<Directory>GameSetup</Directory>
+		</Skin>
+	</UISkin>
+
+</Civ5Package>

--- a/Vox Populi Installer Files/VPUI/VPUI_2.Civ5Pkg
+++ b/Vox Populi Installer Files/VPUI/VPUI_2.Civ5Pkg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Civ5Package>
+	<GUID>{570f793e-fc33-417f-ae18-7cecccdd5f85}</GUID>
+	<Version>1</Version>
+	<Priority>250</Priority>
+	<PTags>
+		<Tag>Version</Tag>
+	</PTags>
+	<Name>
+		<Value language="en_US">Vox Populi UI Additions</Value>
+	</Name>
+	<Description>
+		<Value language="en_US">Vox Populi UI Additions</Value>
+	</Description>
+
+	<UISkin name="Expansion2Primary" set="Expansion2" platform="Common">
+		<Skin>
+			<Directory>FrontEnd</Directory>
+			<Directory>GameSetup</Directory>
+		</Skin>
+	</UISkin>
+
+</Civ5Package>


### PR DESCRIPTION
Adds VP tips to mod configuration pop-up and loading screen, for both EUI and nonEUI versions. Tips are stored in a table in the repurposed ContentSwitch.lua and can be expanded easily. This required dlc-type modding though, so I introduced a VPUI dlc mod, which also allows us to get rid of annoying EULA/Legal screens in the nonEUI versions. This can be used to add VP-specific options in the future. 

The modified EULA/Legal screen luas are taken from EUI, but the files were actually made by someone on civfanatics called Temudjin. The code isn't anything original though, basically sets a boolean to true and comments out a function, there is nothing problematic credits-wise, I've sent a message to Temudjin in any case.

Installer is modified accordingly, I compiled&tested it without errors.