### PR TITLE
Coup notification fix

### DIFF
--- a/(1) Community Patch/Core Files/Text/CoreText_en_US.xml
+++ b/(1) Community Patch/Core Files/Text/CoreText_en_US.xml
@@ -2445,7 +2445,7 @@
 			<Text>Intelligence reports from {@2_CivName} indicate that {@1_CityName} is ripe for a coup. Complete this coup, and you will be greatly rewarded!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_QUEST_COUP">
-			<Text>Intelligence from {@1_CivName}</Text>
+			<Text>Intelligence from {@2_CivName}</Text>
 		</Row>
 
 		<Row Tag="TXT_KEY_NOTIFICATION_QUEST_COUP_CITY_COMPLETE">

--- a/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
@@ -10279,7 +10279,7 @@ CvCity* CvMinorCivAI::GetBestSpyTarget(PlayerTypes ePlayer, bool bMinor)
 		if(GetPlayer()->getTeam() == GET_PLAYER(eTarget).getTeam())
 			continue;
 		
-		if(bMinor && GetAlly() == ePlayer)
+		if(bMinor && GET_PLAYER(eTarget).GetMinorCivAI()->GetAlly() == ePlayer)
 			continue;
 
 		if(bMinor && GET_PLAYER(eTarget).GetMinorCivAI()->IsCoupAttempted(ePlayer))


### PR DESCRIPTION
The check on being allied was done for the CS giving the quest, not the targeted one

And the short notification ("Intelligence from...") also showed the wrong CS
![Screenshot (119)](https://user-images.githubusercontent.com/95587882/194644414-0aeadb00-bb9d-4d23-b586-09d9937b9b5a.png)
