### PR TITLE
Era scaling GE&GM yields modmod

### DIFF
--- a/(1) Community Patch/Core Files/Core Tables/CustomModOptions.xml
+++ b/(1) Community Patch/Core Files/Core Tables/CustomModOptions.xml
@@ -439,6 +439,8 @@
    <Row Class="4" Name="CIVILIANS_RETREAT_WITH_MILITARY" Value="0"/>
     <!-- Linked & group movement -->
    <Row Class="4" Name="LINKED_MOVEMENT" Value="0"/>
+    <!-- Era scaling for GE & GM yields -->
+   <Row Class="4" Name="GP_ERA_SCALING" Value="0"/>
 	  
     <!-- Events sent when terraforming occurs (v33) -->
     <!--   GameEvents.TerraformingMap.Add(function(iEvent, iLoad) end) -->

--- a/CvGameCoreDLL_Expansion2/CustomMods.cpp
+++ b/CvGameCoreDLL_Expansion2/CustomMods.cpp
@@ -559,6 +559,7 @@ int CustomMods::getOption(string sOption, int defValue) {
 		MOD_OPT_CACHE(ATTRITION);
 		MOD_OPT_CACHE(CIVILIANS_RETREAT_WITH_MILITARY);
 		MOD_OPT_CACHE(LINKED_MOVEMENT);
+		MOD_OPT_CACHE(GP_ERA_SCALING);
 
 		m_bInit = true;
 	}

--- a/CvGameCoreDLL_Expansion2/CustomMods.h
+++ b/CvGameCoreDLL_Expansion2/CustomMods.h
@@ -457,7 +457,6 @@
 
 // Enables the experimental AI unit production logic
 #define MOD_AI_UNIT_PRODUCTION						gCustomMods.isAI_UNIT_PRODUCTION()
-
 // Land units blockade undefended adjacent tiles
 #define MOD_ADJACENT_BLOCKADE						gCustomMods.isADJACENT_BLOCKADE()
 // Units take damage in enemy lands
@@ -466,6 +465,8 @@
 #define MOD_CIVILIANS_RETREAT_WITH_MILITARY			gCustomMods.isCIVILIANS_RETREAT_WITH_MILITARY()
 // Linked&Group Movement
 #define MOD_LINKED_MOVEMENT							gCustomMods.isLINKED_MOVEMENT()
+// Era scaling for GE & GM yields
+#define MOD_GP_ERA_SCALING							gCustomMods.isGP_ERA_SCALING()
 
 //
 //	 GameEvents.TradeRouteCompleted.Add(function( iOriginOwner, iOriginCity, iDestOwner, iDestCity, eDomain, eConnectionTradeType) end)
@@ -1538,6 +1539,7 @@ public:
 	MOD_OPT_DECL(ATTRITION);
 	MOD_OPT_DECL(CIVILIANS_RETREAT_WITH_MILITARY);
 	MOD_OPT_DECL(LINKED_MOVEMENT);
+	MOD_OPT_DECL(GP_ERA_SCALING);
 
 protected:
 	bool m_bInit;

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -11965,14 +11965,21 @@ int CvUnit::getMaxHurryProduction(CvCity* pCity) const
 
 	iProduction = (m_pUnitInfo->GetBaseHurry() + (m_pUnitInfo->GetHurryMultiplier() * pCity->getPopulation()));
 
-#if defined(MOD_BALANCE_CORE_NEW_GP_ATTRIBUTES)
-	//Let's make the GM a little more flexible.
+	if (MOD_GP_ERA_SCALING)
+	{
+		int EraModifiers[5] = { 200, 250, 400, 475, 575 }; // starts from renaissance
+		int iCurrentEra = GET_PLAYER(getOwner()).GetCurrentEra();
+		int iIndex = MAX(0, iCurrentEra - 4);
+
+		iProduction = ((m_pUnitInfo->GetBaseHurry() * EraModifiers[iIndex] / 100) + (m_pUnitInfo->GetHurryMultiplier() * pCity->getPopulation()));
+	}
+
+	//Let's make the GE a little more flexible.
 	if (MOD_BALANCE_CORE_NEW_GP_ATTRIBUTES)
 	{
 		//scale up our value
 		iProduction = GetScaleAmount(iProduction);
 	}
-#endif
 
 	iProduction *= GC.getGame().getGameSpeedInfo().getUnitHurryPercent();
 	iProduction /= 100;
@@ -12141,6 +12148,16 @@ int CvUnit::getTradeGold(const CvPlot* /*pPlot*/) const
 
 	// Amount of Gold also increases with how far into the game we are
 	iGold += (m_pUnitInfo->GetNumGoldPerEra() * GET_TEAM(getTeam()).GetCurrentEra());
+
+	if (MOD_GP_ERA_SCALING)
+	{
+		int EraModifiers[5] = { 160, 190, 260, 290, 330 }; // starts from renaissance
+		int iCurrentEra = GET_PLAYER(getOwner()).GetCurrentEra();
+		int iIndex = MAX(0, iCurrentEra - 4);
+
+		iGold *= EraModifiers[iIndex];
+		iGold /= 100;
+	}
 
 	iGold *= GC.getGame().getGameSpeedInfo().getUnitTradePercent();
 	iGold /= 100;


### PR DESCRIPTION
Adds era scaling to GE & GM yields, active from renaissance and onwards. GE scales from base hurry (100 prod), GM scales with base gold + era gold, as GM needed a more hefty buff. Scalars are based on wonder production and investment cost.