### PR TITLE
SHIFT+LCLICK Force Ends Turn, Final Tweaks to Linked&Group Movement

### DIFF
--- a/(2) Vox Populi/Core Files/CoreLua/ActionInfoPanel.lua
+++ b/(2) Vox Populi/Core Files/CoreLua/ActionInfoPanel.lua
@@ -172,6 +172,7 @@ function OnEndTurnClicked()
 			Events.GameplayFX(hex.x, hex.y, -1);				
 		else
 			print("pUnit = player:GetFirstReadyUnit() IS NIL")
+	 		player:EndTurnsForReadyUnits(false) -- end turns for all idle units
 		end	
 	--elseif (blockingType == EndTurnBlockingTypes.ENDTURN_BLOCKING_UNITS) then
 	--	-- Skip active Unit's turn

--- a/(2) Vox Populi/Core Files/CoreLua/ActionInfoPanel.lua
+++ b/(2) Vox Populi/Core Files/CoreLua/ActionInfoPanel.lua
@@ -97,6 +97,7 @@ end
 function OnEndTurnClicked()
 
 	local player = Players[Game.GetActivePlayer()];
+	local bShift = UIManager:GetShift();
 	if not player:IsTurnActive() then
 		print("Player's turn not active");
 		return;
@@ -114,6 +115,12 @@ function OnEndTurnClicked()
 		return;
 	end
 
+	-- VP START
+	player:EndTurnsForReadyUnits(true) -- end turns for linked units by issuing a skip mission order
+	if bShift then
+		player:EndTurnsForReadyUnits(false) -- end turns for all idle units
+	end
+	-- VP END
 	local blockingType = player:GetEndTurnBlockingType();
 	local blockingNotificationIndex = player:GetEndTurnBlockingNotificationIndex();
 	
@@ -163,6 +170,8 @@ function OnEndTurnClicked()
 			UI.SelectUnit(pUnit);
 			local hex = ToHexFromGrid( Vector2(pPlot:GetX(), pPlot:GetY() ) );
 			Events.GameplayFX(hex.x, hex.y, -1);				
+		else
+			print("pUnit = player:GetFirstReadyUnit() IS NIL")
 		end	
 	--elseif (blockingType == EndTurnBlockingTypes.ENDTURN_BLOCKING_UNITS) then
 	--	-- Skip active Unit's turn

--- a/(2) Vox Populi/LUA/UnitPanel.lua
+++ b/(2) Vox Populi/LUA/UnitPanel.lua
@@ -64,7 +64,7 @@ function OnLinkUnitsClicked()
 
 	if unit:IsLinked() then
 		unit:UnlinkUnits()
-	else
+	elseif unit:CanLinkUnits() then
 		unit:LinkUnits()
 	end
 	UpdateLinkIcon(unit)

--- a/(3a) EUI Compatibility Files/LUA/UnitPanel.lua
+++ b/(3a) EUI Compatibility Files/LUA/UnitPanel.lua
@@ -345,7 +345,7 @@ function OnLinkUnitsClicked()
 
 	if unit:IsLinked() then
 		unit:UnlinkUnits()
-	else
+	elseif unit:CanLinkUnits() then
 		unit:LinkUnits()
 	end
 	UpdateLinkIcon(unit)

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -11942,28 +11942,30 @@ const CvUnit* CvPlayer::GetFirstReadyUnit() const
 }
 
 //	--------------------------------------------------------------------------------
