### PR TITLE
Fix reformation belief bug when no religion owned

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvDllNetMessageHandler.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDllNetMessageHandler.cpp
@@ -386,7 +386,10 @@ void CvDllNetMessageHandler::ResponseFoundPantheon(PlayerTypes ePlayer, BeliefTy
 			if (!pkGameReligions->HasAddedReformationBelief(ePlayer) && kPlayer.GetReligions()->HasCreatedReligion())
 			{
 				ReligionTypes eReligion = kPlayer.GetReligions()->GetOwnedReligion();
-				pkGameReligions->AddReformationBelief(ePlayer, eReligion, eBelief);
+				if (eReligion != NO_RELIGION)
+				{
+					pkGameReligions->AddReformationBelief(ePlayer, eReligion, eBelief);
+				}
 			}
 		}
 	}

--- a/CvGameCoreDLL_Expansion2/CvReligionClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvReligionClasses.cpp
@@ -657,7 +657,7 @@ void CvGameReligions::DoPlayerTurn(CvPlayer& kPlayer)
 
 	// Pick a Reformation belief?
 	ReligionTypes eOwnedReligion = GET_PLAYER(ePlayer).GetReligions()->GetOwnedReligion();
-	if (!HasAddedReformationBelief(ePlayer) && (kPlayer.GetPlayerPolicies()->HasPolicyGrantingReformationBelief() || kPlayer.IsReformation()))
+	if (eOwnedReligion != NO_RELIGION && !HasAddedReformationBelief(ePlayer) && (kPlayer.GetPlayerPolicies()->HasPolicyGrantingReformationBelief() || kPlayer.IsReformation()))
 	{
 		if (!kPlayer.isHuman())
 		{

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaGame.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaGame.cpp
@@ -3040,7 +3040,7 @@ int CvLuaGame::lAddReformation(lua_State* L)
 
 	CvPlayerAI& kPlayer = GET_PLAYER(ePlayer);
 	CvGameReligions* pkGameReligions = GC.getGame().GetGameReligions();
-	if (!pkGameReligions->HasAddedReformationBelief(ePlayer) && kPlayer.GetReligions()->HasCreatedReligion() && kPlayer.GetReligions()->GetOwnedReligion() == eReligion)
+	if (!pkGameReligions->HasAddedReformationBelief(ePlayer) && kPlayer.GetReligions()->HasCreatedReligion() && kPlayer.GetReligions()->GetOwnedReligion() != NO_RELIGION && kPlayer.GetReligions()->GetOwnedReligion() == eReligion)
 	{
 		pkGameReligions->AddReformationBelief(ePlayer, eReligion, eBelief);
 	}


### PR DESCRIPTION
Fix for #9330 and #8811: It should only be possible to choose a reformation belief if the player owns a religion