### PR TITLE
Swordline change triggers for custom units&civs

### DIFF
--- a/(2) Vox Populi/Balance Changes/Units/UnitTriggers.sql
+++ b/(2) Vox Populi/Balance Changes/Units/UnitTriggers.sql
@@ -1,0 +1,23 @@
+CREATE TRIGGER VP_SwordsmanPromotion_Replace
+AFTER INSERT ON Units
+WHEN (SELECT Class FROM Units WHERE Type = NEW.UnitType) = 'UNITCLASS_SWORDSMAN'
+BEGIN
+    DELETE FROM Unit_FreePromotions WHERE PromotionType = 'PROMOTION_COVER_1' AND UnitType = NEW.UnitType;
+    INSERT INTO Unit_FreePromotions (UnitType, PromotionType) VALUES (NEW.UnitType, 'PROMOTION_PROFESSIONAL_SOLDIER');
+END;
+
+CREATE TRIGGER VP_LongswordPromotion_Replace
+AFTER INSERT ON Units
+WHEN (SELECT Class FROM Units WHERE Type = NEW.UnitType) = 'UNITCLASS_LONGSWORDSMAN'
+BEGIN
+    DELETE FROM Unit_FreePromotions WHERE PromotionType = 'PROMOTION_COVER_1' AND UnitType = NEW.UnitType;
+    INSERT INTO Unit_FreePromotions (UnitType, PromotionType) VALUES (NEW.UnitType, 'PROMOTION_PROFESSIONAL_SOLDIER');
+END;
+
+CREATE TRIGGER VP_Tercio_Professionalization
+AFTER INSERT ON Units
+WHEN (SELECT Class FROM Units WHERE Type = NEW.UnitType) = 'UNITCLASS_TERCIO'
+BEGIN
+    INSERT INTO Unit_FreePromotions (UnitType, PromotionType) VALUES (NEW.UnitType, 'PROMOTION_PROFESSIONAL_SOLDIER');
+	UPDATE Units SET Combat = Combat - 1 WHERE Type = NEW.UnitType;
+END;

--- a/(2) Vox Populi/Vox Populi.civ5proj
+++ b/(2) Vox Populi/Vox Populi.civ5proj
@@ -917,6 +917,11 @@
         <Type>UpdateDatabase</Type>
         <Filename>Compatibility/MoreLuxuries/Text/Text_en_US.sql</Filename>
       </Action>
+      <Action>
+        <Set>OnModActivated</Set>
+        <Type>UpdateDatabase</Type>
+        <FileName>Balance Changes/Units/UnitTriggers.sql</FileName>
+      </Action>
     </ModActions>
     <ModReferences />
     <ReloadStrategicViewSystem>true</ReloadStrategicViewSystem>
@@ -4547,6 +4552,10 @@
       <ImportIntoVFS>False</ImportIntoVFS>
     </Content>
     <Content Include="Compatibility\MoreLuxuries\Text\Text_en_US.sql">
+      <SubType>Lua</SubType>
+      <ImportIntoVFS>False</ImportIntoVFS>
+    </Content>
+    <Content Include="Balance\Units\UnitTriggers.sql">
       <SubType>Lua</SubType>
       <ImportIntoVFS>False</ImportIntoVFS>
     </Content>


### PR DESCRIPTION
https://github.com/LoneGazebo/Community-Patch-DLL/commit/576630d281e1ddad9d60957bd329a245a908c966

These triggers should bring any custom civs in line with the latest unit changes. That said, VP doesn't really use triggers much, exceptions are HappinessCompatibility.sql, LeftOverUnits.sql for Unit_BuildingClassPurchaseRequireds, and some triggers for adding custom resources to Hacienda, but they aren't "core" changes like Unit Combat Strength or Promotions. Then again, it's very late in VPs development, so burden of maintaining compatibility can be moved from modmods to VP in some cases. 
I don't know if triggers have any performance effect when they are not hit, I placed the file at the end so it shouldn't do anything for a pure VP installation. 