### PR TITLE
clang-tidy

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvGameCoreDLLPCH.h
+++ b/CvGameCoreDLL_Expansion2/CvGameCoreDLLPCH.h
@@ -16,7 +16,7 @@
 #ifndef CVGAMECOREDLLPCH_H
 #define CVGAMECOREDLLPCH_H
 
-#include <assert.h>
+#include <cassert>
 
 /// Displays a platform specific assertion related dialogue.
 /// 
@@ -126,12 +126,12 @@
 #include <MMSystem.h>
 
 #include <algorithm>
-#include <vector>
+#include <cassert>
+#include <cmath>
 #include <list>
-#include <math.h>
-#include <tchar.h>
-#include <assert.h>
 #include <map>
+#include <tchar.h>
+#include <vector>
 #define _SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS
 #include <hash_map>
 #include <limits>

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -33,7 +33,7 @@
 #include "CvUnitMission.h"
 #include "FMemoryStream.h"
 #include "ICvDLLUserInterface.h"
-#include <math.h>
+#include <cmath>
 
 #include "CvDllPlot.h"
 #include "CvDllUnit.h"


### PR DESCRIPTION
v90 build works.

[modernize-deprecated-headers](https://clang.llvm.org/extra/clang-tidy/checks/modernize/deprecated-headers.html)