### PR TITLE
cppcoreguidelines

### DIFF
--- a/CvGameCoreDLL_Expansion2/CustomMods.cpp
+++ b/CvGameCoreDLL_Expansion2/CustomMods.cpp
@@ -16,7 +16,7 @@ CustomMods::CustomMods() :
 int CustomMods::eventHook(const char* szName, const char* p, ...) {
 	CvLuaArgsHandle args;
 
-	va_list vl;
+	va_list vl = NULL;
 	va_start(vl, p);
 
 	for (const char* it = p; *it; ++it) {
@@ -42,7 +42,7 @@ int CustomMods::eventHook(const char* szName, const char* p, ...) {
 int CustomMods::eventTestAll(const char* szName, const char* p, ...) {
 	CvLuaArgsHandle args;
 
-	va_list vl;
+	va_list vl = NULL;
 	va_start(vl, p);
 
 	for (const char* it = p; *it; ++it) {
@@ -68,7 +68,7 @@ int CustomMods::eventTestAll(const char* szName, const char* p, ...) {
 int CustomMods::eventTestAny(const char* szName, const char* p, ...) {
 	CvLuaArgsHandle args;
 
-	va_list vl;
+	va_list vl = NULL;
 	va_start(vl, p);
 
 	for (const char* it = p; *it; ++it) {
@@ -94,7 +94,7 @@ int CustomMods::eventTestAny(const char* szName, const char* p, ...) {
 int CustomMods::eventAccumulator(int &iValue, const char* szName, const char* p, ...) {
 	CvLuaArgsHandle args;
 
-	va_list vl;
+	va_list vl = NULL;
 	va_start(vl, p);
 
 	for (const char* it = p; *it; ++it) {
@@ -120,7 +120,7 @@ int CustomMods::eventAccumulator(int &iValue, const char* szName, const char* p,
 int CustomMods::eventHook(const char* szName, CvLuaArgsHandle &args) {
 	ICvEngineScriptSystem1* pkScriptSystem = gDLL->GetScriptSystem();
 	if (pkScriptSystem) {
-		bool bResult;
+		bool bResult = 0;
 		if (LuaSupport::CallHook(pkScriptSystem, szName, args.get(), bResult)) {
 			return GAMEEVENTRETURN_HOOK;
 		}

--- a/CvGameCoreDLL_Expansion2/CvAchievementInfo.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAchievementInfo.cpp
@@ -37,7 +37,7 @@ bool CvAchievementInfo::CacheResults(Database::Results& kResults, CvDatabaseUtil
 	return true;
 }
 
-CvAchievementXMLEntries::CvAchievementXMLEntries(void)
+CvAchievementXMLEntries::CvAchievementXMLEntries(void) : m_paAchievementEntries()
 {
 
 }

--- a/CvGameCoreDLL_Expansion2/CvAdvisorCounsel.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAdvisorCounsel.cpp
@@ -19,7 +19,7 @@
 
 #define NUM_COUNSEL_SLOTS 50
 
-CvAdvisorCounsel::CvAdvisorCounsel(void)
+CvAdvisorCounsel::CvAdvisorCounsel(void) : m_aCounsel()
 {
 	Init();
 }
@@ -83,7 +83,7 @@ void CvAdvisorCounsel::BuildCounselList(PlayerTypes ePlayer)
 
 	if(GET_PLAYER(ePlayer).getNumCities() == 0)
 	{
-		bool bSuccess;
+		bool bSuccess = 0;
 		strLoc = Localization::Lookup("TXT_KEY_BUILD_A_CITY_MCFLY_ECONOMIC");
 		bSuccess = SetCounselEntry(uiCounselIndex, ADVISOR_ECONOMIC, strLoc.toUTF8(), 99);
 		CvAssertMsg(bSuccess, "Unable to add counsel to list. Too many strategies running at once");
@@ -163,9 +163,9 @@ void CvAdvisorCounsel::BuildCounselList(PlayerTypes ePlayer)
 	}
 
 	// go through city strategies
-	int iLoop;
-	CvCity* pLoopCity;
-	CvCityStrategyAI* pCityStrategyAI;
+	int iLoop = 0;
+	CvCity* pLoopCity = NULL;
+	CvCityStrategyAI* pCityStrategyAI = NULL;
 	for(pLoopCity = GET_PLAYER(ePlayer).firstCity(&iLoop); pLoopCity != NULL; pLoopCity = GET_PLAYER(ePlayer).nextCity(&iLoop))
 	{
 		pCityStrategyAI = pLoopCity->GetCityStrategyAI();
@@ -1380,8 +1380,8 @@ void CvAdvisorCounsel::BuildCounselList(PlayerTypes ePlayer)
 
 				PlayerTypes eCheckPlayer = (PlayerTypes)ui2;
 
-				int iCityIndex;
-				CvCity* pCapCity;
+				int iCityIndex = 0;
+				CvCity* pCapCity = NULL;
 				for(pCapCity = GET_PLAYER(eCheckPlayer).firstCity(&iCityIndex); pCapCity != NULL; pCapCity = GET_PLAYER(eCheckPlayer).nextCity(&iCityIndex))
 				{
 					if(pCapCity->getOriginalOwner() == eMinorPlayer)

--- a/CvGameCoreDLL_Expansion2/CvBeliefClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvBeliefClasses.h
@@ -25,7 +25,7 @@ class CvBeliefEntry: public CvBaseInfo
 {
 public:
 	CvBeliefEntry(void);
-	~CvBeliefEntry(void);
+	virtual ~CvBeliefEntry(void);
 
 	int GetMinPopulation() const;
 	int GetMinFollowers() const;

--- a/CvGameCoreDLL_Expansion2/CvDLLFAStarIFaceBase.h
+++ b/CvGameCoreDLL_Expansion2/CvDLLFAStarIFaceBase.h
@@ -18,6 +18,7 @@ typedef int(*CvAStarFunc)(FAStarNode*, FAStarNode*, int, const void*, CvAStar*);
 class CvDLLFAStarIFaceBase
 {
 public:
+virtual ~CvDLLFAStarIFaceBase() = default;
 	virtual CvAStar* create() = 0;
 	virtual void destroy(CvAStar*& ptr, bool bSafeDelete=true) = 0;
 	virtual bool GeneratePath(CvAStar*, int iXstart, int iYstart, int iXdest, int iYdest, bool bUseHexes = false, bool bCardinalOnly = false, int iInfo = 0, bool bReuse = false) = 0;

--- a/CvGameCoreDLL_Expansion2/CvDllBuildInfo.h
+++ b/CvGameCoreDLL_Expansion2/CvDllBuildInfo.h
@@ -14,7 +14,7 @@ class CvDllBuildInfo : public ICvBuildInfo1
 {
 public:
 	CvDllBuildInfo(_In_ CvBuildInfo* pBuildInfo);
-	~CvDllBuildInfo();
+	virtual ~CvDllBuildInfo();
 
 	void* DLLCALL QueryInterface(GUID guidInterface);
 

--- a/CvGameCoreDLL_Expansion2/CvDllBuildingInfo.h
+++ b/CvGameCoreDLL_Expansion2/CvDllBuildingInfo.h
@@ -15,7 +15,7 @@ class CvDllBuildingInfo : public ICvBuildingInfo1
 {
 public:
 	CvDllBuildingInfo(_In_ CvBuildingEntry* pBuildingInfo);
-	~CvDllBuildingInfo();
+	virtual ~CvDllBuildingInfo();
 
 	void* DLLCALL QueryInterface(GUID guidInterface);
 

--- a/CvGameCoreDLL_Expansion2/CvDllCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDllCity.cpp
@@ -185,13 +185,13 @@ IDInfo CvDllCity::GetIDInfo() const
 //------------------------------------------------------------------------------
 bool CvDllCity::IsWorkingPlot(ICvPlot1* pPlot) const
 {
-	CvPlot* pkPlot = (NULL != pPlot)? static_cast<CvDllPlot*>(pPlot)->GetInstance() : NULL;
+	CvPlot* pkPlot = (NULL != pPlot)? dynamic_cast<CvDllPlot*>(pPlot)->GetInstance() : NULL;
 	return (NULL != pkPlot)? m_pCity->GetCityCitizens()->IsWorkingPlot(pkPlot) : false;
 }
 //------------------------------------------------------------------------------
 bool CvDllCity::CanWork(ICvPlot1* pPlot) const
 {
-	CvPlot* pkPlot = (NULL != pPlot)? static_cast<CvDllPlot*>(pPlot)->GetInstance() : NULL;
+	CvPlot* pkPlot = (NULL != pPlot)? dynamic_cast<CvDllPlot*>(pPlot)->GetInstance() : NULL;
 	return (NULL != pkPlot)? m_pCity->GetCityCitizens()->IsCanWork(pkPlot) : false;
 }
 //------------------------------------------------------------------------------

--- a/CvGameCoreDLL_Expansion2/CvDllCity.h
+++ b/CvGameCoreDLL_Expansion2/CvDllCity.h
@@ -12,7 +12,7 @@ class CvDllCity : public ICvCity1
 {
 public:
 	CvDllCity(_In_ CvCity* pCity);
-	~CvDllCity();
+	virtual ~CvDllCity();
 
 	void* DLLCALL QueryInterface(GUID guidInterface);
 

--- a/CvGameCoreDLL_Expansion2/CvDllCivilizationInfo.h
+++ b/CvGameCoreDLL_Expansion2/CvDllCivilizationInfo.h
@@ -14,7 +14,7 @@ class CvDllCivilizationInfo : public ICvCivilizationInfo1
 {
 public:
 	CvDllCivilizationInfo(_In_ CvCivilizationInfo* pCivilizationInfo);
-	~CvDllCivilizationInfo();
+	virtual ~CvDllCivilizationInfo();
 
 	void* DLLCALL QueryInterface(GUID guidInterface);
 

--- a/CvGameCoreDLL_Expansion2/CvDllColorInfo.h
+++ b/CvGameCoreDLL_Expansion2/CvDllColorInfo.h
@@ -14,7 +14,7 @@ class CvDllColorInfo : public ICvColorInfo1
 {
 public:
 	CvDllColorInfo(_In_ CvColorInfo* pColorInfo);
-	~CvDllColorInfo();
+	virtual ~CvDllColorInfo();
 
 	void* DLLCALL QueryInterface(GUID guidInterface);
 

--- a/CvGameCoreDLL_Expansion2/CvDllCombatInfo.h
+++ b/CvGameCoreDLL_Expansion2/CvDllCombatInfo.h
@@ -12,7 +12,7 @@ class CvDllCombatInfo : public ICvCombatInfo1
 {
 public:
 	CvDllCombatInfo(_In_ CvCombatInfo* pCombatInfo);
-	~CvDllCombatInfo();
+	virtual ~CvDllCombatInfo();
 
 	void* DLLCALL QueryInterface(GUID guidInterface);
 

--- a/CvGameCoreDLL_Expansion2/CvDllContext.h
+++ b/CvGameCoreDLL_Expansion2/CvDllContext.h
@@ -19,7 +19,7 @@ class CvDllWorldBuilderMapLoader;
 class CvDllGameContext : public ICvGameContext3
 {
 public:
-	~CvDllGameContext();
+	virtual ~CvDllGameContext();
 
 	void* DLLCALL QueryInterface(GUID guidInterface);
 

--- a/CvGameCoreDLL_Expansion2/CvDllDeal.h
+++ b/CvGameCoreDLL_Expansion2/CvDllDeal.h
@@ -12,7 +12,7 @@ class CvDllDeal : public ICvDeal1
 {
 public:
 	CvDllDeal(_In_ CvDeal* pDeal);
-	~CvDllDeal();
+	virtual ~CvDllDeal();
 
 	void* DLLCALL QueryInterface(GUID guidInterface);
 

--- a/CvGameCoreDLL_Expansion2/CvDllDiplomacyAI.h
+++ b/CvGameCoreDLL_Expansion2/CvDllDiplomacyAI.h
@@ -15,7 +15,7 @@ class CvDllDiplomacyAI : public ICvDiplomacyAI1
 {
 public:
 	CvDllDiplomacyAI(_In_ CvDiplomacyAI* pDiplomacyAI);
-	~CvDllDiplomacyAI();
+	virtual ~CvDllDiplomacyAI();
 
 	void* DLLCALL QueryInterface(GUID guidInterface);
 

--- a/CvGameCoreDLL_Expansion2/CvDllEraInfo.h
+++ b/CvGameCoreDLL_Expansion2/CvDllEraInfo.h
@@ -13,7 +13,7 @@ class CvDllEraInfo : public ICvEraInfo1
 {
 public:
 	CvDllEraInfo(_In_ CvEraInfo* pEraInfo);
-	~CvDllEraInfo();
+	virtual ~CvDllEraInfo();
 
 	void* DLLCALL QueryInterface(GUID guidInterface);
 

--- a/CvGameCoreDLL_Expansion2/CvDllFeatureInfo.h
+++ b/CvGameCoreDLL_Expansion2/CvDllFeatureInfo.h
@@ -14,7 +14,7 @@ class CvDllFeatureInfo : public ICvFeatureInfo1
 {
 public:
 	CvDllFeatureInfo(_In_ CvFeatureInfo* pFeatureInfo);
-	~CvDllFeatureInfo();
+	virtual ~CvDllFeatureInfo();
 
 	void* DLLCALL QueryInterface(GUID guidInterface);
 

--- a/CvGameCoreDLL_Expansion2/CvDllGame.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDllGame.cpp
@@ -131,7 +131,7 @@ int CvDllGame::CountNumHumanGameTurnActive()
 //------------------------------------------------------------------------------
 bool CvDllGame::CyclePlotUnits(ICvPlot1* pPlot, bool bForward, bool bAuto, int iCount)
 {
-	CvPlot* pkPlot = (NULL != pPlot)? static_cast<CvDllPlot*>(pPlot)->GetInstance() : NULL;
+	CvPlot* pkPlot = (NULL != pPlot)? dynamic_cast<CvDllPlot*>(pPlot)->GetInstance() : NULL;
 	return m_pGame->cyclePlotUnits(pkPlot, bForward, bAuto, iCount);
 }
 //------------------------------------------------------------------------------
@@ -237,7 +237,7 @@ bool CvDllGame::GetPbemTurnSent() const
 //------------------------------------------------------------------------------
 ICvUnit1* CvDllGame::GetPlotUnit(ICvPlot1* pPlot, int iIndex)
 {
-	CvPlot* pkPlot = (NULL != pPlot)? static_cast<CvDllPlot*>(pPlot)->GetInstance() : NULL;
+	CvPlot* pkPlot = (NULL != pPlot)? dynamic_cast<CvDllPlot*>(pPlot)->GetInstance() : NULL;
 	CvUnit* pkUnit = m_pGame->getPlotUnit(pkPlot, iIndex);
 
 	return (NULL != pkUnit)? new CvDllUnit(pkUnit) : NULL;
@@ -387,13 +387,13 @@ void CvDllGame::ResetTurnTimer()
 //------------------------------------------------------------------------------
 void CvDllGame::SelectAll(ICvPlot1* pPlot)
 {
-	CvPlot* pkPlot = (NULL != pPlot)? static_cast<CvDllPlot*>(pPlot)->GetInstance() : NULL;
+	CvPlot* pkPlot = (NULL != pPlot)? dynamic_cast<CvDllPlot*>(pPlot)->GetInstance() : NULL;
 	m_pGame->selectAll(pkPlot);
 }
 //------------------------------------------------------------------------------
 void CvDllGame::SelectGroup(ICvUnit1* pUnit, bool bShift, bool bCtrl, bool bAlt)
 {
-	CvUnit* pkUnit = (NULL != pUnit)? static_cast<CvDllUnit*>(pUnit)->GetInstance() : NULL;
+	CvUnit* pkUnit = (NULL != pUnit)? dynamic_cast<CvDllUnit*>(pUnit)->GetInstance() : NULL;
 	m_pGame->selectGroup(pkUnit, bShift, bCtrl, bAlt);
 }
 //------------------------------------------------------------------------------
@@ -404,7 +404,7 @@ bool CvDllGame::SelectionListIgnoreBuildingDefense()
 //------------------------------------------------------------------------------
 void CvDllGame::SelectionListMove(ICvPlot1* pPlot, bool bShift)
 {
-	CvPlot* pkPlot = (NULL != pPlot)? static_cast<CvDllPlot*>(pPlot)->GetInstance() : NULL;
+	CvPlot* pkPlot = (NULL != pPlot)? dynamic_cast<CvDllPlot*>(pPlot)->GetInstance() : NULL;
 	m_pGame->selectionListMove(pkPlot, bShift);
 }
 //------------------------------------------------------------------------------
@@ -415,7 +415,7 @@ void CvDllGame::SelectSettler()
 //------------------------------------------------------------------------------
 void CvDllGame::SelectUnit(ICvUnit1* pUnit, bool bClear, bool bToggle, bool bSound)
 {
-	CvUnit* pkUnit = (NULL != pUnit)? static_cast<CvDllUnit*>(pUnit)->GetInstance() : NULL;
+	CvUnit* pkUnit = (NULL != pUnit)? dynamic_cast<CvDllUnit*>(pUnit)->GetInstance() : NULL;
 	m_pGame->selectUnit(pkUnit, bClear, bToggle, bSound);
 }
 //------------------------------------------------------------------------------

--- a/CvGameCoreDLL_Expansion2/CvDllGame.h
+++ b/CvGameCoreDLL_Expansion2/CvDllGame.h
@@ -12,7 +12,7 @@ class CvDllGame : public ICvGame2
 {
 public:
 	CvDllGame(CvGame* pGame);
-	~CvDllGame();
+	virtual ~CvDllGame();
 
 	void* DLLCALL QueryInterface(GUID guidInterface);
 

--- a/CvGameCoreDLL_Expansion2/CvDllGameAsynch.h
+++ b/CvGameCoreDLL_Expansion2/CvDllGameAsynch.h
@@ -12,7 +12,7 @@ class CvDllGameAsynch : public ICvGameAsynch1
 {
 public:
 	CvDllGameAsynch(CvGame* pGame);
-	~CvDllGameAsynch();
+	virtual ~CvDllGameAsynch();
 
 	void* DLLCALL QueryInterface(GUID guidInterface);
 

--- a/CvGameCoreDLL_Expansion2/CvDllGameDeals.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDllGameDeals.cpp
@@ -136,7 +136,7 @@ bool CvDllGameDeals::ProposedDealExists(PlayerTypes eFromPlayer, PlayerTypes eTo
 ICvDeal1* CvDllGameDeals::GetProposedDeal(PlayerTypes eFromPlayer, PlayerTypes eToPlayer)
 {
 #if defined(MOD_ACTIVE_DIPLOMACY)
-	CvDeal* pDeal;
+	CvDeal* pDeal = NULL;
 	if((!GET_PLAYER(eFromPlayer).isHuman() || !GET_PLAYER(eToPlayer).isHuman()) && GC.getGame().isReallyNetworkMultiPlayer() && MOD_ACTIVE_DIPLOMACY)
 	{
 		pDeal = m_pGameDeals->GetProposedMPDeal(eFromPlayer, eToPlayer, 0);

--- a/CvGameCoreDLL_Expansion2/CvDllGameDeals.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDllGameDeals.cpp
@@ -80,7 +80,7 @@ CvGameDeals* CvDllGameDeals::GetInstance()
 //------------------------------------------------------------------------------
 void CvDllGameDeals::AddProposedDeal(ICvDeal1* pDeal)
 {
-	CvDeal* pkDeal = (NULL != pDeal)? static_cast<CvDllDeal*>(pDeal)->GetInstance() : NULL;
+	CvDeal* pkDeal = (NULL != pDeal)? dynamic_cast<CvDllDeal*>(pDeal)->GetInstance() : NULL;
 	if(pkDeal != NULL)
 	{
 		m_pGameDeals->AddProposedDeal(*pkDeal);
@@ -110,7 +110,7 @@ ICvDeal1* CvDllGameDeals::GetTempDeal()
 //------------------------------------------------------------------------------
 void CvDllGameDeals::SetTempDeal(ICvDeal1* pDeal)
 {
-	CvDeal* pkDeal = (NULL != pDeal)? static_cast<CvDllDeal*>(pDeal)->GetInstance() : NULL;
+	CvDeal* pkDeal = (NULL != pDeal)? dynamic_cast<CvDllDeal*>(pDeal)->GetInstance() : NULL;
 	m_pGameDeals->SetTempDeal(pkDeal);
 }
 //------------------------------------------------------------------------------

--- a/CvGameCoreDLL_Expansion2/CvDllGameDeals.h
+++ b/CvGameCoreDLL_Expansion2/CvDllGameDeals.h
@@ -12,7 +12,7 @@ class CvDllGameDeals : public ICvGameDeals1
 {
 public:
 	CvDllGameDeals(_In_ CvGameDeals* pGameDeals);
-	~CvDllGameDeals();
+	virtual ~CvDllGameDeals();
 
 	void* DLLCALL QueryInterface(GUID guidInterface);
 

--- a/CvGameCoreDLL_Expansion2/CvDllGameOptionInfo.h
+++ b/CvGameCoreDLL_Expansion2/CvDllGameOptionInfo.h
@@ -14,7 +14,7 @@ class CvDllGameOptionInfo : public ICvGameOptionInfo1
 {
 public:
 	CvDllGameOptionInfo(_In_ CvGameOptionInfo* pGameOptionInfo);
-	~CvDllGameOptionInfo();
+	virtual ~CvDllGameOptionInfo();
 
 	void* DLLCALL QueryInterface(GUID guidInterface);
 

--- a/CvGameCoreDLL_Expansion2/CvDllGameSpeedInfo.h
+++ b/CvGameCoreDLL_Expansion2/CvDllGameSpeedInfo.h
@@ -14,7 +14,7 @@ class CvDllGameSpeedInfo : public ICvGameSpeedInfo1
 {
 public:
 	CvDllGameSpeedInfo(_In_ CvGameSpeedInfo* pGameSpeedInfo);
-	~CvDllGameSpeedInfo();
+	virtual ~CvDllGameSpeedInfo();
 
 	void* DLLCALL QueryInterface(GUID guidInterface);
 

--- a/CvGameCoreDLL_Expansion2/CvDllHandicapInfo.h
+++ b/CvGameCoreDLL_Expansion2/CvDllHandicapInfo.h
@@ -14,7 +14,7 @@ class CvDllHandicapInfo : public ICvHandicapInfo1
 {
 public:
 	CvDllHandicapInfo(_In_ CvHandicapInfo* pHandicapInfo);
-	~CvDllHandicapInfo();
+	virtual ~CvDllHandicapInfo();
 
 	void* DLLCALL QueryInterface(GUID guidInterface);
 

--- a/CvGameCoreDLL_Expansion2/CvDllImprovementInfo.h
+++ b/CvGameCoreDLL_Expansion2/CvDllImprovementInfo.h
@@ -13,7 +13,7 @@ class CvDllImprovementInfo : public ICvImprovementInfo1
 {
 public:
 	CvDllImprovementInfo(_In_ CvImprovementEntry* pImprovementInfo);
-	~CvDllImprovementInfo();
+	virtual ~CvDllImprovementInfo();
 
 	void* DLLCALL QueryInterface(GUID guidInterface);
 

--- a/CvGameCoreDLL_Expansion2/CvDllInterfaceModeInfo.h
+++ b/CvGameCoreDLL_Expansion2/CvDllInterfaceModeInfo.h
@@ -14,7 +14,7 @@ class CvDllInterfaceModeInfo : public ICvInterfaceModeInfo1
 {
 public:
 	CvDllInterfaceModeInfo(_In_ CvInterfaceModeInfo* pInterfaceModeInfo);
-	~CvDllInterfaceModeInfo();
+	virtual ~CvDllInterfaceModeInfo();
 
 	void* DLLCALL QueryInterface(GUID guidInterface);
 

--- a/CvGameCoreDLL_Expansion2/CvDllLeaderheadInfo.h
+++ b/CvGameCoreDLL_Expansion2/CvDllLeaderheadInfo.h
@@ -14,7 +14,7 @@ class CvDllLeaderHeadInfo : public ICvLeaderHeadInfo1
 {
 public:
 	CvDllLeaderHeadInfo(_In_ CvLeaderHeadInfo* pLeaderHeadInfo);
-	~CvDllLeaderHeadInfo();
+	virtual ~CvDllLeaderHeadInfo();
 
 	void* DLLCALL QueryInterface(GUID guidInterface);
 

--- a/CvGameCoreDLL_Expansion2/CvDllMap.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDllMap.cpp
@@ -117,7 +117,7 @@ ICvCity1* CvDllMap::FindCity(int iX,
 	CvCity* pkSkipCity = NULL;
 	if(pSkipCity)
 	{
-		pkSkipCity = static_cast<CvDllCity*>(pSkipCity)->GetInstance();
+		pkSkipCity = dynamic_cast<CvDllCity*>(pSkipCity)->GetInstance();
 	}
 
 	CvCity* pkCity = m_pMap->findCity(iX, iY, eOwner, eTeam, bSameArea, bCoastalOnly, eTeamAtWarWith, eDirection, pkSkipCity);

--- a/CvGameCoreDLL_Expansion2/CvDllMap.h
+++ b/CvGameCoreDLL_Expansion2/CvDllMap.h
@@ -12,7 +12,7 @@ class CvDllMap : public ICvMap1
 {
 public:
 	CvDllMap(_In_ CvMap* pMap);
-	~CvDllMap();
+	virtual ~CvDllMap();
 
 	void* DLLCALL QueryInterface(GUID guidInterface);
 

--- a/CvGameCoreDLL_Expansion2/CvDllMinorCivInfo.h
+++ b/CvGameCoreDLL_Expansion2/CvDllMinorCivInfo.h
@@ -14,7 +14,7 @@ class CvDllMinorCivInfo : public ICvMinorCivInfo1
 {
 public:
 	CvDllMinorCivInfo(_In_ CvMinorCivInfo* pMinorCivInfo);
-	~CvDllMinorCivInfo();
+	virtual ~CvDllMinorCivInfo();
 
 	void* DLLCALL QueryInterface(GUID guidInterface);
 

--- a/CvGameCoreDLL_Expansion2/CvDllMissionData.h
+++ b/CvGameCoreDLL_Expansion2/CvDllMissionData.h
@@ -14,7 +14,7 @@ class CvDllMissionData: public ICvMissionData1
 {
 public:
 	CvDllMissionData(_In_ const MissionData* pMissionData);
-	~CvDllMissionData();
+	virtual ~CvDllMissionData();
 
 	void* DLLCALL QueryInterface(GUID guidInterface);
 

--- a/CvGameCoreDLL_Expansion2/CvDllMissionInfo.h
+++ b/CvGameCoreDLL_Expansion2/CvDllMissionInfo.h
@@ -14,7 +14,7 @@ class CvDllMissionInfo : public ICvMissionInfo1
 {
 public:
 	CvDllMissionInfo(_In_ CvMissionInfo* pMissionInfo);
-	~CvDllMissionInfo();
+	virtual ~CvDllMissionInfo();
 
 	void* DLLCALL QueryInterface(GUID guidInterface);
 

--- a/CvGameCoreDLL_Expansion2/CvDllNetLoadGameInfo.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDllNetLoadGameInfo.cpp
@@ -11,7 +11,7 @@
 #include "CvDllContext.h"
 
 CvDllNetLoadGameInfo::CvDllNetLoadGameInfo()
-	: m_uiRefCount(1)
+	: m_slotStatus(), m_uiRefCount(1)
 {
 	m_slotStatus = CvPreGame::GetSlotStatus();
 }

--- a/CvGameCoreDLL_Expansion2/CvDllNetLoadGameInfo.h
+++ b/CvGameCoreDLL_Expansion2/CvDllNetLoadGameInfo.h
@@ -12,7 +12,7 @@ class CvDllNetLoadGameInfo : public ICvNetLoadGameInfo1
 {
 public:
 	CvDllNetLoadGameInfo();
-	~CvDllNetLoadGameInfo();
+	virtual ~CvDllNetLoadGameInfo();
 
 	void* DLLCALL QueryInterface(GUID guidInterface);
 

--- a/CvGameCoreDLL_Expansion2/CvDllNetMessageExt.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDllNetMessageExt.cpp
@@ -59,8 +59,8 @@ namespace NetMessageExt
 		void DoCityEventChoice(PlayerTypes ePlayer, int iCityID, CityEventChoiceTypes eEventChoice, CityEventTypes eCityEvent, int iEspionageValue, PlayerTypes eSpyOwner)
 		{
 			CvPlayer& kActualPlayer = GET_PLAYER(ePlayer);
-			int iLoop;
-			CvCity* pLoopCity;
+			int iLoop = 0;
+			CvCity* pLoopCity = NULL;
 			for (pLoopCity = kActualPlayer.firstCity(&iLoop); pLoopCity != NULL; pLoopCity = kActualPlayer.nextCity(&iLoop))
 			{
 				if (pLoopCity->GetID() == iCityID)

--- a/CvGameCoreDLL_Expansion2/CvDllNetMessageHandler.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDllNetMessageHandler.cpp
@@ -1270,7 +1270,7 @@ void CvDllNetMessageHandler::ResponseSellBuilding(PlayerTypes ePlayer, int iCity
 			args->Push(iCityID);
 			args->Push(eBuilding);
 
-			bool bResult;
+			bool bResult = 0;
 			LuaSupport::CallHook(pkScriptSystem, "CitySoldBuilding", args.get(), bResult);
 		}
 #if defined(MOD_EVENTS_CITY)

--- a/CvGameCoreDLL_Expansion2/CvDllNetMessageHandler.h
+++ b/CvGameCoreDLL_Expansion2/CvDllNetMessageHandler.h
@@ -13,7 +13,7 @@ class CvDllNetMessageHandler : public ICvNetMessageHandler3
 {
 public:
 	CvDllNetMessageHandler();
-	~CvDllNetMessageHandler();
+	virtual ~CvDllNetMessageHandler();
 
 	void* DLLCALL QueryInterface(GUID guidInterface);
 

--- a/CvGameCoreDLL_Expansion2/CvDllNetworkSyncronization.h
+++ b/CvGameCoreDLL_Expansion2/CvDllNetworkSyncronization.h
@@ -13,7 +13,7 @@ class CvDllNetworkSyncronization : public ICvNetworkSyncronization1
 {
 public:
 	CvDllNetworkSyncronization();
-	~CvDllNetworkSyncronization();
+	virtual ~CvDllNetworkSyncronization();
 
 	void* DLLCALL QueryInterface(GUID guidInterface);
 

--- a/CvGameCoreDLL_Expansion2/CvDllPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDllPlayer.cpp
@@ -308,7 +308,7 @@ ICvUnit1* CvDllPlayer::NextUnit(int* pIterIdx, bool bRev)
 //------------------------------------------------------------------------------
 int CvDllPlayer::GetPlotDanger(ICvPlot1* pPlot) const
 {
-	CvDllPlot* pDllPlot = static_cast<CvDllPlot*>(pPlot);
+	CvDllPlot* pDllPlot = dynamic_cast<CvDllPlot*>(pPlot);
 	CvPlot& kPlot = (*pDllPlot->GetInstance());
 	return m_pPlayer->GetPlotDanger(kPlot, false);
 }

--- a/CvGameCoreDLL_Expansion2/CvDllPlayer.h
+++ b/CvGameCoreDLL_Expansion2/CvDllPlayer.h
@@ -12,7 +12,7 @@ class CvDllPlayer : public ICvPlayer3
 {
 public:
 	CvDllPlayer(_In_ CvPlayerAI* pPlayer);
-	~CvDllPlayer();
+	virtual ~CvDllPlayer();
 
 	void* DLLCALL QueryInterface(GUID guidInterface);
 

--- a/CvGameCoreDLL_Expansion2/CvDllPlayerColorInfo.h
+++ b/CvGameCoreDLL_Expansion2/CvDllPlayerColorInfo.h
@@ -14,7 +14,7 @@ class CvDllPlayerColorInfo : public ICvPlayerColorInfo1
 {
 public:
 	CvDllPlayerColorInfo(_In_ CvPlayerColorInfo* pPlayerColorInfo);
-	~CvDllPlayerColorInfo();
+	virtual ~CvDllPlayerColorInfo();
 
 	void* DLLCALL QueryInterface(GUID guidInterface);
 

--- a/CvGameCoreDLL_Expansion2/CvDllPlayerOptionInfo.h
+++ b/CvGameCoreDLL_Expansion2/CvDllPlayerOptionInfo.h
@@ -14,7 +14,7 @@ class CvDllPlayerOptionInfo : public ICvPlayerOptionInfo1
 {
 public:
 	CvDllPlayerOptionInfo(_In_ CvPlayerOptionInfo* pPlayerOptionInfo);
-	~CvDllPlayerOptionInfo();
+	virtual ~CvDllPlayerOptionInfo();
 
 	void* DLLCALL QueryInterface(GUID guidInterface);
 

--- a/CvGameCoreDLL_Expansion2/CvDllPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDllPlot.cpp
@@ -97,7 +97,7 @@ void CvDllPlot::UpdateCenterUnit()
 //------------------------------------------------------------------------------
 bool CvDllPlot::IsAdjacent(ICvPlot1* pPlot) const
 {
-	CvPlot* pkPlot = (pPlot != NULL)? static_cast<CvDllPlot*>(pPlot)->GetInstance() : NULL;
+	CvPlot* pkPlot = (pPlot != NULL)? dynamic_cast<CvDllPlot*>(pPlot)->GetInstance() : NULL;
 	return m_pPlot->isAdjacent(pkPlot);
 }
 //------------------------------------------------------------------------------
@@ -129,7 +129,7 @@ bool CvDllPlot::IsCity() const
 //------------------------------------------------------------------------------
 bool CvDllPlot::IsEnemyCity(ICvUnit1* pUnit) const
 {
-	CvUnit* pkUnit = (NULL != pUnit)? static_cast<CvDllUnit*>(pUnit)->GetInstance() : NULL;
+	CvUnit* pkUnit = (NULL != pUnit)? dynamic_cast<CvDllUnit*>(pUnit)->GetInstance() : NULL;
 	if(pkUnit != NULL)
 		return m_pPlot->isEnemyCity(*pkUnit);
 	else
@@ -334,13 +334,13 @@ ICvUnit1* CvDllPlot::GetUnitByIndex(int iIndex) const
 //------------------------------------------------------------------------------
 void CvDllPlot::AddUnit(ICvUnit1* pUnit, bool bUpdate)
 {
-	CvUnit* pkUnit = (NULL != pUnit)? static_cast<CvDllUnit*>(pUnit)->GetInstance() : NULL;
+	CvUnit* pkUnit = (NULL != pUnit)? dynamic_cast<CvDllUnit*>(pUnit)->GetInstance() : NULL;
 	return m_pPlot->addUnit(pkUnit, bUpdate);
 }
 //------------------------------------------------------------------------------
 void CvDllPlot::RemoveUnit(ICvUnit1* pUnit, bool bUpdate)
 {
-	CvUnit* pkUnit = (NULL != pUnit)? static_cast<CvDllUnit*>(pUnit)->GetInstance() : NULL;
+	CvUnit* pkUnit = (NULL != pUnit)? dynamic_cast<CvDllUnit*>(pUnit)->GetInstance() : NULL;
 	return m_pPlot->removeUnit(pkUnit, bUpdate);
 }
 //------------------------------------------------------------------------------

--- a/CvGameCoreDLL_Expansion2/CvDllPlot.h
+++ b/CvGameCoreDLL_Expansion2/CvDllPlot.h
@@ -12,7 +12,7 @@ class CvDllPlot : public ICvPlot1
 {
 public:
 	CvDllPlot(_In_ CvPlot* pPlot);
-	~CvDllPlot();
+	virtual ~CvDllPlot();
 
 	void* DLLCALL QueryInterface(GUID guidInterface);
 

--- a/CvGameCoreDLL_Expansion2/CvDllPolicyInfo.h
+++ b/CvGameCoreDLL_Expansion2/CvDllPolicyInfo.h
@@ -14,7 +14,7 @@ class CvDllPolicyInfo : public ICvPolicyInfo1
 {
 public:
 	CvDllPolicyInfo(_In_ CvPolicyEntry* pPolicyInfo);
-	~CvDllPolicyInfo();
+	virtual ~CvDllPolicyInfo();
 
 	void* DLLCALL QueryInterface(GUID guidInterface);
 

--- a/CvGameCoreDLL_Expansion2/CvDllPromotionInfo.h
+++ b/CvGameCoreDLL_Expansion2/CvDllPromotionInfo.h
@@ -14,7 +14,7 @@ class CvDllPromotionInfo : public ICvPromotionInfo1
 {
 public:
 	CvDllPromotionInfo(_In_ CvPromotionEntry* pPromotionInfo);
-	~CvDllPromotionInfo();
+	virtual ~CvDllPromotionInfo();
 
 	void* DLLCALL QueryInterface(GUID guidInterface);
 

--- a/CvGameCoreDLL_Expansion2/CvDllRandom.h
+++ b/CvGameCoreDLL_Expansion2/CvDllRandom.h
@@ -12,7 +12,7 @@ class CvDllRandom : public ICvRandom1
 {
 public:
 	CvDllRandom(_In_ CvRandom* pRandom);
-	~CvDllRandom();
+	virtual ~CvDllRandom();
 
 	void* DLLCALL QueryInterface(GUID guidInterface);
 

--- a/CvGameCoreDLL_Expansion2/CvDllResourceInfo.h
+++ b/CvGameCoreDLL_Expansion2/CvDllResourceInfo.h
@@ -14,7 +14,7 @@ class CvDllResourceInfo : public ICvResourceInfo1
 {
 public:
 	CvDllResourceInfo(_In_ CvResourceInfo* pResourceInfo);
-	~CvDllResourceInfo();
+	virtual ~CvDllResourceInfo();
 
 	void* DLLCALL QueryInterface(GUID guidInterface);
 

--- a/CvGameCoreDLL_Expansion2/CvDllTeam.h
+++ b/CvGameCoreDLL_Expansion2/CvDllTeam.h
@@ -12,7 +12,7 @@ class CvDllTeam : public ICvTeam1
 {
 public:
 	CvDllTeam(_In_ CvTeam* pTeam);
-	~CvDllTeam();
+	virtual ~CvDllTeam();
 
 	void* DLLCALL QueryInterface(GUID guidInterface);
 

--- a/CvGameCoreDLL_Expansion2/CvDllTechInfo.h
+++ b/CvGameCoreDLL_Expansion2/CvDllTechInfo.h
@@ -14,7 +14,7 @@ class CvDllTechInfo : public ICvTechInfo1
 {
 public:
 	CvDllTechInfo(_In_ CvTechEntry* pTechInfo);
-	~CvDllTechInfo();
+	virtual ~CvDllTechInfo();
 
 	void* DLLCALL QueryInterface(GUID guidInterface);
 

--- a/CvGameCoreDLL_Expansion2/CvDllTerrainInfo.h
+++ b/CvGameCoreDLL_Expansion2/CvDllTerrainInfo.h
@@ -14,7 +14,7 @@ class CvDllTerrainInfo : public ICvTerrainInfo1
 {
 public:
 	CvDllTerrainInfo(_In_ CvTerrainInfo* pTerrainInfo);
-	~CvDllTerrainInfo();
+	virtual ~CvDllTerrainInfo();
 
 	void* DLLCALL QueryInterface(GUID guidInterface);
 

--- a/CvGameCoreDLL_Expansion2/CvDllUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDllUnit.cpp
@@ -206,7 +206,7 @@ void CvDllUnit::GetPosition(int& iX, int& iY) const
 //------------------------------------------------------------------------------
 bool CvDllUnit::CanSwapWithUnitHere(ICvPlot1* pPlot) const
 {
-	CvPlot* pkPlot = (NULL != pPlot)? static_cast<CvDllPlot*>(pPlot)->GetInstance() : NULL;
+	CvPlot* pkPlot = (NULL != pPlot)? dynamic_cast<CvDllPlot*>(pPlot)->GetInstance() : NULL;
 	FAssert(pkPlot != NULL);
 	if(pkPlot != NULL)
 		return m_pUnit->CanSwapWithUnitHere(*pkPlot);
@@ -216,8 +216,8 @@ bool CvDllUnit::CanSwapWithUnitHere(ICvPlot1* pPlot) const
 //------------------------------------------------------------------------------
 bool CvDllUnit::CanEmbarkOnto(ICvPlot1* pOriginPlot, ICvPlot1* pTargetPlot, bool bOverrideEmbarkedCheck) const
 {
-	CvPlot* pkOriginPlot = (NULL != pOriginPlot)? static_cast<CvDllPlot*>(pOriginPlot)->GetInstance() : NULL;
-	CvPlot* pkTargetPlot = (NULL != pTargetPlot)? static_cast<CvDllPlot*>(pTargetPlot)->GetInstance() : NULL;
+	CvPlot* pkOriginPlot = (NULL != pOriginPlot)? dynamic_cast<CvDllPlot*>(pOriginPlot)->GetInstance() : NULL;
+	CvPlot* pkTargetPlot = (NULL != pTargetPlot)? dynamic_cast<CvDllPlot*>(pTargetPlot)->GetInstance() : NULL;
 	FAssert(pkOriginPlot != NULL);
 	FAssert(pkTargetPlot != NULL);
 
@@ -229,8 +229,8 @@ bool CvDllUnit::CanEmbarkOnto(ICvPlot1* pOriginPlot, ICvPlot1* pTargetPlot, bool
 //------------------------------------------------------------------------------
 bool CvDllUnit::CanDisembarkOnto(ICvPlot1* pOriginPlot, ICvPlot1* pTargetPlot, bool bOverrideEmbarkedCheck) const
 {
-	CvPlot* pkOriginPlot = (NULL != pOriginPlot)? static_cast<CvDllPlot*>(pOriginPlot)->GetInstance() : NULL;
-	CvPlot* pkTargetPlot = (NULL != pTargetPlot)? static_cast<CvDllPlot*>(pTargetPlot)->GetInstance() : NULL;
+	CvPlot* pkOriginPlot = (NULL != pOriginPlot)? dynamic_cast<CvDllPlot*>(pOriginPlot)->GetInstance() : NULL;
+	CvPlot* pkTargetPlot = (NULL != pTargetPlot)? dynamic_cast<CvDllPlot*>(pTargetPlot)->GetInstance() : NULL;
 	FAssert(pkOriginPlot != NULL);
 	FAssert(pkTargetPlot != NULL);
 	if(pkOriginPlot != NULL && pkTargetPlot != NULL)
@@ -291,7 +291,7 @@ int CvDllUnit::MovesLeft() const
 //------------------------------------------------------------------------------
 bool CvDllUnit::CanMoveInto(ICvPlot1* pPlot, byte bMoveFlags) const
 {
-	CvPlot* pkPlot = (NULL != pPlot)? static_cast<CvDllPlot*>(pPlot)->GetInstance() : NULL;
+	CvPlot* pkPlot = (NULL != pPlot)? dynamic_cast<CvDllPlot*>(pPlot)->GetInstance() : NULL;
 	if(pkPlot != NULL)
 		return m_pUnit->canMoveInto(*pkPlot, bMoveFlags);
 	else
@@ -300,7 +300,7 @@ bool CvDllUnit::CanMoveInto(ICvPlot1* pPlot, byte bMoveFlags) const
 //------------------------------------------------------------------------------
 TeamTypes CvDllUnit::GetDeclareWarMove(ICvPlot1* pPlot) const
 {
-	CvPlot* pkPlot = (NULL != pPlot)? static_cast<CvDllPlot*>(pPlot)->GetInstance() : NULL;
+	CvPlot* pkPlot = (NULL != pPlot)? dynamic_cast<CvDllPlot*>(pPlot)->GetInstance() : NULL;
 	if(pkPlot != NULL)
 		return m_pUnit->GetDeclareWarMove(*pkPlot);
 	else

--- a/CvGameCoreDLL_Expansion2/CvDllUnit.h
+++ b/CvGameCoreDLL_Expansion2/CvDllUnit.h
@@ -12,7 +12,7 @@ class CvDllUnit : public ICvUnit2
 {
 public:
 	CvDllUnit(_In_ CvUnit* pUnit);
-	~CvDllUnit();
+	virtual ~CvDllUnit();
 
 	void* DLLCALL QueryInterface(GUID guidInterface);
 

--- a/CvGameCoreDLL_Expansion2/CvDllUnitCombatClassInfo.h
+++ b/CvGameCoreDLL_Expansion2/CvDllUnitCombatClassInfo.h
@@ -14,7 +14,7 @@ class CvDllUnitCombatClassInfo : public ICvUnitCombatClassInfo1
 {
 public:
 	CvDllUnitCombatClassInfo(_In_ CvBaseInfo* pUnitCombatClassInfo);
-	~CvDllUnitCombatClassInfo();
+	virtual ~CvDllUnitCombatClassInfo();
 
 	void* DLLCALL QueryInterface(GUID guidInterface);
 

--- a/CvGameCoreDLL_Expansion2/CvDllUnitInfo.h
+++ b/CvGameCoreDLL_Expansion2/CvDllUnitInfo.h
@@ -12,7 +12,7 @@ class CvDllUnitInfo : public ICvUnitInfo1
 {
 public:
 	CvDllUnitInfo(_In_ CvUnitEntry* pUnitInfo);
-	~CvDllUnitInfo();
+	virtual ~CvDllUnitInfo();
 
 	void* DLLCALL QueryInterface(GUID guidInterface);
 

--- a/CvGameCoreDLL_Expansion2/CvDllVictoryInfo.h
+++ b/CvGameCoreDLL_Expansion2/CvDllVictoryInfo.h
@@ -14,7 +14,7 @@ class CvDllVictoryInfo : public ICvVictoryInfo1
 {
 public:
 	CvDllVictoryInfo(_In_ CvVictoryInfo* pVictoryInfo);
-	~CvDllVictoryInfo();
+	virtual ~CvDllVictoryInfo();
 
 	void* DLLCALL QueryInterface(GUID guidInterface);
 

--- a/CvGameCoreDLL_Expansion2/CvDllWorldBuilderMapLoader.h
+++ b/CvGameCoreDLL_Expansion2/CvDllWorldBuilderMapLoader.h
@@ -13,7 +13,7 @@ class CvDllWorldBuilderMapLoader : public ICvWorldBuilderMapLoader2
 {
 public:
 	CvDllWorldBuilderMapLoader();
-	~CvDllWorldBuilderMapLoader();
+	virtual ~CvDllWorldBuilderMapLoader();
 
 	void* DLLCALL QueryInterface(GUID guidInterface);
 

--- a/CvGameCoreDLL_Expansion2/CvDllWorldInfo.h
+++ b/CvGameCoreDLL_Expansion2/CvDllWorldInfo.h
@@ -14,7 +14,7 @@ class CvDllWorldInfo : public ICvWorldInfo1
 {
 public:
 	CvDllWorldInfo(_In_ CvWorldInfo* pWorldInfo);
-	~CvDllWorldInfo();
+	virtual ~CvDllWorldInfo();
 
 	void* DLLCALL QueryInterface(GUID guidInterface);
 

--- a/CvGameCoreDLL_Expansion2/CvEmphasisClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvEmphasisClasses.cpp
@@ -65,7 +65,7 @@ int CvEmphasisEntry::GetYieldChange(int i) const
 // CvEmphasisXMLEntries
 //=====================================
 /// Constructor
-CvEmphasisXMLEntries::CvEmphasisXMLEntries(void)
+CvEmphasisXMLEntries::CvEmphasisXMLEntries(void) : m_paEmphasisEntries()
 {
 
 }
@@ -113,7 +113,7 @@ CvEmphasisEntry* CvEmphasisXMLEntries::GetEntry(int index)
 // CvCityEmphases
 //=====================================
 /// Constructor
-CvCityEmphases::CvCityEmphases()
+CvCityEmphases::CvCityEmphases() : m_iEmphasizeAvoidGrowthCount(), m_iEmphasizeGreatPeopleCount(), m_aiEmphasizeYieldCount(), m_pbEmphasize(), m_pCity()
 {
 }
 

--- a/CvGameCoreDLL_Expansion2/CvEmphasisClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvEmphasisClasses.h
@@ -25,7 +25,7 @@ class CvEmphasisEntry: public CvBaseInfo
 {
 public:
 	CvEmphasisEntry(void);
-	~CvEmphasisEntry(void);
+	virtual ~CvEmphasisEntry(void);
 
 	virtual bool CacheResults(Database::Results& kResults, CvDatabaseUtility& kUtility);
 

--- a/CvGameCoreDLL_Expansion2/CvGoodyHuts.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGoodyHuts.cpp
@@ -69,7 +69,7 @@ bool CvGoodyHuts::IsHasPlayerReceivedGoodyLately(PlayerTypes ePlayer, GoodyTypes
 /// Reset
 void CvGoodyHuts::Reset()
 {
-	int iI, iJ;
+	int iI = 0, iJ = 0;
 
 	// Allocate memory
 	if (m_aaiPlayerGoodyHutResults == NULL)

--- a/CvGameCoreDLL_Expansion2/CvInfosSerializationHelper.cpp
+++ b/CvGameCoreDLL_Expansion2/CvInfosSerializationHelper.cpp
@@ -163,7 +163,7 @@ int Read(FDataStream& kStream, bool* bValid /*= NULL*/)
 /// Helper function to read a single resource type ID as a hash and convert it to an ID
 int ReadHashed(FDataStream& kStream, bool* bValid /*= NULL*/)
 {
-	uint uiHash;
+	uint uiHash = 0;
 	if(bValid) *bValid = true;
 	kStream >> uiHash;
 	if(uiHash != 0)

--- a/CvGameCoreDLL_Expansion2/CvLoggerCSV.cpp
+++ b/CvGameCoreDLL_Expansion2/CvLoggerCSV.cpp
@@ -11,7 +11,7 @@
 void  CvLoggerCSV::WriteCSVLog(const char* strLogName, const char* strHeader)
 	{
 
-		FILogFile *pLog;
+		FILogFile *pLog = NULL;
 
 		pLog = LOGFILEMGR.GetLog(strLogName, FILogFile::kDontTimeStamp);
 
@@ -25,7 +25,7 @@ void  CvLoggerCSV::WriteCSVLog(const char* strLogName, const char* strHeader)
 	{
 		CvAssert(strLogName != NULL);
 
-		FILogFile *pLog;
+		FILogFile *pLog = NULL;
 
 		pLog = LOGFILEMGR.GetLog(strLogName, FILogFile::kDontTimeStamp);
 

--- a/CvGameCoreDLL_Expansion2/CvMapGenerator.cpp
+++ b/CvGameCoreDLL_Expansion2/CvMapGenerator.cpp
@@ -69,7 +69,7 @@ bool CvMapGenerator::GetMapInitData(CvMapInitData& kData, WorldSizeTypes eWorldS
 	kData.m_iGridH = kWorldInfo.getGridHeight();
 	kData.m_iGridW = kWorldInfo.getGridWidth();
 
-	GetMapInitDataArgs args;
+	GetMapInitDataArgs args = {};
 	args.pkScriptSystem = pkScriptSystem;
 	args.pkMapInitData = &kData;
 	args.WorldSize = kWorldInfo.GetID();
@@ -92,7 +92,7 @@ bool CvMapGenerator::GetGameInitialItemsOverrides(CvGameInitialItemsOverrides& k
 {
 	ICvEngineScriptSystem1* pkScriptSystem = gDLL->GetScriptSystem();
 
-	GetGameInitialItemsOverridesArgs args;
+	GetGameInitialItemsOverridesArgs args = {};
 	args.pkScriptSystem = pkScriptSystem;
 	args.pkOverrides = &kOverrides;
 	args.bSuccess = false;

--- a/CvGameCoreDLL_Expansion2/CvProjectProductionAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvProjectProductionAI.cpp
@@ -76,7 +76,7 @@ void CvProjectProductionAI::AddFlavorWeights(FlavorTypes eFlavor, int iWeight)
 	if (iWeight==0)
 		return;
 
-	int iProject;
+	int iProject = 0;
 	CvProjectEntry* entry(NULL);
 
 	// Loop through all projects
@@ -104,9 +104,9 @@ ProjectTypes CvProjectProductionAI::RecommendProject()
 	if(!m_pCity)
 		return NO_PROJECT;
 
-	int iProjectLoop;
-	int iWeight;
-	int iTurnsLeft;
+	int iProjectLoop = 0;
+	int iWeight = 0;
+	int iTurnsLeft = 0;
 
 	// Reset list of all the possible projects
 	m_Buildables.clear();
@@ -336,7 +336,7 @@ void CvProjectProductionAI::LogPossibleBuilds()
 		cityName = m_pCity->getName();
 
 		// Open the log file
-		FILogFile* pLog;
+		FILogFile* pLog = NULL;
 		pLog = LOGFILEMGR.GetLog(m_pCity->GetCityStrategyAI()->GetLogFileName(playerName, cityName), FILogFile::kDontTimeStamp);
 		CvAssert(pLog);
 		if(!pLog) return;

--- a/CvGameCoreDLL_Expansion2/CvReligionClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvReligionClasses.h
@@ -25,7 +25,7 @@ class CvReligionEntry: public CvBaseInfo
 {
 public:
 	CvReligionEntry(void);
-	~CvReligionEntry(void);
+	virtual ~CvReligionEntry(void);
 
 	virtual bool CacheResults(Database::Results& kResults, CvDatabaseUtility& kUtility);
 	

--- a/CvGameCoreDLL_Expansion2/CvReplayMessage.cpp
+++ b/CvGameCoreDLL_Expansion2/CvReplayMessage.cpp
@@ -14,7 +14,7 @@
 //------------------------------------------------------------------------------
 CvReplayMessage::CvReplayMessage()
 	: m_iTurn(-1)
-	, m_eType(NO_REPLAY_MESSAGE)
+	, m_eType(NO_REPLAY_MESSAGE), m_Plots()
 	, m_ePlayer(NO_PLAYER)
 {
 }

--- a/CvGameCoreDLL_Expansion2/CvTargeting.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTargeting.cpp
@@ -125,7 +125,7 @@ static bool CanSeeDisplacementPlot_Strict(int startX, int startY, int dx, int dy
 	// traversing the hex grid.
 
 	// Make DX and DY positive and adjust the step constant for the opposite axis.
-	int stepY;
+	int stepY = 0;
 	if (dy < 0) 
 	{ 
 		dy = -dy;  
@@ -134,7 +134,7 @@ static bool CanSeeDisplacementPlot_Strict(int startX, int startY, int dx, int dy
 	else 
 		stepY = 1; 
 
-	int stepX;
+	int stepX = 0;
 	if (dx < 0) 
 	{ 
 		dx = -dx;  
@@ -356,7 +356,7 @@ static bool CanSeeDisplacementPlot_Loose(int startX, int startY, int dx, int dy,
 	// traversing the hex grid.
 
 	// Make DX and DY positive and adjust the step constant for the opposite axis.
-	int stepY;
+	int stepY = 0;
 	if (dy < 0) 
 	{ 
 		dy = -dy;  
@@ -365,7 +365,7 @@ static bool CanSeeDisplacementPlot_Loose(int startX, int startY, int dx, int dy,
 	else 
 		stepY = 1; 
 
-	int stepX;
+	int stepX = 0;
 	if (dx < 0) 
 	{ 
 		dx = -dx;  

--- a/CvGameCoreDLL_Expansion2/CvTeam.h
+++ b/CvGameCoreDLL_Expansion2/CvTeam.h
@@ -25,7 +25,7 @@ private:
 
 public:
 	CvTeam();
-	~CvTeam();
+	virtual ~CvTeam();
 
 	// inlined for performance reasons, only in the dll
 	static CvTeam& getTeam(TeamTypes eTeam);

--- a/CvGameCoreDLL_Expansion2/CvUnitCycler.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnitCycler.cpp
@@ -29,7 +29,7 @@ CvUnit *CvUnitCycler::Cycle(CvUnit* pUnit, bool bForward, bool bWorkers, bool* p
 	//---------------------------------------------------------------------------------------------
 	// just return the closest suitable unit, no bookkeeping required
 	//---------------------------------------------------------------------------------------------
-	int iUnitLoop;
+	int iUnitLoop = 0;
 	int iMinDist = INT_MAX;
 	CvUnit* pClosestUnit = NULL;
 	for (CvUnit* pLoopUnit = GET_PLAYER(pUnit->getOwner()).firstUnit(&iUnitLoop); pLoopUnit; pLoopUnit = GET_PLAYER(pUnit->getOwner()).nextUnit(&iUnitLoop))

--- a/CvGameCoreDLL_Expansion2/CvUnitMission.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnitMission.cpp
@@ -249,7 +249,7 @@ void CvUnitMission::PopMission(CvUnit* hUnit)
 			}
 		}
 
-		int iNumResource;
+		int iNumResource = 0;
 
 		// Update the amount of a Resource used up by popped Build
 		for(int iResourceLoop = 0; iResourceLoop < GC.getNumResourceInfos(); iResourceLoop++)
@@ -889,7 +889,7 @@ void CvUnitMission::ContinueMission(CvUnit* hUnit, int iSteps)
 						        (kMissionData.eMissionType == CvTypes::getMISSION_MOVE_TO_UNIT()))
 						{
 							// How long does the camera wait before jumping to the next item?
-							int iCameraTime;
+							int iCameraTime = 0;
 
 							if(GET_PLAYER(hUnit->getOwner()).isOption(PLAYEROPTION_QUICK_MOVES))
 							{
@@ -950,7 +950,7 @@ void CvUnitMission::ContinueMission(CvUnit* hUnit, int iSteps)
 /// Eligible to start a new mission?
 bool CvUnitMission::CanStartMission(CvUnit* hUnit, int iMission, int iData1, int iData2, CvPlot* pPlot, bool bTestVisible)
 {
-	CvUnit* pTargetUnit;
+	CvUnit* pTargetUnit = NULL;
 
 	if(hUnit->IsBusy())
 	{
@@ -1342,9 +1342,9 @@ bool CvUnitMission::CanStartMission(CvUnit* hUnit, int iMission, int iData1, int
 /// Initiate a mission
 void CvUnitMission::StartMission(CvUnit* hUnit)
 {
-	bool bDelete;
-	bool bAction;
-	bool bNotify;
+	bool bDelete = 0;
+	bool bAction = 0;
+	bool bNotify = 0;
 
 	static int stackDepth = 0;
 	++stackDepth; // JAR debugging
@@ -1980,11 +1980,11 @@ CvPlot* CvUnitMission::LastMissionPlot(CvUnit* hUnit)
 //		 exhausting its mission queue all in one go.
 int CvUnitMission::CalculateMissionTimer(CvUnit* hUnit, int iSteps)
 {
-	CvUnit* pTargetUnit;
-	CvPlot* pTargetPlot;
+	CvUnit* pTargetUnit = NULL;
+	CvPlot* pTargetPlot = NULL;
 	int iTime = 0;
 
-	MissionData* pkMissionNode;
+	MissionData* pkMissionNode = NULL;
 	if(!hUnit->isHuman())
 	{
 		iTime = 0;
@@ -2108,7 +2108,7 @@ void CvUnitMission::InsertAtEndMissionQueue(CvUnit* hUnit, MissionData mission, 
 /// Delete a specific mission from queue
 MissionData* CvUnitMission::DeleteMissionData(CvUnit* hUnit, MissionData* pNode)
 {
-	MissionData* pNextMissionNode;
+	MissionData* pNextMissionNode = NULL;
 
 	CvAssertMsg(pNode != NULL, "Node is not assigned a valid value");
 	CvAssert(hUnit->getOwner() != NO_PLAYER);
@@ -2288,7 +2288,7 @@ const MissionData* CvUnitMission::IsHeadMission(CvUnit* hUnit, int iMission)
 //	Returns true if the is a move mission at the head of the unit queue and it is complete
 bool CvUnitMission::HasCompletedMoveMission(CvUnit* hUnit)
 {
-	MissionData* pkMissionNode;
+	MissionData* pkMissionNode = NULL;
 	if((pkMissionNode = HeadMissionData(hUnit->m_missionQueue)) != NULL)
 	{
 		MissionData& kMissionData = *pkMissionNode;

--- a/CvGameCoreDLL_Expansion2/cvStopWatch.cpp
+++ b/CvGameCoreDLL_Expansion2/cvStopWatch.cpp
@@ -23,11 +23,11 @@ cvStopWatch::cvStopWatch(const char* szName, const char* szLogFile /* = NULL */,
 	m_szName(szName),
 	m_szLogFile(szLogFile),
 	m_dtseconds(0.0),
-	m_logFlags(logFlags),
-	m_bDisable(bDisable),
-	m_bShowNesting(bShowNesting)
+	m_logFlags(logFlags), m_bStarted(),
+	m_nesting(ms_nesting), m_bDisable(bDisable),
+	m_bShowNesting(bShowNesting), m_oldTimerVal()
 {
-	m_nesting = ms_nesting;
+	
 	++ms_nesting;
 	StartPerfTest();
 }


### PR DESCRIPTION
clang-tidy replacements for cppcoreguidelines. v90 build works.

```
warning: variable is not initialized [cppcoreguidelines-init-variables]
warning: constructor does not initialize fields [cppcoreguidelines-pro-type-member-init]
warning: destructor is public and non-virtual [cppcoreguidelines-virtual-class-destructor]
warning: do not use static_cast to downcast from a base to a derived class; use dynamic_cast instead [cppcoreguidelines-pro-type-static-cast-downcast]
```
https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/init-variables.html
https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/pro-type-member-init.html
https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/virtual-class-destructor.html
https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/pro-type-static-cast-downcast.html

[clang-tidy-results.txt](https://github.com/LoneGazebo/Community-Patch-DLL/files/9739210/clang-tidy-results.txt)
