### PR TITLE
Update cppcheck.yml

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -1,5 +1,8 @@
 name: cppcheck
-on: [push]
+on:
+  push:
+    branches:
+    - master
 jobs:
   analysis:
     runs-on: ubuntu-latest


### PR DESCRIPTION
run on master branch push only


_Originally posted by @RecursiveVision in https://github.com/LoneGazebo/Community-Patch-DLL/issues/8652#issuecomment-1111443921_: Any chance you could make it only scan pushes to master? It's doing it for side branches as well, which I suspect is eating into the limited number of scans.