### PR TITLE
Link icon fix & RCLICK rebases aircraft

### DIFF
--- a/(2) Vox Populi/Core Files/CoreLua/WorldView.lua
+++ b/(2) Vox Populi/Core Files/CoreLua/WorldView.lua
@@ -751,6 +751,13 @@ function MovementRButtonUp()
 			return true;
 		end
 
+		-- rebase with RCLICK
+		if pHeadSelectedUnit:GetDomainType() == DomainTypes.DOMAIN_AIR and pHeadSelectedUnit:CanRebaseAt(0, plotX, plotY) then
+			print("AIIRRRR")
+			Game.SelectionListGameNetMessage(GameMessageTypes.GAMEMESSAGE_PUSH_MISSION, MissionTypes.MISSION_REBASE, plotX, plotY);				
+--			pHeadSelectedUnit:RebaseAt(plotX, plotY)
+		end
+
 		-- Visible enemy... bombardment?
 		if plot:IsVisibleEnemyUnit(pHeadSelectedUnit:GetOwner()) or plot:IsEnemyCity(pHeadSelectedUnit) then
 

--- a/(2) Vox Populi/Core Files/CoreLua/WorldView.lua
+++ b/(2) Vox Populi/Core Files/CoreLua/WorldView.lua
@@ -753,9 +753,7 @@ function MovementRButtonUp()
 
 		-- rebase with RCLICK
 		if pHeadSelectedUnit:GetDomainType() == DomainTypes.DOMAIN_AIR and pHeadSelectedUnit:CanRebaseAt(0, plotX, plotY) then
-			print("AIIRRRR")
 			Game.SelectionListGameNetMessage(GameMessageTypes.GAMEMESSAGE_PUSH_MISSION, MissionTypes.MISSION_REBASE, plotX, plotY);				
---			pHeadSelectedUnit:RebaseAt(plotX, plotY)
 		end
 
 		-- Visible enemy... bombardment?

--- a/(2) Vox Populi/LUA/UnitPanel.lua
+++ b/(2) Vox Populi/LUA/UnitPanel.lua
@@ -341,7 +341,7 @@ function UpdateUnitActions( unit )
     g_PromotionsOpen = false;
 
 	local hideLinkButton = true
-	if unit:GetPlot():GetNumUnits() > 1 and bUnitHasMovesLeft then
+	if unit:CanLinkUnits() and bUnitHasMovesLeft then
 		hideLinkButton = false
 		UpdateLinkIcon(unit)
 	end

--- a/(3a) EUI Compatibility Files/LUA/UnitPanel.lua
+++ b/(3a) EUI Compatibility Files/LUA/UnitPanel.lua
@@ -1165,7 +1165,7 @@ local function UpdateUnitActions( unit )
 
 	end
 
-	if plot:GetNumUnits() > 1 and hasMovesLeft then
+	if unit:CanLinkUnits() and hasMovesLeft then
 		hideLinkButton = false
 		UpdateLinkIcon(unit)
 	end

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -15353,6 +15353,36 @@ void CvUnit::SetLinkedLeaderID(int iLinkedLeaderID)
 		}
 }
 
+
+//	--------------------------------------------------------------------------------
+bool CvUnit::CanLinkUnits()
+{
+	VALIDATE_OBJECT
+
+	const CvPlot* pCurrentPlot = plot();
+
+	if (pCurrentPlot == NULL)
+		return false;
+
+	const IDInfo* pUnitNode = pCurrentPlot->headUnitNode();
+	bool bCanLink = false;
+	CvUnit* pLoopUnit = NULL;
+
+	while (pUnitNode != NULL)
+	{
+		pLoopUnit = ::GetPlayerUnit(*pUnitNode);
+		pUnitNode = pCurrentPlot->nextUnitNode(pUnitNode);
+
+		if (pLoopUnit != NULL && pLoopUnit->getOwner() == getOwner() && !pLoopUnit->isDelayedDeath() && !pLoopUnit->isTrade() && pLoopUnit->getDomainType() != DOMAIN_AIR)
+		{
+			if (pLoopUnit != this)
+				bCanLink = true;
+				return bCanLink;
+		}
+	}
+
+	return bCanLink;
+}
 //	--------------------------------------------------------------------------------
 void CvUnit::LinkUnits()
 {

--- a/CvGameCoreDLL_Expansion2/CvUnit.h
+++ b/CvGameCoreDLL_Expansion2/CvUnit.h
@@ -617,6 +617,7 @@ public:
 	UnitIdContainer GetLinkedUnits();
 	int GetLinkedMaxMoves() const;
 	void SetLinkedMaxMoves(int iValue);
+	bool CanLinkUnits();
 	void LinkUnits();
 	void UnlinkUnits();
 	void MoveLinkedLeader(CvPlot* pDestPlot);

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.cpp
@@ -193,6 +193,7 @@ void CvLuaUnit::PushMethods(lua_State* L, int t)
 	Method(IsLinked);
 	Method(IsLinkedLeader);
 	Method(IsGrouped);
+	Method(CanLinkUnits);
 	Method(LinkUnits);
 	Method(UnlinkUnits);
 	Method(MoveLinkedLeader);
@@ -2439,6 +2440,16 @@ int CvLuaUnit::lIsGrouped(lua_State* L)
 	CvUnit* pkUnit = GetInstance(L);
 	const bool bResult = pkUnit->IsGrouped();
 
+	lua_pushboolean(L, bResult);
+	return 1;
+}
+//------------------------------------------------------------------------------ 
+//bool CanLinkUnits();
+int CvLuaUnit::lCanLinkUnits(lua_State* L)
+{
+	CvUnit* pkUnit = GetInstance(L);
+
+	const bool bResult = pkUnit->CanLinkUnits();
 	lua_pushboolean(L, bResult);
 	return 1;
 }

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.h
@@ -195,6 +195,7 @@ protected:
 	static int lIsLinked(lua_State* L);
 	static int lIsLinkedLeader(lua_State* L);
 	static int lIsGrouped(lua_State* L);
+	static int lCanLinkUnits(lua_State* L);
 	static int lLinkUnits(lua_State* L);
 	static int lUnlinkUnits(lua_State* L);
 	static int lMoveLinkedLeader(lua_State* L);


### PR DESCRIPTION
- Link icon will not show for ineligible units
- Aircraft can be rebased by right-clicking on a valid city