### PR TITLE
#9350 minor civ naval gifts

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvAIOperation.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAIOperation.cpp
@@ -3311,7 +3311,7 @@ CvPlot* OperationalAIHelpers::FindEnemiesNearHomelandPlot(PlayerTypes ePlayer, P
 	return pBestPlot;	
 }
 
-/// Find our port operation operations against this enemy should leave from
+/// Find the closest city from which we can sail to the provided plot
 CvCity* OperationalAIHelpers::GetClosestFriendlyCoastalCity(PlayerTypes ePlayer, const CvPlot* pRefPlot)
 {
 	if (ePlayer==NO_PLAYER || !pRefPlot)

--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -24304,7 +24304,7 @@ int CvCity::getBaseYieldRateModifier(YieldTypes eIndex, int iExtra, CvString* to
 	//Blockade
 	if (eIndex == YIELD_GOLD && isCoastal(/*10*/ GD_INT_GET(MIN_WATER_SIZE_FOR_OCEAN)))
 	{
-		if (/*0 in CP, -25 in VP*/ GD_INT_GET(BLOCKADE_GOLD_PENALTY) != 0 && isCoastal() && IsBlockaded(DOMAIN_SEA))
+		if (/*0 in CP, -25 in VP*/ GD_INT_GET(BLOCKADE_GOLD_PENALTY) != 0 && IsBlockaded(DOMAIN_SEA))
 		{
 			iTempMod = GD_INT_GET(BLOCKADE_GOLD_PENALTY);
 			iModifier += iTempMod;

--- a/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
@@ -14176,13 +14176,18 @@ CvUnit* CvMinorCivAI::DoSpawnUnit(PlayerTypes eMajor, bool bLocal, bool bExplore
 	if (pMajorCapital->plot() == NULL)
 		return NULL;
 
-	CvCity* pClosestCity = NULL;
-	CvCity* pClosestCoastalCity = NULL;
-	bool bBoatsAllowed = MOD_GLOBAL_CS_GIFT_SHIPS && pMinorCapital->isCoastal();
+	bool bBoatsAllowed = MOD_GLOBAL_CS_GIFT_SHIPS && pMinorCapital->isCoastal(/*10*/ GD_INT_GET(MIN_WATER_SIZE_FOR_OCEAN));
 
 	// What's their closest city? If they have at least one coastal city, allow spawning naval units
+	CvCity* pClosestCity = NULL;
+	CvCity* pClosestCoastalCity = bBoatsAllowed ? OperationalAIHelpers::GetClosestFriendlyCoastalCity(eMajor, pMinorCapital->plot()) : NULL;
+
 	int iLowestDistance = MAX_INT;
 	int iLowestCoastalDistance = MAX_INT;
+	// If we are coastal, but we can't find a connection, then keep track of *any* city that is connected to an ocean (otherwise, don't bother checking)
+	if (!bBoatsAllowed || pClosestCoastalCity != NULL)
+		iLowestCoastalDistance = MIN_INT;
+
 	int iCityLoop = 0;
 	for (CvCity* pLoopCity = GET_PLAYER(eMajor).firstCity(&iCityLoop); pLoopCity != NULL; pLoopCity = GET_PLAYER(eMajor).nextCity(&iCityLoop))
 	{
@@ -14195,7 +14200,7 @@ CvUnit* CvMinorCivAI::DoSpawnUnit(PlayerTypes eMajor, bool bLocal, bool bExplore
 			iLowestDistance = iDistance;
 			pClosestCity = pLoopCity;
 
-			if (pLoopCity->isCoastal(/*10*/ GD_INT_GET(MIN_WATER_SIZE_FOR_OCEAN)) && iDistance < iLowestCoastalDistance)
+			if (iDistance < iLowestCoastalDistance && pLoopCity->isCoastal(/*10*/ GD_INT_GET(MIN_WATER_SIZE_FOR_OCEAN)))
 			{
 				iLowestCoastalDistance = iDistance;
 				pClosestCoastalCity = pLoopCity;

--- a/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
@@ -4577,7 +4577,7 @@ void CvMinorCivAI::DoPickUniqueUnit()
 		bool bCoastal = false;
 		if (GetPlayer()->getStartingPlot() != NULL)
 		{
-			if (GetPlayer()->getStartingPlot()->isCoastalLand())
+			if (GetPlayer()->getStartingPlot()->isCoastalLand(/*10*/ GD_INT_GET(MIN_WATER_SIZE_FOR_OCEAN)))
 			{
 				if (GC.getMap().GetAIMapHint() & ciMapHint_NavalOffshore)
 				{
@@ -4590,7 +4590,7 @@ void CvMinorCivAI::DoPickUniqueUnit()
 						PlayerTypes ePlayer = (PlayerTypes) iPlayerLoop;
 						if (GET_PLAYER(ePlayer).isAlive())
 						{
-							if (GET_PLAYER(ePlayer).getStartingPlot() != NULL && GET_PLAYER(ePlayer).getStartingPlot()->isCoastalLand())
+							if (GET_PLAYER(ePlayer).getStartingPlot() != NULL && GET_PLAYER(ePlayer).getStartingPlot()->isCoastalLand(/*10*/ GD_INT_GET(MIN_WATER_SIZE_FOR_OCEAN)))
 							{
 								iCoastal++;
 							}
@@ -4598,7 +4598,7 @@ void CvMinorCivAI::DoPickUniqueUnit()
 						}
 					}
 					//If at least a quarter of all major civ players start on the coast, we should give out boats too.
-					if (iCoastal >= (iPlayers+3) / 4)
+					if (iCoastal*4 >= iPlayers)
 					{
 						bCoastal = true;
 					}
@@ -14181,8 +14181,8 @@ CvUnit* CvMinorCivAI::DoSpawnUnit(PlayerTypes eMajor, bool bLocal, bool bExplore
 	bool bBoatsAllowed = MOD_GLOBAL_CS_GIFT_SHIPS && pMinorCapital->isCoastal();
 
 	// What's their closest city? If they have at least one coastal city, allow spawning naval units
-	int iLowestDistance = 1000;
-	int iLowestCoastalDistance = 1000;
+	int iLowestDistance = MAX_INT;
+	int iLowestCoastalDistance = MAX_INT;
 	int iCityLoop = 0;
 	for (CvCity* pLoopCity = GET_PLAYER(eMajor).firstCity(&iCityLoop); pLoopCity != NULL; pLoopCity = GET_PLAYER(eMajor).nextCity(&iCityLoop))
 	{
@@ -14195,7 +14195,7 @@ CvUnit* CvMinorCivAI::DoSpawnUnit(PlayerTypes eMajor, bool bLocal, bool bExplore
 			iLowestDistance = iDistance;
 			pClosestCity = pLoopCity;
 
-			if (pLoopCity->isCoastal() && iDistance < iLowestCoastalDistance)
+			if (pLoopCity->isCoastal(/*10*/ GD_INT_GET(MIN_WATER_SIZE_FOR_OCEAN)) && iDistance < iLowestCoastalDistance)
 			{
 				iLowestCoastalDistance = iDistance;
 				pClosestCoastalCity = pLoopCity;


### PR DESCRIPTION
Militaristic City States should now gift naval units to the nearest city to which they are attached by the same (ocean) land mass.  If there is no city, then they to the nearest **coastal** city , or do not gift naval units.

In addition, only **coastal** City States will gift naval units.

* as always, coastal = adjacent to body of water made of 10+ plots

Fix for #9350 