### PR TITLE
improved era popup

### DIFF
--- a/(1) Community Patch/Community Patch.civ5proj
+++ b/(1) Community Patch/Community Patch.civ5proj
@@ -1145,6 +1145,10 @@
       <SubType>Lua</SubType>
       <ImportIntoVFS>True</ImportIntoVFS>
     </Content>
+    <Content Include="Core Files\CoreLua\NewEraPopup.lua">
+      <SubType>Lua</SubType>
+      <ImportIntoVFS>True</ImportIntoVFS>
+    </Content>
     <Content Include="Core Files\CoreLua\PathHelpManager.lua">
       <SubType>Lua</SubType>
       <ImportIntoVFS>True</ImportIntoVFS>

--- a/(1) Community Patch/Core Files/Core Tables/CoreTableEntries.sql
+++ b/(1) Community Patch/Core Files/Core Tables/CoreTableEntries.sql
@@ -1737,3 +1737,17 @@ ALTER TABLE UnitPromotions ADD AuraEffectChange INTEGER DEFAULT 0;
 ALTER TABLE Traits ADD ExtraSupply INTEGER DEFAULT 0;
 ALTER TABLE Traits ADD ExtraSupplyPerCity INTEGER DEFAULT 0;
 ALTER TABLE Traits ADD ExtraSupplyPerPopulation INTEGER DEFAULT 0;
+
+-- De-hardcode New Era Popup splash image with a new column and improved LUA file
+-- Add the new column for new era popup splash image	
+ALTER TABLE Eras ADD EraSplashImage TEXT DEFAULT 'ERA_Medievel.dds';
+
+-- Update the base eras with the correct values
+-- Yes, Medieval and Renaissance are correct values, blame the typo to Firaxis
+UPDATE Eras SET EraSplashImage = 'ERA_Classical.dds'  		WHERE Type = 'ERA_CLASSICAL';
+UPDATE Eras SET EraSplashImage = 'ERA_Medievel.dds'   		WHERE Type = 'ERA_MEDIEVAL';
+UPDATE Eras SET EraSplashImage = 'ERA_Renissance.dds' 		WHERE Type = 'ERA_RENAISSANCE';
+UPDATE Eras SET EraSplashImage = 'ERA_Industrial.dds' 		WHERE Type = 'ERA_INDUSTRIAL';
+UPDATE Eras SET EraSplashImage = 'ERA_Modern.dds'     		WHERE Type = 'ERA_MODERN';
+UPDATE Eras SET EraSplashImage = 'ERA_Atomic.dds'     		WHERE Type = 'ERA_POSTMODERN';
+UPDATE Eras SET EraSplashImage = 'ERA_Future.dds'     		WHERE Type = 'ERA_FUTURE';

--- a/(1) Community Patch/Core Files/CoreLua/NewEraPopup.lua
+++ b/(1) Community Patch/Core Files/CoreLua/NewEraPopup.lua
@@ -1,0 +1,75 @@
+-------------------------------------------------
+-- New Era Popup
+-------------------------------------------------
+
+local m_PopupInfo = nil;
+local lastBackgroundImage = "ERA_Medievel.dds"
+
+-------------------------------------------------
+-- On Popup
+-------------------------------------------------
+function OnPopup( popupInfo )
+    if( popupInfo.Type ~= ButtonPopupTypes.BUTTONPOPUP_NEW_ERA ) then
+        return;
+    end
+
+    m_PopupInfo = popupInfo;
+
+    local iEra = popupInfo.Data1;
+    Controls.DescriptionLabel:LocalizeAndSetText("TXT_KEY_POP_NEW_ERA_DESCRIPTION", GameInfo.Eras[iEra].Description);
+	
+    lastBackgroundImage = GameInfo.Eras[iEra].EraSplashImage;
+    Controls.EraImage:SetTexture(lastBackgroundImage);
+	
+    UIManager:QueuePopup( ContextPtr, PopupPriority.NewEraPopup );
+end
+Events.SerialEventGameMessagePopup.Add( OnPopup );
+
+----------------------------------------------------------------        
+-- Input processing
+----------------------------------------------------------------        
+
+-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
+function OnClose()
+    UIManager:DequeuePopup( ContextPtr );
+    Controls.EraImage:UnloadTexture();
+end
+Controls.CloseButton:RegisterCallback( Mouse.eLClick, OnClose);
+
+-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
+
+function InputHandler( uiMsg, wParam, lParam )
+    if uiMsg == KeyEvents.KeyDown then
+        if wParam == Keys.VK_ESCAPE or wParam == Keys.VK_RETURN then
+            OnClose();
+            return true;
+        end
+    end
+end
+ContextPtr:SetInputHandler( InputHandler );
+
+
+-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
+function ShowHideHandler( bIsHide, bInitState )
+
+    if( not bInitState ) then
+       Controls.EraImage:UnloadTexture();
+       if( not bIsHide ) then
+        	Controls.EraImage:SetTexture(lastBackgroundImage);
+        	UI.incTurnTimerSemaphore();
+        	Events.SerialEventGameMessagePopupShown(m_PopupInfo);
+        else
+            UI.decTurnTimerSemaphore();
+            Events.SerialEventGameMessagePopupProcessed.CallImmediate(ButtonPopupTypes.BUTTONPOPUP_NEW_ERA, 0);
+        end
+    end
+end
+ContextPtr:SetShowHideHandler( ShowHideHandler );
+
+----------------------------------------------------------------
+-- 'Active' (local human) player has changed
+----------------------------------------------------------------
+Events.GameplaySetActivePlayer.Add(OnClose);


### PR DESCRIPTION
Improve NewEraPopup.lua to a better one so the splash images is not hardcoded inside the lua file.

The only purpose is so modmod that adds a new era can make use of this.