### PR TITLE
Improvement DLL Updates

### DIFF
--- a/(1) Community Patch/Core Files/Core Tables/CoreTableAdditions.xml
+++ b/(1) Community Patch/Core Files/Core Tables/CoreTableAdditions.xml
@@ -143,18 +143,25 @@
 		<Column name="YieldType" type="text" reference="Yields(Type)"/>
 		<Column name="Yield" type="integer"/>
 	</Table>
-	
+	<!-- Improvement: allows an adjacent improvement of the same type to boost the base yield of this improvement -->
 	<Table name="Improvement_YieldAdjacentSameType">
 		<!-- Refer to Improvements.CultureAdjacentSameType -->
 		<Column name="ImprovementType" type="text" reference="Improvements(Type)"/>
 		<Column name="YieldType" type="text" reference="Yields(Type)"/>
 		<Column name="Yield" type="integer" default="0"/>
 	</Table>
+	<!-- Improvement: allows two adjacent improvements of the same type to boost the base yield of this improvement -->
 	<Table name="Improvement_YieldAdjacentTwoSameType">
 		<!-- Refer to Improvements.CultureAdjacentSameType -->
 		<Column name="ImprovementType" type="text" reference="Improvements(Type)"/>
 		<Column name="YieldType" type="text" reference="Yields(Type)"/>
 		<Column name="Yield" type="integer" default="0"/>
+	</Table>
+	<!-- Improvement: allows a city's "We Love the King Day" to boost the base yield of this improvement when controlled by the city -->
+	<Table name="Improvement_WLTKDYields">
+		<Column name="ImprovementType" type="text" reference="Improvements(Type)"/>
+		<Column name="YieldType" type="text" reference="Yields(Type)"/>
+		<Column name="Yield" type="integer"/>
 	</Table>
 
 	<Table name="Policy_CityYieldFromUnimprovedFeature">
@@ -1865,34 +1872,35 @@
 		<Column name="BeliefType" type="text" reference="Beliefs(Type)"/>
 		<Column name="UnitType" type="text" reference="Units(Type)"/>
 	</Table>
-	<!-- Improvement: allows an improvement to boost the base yield of an adjacent improvement -->
+	<!-- Improvement: allows this improvement to boost the base yield of another adjacent improvement -->
 	<Table name="Improvement_AdjacentImprovementYieldChanges">
 		<Column name="ImprovementType" type="text" reference="Improvements(Type)"/>
 		<Column name="OtherImprovementType" type="text" reference="Improvements(Type)"/>
 		<Column name="YieldType" type="text" reference="Yields(Type)"/>
 		<Column name="Yield" type="integer"/>
 	</Table>
-	<!-- Improvement: allows a resource to boost the base yield of an adjacent improvement -->
+	<!-- Improvement: allows a resource to boost the base yield of this improvement when adjacent -->
 	<Table name="Improvement_AdjacentResourceYieldChanges">
 		<Column name="ImprovementType" type="text" reference="Improvements(Type)"/>
 		<Column name="ResourceType" type="text" reference="Resources(Type)"/>
 		<Column name="YieldType" type="text" reference="Yields(Type)"/>
 		<Column name="Yield" type="integer"/>
 	</Table>
+	<!-- Improvement: allows a terrain to boost the base yield of this improvement when adjacent-->
 	<Table name="Improvement_AdjacentTerrainYieldChanges">
 		<Column name="ImprovementType" type="text" reference="Improvements(Type)"/>
 		<Column name="TerrainType" type="text" reference="Terrains(Type)"/>
 		<Column name="YieldType" type="text" reference="Yields(Type)"/>
 		<Column name="Yield" type="integer"/>
 	</Table>
