### PR TITLE
Chop fixes, Tech Tree icon improvements (EUI)

### DIFF
--- a/(2) Vox Populi/Balance Changes/Text/en_US/OtherText.sql
+++ b/(2) Vox Populi/Balance Changes/Text/en_US/OtherText.sql
@@ -391,6 +391,15 @@ UPDATE Language_en_US
 SET Text = 'Receive an additional [ICON_INTERNATIONAL_TRADE] Trade Route. Reveals [ICON_RES_ALUMINUM] Aluminum, a resource used for many late-game units. Also allows Cities to build the [COLOR_POSITIVE_TEXT]Stock Exchange[ENDCOLOR], a building which boosts [ICON_GOLD] Gold. Also allows you to build the [COLOR_POSITIVE_TEXT]Hydro Plant[ENDCOLOR], which increases [ICON_PRODUCTION] Production from tiles next to a River.'
 WHERE Tag = 'TXT_KEY_TECH_ELECTRICITY_HELP';
 
+-- Tech Tree small icon fixes
+
+UPDATE Language_en_US
+SET Text = 'Chopping Forests/Jungles: +{1_Num}[ICON_PRODUCTION] Production'
+WHERE Tag = 'TXT_KEY_ABLTY_TECH_BOOST_CHOP';
+
+INSERT INTO Language_en_US (Tag, Text) VALUES
+('TXT_KEY_REMOVE_FOREST_JUNGLE_COST_REDUCTION', "Removing Forests/Jungles needs {1_Turns} Turn(s) to complete." );
+
 -- Penicilin and Nanotech 
 
 UPDATE Language_en_US

--- a/(2) Vox Populi/LUA/TechButtonInclude.lua
+++ b/(2) Vox Populi/LUA/TechButtonInclude.lua
@@ -27,6 +27,15 @@ turnsString = Locale.ConvertTextKey("TXT_KEY_TURNS");
 freeString = Locale.ConvertTextKey("TXT_KEY_FREE");
 lockedString = "[ICON_LOCKED]"; --Locale.ConvertTextKey("TXT_KEY_LOCKED");
 
+-- VP/bal: gamespeed is currently only used to calculate chop yields, possibly can be applied in other places too
+local g_GameSpeedBuildPercent = GameInfo.GameSpeeds[Game.GetGameSpeedType()].BuildPercent
+local g_BaseChopYield
+for row in GameInfo.BuildFeatures{BuildType = 'BUILD_REMOVE_FOREST'} do
+	g_BaseChopYield = row.Production
+end
+local g_AdjChopYield = math.floor(g_BaseChopYield / 2 * g_GameSpeedBuildPercent / 100 )
+
+
 function GetTechPedia( void1, void2, button )
 	local searchString = techPediaSearchStrings[tostring(button)];
 	Events.SearchForPediaEntry( searchString );		
@@ -258,7 +267,7 @@ function AddSmallButtonsToTechButton( thisTechButtonInstance, tech, maxSmallButt
 		if thisButton then
 			IconHookup( 0, textureSize, "GENERIC_FUNC_ATLAS", thisButton );
 			thisButton:SetHide( false );
-			thisButton:SetToolTipString( Locale.ConvertTextKey( "TXT_KEY_ABLTY_TECH_BOOST_CHOP", tech.FeatureProductionModifier ) );
+			thisButton:SetToolTipString( Locale.ConvertTextKey( "TXT_KEY_ABLTY_TECH_BOOST_CHOP", g_AdjChopYield ) );
 			buttonNum = buttonNum + 1;
 		end
 	end

--- a/(3a) EUI Compatibility Files/PromotionFlags/PromotionBaseData.sql
+++ b/(3a) EUI Compatibility Files/PromotionFlags/PromotionBaseData.sql
@@ -1,3 +1,11 @@
+-- Icon atlases for new tech boost icons, will create a new one new patch
+UPDATE IconTextureAtlases
+SET Filename='UnitActionsGold.dds'
+WHERE Atlas='UNIT_ACTION_GOLD_ATLAS' AND IconSize='64';
+UPDATE IconTextureAtlases
+SET Filename='UnitActionsGold360.dds'
+WHERE Atlas='UNIT_ACTION_GOLD_ATLAS' AND IconSize='45';
+
 -- add columns to UnitPromotions to handle grouping of ranked promotions
 ALTER TABLE UnitPromotions	ADD RankList									text;
 ALTER TABLE UnitPromotions	ADD RankNumber							integer default 0;


### PR DESCRIPTION
Chop boosts of Bronze Working and Iron Working will display the net production gained from chopping, scaled with gamespeed.

EUI Only:
- Boosts will use the golden version of their opener icons, which currently includes the following:
-- Boosts to chop yields, or decreased chop duration (reduced chop duration icons for forests&jungles are also merged)
- - Boosts to embark (i.e. faster embarked movement, less embark cost from cities etc.) 
- - Boosts to road movement (faster movement on roads & railroads)

The plan is to replace each "generic" icon with a distinct one, I cracked the code but need some time to gather appropriate icons, so hopefully in the next patch.

@RecursiveVision Very light changes, tested. 