### PR TITLE
 Game Speed XP Cap Fix

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -7700,6 +7700,12 @@ int CvCity::maxXPValue() const
 		iMaxValue = std::min(iMaxValue, GD_INT_GET(MINOR_MAX_XP_VALUE));
 	}
 
+	if (MOD_BALANCE_CORE_SCALING_XP)
+	{
+		iMaxValue *= GC.getGame().getGameSpeedInfo().getTrainPercent();
+		iMaxValue /= 100;
+	}
+
 	return iMaxValue;
 }
 #endif

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -17749,6 +17749,12 @@ int CvUnit::maxXPValue() const
 		iMaxValue = std::min(iMaxValue, GD_INT_GET(MINOR_MAX_XP_VALUE));
 	}
 
+	if (MOD_BALANCE_CORE_SCALING_XP)
+	{
+		iMaxValue *= GC.getGame().getGameSpeedInfo().getTrainPercent();
+		iMaxValue /= 100;
+	}
+
 	return iMaxValue;
 }
 


### PR DESCRIPTION
just as game speed affects how much experience is required to gain a level, game speed should affect what the maximum XP one can gain from city state units and barbarians.

#9453
