### PR TITLE
Apply clang-tidy replacements

### DIFF
--- a/CvGameCoreDLL_Expansion2/CustomMods.cpp
+++ b/CvGameCoreDLL_Expansion2/CustomMods.cpp
@@ -218,7 +218,7 @@ int CustomMods::getOption(const char* szOption, int defValue) {
 	return getOption(string(szOption), defValue);
 }
 
-int CustomMods::getOption(string sOption, int defValue) {
+int CustomMods::getOption(const string& sOption, int defValue) {
 	if (!m_bInit) {
 		const char* szBadPrefix = "MOD_";
 

--- a/CvGameCoreDLL_Expansion2/CustomMods.h
+++ b/CvGameCoreDLL_Expansion2/CustomMods.h
@@ -841,8 +841,8 @@ enum BattleTypeTypes
 };
 
 #if defined(MOD_EVENTS_BATTLES)
-#define BATTLE_STARTED(iType, pPlot)              if (MOD_EVENTS_BATTLES) { GAMEEVENTINVOKE_HOOK(GAMEEVENT_BattleStarted, iType, pPlot.getX(), pPlot.getY()); }
-#define BATTLE_JOINED(pCombatant, iRole, bIsCity) if (MOD_EVENTS_BATTLES && pCombatant) { GAMEEVENTINVOKE_HOOK(GAMEEVENT_BattleJoined, (pCombatant)->getOwner(), (pCombatant)->GetID(), iRole, bIsCity); }
+#define BATTLE_STARTED(iType, pPlot)              if (MOD_EVENTS_BATTLES) { GAMEEVENTINVOKE_HOOK(GAMEEVENT_BattleStarted, iType, (pPlot).getX(), (pPlot).getY()); }
+#define BATTLE_JOINED(pCombatant, iRole, bIsCity) if (MOD_EVENTS_BATTLES && (pCombatant)) { GAMEEVENTINVOKE_HOOK(GAMEEVENT_BattleJoined, (pCombatant)->getOwner(), (pCombatant)->GetID(), iRole, bIsCity); }
 #define BATTLE_FINISHED()                         if (MOD_EVENTS_BATTLES) { GAMEEVENTINVOKE_HOOK(GAMEEVENT_BattleFinished); }
 #else
 #define BATTLE_STARTED(pPlot)            __noop
@@ -905,11 +905,11 @@ enum BattleTypeTypes
 }
 
 // Message wrappers
-#define SHOW_PLAYER_MESSAGE(pPlayer, szMessage)       if (pPlayer) DLLUI->AddMessage(0, pPlayer->GetID(), false, GC.getEVENT_MESSAGE_TIME(), szMessage)
-#define SHOW_CITY_MESSAGE(pCity, ePlayer, szMessage)  if (pCity) DLLUI->AddCityMessage(0, pCity->GetIDInfo(), ePlayer, false, GC.getEVENT_MESSAGE_TIME(), szMessage)
-#define SHOW_UNIT_MESSAGE(pUnit, ePlayer, szMessage)  if (pUnit) DLLUI->AddUnitMessage(0, pUnit->GetIDInfo(), ePlayer, false, GC.getEVENT_MESSAGE_TIME(), szMessage)
-#define SHOW_PLOT_MESSAGE(pPlot, ePlayer, szMessage)  if (pPlot) DLLUI->AddPlotMessage(0, pPlot->GetPlotIndex(), ePlayer, false, GC.getEVENT_MESSAGE_TIME(), szMessage)
-#define SHOW_PLOT_POPUP(pPlot, ePlayer, szMessage)  if (pPlot) pPlot->showPopupText(ePlayer, szMessage)
+#define SHOW_PLAYER_MESSAGE(pPlayer, szMessage)       if (pPlayer) DLLUI->AddMessage(0, (pPlayer)->GetID(), false, GC.getEVENT_MESSAGE_TIME(), szMessage)
+#define SHOW_CITY_MESSAGE(pCity, ePlayer, szMessage)  if (pCity) DLLUI->AddCityMessage(0, (pCity)->GetIDInfo(), ePlayer, false, GC.getEVENT_MESSAGE_TIME(), szMessage)
+#define SHOW_UNIT_MESSAGE(pUnit, ePlayer, szMessage)  if (pUnit) DLLUI->AddUnitMessage(0, (pUnit)->GetIDInfo(), ePlayer, false, GC.getEVENT_MESSAGE_TIME(), szMessage)
+#define SHOW_PLOT_MESSAGE(pPlot, ePlayer, szMessage)  if (pPlot) DLLUI->AddPlotMessage(0, (pPlot)->GetPlotIndex(), ePlayer, false, GC.getEVENT_MESSAGE_TIME(), szMessage)
+#define SHOW_PLOT_POPUP(pPlot, ePlayer, szMessage)  if (pPlot) (pPlot)->showPopupText(ePlayer, szMessage)
 
 // GlobalDefines wrappers
 #define GD_INT_DECL(name)         int m_i##name
@@ -940,7 +940,7 @@ enum BattleTypeTypes
 #define GAMEEVENTINVOKE_TESTALL gCustomMods.eventTestAll
 #define GAMEEVENTINVOKE_VALUE   gCustomMods.eventAccumulator
 
-#define GAMEEVENTRETURN_NONE  -1
+#define GAMEEVENTRETURN_NONE  (-1)
 #define GAMEEVENTRETURN_FALSE  0
 #define GAMEEVENTRETURN_TRUE   1
 #define GAMEEVENTRETURN_HOOK   GAMEEVENTRETURN_TRUE
@@ -1169,34 +1169,34 @@ enum BattleTypeTypes
 //to help debug errors
 void CheckSentinel(uint);
 
-#define MOD_SERIALIZE_INIT_READ_NO_SENTINEL(stream) uint uiDllSaveVersion; stream >> uiDllSaveVersion;
-#define MOD_SERIALIZE_INIT_READ(stream) uint uiDllSaveVersion, uiSentinel; stream >> uiDllSaveVersion; stream >> uiSentinel; CheckSentinel(uiSentinel);
-#define MOD_SERIALIZE_READ(version, stream, member, def) if (uiDllSaveVersion >= version) { stream >> member; } else { member = def; }
+#define MOD_SERIALIZE_INIT_READ_NO_SENTINEL(stream) uint uiDllSaveVersion; (stream) >> uiDllSaveVersion;
+#define MOD_SERIALIZE_INIT_READ(stream) uint uiDllSaveVersion, uiSentinel; (stream) >> uiDllSaveVersion; (stream) >> uiSentinel; CheckSentinel(uiSentinel);
+#define MOD_SERIALIZE_READ(version, stream, member, def) if (uiDllSaveVersion >= (version)) { (stream) >> (member); } else { (member) = def; }
 #define MOD_SERIALIZE_READ_AUTO(version, stream, member, size, def)   \
-	if (uiDllSaveVersion >= version) {                                \
-		stream >> member;                                             \
+	if (uiDllSaveVersion >= (version)) {                                \
+		(stream) >> (member);                                             \
 	} else {                                                          \
-		for (int iI = 0; iI < size; iI++) { member.setAt(iI, def); }  \
+		for (int iI = 0; iI < (size); iI++) { (member).setAt(iI, def); }  \
 	}
 #define MOD_SERIALIZE_READ_ARRAY(version, stream, member, type, size, def)	\
-	if (uiDllSaveVersion >= version) {										\
-		ArrayWrapper<type> wrapper(size, member); stream >> wrapper;		\
+	if (uiDllSaveVersion >= (version)) {										\
+		ArrayWrapper<type> wrapper(size, member); (stream) >> wrapper;		\
 	} else {																\
-		for (int iI = 0; iI < size; iI++) { (member)[iI] = def; }			\
+		for (int iI = 0; iI < (size); iI++) { (member)[iI] = def; }			\
 	}
 #define MOD_SERIALIZE_READ_HASH(version, stream, member, type, size, def)		\
-	if (uiDllSaveVersion >= version) {											\
+	if (uiDllSaveVersion >= (version)) {											\
 		CvInfosSerializationHelper::ReadHashedDataArray(stream, member, size);	\
 	} else {																	\
-		for (int iI = 0; iI < size; iI++) { (member)[iI] = def; }				\
+		for (int iI = 0; iI < (size); iI++) { (member)[iI] = def; }				\
 	}
 
-#define MOD_SERIALIZE_INIT_WRITE_NO_SENTINEL(stream) uint uiDllSaveVersion = MOD_DLL_VERSION_NUMBER; stream << uiDllSaveVersion;
-#define MOD_SERIALIZE_INIT_WRITE(stream) uint uiDllSaveVersion = MOD_DLL_VERSION_NUMBER; stream << uiDllSaveVersion; stream << 0xDEADBEEF;
-#define MOD_SERIALIZE_WRITE(stream, member) CvAssert(uiDllSaveVersion == MOD_DLL_VERSION_NUMBER); stream << member
-#define MOD_SERIALIZE_WRITE_AUTO(stream, member) CvAssert(uiDllSaveVersion == MOD_DLL_VERSION_NUMBER); stream << member
-#define MOD_SERIALIZE_WRITE_ARRAY(stream, member, type, size) CvAssert(uiDllSaveVersion == MOD_DLL_VERSION_NUMBER); stream << ArrayWrapper<type>(size, member)
-#define MOD_SERIALIZE_WRITE_CONSTARRAY(stream, member, type, size) CvAssert(uiDllSaveVersion == MOD_DLL_VERSION_NUMBER); stream << ArrayWrapperConst<type>(size, member)
+#define MOD_SERIALIZE_INIT_WRITE_NO_SENTINEL(stream) uint uiDllSaveVersion = MOD_DLL_VERSION_NUMBER; (stream) << uiDllSaveVersion;
+#define MOD_SERIALIZE_INIT_WRITE(stream) uint uiDllSaveVersion = MOD_DLL_VERSION_NUMBER; (stream) << uiDllSaveVersion; (stream) << 0xDEADBEEF;
+#define MOD_SERIALIZE_WRITE(stream, member) CvAssert(uiDllSaveVersion == MOD_DLL_VERSION_NUMBER); (stream) << member
+#define MOD_SERIALIZE_WRITE_AUTO(stream, member) CvAssert(uiDllSaveVersion == MOD_DLL_VERSION_NUMBER); (stream) << member
+#define MOD_SERIALIZE_WRITE_ARRAY(stream, member, type, size) CvAssert(uiDllSaveVersion == MOD_DLL_VERSION_NUMBER); (stream) << ArrayWrapper<type>(size, member)
+#define MOD_SERIALIZE_WRITE_CONSTARRAY(stream, member, type, size) CvAssert(uiDllSaveVersion == MOD_DLL_VERSION_NUMBER); (stream) << ArrayWrapperConst<type>(size, member)
 #define MOD_SERIALIZE_WRITE_HASH(stream, member, type, size, obj) CvAssert(uiDllSaveVersion == MOD_DLL_VERSION_NUMBER); CvInfosSerializationHelper::WriteHashedDataArray<obj, type>(stream, member, size)
 #else
 #define MOD_SERIALIZE_INIT_READ(stream) __noop
@@ -1247,7 +1247,7 @@ public:
 	void preloadCache();
 	void reloadCache();
 	int getOption(const char* szName, int defValue = 0);
-	int getOption(std::string sName, int defValue = 0);
+	int getOption(const std::string& sName, int defValue = 0);
 	int getCivOption(const char* szCiv, const char* szName, int defValue = 0);
 
 	MOD_OPT_DECL(BALANCE_VP);

--- a/CvGameCoreDLL_Expansion2/CvAStarNode.h
+++ b/CvGameCoreDLL_Expansion2/CvAStarNode.h
@@ -258,7 +258,7 @@ public:
 
 protected:
 	vector<pair<int,size_t>> lookup;
-	vector<SMovePlot> storage;
+	std::vector<SMovePlot> storage;
 };
 
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/CvGameCoreDLL_Expansion2/CvAchievementUnlocker.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAchievementUnlocker.cpp
@@ -24,7 +24,7 @@
 #define DEBUG_RELEASE_VALUE(a, b) (a)
 #endif
 
-#define UNDEFINED_TYPE -999
+#define UNDEFINED_TYPE (-999)
 
 int CvAchievementUnlocker::ms_iNumImprovementsPillagedPerTurn = 0;
 //	---------------------------------------------------------------------------

--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
@@ -2627,7 +2627,7 @@ BuildTypes CvBuilderTaskingAI::GetBuildRoute(void)
 }
 
 /// Central logging repository!
-void CvBuilderTaskingAI::LogInfo(CvString strNewLogStr, CvPlayer* pPlayer, bool /*bWriteToOutput*/)
+void CvBuilderTaskingAI::LogInfo(const CvString& strNewLogStr, CvPlayer* pPlayer, bool /*bWriteToOutput*/)
 {
 	if(!(GC.getLogging() && GC.getAILogging() && GC.GetBuilderAILogging()))
 	{
@@ -2653,7 +2653,7 @@ void CvBuilderTaskingAI::LogInfo(CvString strNewLogStr, CvPlayer* pPlayer, bool 
 	pLog->Msg(strLog);
 }
 
-void CvBuilderTaskingAI::LogYieldInfo(CvString strNewLogStr, CvPlayer* pPlayer)
+void CvBuilderTaskingAI::LogYieldInfo(const CvString& strNewLogStr, CvPlayer* pPlayer)
 {
 	if(!(GC.getLogging() && GC.getAILogging() && GC.GetBuilderAILogging()))
 	{

--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.h
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.h
@@ -105,8 +105,8 @@ public:
 	BuildTypes GetRemoveRoute(void);
 	BuildTypes GetBuildRoute(void);
 
-	static void LogInfo(CvString str, CvPlayer* pPlayer, bool bWriteToOutput = false);
-	static void LogYieldInfo(CvString strNewLogStr, CvPlayer* pPlayer); //Log yield related info to BuilderTaskingYieldLog.csv.
+	static void LogInfo(const CvString& str, CvPlayer* pPlayer, bool bWriteToOutput = false);
+	static void LogYieldInfo(const CvString& strNewLogStr, CvPlayer* pPlayer); //Log yield related info to BuilderTaskingYieldLog.csv.
 
 	//---------------------------------------PROTECTED MEMBER VARIABLES---------------------------------
 protected:

--- a/CvGameCoreDLL_Expansion2/CvDealAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDealAI.cpp
@@ -313,7 +313,7 @@ DealOfferResponseTypes CvDealAI::DoHumanOfferDealToThisAI(CvDeal* pDeal)
 }
 
 /// Deal has been accepted
-void CvDealAI::DoAcceptedDeal(PlayerTypes eFromPlayer, CvDeal kDeal, int iDealValueToMe, int iValueImOffering, int iValueTheyreOffering)
+void CvDealAI::DoAcceptedDeal(PlayerTypes eFromPlayer, const CvDeal& kDeal, int iDealValueToMe, int iValueImOffering, int iValueTheyreOffering)
 {
 #if defined(MOD_ACTIVE_DIPLOMACY)
 	if (GC.getGame().isReallyNetworkMultiPlayer() && MOD_ACTIVE_DIPLOMACY)

--- a/CvGameCoreDLL_Expansion2/CvDealAI.h
+++ b/CvGameCoreDLL_Expansion2/CvDealAI.h
@@ -49,7 +49,7 @@ public:
 	// Offer deal to this AI player and see what his response is
 
 	DealOfferResponseTypes DoHumanOfferDealToThisAI(CvDeal* pDeal);
-	void DoAcceptedDeal(PlayerTypes eFromPlayer, CvDeal kDeal, int iDealValueToMe, int iValueImOffering, int iValueTheyreOffering);
+	void DoAcceptedDeal(PlayerTypes eFromPlayer, const CvDeal& kDeal, int iDealValueToMe, int iValueImOffering, int iValueTheyreOffering);
 
 	DemandResponseTypes DoHumanDemand(CvDeal* pDeal);
 	void DoAcceptedDemand(PlayerTypes eFromPlayer, const CvDeal& kDeal);

--- a/CvGameCoreDLL_Expansion2/CvDealClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDealClasses.cpp
@@ -4103,7 +4103,7 @@ void CvGameDeals::Init()
 }
 
 /// Save off a new deal that has been agreed to
-void CvGameDeals::AddProposedDeal(CvDeal kDeal)
+void CvGameDeals::AddProposedDeal(const CvDeal& kDeal)
 {
 #if defined(MOD_ACTIVE_DIPLOMACY)
 	if(GC.getGame().isReallyNetworkMultiPlayer() && MOD_ACTIVE_DIPLOMACY)

--- a/CvGameCoreDLL_Expansion2/CvDealClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvDealClasses.h
@@ -304,7 +304,7 @@ public:
 	template<typename GameDeals, typename Visitor>
 	static void Serialize(GameDeals& gameDeals, Visitor& visitor);
 
-	void AddProposedDeal(CvDeal kDeal);
+	void AddProposedDeal(const CvDeal& kDeal);
 #if defined(MOD_ACTIVE_DIPLOMACY)
 	bool RemoveProposedDeal(PlayerTypes eFromPlayer, PlayerTypes eToPlayer, CvDeal* pDealOut, bool latest);
 	bool FinalizeMPDeal(CvDeal kDeal, bool bAccepted);

--- a/CvGameCoreDLL_Expansion2/CvEconomicAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvEconomicAI.cpp
@@ -832,7 +832,7 @@ CvCity* CvEconomicAI::GetBestGreatWorkCity(CvPlot *pStartPlot, GreatWorkType eGr
 	return pBestCity;
 }
 
-void AppendToLog(CvString& strHeader, CvString& strLog, CvString strHeaderValue, CvString strValue)
+void AppendToLog(CvString& strHeader, CvString& strLog, const CvString& strHeaderValue, const CvString& strValue)
 {
 	strHeader += strHeaderValue;
 	strHeader += ",";
@@ -840,7 +840,7 @@ void AppendToLog(CvString& strHeader, CvString& strLog, CvString strHeaderValue,
 	strLog += ",";
 }
 
-void AppendToLog(CvString& strHeader, CvString& strLog, CvString strHeaderValue, int iValue)
+void AppendToLog(CvString& strHeader, CvString& strLog, const CvString& strHeaderValue, int iValue)
 {
 	strHeader += strHeaderValue;
 	strHeader += ",";
@@ -849,7 +849,7 @@ void AppendToLog(CvString& strHeader, CvString& strLog, CvString strHeaderValue,
 	strLog += str;
 }
 
-void AppendToLog(CvString& strHeader, CvString& strLog, CvString strHeaderValue, float fValue)
+void AppendToLog(CvString& strHeader, CvString& strLog, const CvString& strHeaderValue, float fValue)
 {
 	strHeader += strHeaderValue;
 	strHeader += ",";

--- a/CvGameCoreDLL_Expansion2/CvEspionageClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvEspionageClasses.cpp
@@ -115,7 +115,7 @@ void CvEspionageSpy::ResetSiphonHistory()
 {
 	m_sSiphonHistory = "";
 }
-void CvEspionageSpy::SetSiphonHistory(CvString string)
+void CvEspionageSpy::SetSiphonHistory(const CvString& string)
 {
 	m_sSiphonHistory = string;
 }

--- a/CvGameCoreDLL_Expansion2/CvEspionageClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvEspionageClasses.h
@@ -82,7 +82,7 @@ public:
 	void ResetSpySiphon();
 	CvString GetSiphonHistory();
 	void ResetSiphonHistory();
-	void SetSiphonHistory(CvString string);
+	void SetSiphonHistory(const CvString& string);
 
 	// Public data
 	int m_iName;

--- a/CvGameCoreDLL_Expansion2/CvGame.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGame.cpp
@@ -7031,7 +7031,7 @@ void CvGame::setWinner(TeamTypes eNewWinner, VictoryTypes eNewVictory)
 					}
 
 					//Victory on Map Types
-					CvString winnerMapName = CvPreGame::mapScriptName();
+					const CvString& winnerMapName = CvPreGame::mapScriptName();
 					//OutputDebugString(winnerMapName);
 					//OutputDebugString("\n");
 

--- a/CvGameCoreDLL_Expansion2/CvGameCoreDLLPCH.h
+++ b/CvGameCoreDLL_Expansion2/CvGameCoreDLLPCH.h
@@ -117,7 +117,7 @@
 #endif
 
 // Silences warnings about an unused variable.
-#define UNUSED_VARIABLE(x) ((void)x)
+#define UNUSED_VARIABLE(x) ((void)(x))
 
 // Similar to UNUSED_VARIABLE, but implies that the variable IS used in debug builds.
 #define DEBUG_VARIABLE(x) UNUSED_VARIABLE(x)
@@ -143,7 +143,7 @@ typedef unsigned char    byte;
 typedef unsigned int     uint;
 typedef wchar_t          wchar;
 
-#define LIMIT_RANGE(low, value, high) value = (value < low ? low : (value > high ? high : value));
+#define LIMIT_RANGE(low, value, high) value = ((value) < (low) ? (low) : ((value) > (high) ? (high) : (value)));
 #define M_PI       3.14159265358979323846
 #define fM_PI		3.141592654f		//!< Pi (float)
 

--- a/CvGameCoreDLL_Expansion2/CvGameCoreStructs.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGameCoreStructs.cpp
@@ -598,7 +598,7 @@ CvAirMissionDefinition::CvAirMissionDefinition() :
 //! \param      kCopy The object to copy
 //------------------------------------------------------------------------------------------------
 CvAirMissionDefinition::CvAirMissionDefinition(const CvAirMissionDefinition& kCopy)
-{
+ : CvMissionDefinition(kCopy) {
 	m_fMissionTime = kCopy.m_fMissionTime;
 	m_eMissionType = kCopy.m_eMissionType;
 	m_pPlot = kCopy.m_pPlot;

--- a/CvGameCoreDLL_Expansion2/CvInfosSerializationHelper.h
+++ b/CvGameCoreDLL_Expansion2/CvInfosSerializationHelper.h
@@ -676,7 +676,7 @@ void WriteHashedTypeArray(FDataStream& kStream, TType* paArray, uint uiArraySize
 }
 
 #define CVINFO_V0_TAG_COUNT(x)	(sizeof(x) / sizeof(const char*))
-#define CVINFO_V0_TAGS(x)	&x[0], sizeof(x) / sizeof(const char*)
+#define CVINFO_V0_TAGS(x)	&(x)[0], sizeof(x) / sizeof(const char*)
 
 // Declare a basic serialization info helper
 #define DECLARE_SERIALIZATION_INFO_TYPE_HELPER(theType) \
@@ -687,14 +687,14 @@ extern bool WriteHashed(FDataStream& kStream, const theType eType);
 #define IMPLEMENT_SERIALIZATION_INFO_TYPE_HELPER(theType, theInfoAccess, theNoEnum) \
 bool Write(FDataStream& kStream, const theType eType) \
 { \
-	if(eType != theNoEnum) \
+	if(eType != (theNoEnum)) \
 		return Write(kStream, (const CvBaseInfo*)GC.theInfoAccess(eType)); \
 	else \
 		return Write(kStream, (const CvBaseInfo*)NULL); \
 } \
 bool WriteHashed(FDataStream& kStream, const theType eType) \
 { \
-	if(eType != theNoEnum) \
+	if(eType != (theNoEnum)) \
 		return WriteHashed(kStream, (const CvBaseInfo*)GC.theInfoAccess(eType)); \
 	else \
 		return WriteHashed(kStream, (const CvBaseInfo*)NULL); \

--- a/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
@@ -5532,7 +5532,7 @@ void CvMinorCivAI::DoAddStartingResources(CvPlot* pCityPlot)
 }
 
 /// Notifications
-void CvMinorCivAI::AddNotification(CvString sString, CvString sSummaryString, PlayerTypes ePlayer, int iX, int iY)
+void CvMinorCivAI::AddNotification(const CvString& sString, const CvString& sSummaryString, PlayerTypes ePlayer, int iX, int iY)
 {
 	if(iX == -1 && iY == -1)
 	{
@@ -5553,7 +5553,7 @@ void CvMinorCivAI::AddNotification(CvString sString, CvString sSummaryString, Pl
 }
 
 /// Quest Notifications
-void CvMinorCivAI::AddQuestNotification(CvString sString, CvString sSummaryString, PlayerTypes ePlayer, int iX, int iY, bool bNewQuest)
+void CvMinorCivAI::AddQuestNotification(CvString sString, const CvString& sSummaryString, PlayerTypes ePlayer, int iX, int iY, bool bNewQuest)
 {
 	CvNotifications* pNotifications = GET_PLAYER(ePlayer).GetNotifications();
 	if(pNotifications)

--- a/CvGameCoreDLL_Expansion2/CvMinorCivAI.h
+++ b/CvGameCoreDLL_Expansion2/CvMinorCivAI.h
@@ -373,8 +373,8 @@ public:
 
 	void DoAddStartingResources(CvPlot* pCityPlot);
 
-	void AddNotification(CvString sString, CvString sSummaryString, PlayerTypes ePlayer, int iX = -1, int iY = -1);
-	void AddQuestNotification(CvString sString, CvString sSummaryString, PlayerTypes ePlayer, int iX = -1, int iY = -1, bool bNewQuest = false);
+	void AddNotification(const CvString& sString, const CvString& sSummaryString, PlayerTypes ePlayer, int iX = -1, int iY = -1);
+	void AddQuestNotification(CvString sString, const CvString& sSummaryString, PlayerTypes ePlayer, int iX = -1, int iY = -1, bool bNewQuest = false);
 
 	// ******************************
 	// Threatened by Barbarians event

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -27774,7 +27774,7 @@ void CvPlayer::doInstantYield(InstantYieldType iType, bool bCityFaith, GreatPers
 		}
 	}
 }
-void CvPlayer::addInstantYieldText(InstantYieldType iType, CvString strInstantYield)
+void CvPlayer::addInstantYieldText(InstantYieldType iType, const CvString& strInstantYield)
 {
 	VALIDATE_OBJECT
 	CvAssertMsg(iType >= 0, "iType expected to be >= 0");
@@ -27782,7 +27782,7 @@ void CvPlayer::addInstantYieldText(InstantYieldType iType, CvString strInstantYi
 
 	m_aistrInstantYield[iType] = m_aistrInstantYield[iType] + strInstantYield;
 }
-void CvPlayer::setInstantYieldText(InstantYieldType iType, CvString strInstantYield)
+void CvPlayer::setInstantYieldText(InstantYieldType iType, const CvString& strInstantYield)
 {
 	VALIDATE_OBJECT
 	CvAssertMsg(iType >= 0, "iType expected to be >= 0");
@@ -27796,7 +27796,7 @@ CvString CvPlayer::getInstantYieldText(InstantYieldType iType) const
 	CvAssertMsg(iType < NUM_INSTANT_YIELD_TYPES, "iType expected to be < NUM_INSTANT_YIELD_TYPES");
 	return m_aistrInstantYield[iType];
 }
-void CvPlayer::doInstantGWAM(GreatPersonTypes eGreatPerson, CvString strName, bool bConquest)
+void CvPlayer::doInstantGWAM(GreatPersonTypes eGreatPerson, const CvString& strName, bool bConquest)
 {
 	CvCity* pCapital = getCapitalCity();
 	int iEventGP = 0;
@@ -28276,7 +28276,7 @@ void CvPlayer::doInstantGreatPersonProgress(InstantYieldType iType, bool bSuppre
 }
 
 //	--------------------------------------------------------------------------------
-void CvPlayer::addInstantGreatPersonProgressText(InstantYieldType iType, CvString strInstantYield)
+void CvPlayer::addInstantGreatPersonProgressText(InstantYieldType iType, const CvString& strInstantYield)
 {
 	VALIDATE_OBJECT
 	CvAssertMsg(iType >= 0, "iType expected to be >= 0");
@@ -28292,7 +28292,7 @@ void CvPlayer::addInstantGreatPersonProgressText(InstantYieldType iType, CvStrin
 		m_aistrInstantGreatPersonProgress.insert(std::make_pair((int)iType, strInstantYield));
 	}
 }
-void CvPlayer::setInstantGreatPersonProgressText(InstantYieldType iType, CvString strInstantYield)
+void CvPlayer::setInstantGreatPersonProgressText(InstantYieldType iType, const CvString& strInstantYield)
 {
 	VALIDATE_OBJECT
 	CvAssertMsg(iType >= 0, "iType expected to be >= 0");
@@ -42193,7 +42193,7 @@ std::string CvPlayer::getScriptData() const
 }
 
 //	--------------------------------------------------------------------------------
-void CvPlayer::setScriptData(std::string strNewValue)
+void CvPlayer::setScriptData(const std::string& strNewValue)
 {
 	m_strScriptData = strNewValue;
 }

--- a/CvGameCoreDLL_Expansion2/CvPlayer.h
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.h
@@ -1122,14 +1122,14 @@ public:
 	void DoUnitKilledCombat(CvUnit* pKillingUnit, PlayerTypes eKilledPlayer, UnitTypes eUnitType);
 #if defined(MOD_BALANCE_CORE)
 	void doInstantYield(InstantYieldType iType, bool bCityFaith = false, GreatPersonTypes eGreatPerson = NO_GREATPERSON, BuildingTypes eBuilding = NO_BUILDING, int iPassYield = 0, bool bEraScale = true, PlayerTypes ePlayer = NO_PLAYER, CvPlot* pPlot = NULL, bool bSuppress = false, CvCity* pCity = NULL, bool bSeaTrade = false, bool bInternational = true, bool bEvent = false, YieldTypes eYield = NO_YIELD, CvUnit* pUnit = NULL, TerrainTypes ePassTerrain = NO_TERRAIN, CvMinorCivQuest* pQuestData = NULL, CvCity* pOtherCity = NULL, CvUnit* pAttackingUnit = NULL);
-	void addInstantYieldText(InstantYieldType iType, CvString strInstantYield);
-	void setInstantYieldText(InstantYieldType iType, CvString strInstantYield);
+	void addInstantYieldText(InstantYieldType iType, const CvString& strInstantYield);
+	void setInstantYieldText(InstantYieldType iType, const CvString& strInstantYield);
 	CvString getInstantYieldText(InstantYieldType iType)  const;
-	void doInstantGWAM(GreatPersonTypes eGreatPerson, CvString strUnitName, bool bConquest = false);
+	void doInstantGWAM(GreatPersonTypes eGreatPerson, const CvString& strUnitName, bool bConquest = false);
 	void doPolicyGEorGM(int iPolicyGEorGM);
 	void doInstantGreatPersonProgress(InstantYieldType iType, bool bSuppress = false, CvCity* pCity = NULL, BuildingTypes eBuilding = NO_BUILDING, int iPassValue = 0, GreatPersonTypes ePassGreatPerson = NO_GREATPERSON);
-	void addInstantGreatPersonProgressText(InstantYieldType iType, CvString strInstantYield);
-	void setInstantGreatPersonProgressText(InstantYieldType iType, CvString strInstantYield);
+	void addInstantGreatPersonProgressText(InstantYieldType iType, const CvString& strInstantYield);
+	void setInstantGreatPersonProgressText(InstantYieldType iType, const CvString& strInstantYield);
 	CvString getInstantGreatPersonProgressText(InstantYieldType iType)  const;
 #endif
 	// Great People Expenditure
@@ -2422,7 +2422,7 @@ public:
 
 	// Arbitrary Script Data
 	std::string getScriptData() const;
-	void setScriptData(std::string szNewValue);
+	void setScriptData(const std::string& szNewValue);
 
 	const CvString& getPbemEmailAddress() const;
 	void setPbemEmailAddress(const char* szAddress);

--- a/CvGameCoreDLL_Expansion2/CvStartPositioner.cpp
+++ b/CvGameCoreDLL_Expansion2/CvStartPositioner.cpp
@@ -320,7 +320,7 @@ int CvStartPositioner::GetRegion(int iX, int iY)
 // PRIVATE METHODS
 
 /// Compute the fertility of each tile on the map
-void CvStartPositioner::DivideContinentIntoRegions(CvContinent continent)
+void CvStartPositioner::DivideContinentIntoRegions(const CvContinent& continent)
 {
 	// Create a start region out of the entire continent
 	CvStartRegion region;
@@ -629,7 +629,7 @@ int CvStartPositioner::ComputeRowFertility(int iAreaID, int xMin, int xMax, int 
 }
 
 /// Pick a start position for a civ within a specific region
-bool CvStartPositioner::AddCivToRegion(int iPlayerIndex, CvStartRegion region, bool bRelaxFoodReq)
+bool CvStartPositioner::AddCivToRegion(int iPlayerIndex, const CvStartRegion& region, bool bRelaxFoodReq)
 {
 	CvString strString;
 	int uiBestFoundValue = 0;
@@ -826,7 +826,7 @@ int CvStartPositioner::StartingPlotRange() const
 }
 
 /// Log current status of the operation
-void CvStartPositioner::LogStartPositionMessage(CvString strMsg)
+void CvStartPositioner::LogStartPositionMessage(const CvString& strMsg)
 {
 	if(GC.getLogging() && GC.getAILogging())
 	{

--- a/CvGameCoreDLL_Expansion2/CvStartPositioner.h
+++ b/CvGameCoreDLL_Expansion2/CvStartPositioner.h
@@ -202,17 +202,17 @@ private:
 	void AssignStartingLocations();
 	int GetRegion(int iX, int iY);
 
-	void DivideContinentIntoRegions(CvContinent continent);
+	void DivideContinentIntoRegions(const CvContinent& continent);
 	void ComputeTileFertilityValues();
 	void SubdivideRegion(CvStartRegion region, int numDivisions);
 	void ChopIntoTwoRegions(bool bTaller, CvStartRegion* region, CvStartRegion* secondRegion, int iChopPercent);
 	void ChopIntoThreeRegions(bool bTaller, CvStartRegion* region, CvStartRegion* secondRegion, CvStartRegion* thirdRegion);
 	int ComputeRowFertility(int iAreaID, int xMin, int xMax, int yMin, int yMax);
-	bool AddCivToRegion(int iPlayerIndex, CvStartRegion region, bool bRelaxFoodReq);
+	bool AddCivToRegion(int iPlayerIndex, const CvStartRegion& region, bool bRelaxFoodReq);
 	int StartingPlotRange() const;
 
 	// Logging
-	void LogStartPositionMessage(CvString strMsg);
+	void LogStartPositionMessage(const CvString& strMsg);
 
 	// References to other objects
 	CvCitySiteEvaluator* m_pSiteEvaluator;

--- a/CvGameCoreDLL_Expansion2/CvTreasury.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTreasury.cpp
@@ -850,7 +850,7 @@ int CvTreasury::AverageIncome100(int iTurns)
 	return 0;
 }
 
-void CvTreasury::LogExpenditure(CvString strExpenditure, int iAmount, int iColumn)
+void CvTreasury::LogExpenditure(const CvString& strExpenditure, int iAmount, int iColumn)
 {
 	if(!(GC.getLogging() && GC.getAILogging()))
 	{
@@ -1043,7 +1043,7 @@ FDataStream& operator<<(FDataStream& stream, const CvTreasury& treasury)
 	return stream;
 }
 
-void TreasuryHelpers::AppendToLog(CvString& strHeader, CvString& strLog, CvString strHeaderValue, CvString strValue)
+void TreasuryHelpers::AppendToLog(CvString& strHeader, CvString& strLog, const CvString& strHeaderValue, const CvString& strValue)
 {
 	strHeader += strHeaderValue;
 	strHeader += ",";
@@ -1051,7 +1051,7 @@ void TreasuryHelpers::AppendToLog(CvString& strHeader, CvString& strLog, CvStrin
 	strLog += ",";
 }
 
-void TreasuryHelpers::AppendToLog(CvString& strHeader, CvString& strLog, CvString strHeaderValue, int iValue)
+void TreasuryHelpers::AppendToLog(CvString& strHeader, CvString& strLog, const CvString& strHeaderValue, int iValue)
 {
 	strHeader += strHeaderValue;
 	strHeader += ",";
@@ -1060,7 +1060,7 @@ void TreasuryHelpers::AppendToLog(CvString& strHeader, CvString& strLog, CvStrin
 	strLog += str;
 }
 
-void TreasuryHelpers::AppendToLog(CvString& strHeader, CvString& strLog, CvString strHeaderValue, float fValue)
+void TreasuryHelpers::AppendToLog(CvString& strHeader, CvString& strLog, const CvString& strHeaderValue, float fValue)
 {
 	strHeader += strHeaderValue;
 	strHeader += ",";

--- a/CvGameCoreDLL_Expansion2/CvTreasury.h
+++ b/CvGameCoreDLL_Expansion2/CvTreasury.h
@@ -108,7 +108,7 @@ public:
 
 	// Methods to query financial history
 	int AverageIncome100(int iTurns);
-	void LogExpenditure(CvString strExpenditure, int iAmount, int iColumn);
+	void LogExpenditure(const CvString& strExpenditure, int iAmount, int iColumn);
 
 	int GetVassalGoldMaintenance() const;
 
@@ -154,9 +154,9 @@ FDataStream& operator<<(FDataStream&, const CvTreasury&);
 
 namespace TreasuryHelpers
 {
-	void AppendToLog (CvString& strHeader, CvString& strLog, CvString strHeaderValue, CvString strValue);
-	void AppendToLog (CvString& strHeader, CvString& strLog, CvString strHeaderValue, int iValue);
-	void AppendToLog (CvString& strHeader, CvString& strLog, CvString strHeaderValue, float fValue);
+	void AppendToLog (CvString& strHeader, CvString& strLog, const CvString& strHeaderValue, const CvString& strValue);
+	void AppendToLog (CvString& strHeader, CvString& strLog, const CvString& strHeaderValue, int iValue);
+	void AppendToLog (CvString& strHeader, CvString& strLog, const CvString& strHeaderValue, float fValue);
 }
 
 #endif // CV_TREASURY_H

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -15356,7 +15356,7 @@ void CvUnit::SetIsGrouped(bool bValue)
 }
 
 //	--------------------------------------------------------------------------------
-void CvUnit::SetLinkedUnits(UnitIdContainer LinkedUnits)
+void CvUnit::SetLinkedUnits(const UnitIdContainer& LinkedUnits)
 {
 	VALIDATE_OBJECT
 		m_LinkedUnitIDs = LinkedUnits;
@@ -25426,7 +25426,7 @@ const CvString CvUnit::getUnitName() const
 	return m_strUnitName.GetCString();
 }
 //	--------------------------------------------------------------------------------
-void CvUnit::setUnitName(const CvString strNewValue)
+void CvUnit::setUnitName(const CvString& strNewValue)
 {
 	VALIDATE_OBJECT
 
@@ -25461,7 +25461,7 @@ const CvString CvUnit::getGreatName() const
 }
 
 //	--------------------------------------------------------------------------------
-void CvUnit::setGreatName(CvString strName)
+void CvUnit::setGreatName(const CvString& strName)
 {
 	VALIDATE_OBJECT
 	m_strGreatName = strName;
@@ -25632,7 +25632,7 @@ std::string CvUnit::getScriptData() const
 }
 
 //	--------------------------------------------------------------------------------
-void CvUnit::setScriptData(std::string strNewValue)
+void CvUnit::setScriptData(const std::string& strNewValue)
 {
 	VALIDATE_OBJECT
 	m_strScriptData = strNewValue;

--- a/CvGameCoreDLL_Expansion2/CvUnit.h
+++ b/CvGameCoreDLL_Expansion2/CvUnit.h
@@ -615,7 +615,7 @@ public:
 	void SetLinkedLeaderID(int iLinkedLeaderID);
 	bool IsGrouped() const;
 	void SetIsGrouped(bool bValue);
-	void SetLinkedUnits(UnitIdContainer LinkedUnits);
+	void SetLinkedUnits(const UnitIdContainer& LinkedUnits);
 	UnitIdContainer GetLinkedUnits();
 	int GetLinkedMaxMoves() const;
 	void SetLinkedMaxMoves(int iValue);
@@ -1596,13 +1596,13 @@ public:
 	const char* getNameKey() const;
 #if defined(MOD_PROMOTIONS_UNIT_NAMING)
 	const CvString getUnitName() const;
-	void setUnitName(const CvString strNewValue);
+	void setUnitName(const CvString& strNewValue);
 #endif
 	const CvString getNameNoDesc() const;
 	void setName(const CvString strNewValue);
 #if defined(MOD_GLOBAL_NO_LOST_GREATWORKS)
 	const CvString getGreatName() const;
-	void setGreatName(CvString strName);
+	void setGreatName(const CvString& strName);
 #endif
 	GreatWorkType GetGreatWork() const;
 	void SetGreatWork(GreatWorkType eGreatWork);
@@ -1635,7 +1635,7 @@ public:
 
 	// Arbitrary Script Data
 	std::string getScriptData() const;
-	void setScriptData(std::string szNewValue);
+	void setScriptData(const std::string& szNewValue);
 	int getScenarioData() const;
 	void setScenarioData(int iNewValue);
 


### PR DESCRIPTION
For potential cherry picking only. I've scaled down the replacements to ensure v90 build works.

[compile_commands.json](https://github.com/LoneGazebo/Community-Patch-DLL/files/9590858/compile_commands.json.txt)

[.clang-tidy](https://github.com/LoneGazebo/Community-Patch-DLL/files/9590849/clang-tidy.txt)

List of all clang-tidy options that provide potential fixes: https://clang.llvm.org/extra/clang-tidy/checks/list.html

When using compile_commands.json, v90 headers must use -isystem instead of -I. Also, clang-diagnostic-errors can't be suppressed but majority are false positives due to msvc.

Related stackoverflow: https://stackoverflow.com/questions/50355930/ignore-clang-diagnostic-error-clang-tidy-caused-by-3rd-party-headers

```
"C:\Program Files\LLVM\bin\clang-tidy.exe" -p C:\Users\user\Documents\GitHub\Community-Patch-DLL\CvGameCoreDLL_Expansion2 C:\Users\user\Documents\GitHub\Community-Patch-DLL\CvGameCoreDLL_Expansion2\* --extra-arg=-std=c++03 --extra-arg=-w --export-fixes=clang-tidy-fixes.yaml >> clang-tidy-results.txt 2>&1
```
[clang-tidy-results.txt](https://github.com/LoneGazebo/Community-Patch-DLL/files/9590856/clang-tidy-results.txt)

Remove false positives and incorrect ReplacementText contained within generated clang-tidy-fixes.yaml.

[clang-tidy-fixes.yaml.txt](https://github.com/LoneGazebo/Community-Patch-DLL/files/9590859/clang-tidy-fixes.yaml.txt)

```
"C:\Program Files\LLVM\bin\clang-apply-replacements.exe" C:\Users\user\Documents\GitHub\Community-Patch-DLL
```
