### PR TITLE
Fix for Resetting Build Progress

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -203,7 +203,6 @@ void CvPlot::reset()
 	m_eFeatureType = NO_FEATURE;
 	m_eResourceType = NO_RESOURCE;
 	m_eImprovementType = NO_IMPROVEMENT;
-	m_eImprovementTypeUnderConstruction = NO_IMPROVEMENT;
 	m_ePlayerBuiltImprovement = NO_PLAYER;
 	m_ePlayerResponsibleForImprovement = NO_PLAYER;
 	m_ePlayerResponsibleForRoute = NO_PLAYER;
@@ -7357,12 +7356,6 @@ void CvPlot::setImprovementType(ImprovementTypes eNewValue, PlayerTypes eBuilder
 		PlayerTypes owningPlayerID = getOwner();
 		if(eOldImprovement != NO_IMPROVEMENT)
 		{
-#if defined(MOD_BALANCE_CORE)
-			if(IsImprovementPillaged())
-			{
-				SetImprovementPillaged(false, false);
-			}
-#endif
 			CvImprovementEntry& oldImprovementEntry = *GC.getImprovementInfo(eOldImprovement);
 
 			DomainTypes eTradeRouteDomain = NO_DOMAIN;
@@ -11701,9 +11694,44 @@ bool CvPlot::setRevealedRouteType(TeamTypes eTeam, RouteTypes eNewValue)
 }
 
 //	--------------------------------------------------------------------------------
-void CvPlot::SilentlyResetAllBuildProgress()
+//	Reset all current builds related to route or improvement, based on eBuild.
+void CvPlot::SilentlyResetAllBuildProgress(BuildTypes eBuild)
 {
-	m_buildProgress.clear();
+	if (m_buildProgress.size() == 0)
+		return;
+
+	if (eBuild == NO_BUILD)
+	{
+		m_buildProgress.clear();
+		return;
+	}
+
+	CvBuildInfo* pkBuildInfo = GC.getBuildInfo(eBuild);
+	if(pkBuildInfo == NULL)
+		return;
+	
+	bool bBuildImprovement = pkBuildInfo->getImprovement() != NO_IMPROVEMENT;
+	bool bBuildRoute = pkBuildInfo->getRoute() != NO_ROUTE;
+
+	for (map<BuildTypes, int>::iterator it = m_buildProgress.begin(), next_it = it; it != m_buildProgress.end(); it = next_it)
+	{
+		++next_it;
+
+		CvBuildInfo* pkIterInfo = GC.getBuildInfo(it->first);
+		if(pkIterInfo == NULL)
+			continue;
+
+		bool bIterImprovement = pkIterInfo->getImprovement() != NO_IMPROVEMENT;
+		bool bIterRoute = pkIterInfo->getRoute() != NO_ROUTE;
+
+		// Two groupings: Improvement (build or repair), Route(build, repair or remove)
+		if ((bBuildImprovement && (bIterImprovement || (pkIterInfo->isRepair() && !IsRoutePillaged()))) ||
+			(bBuildRoute && (bIterRoute || (pkIterInfo->isRepair() && !IsImprovementPillaged()) || pkIterInfo->IsRemoveRoute())) ||
+			(pkBuildInfo->IsRemoveRoute() && (bIterRoute || (pkIterInfo->isRepair() && !IsImprovementPillaged()))))
+		{
+			m_buildProgress.erase(it);
+		}
+	}
 }
 
 
@@ -11747,15 +11775,12 @@ bool CvPlot::changeBuildProgress(BuildTypes eBuild, int iChange, PlayerTypes ePl
 
 	if(iChange != 0)
 	{
-		ImprovementTypes eImprovement = (ImprovementTypes)pkBuildInfo->getImprovement();
-		if (eImprovement != NO_IMPROVEMENT)
+		// wipe out related build progress when starting a new build
+		if (getBuildProgress(eBuild) == 0)
 		{
-			if (eImprovement != m_eImprovementTypeUnderConstruction)
-			{
-				SilentlyResetAllBuildProgress();
-				m_eImprovementTypeUnderConstruction = eImprovement;
-			}
+			SilentlyResetAllBuildProgress(eBuild);
 		}
+		ImprovementTypes eImprovement = (ImprovementTypes)pkBuildInfo->getImprovement();
 
 		m_iLastTurnBuildChanged = GC.getGame().getGameTurn();
 
@@ -11770,15 +11795,6 @@ bool CvPlot::changeBuildProgress(BuildTypes eBuild, int iChange, PlayerTypes ePl
 			if (eImprovement != NO_IMPROVEMENT)
 			{
 				setImprovementType(eImprovement, ePlayer);
-
-				// Building a GP improvement on a resource needs to clear any previous pillaged state
-				if (GC.getImprovementInfo(eImprovement)->IsCreatedByGreatPerson()) {
-#if defined(MOD_EVENTS_TILE_IMPROVEMENTS)
-					SetImprovementPillaged(false, false);
-#else
-					SetImprovementPillaged(false);
-#endif
-				}
 
 				CvImprovementEntry& newImprovementEntry = *GC.getImprovementInfo(eImprovement);
 
@@ -12687,7 +12703,6 @@ void CvPlot::Serialize(Plot& plot, Visitor& visitor)
 	visitor.template as<FeatureTypes>(plot.m_eFeatureType);
 	visitor.template as<ResourceTypes>(plot.m_eResourceType);
 	visitor.template as<ImprovementTypes>(plot.m_eImprovementType);
-	visitor.template as<ImprovementTypes>(plot.m_eImprovementTypeUnderConstruction);
 
 	visitor(plot.m_ePlayerBuiltImprovement);
 	visitor(plot.m_ePlayerResponsibleForImprovement);

--- a/CvGameCoreDLL_Expansion2/CvPlot.h
+++ b/CvGameCoreDLL_Expansion2/CvPlot.h
@@ -673,7 +673,7 @@ public:
 	int getBuildProgress(BuildTypes eBuild) const;
 	bool changeBuildProgress(BuildTypes eBuild, int iChange, PlayerTypes ePlayer = NO_PLAYER, bool bNewBuild = false);
 	bool getAnyBuildProgress() const;
-	void SilentlyResetAllBuildProgress();
+	void SilentlyResetAllBuildProgress(BuildTypes eBuild = NO_BUILD);
 
 	bool isLayoutDirty() const;							// The plot layout contains resources, routes, and improvements
 	void setLayoutDirty(bool bDirty);
@@ -961,7 +961,6 @@ protected:
 #endif
 	char /*ResourceTypes*/ m_eResourceType;
 	char /*ImprovementTypes*/ m_eImprovementType;
-	char /*ImprovementTypes*/ m_eImprovementTypeUnderConstruction;
 	char /*PlayerTypes*/ m_ePlayerBuiltImprovement;
 	char /*PlayerTypes*/ m_ePlayerResponsibleForImprovement;
 	char /*PlayerTypes*/ m_ePlayerResponsibleForRoute;

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -13673,8 +13673,6 @@ bool CvUnit::build(BuildTypes eBuild)
 			}
 		}
 
-		// wipe out all build progress also
-		pPlot->SilentlyResetAllBuildProgress();
 #if defined(MOD_CIV6_WORKER)
 		if(!MOD_CIV6_WORKER)
 			bFinished = pPlot->changeBuildProgress(eBuild, iWorkRateWithMoves, getOwner());


### PR DESCRIPTION
- Road and Improvement builds-in-progress can now coexist
- removed redundant reset-builds and related member variable
- removed redundant set-pillage-states during or near setImprovementType()