### PR TITLE
Fix for Issue 9225

### DIFF
--- a/(2) Vox Populi/LUA/TradeLogic.lua
+++ b/(2) Vox Populi/LUA/TradeLogic.lua
@@ -730,8 +730,8 @@ end
 -- Update buttons at the bottom
 ---------------------------------------------------------
 function DoUpdateButtons()
-	
-	-- Dealing with a human in a MP game
+
+-- Dealing with a human in a MP game
     if (g_bPVPTrade) then
 		
         --print( "PVP Updating ProposeButton" );
@@ -1879,7 +1879,7 @@ function ResetDisplay()
 			instance.Button:SetHide(false);
 
 			pResource = GameInfo.Resources[resType];
-			iResourceCount = g_Deal:GetNumResource(g_iUs, resType);
+			iResourceCount = g_pUs:GetNumResourceAvailable(resType, false);
 			strString = pResource.IconString .. " " .. Locale.ConvertTextKey(pResource.Description) .. " (" .. iResourceCount .. ")";
 			instance.Button:SetText(strString);
 		else
@@ -1957,7 +1957,7 @@ function ResetDisplay()
 			instance.Button:SetHide(false);
 			
 			pResource = GameInfo.Resources[resType];
-			iResourceCount = g_Deal:GetNumResource(g_iThem, resType);
+			iResourceCount = g_pThem:GetNumResourceAvailable(resType, false);
 			strString = pResource.IconString .. " " .. Locale.ConvertTextKey(pResource.Description) .. " (" .. iResourceCount .. ")";
 			instance.Button:SetText(strString);
 
@@ -3317,13 +3317,13 @@ function PocketResourceHandler( isUs, resourceId )
 	end
 	
     if( isUs == 1 ) then
-		if (iAmount > g_Deal:GetNumResource(g_iUs, resourceId)) then
-			iAmount = g_Deal:GetNumResource(g_iUs, resourceId);
+		if (iAmount > g_pUs:GetNumResourceAvailable(resourceId, false)) then
+			iAmount = g_pUs:GetNumResourceAvailable(resourceId, false);
 		end
         g_Deal:AddResourceTrade( g_iUs, resourceId, iAmount, g_iDealDuration );
     else
-		if (iAmount > g_Deal:GetNumResource(g_iThem, resourceId)) then
-			iAmount = g_Deal:GetNumResource(g_iThem, resourceId);
+		if (iAmount > g_pThem:GetNumResourceAvailable(resourceId, false)) then
+			iAmount = g_pThem:GetNumResourceAvailable(resourceId, false);
 		end
         g_Deal:AddResourceTrade( g_iThem, resourceId, iAmount, g_iDealDuration );
     end
@@ -3517,7 +3517,7 @@ Controls.ThemTableRevokeVassalage:SetVoid1( 0 );
 -------------------------------------------------------------------
 -------------------------------------------------------------------
 function ChangeResourceAmount( string, control )
-	
+
 	local bIsUs = control:GetVoid1() == 1;
 	local iResourceID = control:GetVoid2();
 	
@@ -3536,18 +3536,21 @@ function ChangeResourceAmount( string, control )
     else
         control:SetText( 0 );
     end
-    
+	
     -- Can't offer more than someone has
-    if (iNumResource > g_Deal:GetNumResource(iPlayer, iResourceID)) then
-		iNumResource = g_Deal:GetNumResource(iPlayer, iResourceID);
+    if (iNumResource > pPlayer:GetNumResourceAvailable(iResourceID, false)) then
+		iNumResource = pPlayer:GetNumResourceAvailable(iResourceID, false);
 		control:SetText(iNumResource);
 	end
-    
+	
     if ( bIsUs ) then
         g_Deal:ChangeResourceTrade( g_iUs, iResourceID, iNumResource, g_iDealDuration );
     else
         g_Deal:ChangeResourceTrade( g_iThem, iResourceID, iNumResource, g_iDealDuration );
     end
+	--CBP
+	DoUIDealChangedByHuman();
+	--END
 end
 
 -----------------------------------------------------------------------------------------------------------------------

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaDeal.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaDeal.cpp
@@ -55,8 +55,6 @@ void CvLuaDeal::PushMethods(lua_State* L, int t)
 	Method(GetReasonsItemUntradeable);
 	Method(BlockTemporaryForPermanentTrade);
 
-	Method(GetNumResource);
-
 	Method(AddGoldTrade);
 	Method(AddGoldPerTurnTrade);
 	Method(AddMapTrade);
@@ -167,21 +165,6 @@ int CvLuaDeal::lBlockTemporaryForPermanentTrade(lua_State* L)
 	return 1;
 }
 
-//------------------------------------------------------------------------------
-int CvLuaDeal::lGetNumResource(lua_State* L)
-{
-	CvDeal* pkDeal = GetInstance(L);
-	const PlayerTypes ePlayer = (PlayerTypes) lua_tointeger(L, 2);
-	const ResourceTypes eResource = (ResourceTypes) lua_tointeger(L, 3);
-
-	//the name of this method is highly misleading ... 
-	//we actually want to report the amount of resources the player has available outside of this deal
-	int iNumAvailablePreDeal = GET_PLAYER(ePlayer).getNumResourceAvailable(eResource, false);
-	int iResult = iNumAvailablePreDeal - pkDeal->GetNumResourceInDeal(ePlayer, eResource);
-
-	lua_pushinteger(L, iResult);
-	return 1;
-}
 
 //------------------------------------------------------------------------------
 int CvLuaDeal::lResetIterator(lua_State* L)

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaDeal.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaDeal.h
@@ -105,8 +105,6 @@ protected:
 	static int lGetReasonsItemUntradeable(lua_State* L);
 	static int lBlockTemporaryForPermanentTrade(lua_State* L);
 
-	static int lGetNumResource(lua_State* L);
-
 	static int lAddGoldTrade(lua_State* L)
 	{
 		return BasicLuaMethod(L, &CvDeal::AddGoldTrade);


### PR DESCRIPTION
Fix for Issue #9225. The issue here was the following function with a misleading name:
```
int CvLuaDeal::lGetNumResource(lua_State* L)
{
	CvDeal* pkDeal = GetInstance(L);
	const PlayerTypes ePlayer = (PlayerTypes) lua_tointeger(L, 2);
	const ResourceTypes eResource = (ResourceTypes) lua_tointeger(L, 3);

	//the name of this method is highly misleading ... 
	//we actually want to report the amount of resources the player has available outside of this deal
	int iNumAvailablePreDeal = GET_PLAYER(ePlayer).getNumResourceAvailable(eResource, false);
	int iResult = iNumAvailablePreDeal - pkDeal->GetNumResourceInDeal(ePlayer, eResource);

	lua_pushinteger(L, iResult);
	return 1;
}
```
It was used in TradeLogic.lua incorrectly to get the number of tradeable resources, as the function name would suggest (why didn't they change the name of the function instead of making a comment about a misleading name?...)
In the Lua file there is actually no need for a function returning "the amount of resources the player has available outside of this deal", and the total number of tradeable resources is accessible using CvPlayer::getNumResourceAvailable, so I removed CvLuaDeal::lGetNumResource altogether and changed the Lua file accordingly.

Also fixed an issue that the deal valuation is not updated when the amount of strategic resources proposed is changed.