### PR TITLE
clang-tidy

### DIFF
--- a/CvGameCoreDLLUtil/include/CvWeightedVector.h
+++ b/CvGameCoreDLLUtil/include/CvWeightedVector.h
@@ -269,7 +269,7 @@ public:
 	};
 
 private:
-	vector<WeightedElement> m_items;
+	std::vector<WeightedElement> m_items;
 };
 
 //-------------------------------

--- a/CvGameCoreDLL_Expansion2/CvBuildingProductionAI.h
+++ b/CvGameCoreDLL_Expansion2/CvBuildingProductionAI.h
@@ -45,7 +45,7 @@ public:
 	// Logging
 	void LogPossibleBuilds();
 	// Fast version with precomputed stats
-	int CheckBuildingBuildSanity(BuildingTypes eBuilding, int iValue, const SPlotStats& plotStats, const vector<int>& allExistingBuildings,
+	int CheckBuildingBuildSanity(BuildingTypes eBuilding, int iValue, const SPlotStats& plotStats, const std::vector<int>& allExistingBuildings,
 		bool bNoBestWonderCityCheck = false, bool bFreeBuilding = false, bool bIgnoreSituational = false);
 	// Slow version
 	int CheckBuildingBuildSanity(BuildingTypes eBuilding, int iValue, 

--- a/CvGameCoreDLL_Expansion2/CvImprovementClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvImprovementClasses.h
@@ -378,7 +378,7 @@ public:
 	std::vector<CvImprovementEntry*>& GetImprovementEntries();
 	int GetNumImprovements();
 	_Ret_maybenull_ CvImprovementEntry* GetEntry(int index);
-	CvImprovementEntry* GetImprovementForResource(int eResource);
+	class CvImprovementEntry* GetImprovementForResource(int eResource);
 
 	// Binary cache functions
 	void DeleteArray();


### PR DESCRIPTION
Some clang-tidy changes for review. Clang-tidy can be a rabbit hole (https://github.com/LoneGazebo/Community-Patch-DLL/pull/9215) but someone with more knowledge would have to use the tool.

```
error: no template named 'vector'; did you mean 'std::vector'? [clang-diagnostic-error]
error: must use 'class' tag to refer to type 'CvImprovementEntry' in this scope [clang-diagnostic-error]
```