### PR TITLE
Minor Songhai nerf

### DIFF
--- a/(2) Vox Populi/Balance Changes/Leaders/Vanilla/VanillaLeaderChanges.sql
+++ b/(2) Vox Populi/Balance Changes/Leaders/Vanilla/VanillaLeaderChanges.sql
@@ -166,6 +166,8 @@ UPDATE Traits
 SET FasterAlongRiver = '1'
 WHERE Type = 'TRAIT_AMPHIB_WARLORD';
 
+DELETE FROM Trait_FreePromotionUnitCombats WHERE TraitType = "TRAIT_AMPHIB_WARLORD" AND PromotionType = "PROMOTION_WAR_CANOES"; -- Remove embarked defense & sight bonuses
+
 -- Catherine -- Move Krepost, give bonus
 DELETE FROM Building_DomainFreeExperiences
 WHERE BuildingType = 'BUILDING_KREPOST';

--- a/(2) Vox Populi/Balance Changes/Text/en_US/CivText.sql
+++ b/(2) Vox Populi/Balance Changes/Text/en_US/CivText.sql
@@ -1095,7 +1095,7 @@ SET Text = 'Adobe, the Spanish word for mud brick, is a natural building materia
 WHERE Tag = 'TXT_KEY_CIV5_BUILDING_MUD_PYRAMID_MOSQUE_PEDIA';
 
 UPDATE Language_en_US
-SET Text = 'Triple [ICON_GOLD] Gold from pillaging Encampments and Cities. Land Units gain the [COLOR_POSITIVE_TEXT]War Canoe[ENDCOLOR] and [COLOR_POSITIVE_TEXT]Amphibious[ENDCOLOR] Promotions, and move along Rivers as if they were Roads. Rivers create [ICON_CONNECTED] City Connections.'
+SET Text = 'Triple [ICON_GOLD] Gold from pillaging Encampments and Cities. Land Units gain the [COLOR_POSITIVE_TEXT]Amphibious[ENDCOLOR] Promotion, and move along Rivers as if they were Roads. Rivers create [ICON_CONNECTED] City Connections.'
 WHERE Tag = 'TXT_KEY_TRAIT_AMPHIB_WARLORD';
 
 UPDATE Language_en_US


### PR DESCRIPTION
Simply removes War Canoes promotion from Songhai land units, which gave them embarked sight and defense. I&People also wanted to take out the "attack from sea without penalty", but that would require splitting the Amphibious promotion, which would create some other annoyances. 