### PR TITLE
Notification Fixes

### DIFF
--- a/(2) Vox Populi/Balance Changes/Text/en_US/UIText.sql
+++ b/(2) Vox Populi/Balance Changes/Text/en_US/UIText.sql
@@ -625,6 +625,11 @@ UPDATE Language_en_US
 SET Text = 'A Lumbermill allows you to improve the Production output of forest tiles. Gains additional Production for every two adjacent Lumbermills, so try to build them in clusters of three if possible.'
 WHERE Tag = 'TXT_KEY_CIV5_IMPROVEMENTS_LUMBERMILL_TEXT';
 
+-- We Love the King Day
+
+UPDATE Language_en_US
+SET Text = 'Because you have {1_Resource:textkey}, the city of {2_CityName:textkey} enters "We Love the King Day", giving it a [ICON_FOOD] growth bonus!'
+WHERE Tag = 'TXT_KEY_NOTIFICATION_CITY_WLTKD';
 
 -- Founding Cities
 

--- a/(2) Vox Populi/Balance Changes/Text/en_US/UIText.xml
+++ b/(2) Vox Populi/Balance Changes/Text/en_US/UIText.xml
@@ -1495,6 +1495,12 @@
 		<Row Tag="TXT_KEY_CITYVIEW_RESET_SPEC_TT">
 			<Text>Click here to have the governor reassign specialists.</Text>
 		</Row>
+		<Row Tag="TXT_KEY_NOTIFICATION_QUEST_ENDED_REVOKED_WAR">
+			<Text>Because you are at war with {1_MinorCivName:textkey}, they have revoked quests previously offered to you.  The war must end before they will offer you quests again.</Text>
+		</Row>
+		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_QUEST_ENDED_REVOKED_WAR">
+			<Text>{1_MinorCivName:textkey} revokes quests</Text>
+		</Row>
 	</Language_en_US>
 	<Civilization_CityNames>
 		<Row>

--- a/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
@@ -6382,7 +6382,7 @@ void CvMinorCivAI::DoObsoleteQuestsForPlayer(PlayerTypes ePlayer, MinorCivQuestT
 	if (eSpecifyQuestType > NO_MINOR_CIV_QUEST_TYPE && eSpecifyQuestType < NUM_MINOR_CIV_QUEST_TYPES)
 		bCheckAllQuests = false;
 
-	bool bQuestRevokedFromBullying = false;
+	bool bQuestRevoked = false;
 
 	QuestListForPlayer::iterator itr_quest;
 	for(itr_quest = m_QuestsGiven[ePlayer].begin(); itr_quest != m_QuestsGiven[ePlayer].end(); itr_quest++)
@@ -6398,7 +6398,7 @@ void CvMinorCivAI::DoObsoleteQuestsForPlayer(PlayerTypes ePlayer, MinorCivQuestT
 				if (bCancelled)
 				{
 					if(itr_quest->IsRevoked(bWar))
-						bQuestRevokedFromBullying = true;
+						bQuestRevoked = true;
 
 					GET_PLAYER(ePlayer).GetDiplomacyAI()->LogMinorCivQuestCancelled(GetPlayer()->GetID(), iOldFriendshipTimes100, iNewFriendshipTimes100, itr_quest->GetType());
 				}
@@ -6406,14 +6406,24 @@ void CvMinorCivAI::DoObsoleteQuestsForPlayer(PlayerTypes ePlayer, MinorCivQuestT
 		}
 	}
 
-	// If quest(s) were revoked because of bullying, send out a notification
-	if(bQuestRevokedFromBullying)
-	{
-		Localization::String strMessage = Localization::Lookup("TXT_KEY_NOTIFICATION_QUEST_ENDED_REVOKED");
-		Localization::String strSummary = Localization::Lookup("TXT_KEY_NOTIFICATION_SUMMARY_QUEST_ENDED_REVOKED");
-		strMessage << GetPlayer()->getNameKey();
-		strSummary << GetPlayer()->getNameKey();
-		AddQuestNotification(strMessage.toUTF8(), strSummary.toUTF8(), ePlayer);
+	// If quest(s) were revoked because of bullying or war, send out a notification
+	if (bQuestRevoked && GetPlayer()->isAlive()) {
+		if (bWar)
+		{
+			Localization::String strMessage = Localization::Lookup("TXT_KEY_NOTIFICATION_QUEST_ENDED_REVOKED_WAR");
+			Localization::String strSummary = Localization::Lookup("TXT_KEY_NOTIFICATION_SUMMARY_QUEST_ENDED_REVOKED_WAR");
+			strMessage << GetPlayer()->getNameKey();
+			strSummary << GetPlayer()->getNameKey();
+			AddQuestNotification(strMessage.toUTF8(), strSummary.toUTF8(), ePlayer);
+		}
+		else
+		{
+			Localization::String strMessage = Localization::Lookup("TXT_KEY_NOTIFICATION_QUEST_ENDED_REVOKED");
+			Localization::String strSummary = Localization::Lookup("TXT_KEY_NOTIFICATION_SUMMARY_QUEST_ENDED_REVOKED");
+			strMessage << GetPlayer()->getNameKey();
+			strSummary << GetPlayer()->getNameKey();
+			AddQuestNotification(strMessage.toUTF8(), strSummary.toUTF8(), ePlayer);
+		}
 	}
 }
 


### PR DESCRIPTION
- Change WLTKD notification for 2.7 ("because you acquired" -> "because you have")
- Change text for "City State revokes quest" notification if it's because of a war
- Remove "City State revokes quest" notification is the City State has been conquered