-void CvPlayer::EndTurnsForReadyUnits()
+void CvPlayer::EndTurnsForReadyUnits(bool bEndLinkedTurns)
 {
 	int iLoop;
-	for(CvUnit* pLoopUnit = firstUnit(&iLoop); pLoopUnit; pLoopUnit = nextUnit(&iLoop))
+	for (CvUnit* pLoopUnit = firstUnit(&iLoop); pLoopUnit; pLoopUnit = nextUnit(&iLoop))
 	{
-		if(pLoopUnit->ReadyToMove() && !pLoopUnit->isDelayedDeath() && !pLoopUnit->TurnProcessed())
+		if (pLoopUnit->ReadyToMove() && !pLoopUnit->isDelayedDeath() && !pLoopUnit->TurnProcessed())
 		{
 			pLoopUnit->PushMission(CvTypes::getMISSION_SKIP());
 			pLoopUnit->SetTurnProcessed(true);
-#if defined(MOD_BALANCE_CORE)
-			if(GC.getLogging() && GC.getAILogging())
+		
+			if (GC.getLogging() && GC.getAILogging())
 			{
 				CvString strCiv = GET_PLAYER(pLoopUnit->getOwner()).getCivilizationAdjective();
 				CvString strLogString;
-				strLogString.Format("Warning: Forcing turn end for %s %s at %d,d", strCiv.c_str(), pLoopUnit->getName().c_str(), pLoopUnit->getX(), pLoopUnit->getY() );
+				strLogString.Format("Warning: Forcing turn end for %s %s at %d,d", strCiv.c_str(), pLoopUnit->getName().c_str(), pLoopUnit->getX(), pLoopUnit->getY());
 				GetHomelandAI()->LogHomelandMessage(strLogString);
 			}
-#endif
+		}
+		if (bEndLinkedTurns && pLoopUnit->IsLinked() && !pLoopUnit->IsLinkedLeader())
+		{
+			pLoopUnit->PushMission(CvTypes::getMISSION_SKIP());
 		}
 	}
 }
-
 //	--------------------------------------------------------------------------------
 bool CvPlayer::hasAutoUnit() const
 {

--- a/CvGameCoreDLL_Expansion2/CvPlayer.h
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.h
@@ -243,7 +243,7 @@ public:
 	bool hasReadyUnit() const;
 	int GetCountReadyUnits() const;
 	const CvUnit* GetFirstReadyUnit() const;
-	void EndTurnsForReadyUnits();
+	void EndTurnsForReadyUnits(bool bEndLinkedTurns = false);
 	bool hasAutoUnit() const;
 	bool hasBusyUnit() const;
 	const CvUnit* getBusyUnit() const;

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -15368,7 +15368,7 @@ bool CvUnit::CanLinkUnits()
 
 	const CvPlot* pCurrentPlot = plot();
 
-	if (pCurrentPlot == NULL)
+	if (pCurrentPlot == NULL || !isHuman())
 		return false;
 
 	const IDInfo* pUnitNode = pCurrentPlot->headUnitNode();
@@ -15399,7 +15399,7 @@ void CvUnit::LinkUnits()
 
 	const CvPlot* pCurrentPlot = plot();
 		
-	if (pCurrentPlot == NULL)
+	if (pCurrentPlot == NULL || !isHuman())
 		return;
 
 	const IDInfo* pUnitNode = pCurrentPlot->headUnitNode();

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -15411,6 +15411,8 @@ void CvUnit::LinkUnits()
 	UnitIdContainer LinkedUnitIDs;
 	int iLowestCurrentMoves = getMoves();
 	int iLowestMaxMoves = (IsGrouped()) ? GetLinkedMaxMoves() : maxMoves();
+	bool bLeaderAssigned = false;
+	CvUnit* pLinkedLeader = this;
 
 	while (pUnitNode != NULL)
 	{
@@ -15428,8 +15430,17 @@ void CvUnit::LinkUnits()
 			}
 			if (iLoopMaxMoves < iLowestMaxMoves) {
 				iLowestMaxMoves = iLoopMaxMoves;
+			}			
+			if (!bLeaderAssigned && pLoopUnit->AI_getUnitAIType() == UNITAI_WORKER) { // workers are prioritized, allows them to ask for orders
+				pLoopUnit->SetIsLinkedLeader(true);
+				pLinkedLeader = pLoopUnit;
+				bLeaderAssigned = true;
 			}
 		}
