### PR TITLE
Post-Combat Promotion Selection

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvPromotionClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPromotionClasses.cpp
@@ -3426,7 +3426,7 @@ PromotionTypes CvUnitPromotions::ChangePromotionAfterCombat(PromotionTypes eInde
 	int iNumChoices = aPossiblePromotions.size();
 	if (iNumChoices > 0)
 	{
-		int iChoice = GC.getGame().getSmallFakeRandNum(iNumChoices, pThisUnit->plot()->GetPlotIndex() + pThisUnit->getExperienceTimes100());
+		int iChoice = GC.getGame().getSmallFakeRandNum(iNumChoices, pThisUnit->plot()->GetPlotIndex() + pThisUnit->GetID() + pThisUnit->getDamage());
 		return (PromotionTypes)aPossiblePromotions[iChoice];
 	}
 


### PR DESCRIPTION
Because units created close together in time will generally start with the same experience, and will have the same experience after their first combat, the old seed essentially only cared about where the unit was located when receiving the promotion.  It is way too easy for a unit to end up on the same tile after combat.

Now, the seed includes the unit id (every unit is unique, so this number is always different) and the damage it takes after combat (which is generally random on its own, but also will often be in combat against units that don't have the same health and therefore deal different amounts of average damage).