### PR TITLE
Bugfix canals check

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -1070,6 +1070,7 @@ bool CvPlot::isCoastalLand(int iMinWaterSize, bool bUseCachedValue, bool bCheckC
 	//or if there is an owned fort, citadel or city on them
 	//we do this repeatedly until we reach the required amount of plots or until every item of the list is checked
 	std::vector<const CvPlot*> vAccessibleWaterPlots(1, this);
+	TeamTypes eTeam = getTeam();
 	unsigned int iNumPlotsChecked = 0;
 	do
 	{
@@ -1088,7 +1089,7 @@ bool CvPlot::isCoastalLand(int iMinWaterSize, bool bUseCachedValue, bool bCheckC
 					continue;
 			}
 			//If land, must be owned city, fort or citadel
-			else if (pAdjacentPlot->isOwned())
+			else if (pAdjacentPlot->getTeam()==eTeam)
 			{
 				if (!pAdjacentPlot->isCity() && !(pAdjacentPlot->IsImprovementPassable() && !pAdjacentPlot->IsImprovementPillaged()))
 					continue;
@@ -1099,7 +1100,7 @@ bool CvPlot::isCoastalLand(int iMinWaterSize, bool bUseCachedValue, bool bCheckC
 			}
 			else
 			{
-				//unowned land tile
+				// Land tile not owned by us
 				continue;
 			}
 


### PR DESCRIPTION
In the canals check, cities/forts/citadels that are owned by us should be counted as canals. But the function isOwned() checks if a tile is owned by _anyone_ (`return getOwner() != NO_PLAYER;`) , and we don't want to include cities/forts/citadels owned by other players. Instead of using isOwned(), we must check if the owner of the city/citadel plot is the same as the owner of the plot from which we started the canals check.