+	}
+
+	if (!bLeaderAssigned)	{ // no workers found, ordering unit gets leadership
+		SetIsLinkedLeader(true);
 	}
 
 	for (int iI = 0; iI < (int)v_unitvector.size(); iI++)
@@ -15440,15 +15451,15 @@ void CvUnit::LinkUnits()
 		pUnit->setMoves(iLowestCurrentMoves);
 		pUnit->SetLinkedMaxMoves(iLowestMaxMoves);
 
-		if (this == pUnit) {
-			SetIsLinkedLeader(true);
-		} 
+		if (pUnit->IsLinkedLeader()) {
+			continue;
+		}
 		else {
 			LinkedUnitIDs.push_back(pUnit->GetID());
-			pUnit->SetLinkedLeaderID(this->GetID());
+			pUnit->SetLinkedLeaderID(pLinkedLeader->GetID());
 		}
 	}
-	SetLinkedUnits(LinkedUnitIDs);
+	pLinkedLeader->SetLinkedUnits(LinkedUnitIDs);
 }
 
 //	--------------------------------------------------------------------------------
@@ -15529,18 +15540,30 @@ void CvUnit::DoGroupMovement(CvPlot* pDestPlot)
 		}
 	}
 
-	//	int iFlags = CvUnit::MOVEFLAG_NO_ENEMY_TERRITORY | CvUnit::MOVEFLAG_APPROX_TARGET_RING1 | CvUnit::MOVEFLAG_ABORT_IF_NEW_ENEMY_REVEALED;
 	for (int iI = 0; iI < (int)v_unitvector.size(); iI++) // then move the units
 	{
 		CvUnit* pUnit = v_unitvector[iI];
 
-		int iXDiff = getX() - pUnit->getX();
+		int iXDiff = getX() - pUnit->getX(); // to get the relative position to the central unit
 		int iYDiff = getY() - pUnit->getY();
+		CvPlot* pFirstTargetPlot = GC.getMap().plot(pDestPlot->getX() - iXDiff, pDestPlot->getY() - iYDiff); // ideal plot
 
 		pUnit->SetIsGrouped(true);
 		pUnit->setMoves(iLowestCurrentMoves);
 		pUnit->SetLinkedMaxMoves(iLowestMaxMoves);
-		pUnit->PushMission(CvTypes::getMISSION_MOVE_TO(), pDestPlot->getX() - iXDiff, pDestPlot->getY() - iYDiff);
+		// first we try to move the unit and keep its relative position, if fails, we try to move the unit to ring1 and then ring2.
+		if (pUnit->canMoveInto(*pFirstTargetPlot, CvUnit::MOVEFLAG_DESTINATION)) {
+			pUnit->PushMission(CvTypes::getMISSION_MOVE_TO(), pFirstTargetPlot->getX(), pFirstTargetPlot->getY(), CvUnit::MOVEFLAG_DESTINATION | CvUnit::MOVEFLAG_ABORT_IF_NEW_ENEMY_REVEALED);
+		}
+		else if (pUnit->canMoveInto(*pDestPlot, CvUnit::MOVEFLAG_DESTINATION | CvUnit::MOVEFLAG_APPROX_TARGET_RING1)) {
+			pUnit->PushMission(CvTypes::getMISSION_MOVE_TO(), pDestPlot->getX(), pDestPlot->getY(), CvUnit::MOVEFLAG_DESTINATION | CvUnit::MOVEFLAG_ABORT_IF_NEW_ENEMY_REVEALED | CvUnit::MOVEFLAG_APPROX_TARGET_RING1);
+		}
+		else if (pUnit->canMoveInto(*pDestPlot, CvUnit::MOVEFLAG_DESTINATION | CvUnit::MOVEFLAG_APPROX_TARGET_RING2)) {
+			pUnit->PushMission(CvTypes::getMISSION_MOVE_TO(), pDestPlot->getX(), pDestPlot->getY(), CvUnit::MOVEFLAG_DESTINATION | CvUnit::MOVEFLAG_ABORT_IF_NEW_ENEMY_REVEALED | CvUnit::MOVEFLAG_APPROX_TARGET_RING2);
+		}
+		else {
+			pUnit->SetIsGrouped(false); // cannot move the unit, kick it out of the group
+		}
 	}
 
 	SetIsGrouped(true); 

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -15371,8 +15371,12 @@ bool CvUnit::CanLinkUnits()
 	if (pCurrentPlot == NULL || !isHuman())
 		return false;
 
