### PR TITLE
Remove "Influence" from G.Merchant trade mission text

### DIFF
--- a/(2) Vox Populi/CSD/Gameplay/GameplayText.sql
+++ b/(2) Vox Populi/CSD/Gameplay/GameplayText.sql
@@ -33,7 +33,7 @@ SET Text = 'If the unit is inside City-State territory that you are not at war w
 WHERE Tag = 'TXT_KEY_MISSION_CONDUCT_TRADE_MISSION_HELP' AND EXISTS (SELECT * FROM CSD WHERE Type='CSD_TEXT' AND Value= 1 );
 
 UPDATE Language_en_US
-SET Text = 'You have gained {1_Num} [ICON_GOLD] Gold and {2_Num} [ICON_INFLUENCE] Influence from the Diplomatic Mission!'
+SET Text = 'You have gained {1_Num} [ICON_GOLD] Gold from the Trade Mission!'
 WHERE Tag = 'TXT_KEY_MERCHANT_RESULT' AND EXISTS (SELECT * FROM CSD WHERE Type='CSD_TEXT' AND Value= 1 );
 
 UPDATE Language_en_US


### PR DESCRIPTION
I don't know of any GMerchant variant that gives influence, didn't get any answers either when asked on discord. Diplo units (including GD) already display another text, so there should be no need for this.