### PR TITLE
Archaeology p1

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvCultureClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCultureClasses.cpp
@@ -3305,8 +3305,8 @@ ArchaeologyChoiceType CvPlayerCulture::GetArchaeologyChoice(CvPlot *pPlot)
 		eRtnValue = ARCHAEOLOGY_ARTIFACT_PLAYER1;
 	}
 
-	// Otherwise go for Landmark if from Ancient Era, or if have enough other Archaeologists and Antiquity sites to fill all slots
-	else if (pPlot->GetArchaeologicalRecord().m_eEra == 0)
+	// Otherwise go for Landmark if from Medieval Era or earlier, or if have enough other Archaeologists and Antiquity sites to fill all slots
+	else if (pPlot->GetArchaeologicalRecord().m_eEra <= 2)
 	{
 		eRtnValue = ARCHAEOLOGY_LANDMARK;
 	}
@@ -3335,12 +3335,12 @@ ArchaeologyChoiceType CvPlayerCulture::GetArchaeologyChoice(CvPlot *pPlot)
 		}
 	}
 
-	// If chose an artifact, would player 2's be better?
+	// If artifact is chosen, would player 2's be better?
 	if (eRtnValue == ARCHAEOLOGY_ARTIFACT_PLAYER1)
 	{
+		// For now have AI player try to collect their own artifacts
 		if (pPlot->GetArchaeologicalRecord().m_ePlayer2 == m_pPlayer->GetID())
 		{
-			// For now have AI player try to collect their own artifacts
 			eRtnValue = ARCHAEOLOGY_ARTIFACT_PLAYER2;
 		}
 	}

--- a/CvGameCoreDLL_Expansion2/CvCultureClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvCultureClasses.h
@@ -1,5 +1,5 @@
 /*	-------------------------------------------------------------------------------------------------------
-	© 1991-2012 Take-Two Interactive Software and its subsidiaries.  Developed by Firaxis Games.  
+	Â© 1991-2012 Take-Two Interactive Software and its subsidiaries.  Developed by Firaxis Games.  
 	Sid Meier's Civilization V, Civ, Civilization, 2K Games, Firaxis Games, Take-Two Interactive Software 
 	and their respective logos are all trademarks of Take-Two interactive Software, Inc.  
 	All other marks and trademarks are the property of their respective owners.  

--- a/CvGameCoreDLL_Expansion2/CvGameQueries.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGameQueries.cpp
@@ -1,5 +1,5 @@
 /*	-------------------------------------------------------------------------------------------------------
-	© 1991-2012 Take-Two Interactive Software and its subsidiaries.  Developed by Firaxis Games.  
+	Â© 1991-2012 Take-Two Interactive Software and its subsidiaries.  Developed by Firaxis Games.  
 	Sid Meier's Civilization V, Civ, Civilization, 2K Games, Firaxis Games, Take-Two Interactive Software 
 	and their respective logos are all trademarks of Take-Two interactive Software, Inc.  
 	All other marks and trademarks are the property of their respective owners.  

--- a/CvGameCoreDLL_Expansion2/CvGameQueries.h
+++ b/CvGameCoreDLL_Expansion2/CvGameQueries.h
@@ -1,5 +1,5 @@
 /*	-------------------------------------------------------------------------------------------------------
-	© 1991-2012 Take-Two Interactive Software and its subsidiaries.  Developed by Firaxis Games.  
+	Â© 1991-2012 Take-Two Interactive Software and its subsidiaries.  Developed by Firaxis Games.  
 	Sid Meier's Civilization V, Civ, Civilization, 2K Games, Firaxis Games, Take-Two Interactive Software 
 	and their respective logos are all trademarks of Take-Two interactive Software, Inc.  
 	All other marks and trademarks are the property of their respective owners.  

--- a/CvGameCoreDLL_Expansion2/CvImprovementClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvImprovementClasses.cpp
@@ -1,5 +1,5 @@
 /*	-------------------------------------------------------------------------------------------------------
-	© 1991-2012 Take-Two Interactive Software and its subsidiaries.  Developed by Firaxis Games.  
+	Â© 1991-2012 Take-Two Interactive Software and its subsidiaries.  Developed by Firaxis Games.  
 	Sid Meier's Civilization V, Civ, Civilization, 2K Games, Firaxis Games, Take-Two Interactive Software 
 	and their respective logos are all trademarks of Take-Two interactive Software, Inc.  
 	All other marks and trademarks are the property of their respective owners.  

--- a/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
@@ -7221,9 +7221,32 @@ bool CvMinorCivAI::IsValidQuestForPlayer(PlayerTypes ePlayer, MinorCivQuestTypes
 		if (IsRecentlyBulliedByMajor(ePlayer))
 			return false;
 
-		// Any nearby camps?
-		if(GetBestNearbyDig() == NULL)
+		// Any nearby dig sites?
+		CvPlot* pDigPlot = GetBestNearbyDig();
+		if(pDigPlot == NULL)
 			return false;
+		// Can the player send an archaeologist?
+		for (int i = 0; i < GC.getNumBuildInfos(); i++)
+		{
+			BuildTypes eBuild = (BuildTypes)i;
+			CvBuildInfo* pBuildInfo = GC.getBuildInfo(eBuild);
+			if (pBuildInfo == NULL || eBuild == NO_BUILD)
+				continue;
+			// Does the build action create an archaeology prompt?
+			ImprovementTypes eImprovement = (ImprovementTypes)pBuildInfo->getImprovement();
+			if (eImprovement == NO_IMPROVEMENT)
+				continue;
+			CvImprovementEntry& pImprovementEntry = *GC.getImprovementInfo(eImprovement);
+			ResourceTypes eResource = pDigPlot->getResourceType(GET_PLAYER(ePlayer).getTeam());
+			if (!(pImprovementEntry.IsPromptWhenComplete() && pImprovementEntry.IsImprovementResourceMakesValid(eResource)))
+				continue;
+			// Does the player have access to the build action?
+			if (!GET_PLAYER(ePlayer).canBuild(pDigPlot, eBuild, false /*bTestEra*/, false /*bTestVisible*/, false /*bTestGold*/, false /*bTestPlotOwner*/))
+				continue;
+
+			return true;
+		}
+		return false;
 	}
 	// Circumnavigation
 	else if(eQuest == MINOR_CIV_QUEST_CIRCUMNAVIGATION)

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -38593,6 +38593,45 @@ bool CvPlayer::IsResourceRevealed(ResourceTypes eResource, bool bCheckTeam) cons
 
 //	--------------------------------------------------------------------------------
 //	--------------------------------------------------------------------------------
