### PR TITLE
Fix coup quest not expiring when target CS conquered

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
@@ -1945,8 +1945,13 @@ bool CvMinorCivQuest::IsExpired()
 		PlayerTypes ePlayer = (PlayerTypes) m_iData1;
 		if(ePlayer != NO_PLAYER)
 		{
+			//City-state dead?
+			if (!GET_PLAYER(ePlayer).isAlive())
+			{
+				return true;
+			}
 			//Failed coup?
-			if(GET_PLAYER(ePlayer).GetMinorCivAI()->IsCoupAttempted(m_eAssignedPlayer))
+			else if(GET_PLAYER(ePlayer).GetMinorCivAI()->IsCoupAttempted(m_eAssignedPlayer))
 			{
 				if(GET_PLAYER(ePlayer).GetMinorCivAI()->GetAlly() != m_eAssignedPlayer)
 				{
@@ -1955,7 +1960,7 @@ bool CvMinorCivQuest::IsExpired()
 			}
 			//already Allied?
 			else if(GET_PLAYER(ePlayer).GetMinorCivAI()->IsAllies(m_eAssignedPlayer))
-				return true;
+				return true;		
 		}
 	}
 	else if (m_eType == MINOR_CIV_QUEST_UNIT_GET_CITY)


### PR DESCRIPTION
The quest to stage a coup in a CS didn't expire if the target had been conquered. In my last game, this lead to both the quest to coup a CS and the quest to liberate it being active at the same time:
![Screenshot (177)](https://user-images.githubusercontent.com/95587882/204160272-5a16ef84-5702-4b6a-85fb-74ac0fab437f.png)