### PR TITLE
Great Merchant Trade Action

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -12105,7 +12105,7 @@ bool CvUnit::canTrade(const CvPlot* pPlot, bool bTestVisible) const
 		return false;
 	}
 
-	if (m_pUnitInfo->GetBaseGold() == 0 && GetDiploMissionInfluence() == 0)
+	if (GetGoldBlastStrength() == 0 && GetDiploMissionInfluence() == 0)
 	{
 		return false;
 	}


### PR DESCRIPTION
With the change from the trade mission gold being decided at expend instead of on birth, we can and should stop the reliance on the unit info's base gold for whether the GM can perform a trade action.

Fixes bug where MoVs and GMs don't get the Trade mission because they no longer have a Base Gold value.