+	const CvUnit* pThisUnit = this;
+
+	if (pThisUnit == NULL || pThisUnit->isDelayedDeath() || pThisUnit->isTrade() || pThisUnit->getDomainType() == DOMAIN_AIR)
+		return false;
+
 	const IDInfo* pUnitNode = pCurrentPlot->headUnitNode();
-	bool bCanLink = false;
 	CvUnit* pLoopUnit = NULL;
 
 	while (pUnitNode != NULL)
@@ -15384,13 +15388,12 @@ bool CvUnit::CanLinkUnits()
 		{
 			if (pLoopUnit != this)
 			{
-				bCanLink = true;
-				return bCanLink;
+				return true;
 			}
 		}
 	}
 
-	return bCanLink;
+	return false;
 }
 //	--------------------------------------------------------------------------------
 void CvUnit::LinkUnits()

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -5465,7 +5465,7 @@ void CvUnit::move(CvPlot& targetPlot, bool bShow)
 		for (int iI = 0; iI < (int)LinkedUnitIDs.size(); iI++)
 		{
 			CvUnit* pLinkedUnit = GET_PLAYER(m_eOwner).getUnit(LinkedUnitIDs[iI]);
-			if (!pLinkedUnit->canMoveInto(targetPlot)) {
+			if (!pLinkedUnit->canMoveInto(targetPlot, CvUnit::MOVEFLAG_DESTINATION)) {
 				bCanDoLinkedMove = false;
 				break;
 			}

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
@@ -792,6 +792,7 @@ void CvLuaPlayer::PushMethods(lua_State* L, int t)
 
 	Method(GetEndTurnBlockingType);
 	Method(GetEndTurnBlockingNotificationIndex);
+	Method(EndTurnsForReadyUnits);
 	Method(HasReceivedNetTurnComplete);
 	Method(IsStrike);
 
@@ -9341,6 +9342,15 @@ int CvLuaPlayer::lGetEndTurnBlockingType(lua_State* L)
 int CvLuaPlayer::lGetEndTurnBlockingNotificationIndex(lua_State* L)
 {
 	return BasicLuaMethod(L, &CvPlayerAI::GetEndTurnBlockingNotificationIndex);
+}
+// CvPlayer:: EndTurnsForReadyUnits(bool bEndLinkedTurns)
+int CvLuaPlayer::lEndTurnsForReadyUnits(lua_State* L)
+{
+	CvPlayerAI* pkPlayer = GetInstance(L);
+	const bool bEndLinkedTurns = lua_toboolean(L, 2);
+	
+	pkPlayer->EndTurnsForReadyUnits(bEndLinkedTurns);
+	return 1;
 }
 
 //------------------------------------------------------------------------------

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.h
@@ -874,6 +874,7 @@ protected:
 
 	static int lGetEndTurnBlockingType(lua_State* L);
 	static int lGetEndTurnBlockingNotificationIndex(lua_State* L);
+	static int lEndTurnsForReadyUnits(lua_State* L);
 
 	static int lIsStrike(lua_State* L);
 


### PR DESCRIPTION
Shift clicking on the end turn button gives "skip mission" order to all idle units, this is also called when GetFirstReadyUnit() returns nil. I'm pretty sure that 99% cases of "can't progress turn" problems are due to that, this will provide a workaround while I take a look. May require clicking twice to take affect though.

On the link&group front, worker units will automatically be set as leaders because only leaders ask for orders. Group movement will check the destination plots and try to get close (ring1, ring2 etc.).