-	<!-- Improvement: allows an improvement to boost the base yield of an adjacent feature -->
+	<!-- Improvement: allows a feature to boost the base yield of this improvement when adjacent -->
 	<Table name="Improvement_AdjacentFeatureYieldChanges">
 		<Column name="ImprovementType" type="text" reference="Improvements(Type)"/>
 		<Column name="FeatureType" type="text" reference="Features(Type)"/>
 		<Column name="YieldType" type="text" reference="Yields(Type)"/>
 		<Column name="Yield" type="integer"/>
 	</Table>
-	<!-- Improvement: allows an improvement to boost the base yield of an adjacent improvement -->
+	<!-- Improvement: allows a feature to boost the base yield of this improvement when on the same tile -->
 	<Table name="Improvement_FeatureYieldChanges">
 		<Column name="ImprovementType" type="text" reference="Improvements(Type)"/>
 		<Column name="FeatureType" type="text" reference="Features(Type)"/>

--- a/(1) Community Patch/Core Files/Core Tables/CoreTableEntries.sql
+++ b/(1) Community Patch/Core Files/Core Tables/CoreTableEntries.sql
@@ -1094,6 +1094,12 @@ ALTER TABLE Improvements ADD COLUMN 'Lakeside' BOOLEAN DEFAULT 0;
 -- Improvements can be made valid by being adjacent to a city
 ALTER TABLE Improvements ADD COLUMN 'Cityside' BOOLEAN DEFAULT 0;
 
+-- Improvements can be made valid by being adjacent to X of the same improvement
+ALTER TABLE Improvements ADD COLUMN 'XSameAdjacentMakesValid' INTEGER DEFAULT 0;
+
+-- Improvements can be made valid by being on coast terrain
+ALTER TABLE Improvements ADD COLUMN 'CoastMakesValid' BOOLEAN DEFAULT 0;
+
 -- Improvements can generate vision for builder x tiles away (radially)
 ALTER TABLE Improvements ADD COLUMN 'GrantsVisionXTiles' INTEGER DEFAULT 0;
 

--- a/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
@@ -366,7 +366,7 @@ void CvHomelandAI::FindHomelandTargets()
 
 							CvImprovementEntry* pImprovement = GC.getImprovementInfo(eNavalImprovement);
 							//sometimes we have different improvements for the same resource on land and water
-							if (!pImprovement->IsWater())
+							if (!(pImprovement->IsWater() || pImprovement->IsCoastMakesValid()))
 								continue;
 
 							if (pImprovement->IsConnectsResource(pLoopPlot->getResourceType()))

--- a/CvGameCoreDLL_Expansion2/CvImprovementClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvImprovementClasses.cpp
@@ -127,6 +127,7 @@ CvImprovementEntry::CvImprovementEntry(void):
 	m_bRemovesResource(false),
 	m_bPromptWhenComplete(false),
 	m_bWater(false),
+	m_bCoastMakesValid(false),
 	m_bCoastal(false),
 	m_bDestroyedWhenPillaged(false),
 	m_bDisplacePillager(false),
@@ -147,6 +148,7 @@ CvImprovementEntry::CvImprovementEntry(void):
 	m_iMovesChange(0),
 #endif
 	m_bNoTwoAdjacent(false),
+	m_iXSameAdjacentMakesValid(0),
 	m_bAdjacentLuxury(false),
 	m_bAllowsWalkWater(false),
 	m_bCreatedByGreatPerson(false),
