### PR TITLE
clang-tidy

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvAStar.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAStar.cpp
@@ -378,7 +378,7 @@ bool CvAStar::FindPathWithCurrentConfiguration(int iXstart, int iYstart, int iXd
 
 	//here the magic happens
 	bool bSuccess = false;
-	while(1)
+	while(true)
 	{
 		m_iRounds++;
 

--- a/CvGameCoreDLL_Expansion2/CvAdvisorRecommender.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAdvisorRecommender.cpp
@@ -71,7 +71,7 @@ void CvAdvisorRecommender::UpdateCityRecommendations(CvCity* pCity)
 		buildable.m_iTurnsToConstruct = pCity->getProductionTurnsLeft(eBuilding, 0);
 
 		int iFlavorWeight = pCityStrategy->GetBuildingProductionAI()->GetWeight(eBuilding);
-		int iSaneWeight = pCityStrategy->GetBuildingProductionAI()->CheckBuildingBuildSanity(eBuilding, iFlavorWeight, 0, 0);
+		int iSaneWeight = pCityStrategy->GetBuildingProductionAI()->CheckBuildingBuildSanity(eBuilding, iFlavorWeight, false, false);
 
 		m_aCityBuildables.push_back(buildable, iSaneWeight);
 	}

--- a/CvGameCoreDLL_Expansion2/CvCityCitizens.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCityCitizens.cpp
@@ -1381,7 +1381,7 @@ CvPlot* CvCityCitizens::GetBestCityPlotWithValue(int& iChosenValue, ePlotSelecti
 			break;
 		}
 
-		if (0) // (pLog)
+		if (false) // (pLog)
 		{
 			CvString strOutBuf;
 			strOutBuf.Format("check index %d, plot %d:%d (%df%dp%dg%do), score %d with forced work status %d. current net food %d", 

--- a/CvGameCoreDLL_Expansion2/CvDealClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDealClasses.cpp
@@ -3599,7 +3599,7 @@ bool CvDeal::IsAllowEmbassyTrade(PlayerTypes eFrom)
 			return true;
 		}
 	}
-	return 0;
+	return false;
 }
 
 bool CvDeal::IsOpenBordersTrade(PlayerTypes eFrom)
@@ -3612,7 +3612,7 @@ bool CvDeal::IsOpenBordersTrade(PlayerTypes eFrom)
 			return true;
 		}
 	}
-	return 0;
+	return false;
 }
 
 bool CvDeal::IsDefensivePactTrade(PlayerTypes eFrom)
@@ -3625,7 +3625,7 @@ bool CvDeal::IsDefensivePactTrade(PlayerTypes eFrom)
 			return true;
 		}
 	}
-	return 0;
+	return false;
 }
 
 bool CvDeal::IsResearchAgreementTrade(PlayerTypes eFrom)
@@ -3638,7 +3638,7 @@ bool CvDeal::IsResearchAgreementTrade(PlayerTypes eFrom)
 			return true;
 		}
 	}
-	return 0;
+	return false;
 }
 
 bool CvDeal::IsPeaceTreatyTrade(PlayerTypes eFrom)
@@ -3651,7 +3651,7 @@ bool CvDeal::IsPeaceTreatyTrade(PlayerTypes eFrom)
 			return true;
 		}
 	}
-	return 0;
+	return false;
 }
 
 bool CvDeal::IsThirdPartyPeaceTrade(PlayerTypes eFrom, TeamTypes eThirdPartyTeam)
@@ -3664,7 +3664,7 @@ bool CvDeal::IsThirdPartyPeaceTrade(PlayerTypes eFrom, TeamTypes eThirdPartyTeam
 			return true;
 		}
 	}
-	return 0;
+	return false;
 }
 
 bool CvDeal::IsThirdPartyWarTrade(PlayerTypes eFrom, TeamTypes eThirdPartyTeam)
@@ -3677,7 +3677,7 @@ bool CvDeal::IsThirdPartyWarTrade(PlayerTypes eFrom, TeamTypes eThirdPartyTeam)
 			return true;
 		}
 	}
