### PR TITLE
Fix: World Builder maps are incorrectly assigning teams

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvWorldBuilderMapLoader.cpp
+++ b/CvGameCoreDLL_Expansion2/CvWorldBuilderMapLoader.cpp
@@ -428,11 +428,13 @@ void CvWorldBuilderMapLoader::SetupPlayers()
 				break;
 			}
 		}
+ 
+		const TeamTypes eTeam = (TeamTypes)((kPlayer.m_byTeam - uiPlayerCount) + MAX_MAJOR_CIVS);
 
 		CvPreGame::setHandicap(ePlayer, eHandicap);
 
 		CvPreGame::setSlotStatus(ePlayer, SS_COMPUTER);
-		CvPreGame::setTeamType(ePlayer, (TeamTypes)kPlayer.m_byTeam);
+		CvPreGame::setTeamType(ePlayer, eTeam);
 		CvPreGame::setMinorCiv(ePlayer, true);
 	}
 }


### PR DESCRIPTION
Fixes #9226

Comparing the WB load to the base game, and it seems that WorldBuilder assumes City State teams start right after the max number of players. However, the base Vox Populi game expects City State indices to always start after index `MAX_MAJOR_CIVS`.

Therefore, we need to change the math of calculating the Team ID when loading WorldBuilder maps in, so that it always starts City State 1 at index `MAX_MAJOR_CIVS` (22). 