### PR TITLE
2.6

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
@@ -28791,16 +28791,6 @@ void CvDiplomacyAI::DoFirstContactInitRelationship(PlayerTypes ePlayer)
 	if (GC.getGame().isFinalInitialized())
 	{
 		DoUpdateConquestStats();
-		DoUpdatePlayerMilitaryStrengths();
-		// Update Military Strengths for all Teammates as well because the values are needed for updating the Target Values
-		for (int iPlayerLoop = 0; iPlayerLoop < MAX_MAJOR_CIVS; iPlayerLoop++)
-		{
-			PlayerTypes eLoopPlayer = (PlayerTypes)iPlayerLoop;
-			if (IsPlayerValid(eLoopPlayer, true) && eLoopPlayer != ePlayer && IsTeammate(eLoopPlayer))
-			{
-				GET_PLAYER(eLoopPlayer).GetDiplomacyAI()->DoUpdatePlayerMilitaryStrengths();
-			}
-		}
 		DoUpdatePlayerEconomicStrengths();
 		DoUpdatePlayerTargetValues();
 		DoUpdateMilitaryAggressivePostures();

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
@@ -28792,6 +28792,15 @@ void CvDiplomacyAI::DoFirstContactInitRelationship(PlayerTypes ePlayer)
 	{
 		DoUpdateConquestStats();
 		DoUpdatePlayerMilitaryStrengths();
+		// Update Military Strengths for all Teammates as well because the values are needed for updating the Target Values
+		for (int iPlayerLoop = 0; iPlayerLoop < MAX_MAJOR_CIVS; iPlayerLoop++)
+		{
+			PlayerTypes eLoopPlayer = (PlayerTypes)iPlayerLoop;
+			if (IsPlayerValid(eLoopPlayer, true) && eLoopPlayer != ePlayer && IsTeammate(eLoopPlayer))
+			{
+				GET_PLAYER(eLoopPlayer).GetDiplomacyAI()->DoUpdatePlayerMilitaryStrengths();
+			}
+		}
 		DoUpdatePlayerEconomicStrengths();
 		DoUpdatePlayerTargetValues();
 		DoUpdateMilitaryAggressivePostures();

--- a/CvGameCoreDLL_Expansion2/CvTeam.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTeam.cpp
@@ -4137,6 +4137,37 @@ void CvTeam::makeHasMet(TeamTypes eIndex, bool bSuppressMessages)
 				}
 			}
 		}
+		for (int iMyPlayersLoop = 0; iMyPlayersLoop < MAX_CIV_PLAYERS; iMyPlayersLoop++)
+		{
+			PlayerTypes eMyPlayer = (PlayerTypes)iMyPlayersLoop;
+
+			if (GET_PLAYER(eMyPlayer).isAlive())
+			{
+				if (GET_PLAYER(eMyPlayer).getTeam() == GetID())
+				{
+					// Now loop through players on Their team
+					for (int iTheirPlayersLoop = 0; iTheirPlayersLoop < MAX_CIV_PLAYERS; iTheirPlayersLoop++)
+					{
+						PlayerTypes eTheirPlayer = (PlayerTypes)iTheirPlayersLoop;
+
+						// Don't calculate proximity to oneself!
+						if (eMyPlayer != eTheirPlayer)
+						{
+							if (GET_PLAYER(eTheirPlayer).isAlive())
+							{
+								if (GET_PLAYER(eTheirPlayer).getTeam() == eIndex)
+								{
+									if (isMajorCiv())
+									{
+										GET_PLAYER(eMyPlayer).GetDiplomacyAI()->DoUpdatePlayerMilitaryStrengths();
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
 
 		// First Contact in Diplo AI (Civ 5)
 		for(int iMyPlayersLoop = 0; iMyPlayersLoop < MAX_CIV_PLAYERS; iMyPlayersLoop++)


### PR DESCRIPTION
Fix for issues #9197 and #9194.

Explanation: When two players are in the same team and a city state is met, the "UNREACHABLE" in CvDiplomacyAI, Line 11195 (which was recently added) is reached while trying to compare the military strength of the teammates to that of the city state.

In  `CvTeam::makeHasMet`, a loop is done through all team members and the functions `CvDiplomacyAI::DoUpdatePlayerMilitaryStrengths()` and `DoUpdatePlayerTargetValues()` are called for each (via `CvDiplomacyAI::DoFirstContact` and `CvDiplomacyAI::DoFirstContactInitRelationship`). But `CvDiplomacyAI::DoUpdatePlayerTargetValues()` requires the knowledge of the military strengths of **all** team members (Line 11132 ff). When it's called for the first one, these values are not yet available as `DoUpdatePlayerMilitaryStrengths()` hasn't been called for the other team members yet.

I moved the call of `DoUpdatePlayerMilitaryStrengths()` from `CvDiplomacyAI::DoFirstContactInitRelationship` to `CvTeam::makeHasMet` and into a separate loop there. The functions `CvDiplomacyAI::DoFirstContact` and `CvDiplomacyAI::DoFirstContactInitRelationship` are not called from anywhere else than from `CvTeam::makeHasMet` as far as I see, so removing `DoUpdatePlayerMilitaryStrengths()` from there should be fine. 