-	return 0;
+	return false;
 }
 
 bool CvDeal::IsVoteCommitmentTrade(PlayerTypes eFrom)
@@ -4010,7 +4010,7 @@ bool CvDeal::IsMapTrade(PlayerTypes eFrom)
 		}
 
 	}
-	return 0;
+	return false;
 }
 
 bool CvDeal::IsTechTrade(PlayerTypes eFrom, TechTypes eTech)
@@ -4026,7 +4026,7 @@ bool CvDeal::IsTechTrade(PlayerTypes eFrom, TechTypes eTech)
 		}
 
 	}
-	return 0;
+	return false;
 }
 
 bool CvDeal::IsVassalageTrade(PlayerTypes eFrom)
@@ -4039,7 +4039,7 @@ bool CvDeal::IsVassalageTrade(PlayerTypes eFrom)
 			return true;
 		}
 	}
-	return 0;
+	return false;
 }
 
 bool CvDeal::IsRevokeVassalageTrade(PlayerTypes eFrom)
@@ -4052,7 +4052,7 @@ bool CvDeal::IsRevokeVassalageTrade(PlayerTypes eFrom)
 			return true;
 		}
 	}
-	return 0;
+	return false;
 }
 
 /// Delete a tech trade

--- a/CvGameCoreDLL_Expansion2/CvDllGameDeals.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDllGameDeals.cpp
@@ -124,7 +124,7 @@ bool CvDllGameDeals::ProposedDealExists(PlayerTypes eFromPlayer, PlayerTypes eTo
 #if defined(MOD_ACTIVE_DIPLOMACY)
 	if((!GET_PLAYER(eFromPlayer).isHuman() || !GET_PLAYER(eToPlayer).isHuman()) && GC.getGame().isReallyNetworkMultiPlayer() && MOD_ACTIVE_DIPLOMACY)
 	{
-		return m_pGameDeals->GetProposedMPDeal(eFromPlayer, eToPlayer, 0) != NULL;
+		return m_pGameDeals->GetProposedMPDeal(eFromPlayer, eToPlayer, false) != NULL;
 	}
 	else
 		return m_pGameDeals->ProposedDealExists(eFromPlayer, eToPlayer);
@@ -139,7 +139,7 @@ ICvDeal1* CvDllGameDeals::GetProposedDeal(PlayerTypes eFromPlayer, PlayerTypes e
 	CvDeal* pDeal;
 	if((!GET_PLAYER(eFromPlayer).isHuman() || !GET_PLAYER(eToPlayer).isHuman()) && GC.getGame().isReallyNetworkMultiPlayer() && MOD_ACTIVE_DIPLOMACY)
 	{
-		pDeal = m_pGameDeals->GetProposedMPDeal(eFromPlayer, eToPlayer, 0);
+		pDeal = m_pGameDeals->GetProposedMPDeal(eFromPlayer, eToPlayer, false);
 	}
 	else
 	{

--- a/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
@@ -2523,7 +2523,7 @@ void CvMinorCivQuest::DoStartQuest(int iStartTurn, PlayerTypes pCallingPlayer)
 		EconomicAIStrategyTypes eNavalRecon = (EconomicAIStrategyTypes) GC.getInfoTypeForString("ECONOMICAISTRATEGY_NEED_RECON_SEA");
 		if(!pAssignedPlayer->GetEconomicAI()->IsUsingStrategy(eNavalRecon) && !pAssignedPlayer->isHuman())
 		{
-			pAssignedPlayer->GetEconomicAI()->SetUsingStrategy(eNavalRecon, 1);
+			pAssignedPlayer->GetEconomicAI()->SetUsingStrategy(eNavalRecon, true);
 		}
 	}
 	// Influence
@@ -2582,7 +2582,7 @@ void CvMinorCivQuest::DoStartQuest(int iStartTurn, PlayerTypes pCallingPlayer)
 		EconomicAIStrategyTypes eNavalRecon = (EconomicAIStrategyTypes) GC.getInfoTypeForString("ECONOMICAISTRATEGY_NEED_RECON_SEA");
 		if(!pAssignedPlayer->GetEconomicAI()->IsUsingStrategy(eNavalRecon) && !pAssignedPlayer->isHuman())
 		{
-			pAssignedPlayer->GetEconomicAI()->SetUsingStrategy(eNavalRecon, 1);
+			pAssignedPlayer->GetEconomicAI()->SetUsingStrategy(eNavalRecon, true);
 		}
 	}
 	// Liberate a City State
@@ -4237,8 +4237,8 @@ void CvMinorCivAI::Reset()
 
 	m_bIsRebellion = false;
 	m_iTurnsSinceRebellion = 0;
-	m_bIsRebellionActive = 0;
-	m_bIsHordeActive = 0;
+	m_bIsRebellionActive = false;
+	m_bIsHordeActive = false;
 	m_iCooldownSpawn = 0;
 	m_ePermanentAlly = NO_PLAYER;
 	m_bNoAlly = false;
@@ -10159,7 +10159,7 @@ bool CvMinorCivAI::IsCoupAttempted(PlayerTypes ePlayer)
 {
 	CvAssertMsg(ePlayer >= 0, "eForPlayer is expected to be non-negative (invalid Index)");
 	CvAssertMsg(ePlayer < MAX_MAJOR_CIVS, "eForPlayer is expected to be within maximum bounds (invalid Index)");
-	if(ePlayer < 0 || ePlayer >= REALLY_MAX_PLAYERS) return 0;  // as defined in Reset()
+	if(ePlayer < 0 || ePlayer >= REALLY_MAX_PLAYERS) return false;  // as defined in Reset()
 	return m_abCoupAttempted[ePlayer];
 }
 void CvMinorCivAI::SetTargetedAreaID(PlayerTypes ePlayer, int iValue)

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -21031,7 +21031,7 @@ void CvUnit::setGameTurnCreated(int iNewValue)
 int CvUnit::getDamage() const
 {
 	//for debugging - hook in here and mouse over a unit to get the current tactical zone info
-	if (0)
+	if (false)
 		OutputDebugString( getTacticalZoneInfo().c_str() );
 
 	VALIDATE_OBJECT

--- a/CvGameCoreDLL_Expansion2/CvUnitClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnitClasses.cpp
@@ -61,10 +61,10 @@ CvUnitEntry::CvUnitEntry(void) :
 	m_bCultureFromExperienceOnDisband(false),
 	m_bFreeUpgrade(false),
 	m_bUnitEraUpgrade(false),
-	m_bWarOnly(0),
+	m_bWarOnly(false),
 	m_bWLTKD(false),
 	m_bGoldenAge(false),
-	m_bCultureBoost(0),
+	m_bCultureBoost(false),
 	m_bExtraAttackHealthOnKill(false),
 	m_bHighSeaRaider(false),
 #endif

--- a/CvGameCoreDLL_Expansion2/CvWonderProductionAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvWonderProductionAI.cpp
@@ -172,7 +172,7 @@ BuildingTypes CvWonderProductionAI::ChooseWonder(bool /* bAdjustForOtherPlayers 
 			if (iWeight <= 0)
 				continue;
 
-			iWeight = pLoopCity->GetCityStrategyAI()->GetBuildingProductionAI()->CheckBuildingBuildSanity(eBuilding, iWeight, 0, 0, 1);
+			iWeight = pLoopCity->GetCityStrategyAI()->GetBuildingProductionAI()->CheckBuildingBuildSanity(eBuilding, iWeight, false, false, true);
 			if(iWeight > 0)
 				m_Buildables.push_back(iBldgLoop, iWeight);
 		}


### PR DESCRIPTION
Just a clean up. v90 build works.

`warning: converting integer literal to bool, use bool literal instead [modernize-use-bool-literals]`