### PR TITLE
Resource Diversity Modifier reduction

### DIFF
--- a/(2) Vox Populi/Balance Changes/CoreDefines.sql
+++ b/(2) Vox Populi/Balance Changes/CoreDefines.sql
@@ -80,7 +80,7 @@ UPDATE Defines SET Value = '65' WHERE Name = 'INTERNATIONAL_TRADE_CITY_GPT_DIVIS
 UPDATE Defines SET Value = '25' WHERE Name = 'TRADE_ROUTE_BASE_SEA_MODIFIER';
 UPDATE Defines SET Value = '600' WHERE Name = 'TRADE_ROUTE_BASE_FOOD_VALUE';	
 UPDATE Defines SET Value = '600' WHERE Name = 'TRADE_ROUTE_BASE_PRODUCTION_VALUE';
-UPDATE Defines SET Value = '10' WHERE Name = 'TRADE_ROUTE_DIFFERENT_RESOURCE_VALUE';
+UPDATE Defines SET Value = '5' WHERE Name = 'TRADE_ROUTE_DIFFERENT_RESOURCE_VALUE';
 UPDATE Defines SET Value = '125' WHERE Name = 'TRADE_ROUTE_CULTURE_DIVISOR_TIMES100';
 UPDATE Defines SET Value = '125' WHERE Name = 'TRADE_ROUTE_SCIENCE_DIVISOR_TIMES100';
 -- These 5 values change the amount of science earned from trade routes with influence civs. Each is adding to an incremental value (so Familiar is already 1, Popular already 2, etc.)

--- a/CvGameCoreDLL_Expansion2/CvTradeClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTradeClasses.cpp
@@ -2802,7 +2802,6 @@ int CvPlayerTrade::GetTradeConnectionResourceValueTimes100(const TradeConnection
 
 				int iValue = 0;
 
-				ResourceClassTypes eResourceClassBonus = (ResourceClassTypes)GC.getInfoTypeForString("RESOURCECLASS_BONUS");
 				for (int i = 0; i < GC.getNumResourceInfos(); i++)
 				{
 					ResourceTypes eResource = (ResourceTypes)i;
@@ -2817,7 +2816,7 @@ int CvPlayerTrade::GetTradeConnectionResourceValueTimes100(const TradeConnection
 							if (GET_PLAYER(pOriginCity->getOwner()).HasGlobalMonopoly(eResource) || GET_PLAYER(pDestCity->getOwner()).HasGlobalMonopoly(eResource))
 								bMonopoly = true;
 
-							if (eResourceClassBonus == eResourceClassCurrent)
+							if (RESOURCEUSAGE_BONUS == eResourceClassCurrent)
 								bIsBonus = true;
 						}
 						
@@ -2826,7 +2825,7 @@ int CvPlayerTrade::GetTradeConnectionResourceValueTimes100(const TradeConnection
 						{		
 							if (pOriginCity->IsHasResourceLocal(eResource, true) != pDestCity->IsHasResourceLocal(eResource, true))
 							{
-								iValue += (bMonopoly ? 2 : 1 ) * /*50 in CP, 10 in VP*/ GD_INT_GET(TRADE_ROUTE_DIFFERENT_RESOURCE_VALUE);
+								iValue += (bMonopoly ? 2 : 1 ) * /*50 in CP, 5 in VP*/ GD_INT_GET(TRADE_ROUTE_DIFFERENT_RESOURCE_VALUE);
 							}
 						}
 					}


### PR DESCRIPTION
I know everyone loves massive amounts of gold, which may be why this has flown largely under the radar (except myeong1129 who was particularly sensitive to it while playing Portugal).

It's current state overpowers literally everything else if you find a good variety of resources.  I would still like to keep bonus resources (so they have some measure of use outside of their single bonus yield), so I am just dropping the value.