### PR TITLE
Kasbah/Encampment Hotfix

### DIFF
--- a/(2) Vox Populi/Balance Changes/Leaders/BraveNew/BNWLeaderChanges.sql
+++ b/(2) Vox Populi/Balance Changes/Leaders/BraveNew/BNWLeaderChanges.sql
@@ -29,10 +29,6 @@ SET Yield = '2'
 WHERE YieldType = 'YIELD_PRODUCTION' AND ImprovementType = 'IMPROVEMENT_KASBAH';
 
 UPDATE Improvements
-SET Cityside = '1'
-WHERE Type = 'IMPROVEMENT_KASBAH';
-
-UPDATE Improvements
 SET DefenseModifier = '30'
 WHERE Type = 'IMPROVEMENT_KASBAH';
 
@@ -43,6 +39,13 @@ WHERE Type = 'IMPROVEMENT_KASBAH';
 UPDATE Improvements
 SET NearbyEnemyDamage = '5'
 WHERE Type = 'IMPROVEMENT_KASBAH';
+
+UPDATE Improvements
+SET Cityside = '1'
+WHERE Type = 'IMPROVEMENT_KASBAH';
+
+DELETE FROM Improvement_ValidTerrains
+WHERE ImprovementType = 'IMPROVEMENT_KASBAH';
 
 UPDATE Builds
 SET PrereqTech = 'TECH_CHIVALRY'
@@ -379,9 +382,14 @@ VALUES
 	('BUILDING_CANDI', 'YIELD_FAITH', 15),
 	('BUILDING_CANDI', 'YIELD_CULTURE', 15);
 
--- all terrains are valid for these improvements
-DELETE FROM Improvement_ValidTerrains
-WHERE ImprovementType IN ('IMPROVEMENT_KASBAH', 'IMPROVEMENT_ENCAMPMENT_SHOSHONE');
+INSERT INTO Improvement_ValidTerrains
+	(ImprovementType, TerrainType)
+VALUES
+	('IMPROVEMENT_ENCAMPMENT_SHOSHONE', 'TERRAIN_GRASS'),
+	('IMPROVEMENT_ENCAMPMENT_SHOSHONE', 'TERRAIN_PLAINS'),
+	('IMPROVEMENT_ENCAMPMENT_SHOSHONE', 'TERRAIN_TUNDRA'),
+	('IMPROVEMENT_ENCAMPMENT_SHOSHONE', 'TERRAIN_SNOW'),
+	('IMPROVEMENT_ENCAMPMENT_SHOSHONE', 'TERRAIN_DESERT');
 
 INSERT INTO Building_DomainFreeExperiencePerGreatWorkGlobal
 	(BuildingType, DomainType, Experience)

--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -2192,16 +2192,18 @@ bool CvPlot::canHaveImprovement(ImprovementTypes eImprovement, PlayerTypes ePlay
 
 	ResourceTypes thisResource = getResourceType( ePlayer!=NO_PLAYER ? GET_PLAYER(ePlayer).getTeam() : NO_TEAM );
 	// The functionality of this line is different in Civ 4: in that game a "Valid" Resource ALLOWS an Improvement on a Tile.  In Civ 5 this makes a Resource REQUIRE a certain Improvement
-	if(thisResource != NO_RESOURCE &&
-	        !pkImprovementInfo->IsBuildableOnResources() &&	// Some improvements can be built anywhere
-	        !pkImprovementInfo->IsImprovementResourceMakesValid(thisResource))
+	if(thisResource != NO_RESOURCE)
 	{
-		return false;
-	}
-	// If there IS a valid resource here then set validity to true (because something has to)
-	else if(thisResource != NO_RESOURCE)
-	{
-		bValid = true;
+		// If there IS a valid resource here then set validity to true
+		if(pkImprovementInfo->IsImprovementResourceMakesValid(thisResource))
+		{
+			bValid = true;
+		}
+		// Some improvements can ignore resource requirements, but otherwise not satisfying the requirements is an automatic fail
+		else if (!pkImprovementInfo->IsBuildableOnResources())
+		{
+			return false;
+		}
 	}
 
 	if(pkImprovementInfo->IsNoFreshWater() && isFreshWater())


### PR DESCRIPTION
 - The BuildableOnResources columns in the Improvements table is no longer its own restriction; ie. If you select BuildableOnResources and no other placement criteria, the improvement cannot be built anywhere.
 - Improvements are unable to be built on resources by default, regardless of their other placement criteria.  BuildableOnResources allows the improvement to ignore resources when looking at its placement criteria.
 - Fix to allow Kasbah to work with the reassigned Cityside (which is now a MakesValid)

 - Encampment doesn't have any other Validity criteria, so needs an all-encompassing ValidTerrain
 - fixes #9525 