### PR TITLE
make Reset Specialist Localizable

### DIFF
--- a/(2) Vox Populi/Balance Changes/Text/en_US/UIText.xml
+++ b/(2) Vox Populi/Balance Changes/Text/en_US/UIText.xml
@@ -1473,6 +1473,12 @@
 		<Row Tag="TXT_KEY_CITY_PRODUCTION_AUTOMATED">
 			<Text>[ICON_AUTOMATED] Production automated</Text>
 		</Row>
+		<Row Tag="TXT_KEY_CITYVIEW_RESET_SPEC">
+			<Text>Reset Specialists</Text>
+		</Row>
+		<Row Tag="TXT_KEY_CITYVIEW_RESET_SPEC_TT">
+			<Text>Click here to have the governor reassign specialists.</Text>
+		</Row>
 	</Language_en_US>
 	<Civilization_CityNames>
 		<Row>

--- a/(2) Vox Populi/LUA/CityView.xml
+++ b/(2) Vox Populi/LUA/CityView.xml
@@ -403,13 +403,13 @@
             </CheckBox>
             <Box Anchor="L,B" Color="27.53.64.255" Offset="0,0" Size="254,2"/>
           </Box>
-		  <Button Size="254,32" Anchor="L,B" ID="ResetSpecialistsButton" ToolTip="Click here to have the governor reassign specialists.">
+		  <Button Size="254,32" Anchor="L,B" ID="ResetSpecialistsButton" ToolTip="TXT_KEY_CITYVIEW_RESET_SPEC_TT">
 			<ShowOnMouseOver>
 			  <AlphaAnim Anchor="L,C" Size="254,28" Pause="0" Cycle="Bounce" Speed="1" AlphaStart=".7" AlphaEnd=".3">
 				<Grid Size="254,28" Offset="0,0" Padding="0,0" Style="GridSquareHL8"/>
 			  </AlphaAnim>
 			</ShowOnMouseOver>
-			<Label Anchor="C,C" String="Reset Specialists" Font="TwCenMT16" FontStyle="Shadow" ColorLayer0="Beige" ColorLayer1="Black" TextAnchor="R,C" TextAnchorSide="O,O"/>
+			<Label Anchor="C,C" String="TXT_KEY_CITYVIEW_RESET_SPEC" Font="TwCenMT16" FontStyle="Shadow" ColorLayer0="Beige" ColorLayer1="Black" TextAnchor="R,C" TextAnchorSide="O,O"/>
 		  </Button>
 			<Box Anchor="L,B" Color="27.53.64.255" Offset="0,0" Size="254,2" ID="ResetSpecialistsFooter"/>
         </Stack>

--- a/(2) Vox Populi/LUA/CityView_small.xml
+++ b/(2) Vox Populi/LUA/CityView_small.xml
@@ -398,13 +398,13 @@
             </CheckBox>
               <Box Anchor="L,B" Color="27.53.64.255" Offset="0,0" Size="254,2"/>
           </Box>
-		  <Button Size="254,32" Anchor="L,B" ID="ResetSpecialistsButton" ToolTip="Click here to have the governor reassign specialists.">
+		  <Button Size="254,32" Anchor="L,B" ID="ResetSpecialistsButton" ToolTip="TXT_KEY_CITYVIEW_RESET_SPEC_TT">
 			<ShowOnMouseOver>
 			  <AlphaAnim Anchor="L,C" Size="254,28" Pause="0" Cycle="Bounce" Speed="1" AlphaStart=".7" AlphaEnd=".3">
 				<Grid Size="254,28" Offset="0,0" Padding="0,0" Style="GridSquareHL8"/>
 			  </AlphaAnim>
 			</ShowOnMouseOver>
-			<Label Anchor="C,C" String="Reset Specialists" Font="TwCenMT16" FontStyle="Shadow" ColorLayer0="Beige" ColorLayer1="Black" TextAnchor="R,C" TextAnchorSide="O,O"/>
+			<Label Anchor="C,C" String="TXT_KEY_CITYVIEW_RESET_SPEC" Font="TwCenMT16" FontStyle="Shadow" ColorLayer0="Beige" ColorLayer1="Black" TextAnchor="R,C" TextAnchorSide="O,O"/>
 		  </Button>
 			<Box Anchor="L,B" Color="27.53.64.255" Offset="0,0" Size="254,2" ID="ResetSpecialistsFooter"/>
         </Stack>