@@ -294,6 +296,7 @@ bool CvImprovementEntry::CacheResults(Database::Results& kResults, CvDatabaseUti
 	m_bRemovesResource = kResults.GetBool("RemovesResource");
 	m_bPromptWhenComplete = kResults.GetBool("PromptWhenComplete");
 	m_bWater = kResults.GetBool("Water");
+	m_bCoastMakesValid = kResults.GetBool("CoastMakesValid");
 	m_bCoastal = kResults.GetBool("Coastal");
 	m_bDestroyedWhenPillaged = kResults.GetBool("DestroyedWhenPillaged");
 	m_bDisplacePillager = kResults.GetBool("DisplacePillager");
@@ -335,6 +338,7 @@ bool CvImprovementEntry::CacheResults(Database::Results& kResults, CvDatabaseUti
 	m_iMovesChange = kResults.GetInt("MovesChange");
 #endif
 	m_bNoTwoAdjacent = kResults.GetBool("NoTwoAdjacent");
+	m_iXSameAdjacentMakesValid = kResults.GetInt("XSameAdjacentMakesValid");
 	m_bAdjacentLuxury = kResults.GetBool("AdjacentLuxury");
 	m_bAllowsWalkWater = kResults.GetBool("AllowsWalkWater");
 	m_bCreatedByGreatPerson = kResults.GetBool("CreatedByGreatPerson");
@@ -1084,7 +1088,13 @@ bool CvImprovementEntry::IsWater() const
 	return m_bWater;
 }
 
-/// Is this only placed on the coast?
+/// Requires coast terrain (not lake) to build
+bool CvImprovementEntry::IsCoastMakesValid() const
+{
+	return m_bCoastMakesValid;
+}
+
+/// Is this only placed on land near the coast?
 bool CvImprovementEntry::IsCoastal() const
 {
 	return m_bCoastal;
@@ -1171,6 +1181,11 @@ int CvImprovementEntry::GetGrantsVision() const
 bool CvImprovementEntry::IsNoTwoAdjacent() const
 {
 	return m_bNoTwoAdjacent;
+}
+
+int CvImprovementEntry::GetXSameAdjacentMakesValid() const
+{
+	return m_iXSameAdjacentMakesValid;
 }
 
 /// Does this improvement need to be built next to a luxury resource?

--- a/CvGameCoreDLL_Expansion2/CvImprovementClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvImprovementClasses.cpp
@@ -160,6 +160,7 @@ CvImprovementEntry::CvImprovementEntry(void):
 	m_piPrereqNatureYield(NULL),
 	m_piYieldChange(NULL),
 	m_piYieldPerEra(NULL),
+	m_piWLTKDYieldChange(NULL),
 	m_piRiverSideYieldChange(NULL),
 	m_piCoastalLandYieldChange(NULL),
 	m_piHillsYieldChange(NULL),
@@ -192,6 +193,7 @@ CvImprovementEntry::~CvImprovementEntry(void)
 	SAFE_DELETE_ARRAY(m_piPrereqNatureYield);
 	SAFE_DELETE_ARRAY(m_piYieldChange);
 	SAFE_DELETE_ARRAY(m_piYieldPerEra);
+	SAFE_DELETE_ARRAY(m_piWLTKDYieldChange);
 	SAFE_DELETE_ARRAY(m_piRiverSideYieldChange);
 	SAFE_DELETE_ARRAY(m_piCoastalLandYieldChange);
 	SAFE_DELETE_ARRAY(m_piHillsYieldChange);
@@ -415,6 +417,7 @@ bool CvImprovementEntry::CacheResults(Database::Results& kResults, CvDatabaseUti
 	kUtility.SetYields(m_piCoastalLandYieldChange, "Improvement_CoastalLandYields", "ImprovementType", szImprovementType);
 	kUtility.SetYields(m_piFreshWaterChange, "Improvement_FreshWaterYields", "ImprovementType", szImprovementType);
 	kUtility.SetYields(m_piHillsYieldChange, "Improvement_HillsYields", "ImprovementType", szImprovementType);
+	kUtility.SetYields(m_piWLTKDYieldChange, "Improvement_WLTKDYields", "ImprovementType", szImprovementType);
 	kUtility.SetYields(m_piRiverSideYieldChange, "Improvement_RiverSideYields", "ImprovementType", szImprovementType);
 	kUtility.SetYields(m_piPrereqNatureYield, "Improvement_PrereqNatureYields", "ImprovementType", szImprovementType);
 
@@ -1289,6 +1292,19 @@ int CvImprovementEntry::GetYieldChangePerEra(int i) const
 	CvAssertMsg(i < NUM_YIELD_TYPES, "Index out of bounds");
 	CvAssertMsg(i > -1, "Index out of bounds");
 	return m_piYieldPerEra ? m_piYieldPerEra[i] : 0;
+}
+
+// How much the city having a We Love the King Day improves the yield of this improvement
+int CvImprovementEntry::GetWLTKDYieldChange(int i) const
+{
+	CvAssertMsg(i < NUM_YIELD_TYPES, "Index out of bounds");
+	CvAssertMsg(i > -1, "Index out of bounds");
+	return m_piWLTKDYieldChange ? m_piWLTKDYieldChange[i] : 0;	
+}
+
+int* CvImprovementEntry::GetWLTKDYieldChangeArray()
+{
+	return m_piWLTKDYieldChange;
 }
 
 /// How much being next to a river improves the yield of this improvement

--- a/CvGameCoreDLL_Expansion2/CvImprovementClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvImprovementClasses.h
@@ -1,5 +1,5 @@
 /*	-------------------------------------------------------------------------------------------------------
-	© 1991-2012 Take-Two Interactive Software and its subsidiaries.  Developed by Firaxis Games.  
+	Â© 1991-2012 Take-Two Interactive Software and its subsidiaries.  Developed by Firaxis Games.  
 	Sid Meier's Civilization V, Civ, Civilization, 2K Games, Firaxis Games, Take-Two Interactive Software 
 	and their respective logos are all trademarks of Take-Two interactive Software, Inc.  
 	All other marks and trademarks are the property of their respective owners.  
@@ -127,7 +127,8 @@ public:
 	bool IsRemovesResource() const;
 	bool IsPromptWhenComplete() const;
 	bool IsWater() const;
-	bool IsCoastal() const;
+	bool IsCoastMakesValid() const; // the coast itself (water)
+	bool IsCoastal() const; // land near coast
 	bool IsDestroyedWhenPillaged() const;
 	bool IsDisplacePillager() const;
 	bool IsBuildableOnResources() const;
@@ -146,6 +147,7 @@ public:
 	int GetGrantsVision() const;
 #endif
 	bool IsNoTwoAdjacent() const;
+	int GetXSameAdjacentMakesValid() const;
 	bool IsAdjacentLuxury() const;
 	bool IsAllowsWalkWater() const;
 	bool IsCreatedByGreatPerson() const;
@@ -294,6 +296,7 @@ protected:
 	bool m_bRemovesResource;
 	bool m_bPromptWhenComplete;
 	bool m_bWater;
+	bool m_bCoastMakesValid;
 	bool m_bCoastal;
 	bool m_bDestroyedWhenPillaged;
 	bool m_bDisplacePillager;
@@ -313,7 +316,8 @@ protected:
 	int m_iGrantsVision;
 #endif
 	bool m_bNoTwoAdjacent;
-    bool m_bAdjacentLuxury;
+	int m_iXSameAdjacentMakesValid;
+	bool m_bAdjacentLuxury;
 	bool m_bAllowsWalkWater;
 	bool m_bCreatedByGreatPerson;
 	bool m_bSpecificCivRequired;

--- a/CvGameCoreDLL_Expansion2/CvImprovementClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvImprovementClasses.h
@@ -172,6 +172,8 @@ public:
 	int GetYieldChange(int i) const;
 	int* GetYieldChangeArray();
 	int GetYieldChangePerEra(int i) const;
+	int GetWLTKDYieldChange(int i) const;
+	int* GetWLTKDYieldChangeArray();
 	int GetRiverSideYieldChange(int i) const;
 	int* GetRiverSideYieldChangeArray();
 	int GetCoastalLandYieldChange(int i) const;
@@ -334,6 +336,7 @@ protected:
 	int* m_piPrereqNatureYield;
 	int* m_piYieldChange;
 	int* m_piYieldPerEra;
+	int* m_piWLTKDYieldChange;
 	int* m_piRiverSideYieldChange;
 	int* m_piCoastalLandYieldChange;
 	int* m_piHillsYieldChange;

--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -2213,11 +2213,6 @@ bool CvPlot::canHaveImprovement(ImprovementTypes eImprovement, PlayerTypes ePlay
 		return false;
 	}
 
-	if(pkImprovementInfo->IsAdjacentCity() && !IsAdjacentCity())
-	{
-		return false;
-	}
-
 	if(pkImprovementInfo->IsRequiresFeature() && (getFeatureType() == NO_FEATURE))
 	{
 
@@ -2277,6 +2272,16 @@ bool CvPlot::canHaveImprovement(ImprovementTypes eImprovement, PlayerTypes ePlay
 		return false;
 	}
 
+	if(pkImprovementInfo->IsCoastMakesValid() && (isWater() && !isLake()))
+	{
+		bValid = true;
+	}
+
+	if(pkImprovementInfo->IsAdjacentCity() && IsAdjacentCity())
+	{
+		bValid = true;
+	}
+
 	if(pkImprovementInfo->IsHillsMakesValid() && isHills())
 	{
 		bValid = true;
@@ -2313,6 +2318,30 @@ bool CvPlot::canHaveImprovement(ImprovementTypes eImprovement, PlayerTypes ePlay
 	if((getFeatureType() != NO_FEATURE) && pkImprovementInfo->GetFeatureMakesValid(getFeatureType()))
 	{
 		bValid = true;
+	}
+
+	int iAdjacentSameImprovementMakesValid = pkImprovementInfo->GetXSameAdjacentMakesValid();
+	if (iAdjacentSameImprovementMakesValid > 0)
+	{
+		int iAdjacentSameImprovement = 0;
+
+		for(iI = 0; iI < NUM_DIRECTION_TYPES; ++iI)
+		{
+			pLoopPlot = plotDirection(getX(), getY(), ((DirectionTypes)iI));
+
+			if(pLoopPlot != NULL)
+			{
+				if (pLoopPlot->getImprovementType() == eImprovement)
+				{
+					iAdjacentSameImprovement++;
+				}
+			}
+		}
+
+		if (iAdjacentSameImprovement >= iAdjacentSameImprovementMakesValid)
+		{
+			bValid = true;
+		}
 	}
 
 	if(!bValid)
@@ -7217,6 +7246,9 @@ ImprovementTypes CvPlot::getImprovementTypeNeededToImproveResource(PlayerTypes e
 			continue;
 
 		if(pImprovementInfo->IsWater() != isWater())
+			continue;
+
+		if(pImprovementInfo->IsCoastMakesValid() != (isWater() && !isLake()))
 			continue;
 
 		eImprovementNeeded = eImprovement;

--- a/CvGameCoreDLL_Expansion2/CvPlot.h
+++ b/CvGameCoreDLL_Expansion2/CvPlot.h
@@ -558,12 +558,12 @@ public:
 	int getYield(YieldTypes eIndex) const;
     void changeYield(YieldTypes eYield, int iChange);
 
-	int calculateNatureYield(YieldTypes eIndex, PlayerTypes ePlayer, const CvCity* pOwningCity, bool bIgnoreFeature = false, bool bDisplay = false) const;
+	int calculateNatureYield(YieldTypes eYield, PlayerTypes ePlayer, const CvCity* pOwningCity, bool bIgnoreFeature = false, bool bDisplay = false) const;
 
-	int calculateBestNatureYield(YieldTypes eIndex, PlayerTypes ePlayer) const;
+	int calculateBestNatureYield(YieldTypes eYield, PlayerTypes ePlayer) const;
 	int calculateTotalBestNatureYield(PlayerTypes ePlayer) const;
 
-	int calculateImprovementYield(ImprovementTypes eImprovement, YieldTypes eYield, int iCurrentYield, PlayerTypes ePlayer, bool bOptimal = false, RouteTypes eAssumeThisRoute = NUM_ROUTE_TYPES) const;
+	int calculateImprovementYield(YieldTypes eYield, int iCurrentYield, PlayerTypes ePlayer, ImprovementTypes eImprovement,  const CvCity* pOwningCity, bool bOptimal = false, RouteTypes eAssumeThisRoute = NUM_ROUTE_TYPES) const;
 
 #if defined(MOD_RELIGION_PERMANENT_PANTHEON)
 	int calculatePlayerYield(YieldTypes eYield, int iCurrentYield, PlayerTypes ePlayer, ImprovementTypes eImprovement, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon, const CvReligion* pPlayerPantheon, bool bDisplay) const;
@@ -572,9 +572,9 @@ public:
 #endif
 
 	int calculateReligionNatureYield(YieldTypes eYield, PlayerTypes ePlayer, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon) const;
-	int calculateReligionImprovementYield(ImprovementTypes eImprovement, YieldTypes eYield, PlayerTypes ePlayer, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon) const;
+	int calculateReligionImprovementYield(YieldTypes eYield, PlayerTypes ePlayer, ImprovementTypes eImprovement, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon) const;
 
-	int calculateYield(YieldTypes eIndex, bool bDisplay = false);
+	int calculateYield(YieldTypes eYield, bool bDisplay = false);
 #if defined(MOD_RELIGION_PERMANENT_PANTHEON)
 	int calculateYieldFast(YieldTypes eYield, bool bDisplay, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon, const CvReligion* pPlayerPantheon = NULL);
 #else

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlot.cpp
@@ -1647,20 +1647,20 @@ int CvLuaPlot::lCalculateTotalBestNatureYield(lua_State* L)
 	return BasicLuaMethod(L, &CvPlot::calculateTotalBestNatureYield);
 }
 //------------------------------------------------------------------------------
-//int calculateImprovementYieldChange(ImprovementTypes eImprovement, YieldTypes eYield, PlayerTypes ePlayer, bool bOptimal, RouteTypes eAssumeThisRoute);
+//int calculateImprovementYieldChange(YieldTypes eYield, PlayerTypes ePlayer, ImprovementTypes eImprovement, bool bOptimal, RouteTypes eAssumeThisRoute);
 int CvLuaPlot::lCalculateImprovementYieldChange(lua_State* L)
 {
 	CvPlot* pkPlot = GetInstance(L); CHECK_PLOT_VALID(pkPlot);
 	const ImprovementTypes eImprovement = (ImprovementTypes)lua_tointeger(L, 2);
 	const YieldTypes eYield = (YieldTypes)lua_tointeger(L,3);
 	const PlayerTypes ePlayer = (PlayerTypes)lua_tointeger(L, 4);
-	const bool bOptional = luaL_optbool(L, 5, false);
+	const bool bOptimal = luaL_optbool(L, 5, false);
 
 	RouteTypes eRoute = (RouteTypes)luaL_optint(L, 6, NUM_ROUTE_TYPES);
 	if (lua_gettop(L) == 6)
 		eRoute = (RouteTypes)lua_tointeger(L, 6);
 
-	const int iResult = pkPlot->calculateImprovementYield(eImprovement, eYield, pkPlot->calculateBestNatureYield(eYield, ePlayer), ePlayer, bOptional, eRoute);
+	const int iResult = pkPlot->calculateImprovementYield(eYield, pkPlot->calculateBestNatureYield(eYield, ePlayer), ePlayer, eImprovement, pkPlot->getEffectiveOwningCity(), bOptimal, eRoute);
 	lua_pushinteger(L, iResult);
 	return 1;
 }


### PR DESCRIPTION
DLL updates for improvement abilities related to Siheyuan and Polder

- WLTKD improvement yields (for Siheyuan)
- Cityside no longer a "Requires"  (no change to Kasbah, but makes Siheyuan work)
- CoastMakesValid (for Polder)
- XSameAdjacentMakesValid (for Siheyuan)

- some minor AI site choice optimizations