### PR TITLE
Check for null `pPlot` during `MINOR_CIV_QUEST_UNIT_GET_CITY` completion check

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
@@ -1503,7 +1503,7 @@ bool CvMinorCivQuest::IsComplete()
 		CvPlot* pPlot = GC.getMap().plot(iX, iY);
 
 		// Conquered or destroyed this city? NOTE: If the player liberated the city, it should still have the "previous owner" flag set
-		return (pPlot && pPlot->isCity() && (pPlot->getPlotCity()->getOwner() == m_eAssignedPlayer || pPlot->getPlotCity()->getPreviousOwner() == m_eAssignedPlayer)) || (!pPlot->isCity() && pPlot->GetPlayerThatDestroyedCityHere() == m_eAssignedPlayer);
+		return pPlot && ((pPlot->isCity() && (pPlot->getPlotCity()->getOwner() == m_eAssignedPlayer || pPlot->getPlotCity()->getPreviousOwner() == m_eAssignedPlayer)) || (!pPlot->isCity() && pPlot->GetPlayerThatDestroyedCityHere() == m_eAssignedPlayer));
 	}
 	}
 

--- a/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
@@ -1503,7 +1503,7 @@ bool CvMinorCivQuest::IsComplete()
 		CvPlot* pPlot = GC.getMap().plot(iX, iY);
 
 		// Conquered or destroyed this city? NOTE: If the player liberated the city, it should still have the "previous owner" flag set
-		return (pPlot->isCity() && (pPlot->getPlotCity()->getOwner() == m_eAssignedPlayer || pPlot->getPlotCity()->getPreviousOwner() == m_eAssignedPlayer)) || (!pPlot->isCity() && pPlot->GetPlayerThatDestroyedCityHere() == m_eAssignedPlayer);
+		return (pPlot && pPlot->isCity() && (pPlot->getPlotCity()->getOwner() == m_eAssignedPlayer || pPlot->getPlotCity()->getPreviousOwner() == m_eAssignedPlayer)) || (!pPlot->isCity() && pPlot->GetPlayerThatDestroyedCityHere() == m_eAssignedPlayer);
 	}
 	}
 


### PR DESCRIPTION
A user on discord was crashing because `pPlot` was null at the end of a turn. I don't know why but the plot coordinates were `(-1, -1)`. There's probably an oversight elsewhere that causes a bad plot to be used, but the null check was removed as part of https://github.com/LoneGazebo/Community-Patch-DLL/commit/4cd3032f501f5b594bc5c6273fbcce16e6866fbd so I see little harm in putting it back for now.