--- a/(3a) EUI Compatibility Files/LUA/CityView.xml
+++ b/(3a) EUI Compatibility Files/LUA/CityView.xml
@@ -299,13 +299,13 @@
 						</Label>
 						<Box Anchor="L,B" Color="27.53.64.255" Size="254,2"/>
 					</Box>
-					<Button ID="ResetSpecialistsButton" Void1="0" Size="254,32" Anchor="L,C" ToolTip="Click here to have the governor reassign specialists.">
+					<Button ID="ResetSpecialistsButton" Void1="0" Size="254,32" Anchor="L,C" ToolTip="TXT_KEY_CITYVIEW_RESET_SPEC_TT">
 						<ShowOnMouseOver>
 							<AlphaAnim Anchor="L,C" Size="254,28" Pause="0" Cycle="Bounce" Speed="1" AlphaStart=".7" AlphaEnd=".3">
 								<Grid Size="254,28" Style="GridSquareHL8"/>
 							</AlphaAnim>
 						</ShowOnMouseOver>
-						<Label Anchor="C,C" String="Reset Specialists" Font="TwCenMT16" TextAnchor="R,C" TextAnchorSide="O,O"/>
+						<Label Anchor="C,C" String="TXT_KEY_CITYVIEW_RESET_SPEC" Font="TwCenMT16" TextAnchor="R,C" TextAnchorSide="O,O"/>
 					</Button>
 					<Box ID="ResetSpecialistsFooter" Anchor="L,B" Color="27.53.64.255" Size="254,2" />
 				</Stack>

--- a/(3a) EUI Compatibility Files/LUA/CityView_small.xml
+++ b/(3a) EUI Compatibility Files/LUA/CityView_small.xml
@@ -292,13 +292,13 @@
 						</Label>
 						<Box Anchor="L,B" Color="27.53.64.255" Size="254,2"/>
 					</Box>
-					<Button ID="ResetSpecialistsButton" Void1="0" Size="254,32" Anchor="L,C" ToolTip="Click here to have the governor reassign specialists.">
+					<Button ID="ResetSpecialistsButton" Void1="0" Size="254,32" Anchor="L,C" ToolTip="TXT_KEY_CITYVIEW_RESET_SPEC_TT">
 						<ShowOnMouseOver>
 							<AlphaAnim Anchor="L,C" Size="254,28" Pause="0" Cycle="Bounce" Speed="1" AlphaStart=".7" AlphaEnd=".3">
 								<Grid Size="254,28" Style="GridSquareHL8"/>
 							</AlphaAnim>
 						</ShowOnMouseOver>
-						<Label Anchor="C,C" String="Reset Specialists" Font="TwCenMT16" TextAnchor="R,C" TextAnchorSide="O,O"/>
+						<Label Anchor="C,C" String="TXT_KEY_CITYVIEW_RESET_SPEC" Font="TwCenMT16" TextAnchor="R,C" TextAnchorSide="O,O"/>
 					</Button>
 					<Box ID="ResetSpecialistsFooter" Anchor="L,B" Color="27.53.64.255" Size="254,2" />
 				</Stack>


### PR DESCRIPTION
add key for 'Reset Specialists' : TXT_KEY_CITYVIEW_RESET_SPEC  
add key for 'Click here to have the governor reassign specialists.' : TXT_KEY_CITYVIEW_RESET_SPEC_TT

For English users, nothing changes.  
![image](https://user-images.githubusercontent.com/53367179/185724076-8b443262-4e76-4cbe-bce4-8709dacf5b5c.png)

It allows me to translate into a foreign language.  
![image](https://user-images.githubusercontent.com/53367179/185724080-3d2e04bc-5214-4019-b263-b53f544c953a.png)
