### PR TITLE
Fix missing notifications for discovered resources

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvTeam.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTeam.cpp
@@ -6265,7 +6265,7 @@ void CvTeam::setHasTech(TechTypes eIndex, bool bNewValue, PlayerTypes ePlayer, b
 									}
 								}
 #endif
-								if (pPlayer->HasPolicy(ePolicyReveal) || (eTechReveal != eIndex && GetTeamTechs()->HasTech(eTechReveal)))
+								if ((ePolicyReveal == NO_POLICY || (ePolicyReveal != NO_POLICY && pPlayer->HasPolicy(ePolicyReveal))) && (eTechReveal == NO_TECH || (eTechReveal != eIndex && GetTeamTechs()->HasTech(eTechReveal))))
 								{
 									bRevealed = true;
 									break;
@@ -6451,7 +6451,7 @@ void CvTeam::setHasTech(TechTypes eIndex, bool bNewValue, PlayerTypes ePlayer, b
 							}
 						}
 #endif
-						if (pPlayer->HasPolicy(eRevealPolicy) || (eTechReveal != eIndex && GetTeamTechs()->HasTech(eTechReveal)))
+						if ((eRevealPolicy == NO_POLICY || (eRevealPolicy != NO_POLICY && pPlayer->HasPolicy(eRevealPolicy))) && (eTechReveal == NO_TECH || (eTechReveal != eIndex && GetTeamTechs()->HasTech(eTechReveal))))
 						{
 							bArtifactRevealed = true;
 							break;
@@ -6491,7 +6491,7 @@ void CvTeam::setHasTech(TechTypes eIndex, bool bNewValue, PlayerTypes ePlayer, b
 							}
 						}
 #endif
-						if (pPlayer->HasPolicy(eRevealPolicy) || (eTechReveal != eIndex && GetTeamTechs()->HasTech(eTechReveal)))
+						if ((eRevealPolicy == NO_POLICY || (eRevealPolicy != NO_POLICY && pPlayer->HasPolicy(eRevealPolicy))) && (eTechReveal == NO_TECH || (eTechReveal != eIndex && GetTeamTechs()->HasTech(eTechReveal))))
 						{
 							bHiddenArtifactRevealed = true;
 							break;
@@ -7034,7 +7034,7 @@ void CvTeam::setHasTech(TechTypes eIndex, bool bNewValue, PlayerTypes ePlayer, b
 											}
 										}
 #endif
-										if (pPlayer->HasPolicy(eRevealPolicy) || (eTechReveal != eIndex && GetTeamTechs()->HasTech(eTechReveal)))
+										if ((eRevealPolicy == NO_POLICY || (eRevealPolicy != NO_POLICY && pPlayer->HasPolicy(eRevealPolicy))) && (eTechReveal == NO_TECH || (eTechReveal != eIndex && GetTeamTechs()->HasTech(eTechReveal))))
 										{
 											bRevealed = true;
 											break;
@@ -7115,7 +7115,7 @@ void CvTeam::setHasTech(TechTypes eIndex, bool bNewValue, PlayerTypes ePlayer, b
 											}
 										}
 #endif
-										if (pPlayer->HasPolicy(eRevealPolicy) || (eTechReveal != eIndex && GetTeamTechs()->HasTech(eTechReveal)))
+										if ((eRevealPolicy == NO_POLICY || (eRevealPolicy != NO_POLICY && pPlayer->HasPolicy(eRevealPolicy))) && (eTechReveal == NO_TECH || (eTechReveal != eIndex && GetTeamTechs()->HasTech(eTechReveal))))
 										{
 											bRevealed = true;
 											break;


### PR DESCRIPTION
Fix #8917 

Explanation: The case where no policy or no technology is required for a resource wasn't handled correctly. Since one of these conditions is always fulfilled, no resource notifications where shown at all. Compare also line 8171, where it was already correct (used there for updating plot yields and graphics). 