### PR TITLE
Update Theming in all situations

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvBuildingClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuildingClasses.cpp
@@ -5357,7 +5357,7 @@ int CvCityBuildings::GetBuildingGreatWork(BuildingClassTypes eBuildingClass, int
 void CvCityBuildings::SetBuildingGreatWork(BuildingClassTypes eBuildingClass, int iSlot, int iGreatWorkIndex)
 {
 	m_pCity->ResetGreatWorkYieldCache();
-	
+
 	for(std::vector<BuildingGreatWork>::iterator it = m_aBuildingGreatWork.begin(); it != m_aBuildingGreatWork.end(); ++it)
 	{
 		if((*it).eBuildingClass == eBuildingClass && (*it).iSlot == iSlot)
@@ -5373,6 +5373,11 @@ void CvCityBuildings::SetBuildingGreatWork(BuildingClassTypes eBuildingClass, in
 				{
 					(*it).iGreatWorkIndex = iGreatWorkIndex;
 				}
+
+				if (eBuildingClass != NO_BUILDINGCLASS)
+				{
+					m_pCity->GetCityCulture()->UpdateThemingBonusIndex(eBuildingClass);
+				}
 			}
 
 			GC.GetEngineUserInterface()->setDirty(CityInfo_DIRTY_BIT, true);
@@ -5387,6 +5392,11 @@ void CvCityBuildings::SetBuildingGreatWork(BuildingClassTypes eBuildingClass, in
 		kWork.iSlot = iSlot;
 		kWork.iGreatWorkIndex = iGreatWorkIndex;
 		m_aBuildingGreatWork.push_back(kWork);
+
+		if (eBuildingClass != NO_BUILDINGCLASS)
+		{
+			m_pCity->GetCityCulture()->UpdateThemingBonusIndex(eBuildingClass);
+		}
 	}
 
 	GC.GetEngineUserInterface()->setDirty(CityInfo_DIRTY_BIT, true);

--- a/CvGameCoreDLL_Expansion2/CvCultureClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCultureClasses.cpp
@@ -750,7 +750,10 @@ bool CvGameCulture::SwapGreatWorks (PlayerTypes ePlayer1, int iWork1, PlayerType
 	GC.GetEngineUserInterface()->setDirty(GreatWorksScreen_DIRTY_BIT, true);
 
 	pCity1->UpdateAllNonPlotYields(true);
-	pCity2->UpdateAllNonPlotYields(true);
+	if (pCity1 != pCity2)
+	{
+		pCity2->UpdateAllNonPlotYields(true);
+	}
 
 	return true;
 }
@@ -775,19 +778,11 @@ void CvGameCulture::MoveGreatWorks(PlayerTypes ePlayer, int iCity1, int iBuildin
 	pCity2->GetCityBuildings()->SetBuildingGreatWork((BuildingClassTypes)iBuildingClass2, iWorkIndex2, workType1);
 
 #if defined(MOD_BALANCE_CORE)
-	if ((BuildingClassTypes)iBuildingClass1 != NO_BUILDINGCLASS)
-	{
-		pCity1->GetCityCulture()->UpdateThemingBonusIndex((BuildingClassTypes)iBuildingClass1);
-	}
-	pCity1->ResetGreatWorkYieldCache();
 	pCity1->UpdateAllNonPlotYields(true);
-
-	if ((BuildingClassTypes)iBuildingClass2 != NO_BUILDINGCLASS)
+	if (pCity1 != pCity2)
 	{
-		pCity2->GetCityCulture()->UpdateThemingBonusIndex((BuildingClassTypes)iBuildingClass2);
+		pCity2->UpdateAllNonPlotYields(true);
 	}
-	pCity2->ResetGreatWorkYieldCache();
-	pCity2->UpdateAllNonPlotYields(true);
 #endif
 }
 
@@ -1637,18 +1632,6 @@ void CvPlayerCulture::MoveWorks (GreatWorkSlotType eType, vector<CvGreatWorkBuil
 	if(bSecondUpdate || bUpdate)
 	{
 		std::vector<CvCity*> CityList;
-		for (itBuilding = buildings.begin(); itBuilding != buildings.end(); itBuilding++)
-		{
-			CvCity* pCity = m_pPlayer->getCity(itBuilding->m_iCityID);
-			if (pCity != NULL)
-			{
-				CvBuildingEntry *pkEntry = GC.getBuildingInfo(itBuilding->m_eBuilding);
-				if (pkEntry)
-				{
-					pCity->GetCityCulture()->UpdateThemingBonusIndex((BuildingClassTypes)pkEntry->GetBuildingClassType());
-				}
-			}
-		}
 		for (itBuilding = buildings.begin(); itBuilding != buildings.end(); itBuilding++)
 		{
 			CvCity* pCity = m_pPlayer->getCity(itBuilding->m_iCityID);


### PR DESCRIPTION
 - Moving the call of CvCityCulture::UpdateThemingBonusIndex() to low-level to catch all instances of when theming should be updated (fixes #8903).
 - removed some redundancy