+/// What is the best improvement that connects eResource for this player (does it need to be Civ-Specific)?
+CvImprovementEntry* CvPlayer::GetResourceImprovement(ResourceTypes eResource, bool bCivSpecific) const
+{
+	CvImprovementEntry* pBestImprovement = NULL;
+	for (int iJ = 0; iJ < GC.getNumBuildInfos(); iJ++)
+	{
+		BuildTypes eBuild = ((BuildTypes)iJ);
+		if (eBuild == NO_BUILD)
+			continue;
+
+		CvBuildInfo* pkBuildInfo = GC.getBuildInfo(eBuild);
+		if (!pkBuildInfo)
+			continue;
+
+		ImprovementTypes eUniqueImprovement = (ImprovementTypes)pkBuildInfo->getImprovement();
+		if (eUniqueImprovement == NO_IMPROVEMENT)
+			continue;
+
+		CvImprovementEntry* pkImprovementInfo = GC.getImprovementInfo(eUniqueImprovement);
+		if (pkImprovementInfo->IsConnectsResource(eResource))
+		{
+			// immediately return a civ-specific resource improvement
+			if (pkImprovementInfo->IsSpecificCivRequired() && IsCivilization(pkImprovementInfo->GetRequiredCivilization()))
+			{
+				return pkImprovementInfo;
+			}
+			// store current improvement to be used later if we don't find a civ-specific improvement
+			else if (!bCivSpecific)
+			{
+				pBestImprovement = pkImprovementInfo;
+			}
+		}
+	}
+
+	return pBestImprovement;
+}
+
+//	--------------------------------------------------------------------------------
+//	--------------------------------------------------------------------------------
 /// Do we get copies of each type of luxury connected by eFromPlayer?
 int CvPlayer::getSiphonLuxuryCount(PlayerTypes eFromPlayer) const
 {

--- a/CvGameCoreDLL_Expansion2/CvPlayer.h
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.h
@@ -2147,6 +2147,7 @@ public:
 
 	bool IsResourceCityTradeable(ResourceTypes eResource, bool bCheckTeam = true) const;
 	bool IsResourceRevealed(ResourceTypes eResource, bool bCheckTeam = true) const;
+	CvImprovementEntry* GetResourceImprovement(ResourceTypes eResource, bool bCivSpecific = false) const;
 
 	int getSiphonLuxuryCount(PlayerTypes eFromPlayer) const;
 	void changeSiphonLuxuryCount(PlayerTypes eFromPlayer, int iChange);

--- a/CvGameCoreDLL_Expansion2/CvPlayerAI.h
+++ b/CvGameCoreDLL_Expansion2/CvPlayerAI.h
@@ -1,5 +1,5 @@
 /*	-------------------------------------------------------------------------------------------------------
-	© 1991-2012 Take-Two Interactive Software and its subsidiaries.  Developed by Firaxis Games.  
+	Â© 1991-2012 Take-Two Interactive Software and its subsidiaries.  Developed by Firaxis Games.  
 	Sid Meier's Civilization V, Civ, Civilization, 2K Games, Firaxis Games, Take-Two Interactive Software 
 	and their respective logos are all trademarks of Take-Two interactive Software, Inc.  
 	All other marks and trademarks are the property of their respective owners.  

--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -344,19 +344,6 @@ void CvPlot::doTurn()
 		changeImprovementDuration(1);
 	}
 
-#if defined(MOD_BALANCE_CORE)
-	if (GetArchaeologicalRecord().m_eWork == NO_GREAT_WORK)
-	{
-		ResourceTypes eArtifactResourceType = static_cast<ResourceTypes>(GD_INT_GET(ARTIFACT_RESOURCE));
-		ResourceTypes eHiddenArtifactResourceType = static_cast<ResourceTypes>(GD_INT_GET(HIDDEN_ARTIFACT_RESOURCE));
-
-		if (getResourceType() == eArtifactResourceType || getResourceType() == eHiddenArtifactResourceType)
-		{
-			setResourceType(NO_RESOURCE, 0);
-		}
-	}
-#endif
-
 	verifyUnitValidPlot();
 
 	// Clear world anchor


### PR DESCRIPTION
- Updates to AI considerations for when there exists a Civilization with a UI that functions with Antiquity Site Resources.
   - AI won't consider local antiquity sites for digs if it can "connect" it with its own UI.
   - Minor AI won't create archaeology dig quests for players who can't dig them up.
- AI considers local medieval antiquity sites to be worth keeping as landmarks.