### PR TITLE
FixCargoShips

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -1058,64 +1058,64 @@ bool CvPlot::isCoastalLand(int iMinWaterSize, bool bUseCachedValue, bool bCheckC
 					return true;
 			}
 		}
-	}
 
-	// Not adjacent to water or not adjacent to enough water? If not checking for canals, abort!
-	// Also, water tiles are not land, so always return false
-	if (!bCheckCanals || !MOD_GLOBAL_PASSABLE_FORTS || isWater())
-		return false;
 
-	//check for areas of water connected by canals
-	//starting with the plot itself, we loop through all adjacent plots and add them to a list if they are water tiles
-	//or if there is an owned fort, citadel or city on them
-	//we do this repeatedly until we reach the required amount of plots or until every item of the list is checked
-	std::vector<const CvPlot*> vAccessibleWaterPlots(1, this);
-	TeamTypes eTeam = getTeam();
-	unsigned int iNumPlotsChecked = 0;
-	do
-	{
-		const CvPlot* pPlotBeingChecked = vAccessibleWaterPlots[iNumPlotsChecked];
-		CvPlot** aPlotsToCheck = GC.getMap().getNeighborsUnchecked(pPlotBeingChecked);
-		for (int iCount = 0; iCount < NUM_DIRECTION_TYPES; iCount++)
+		//If not checking for canals, abort!
+		// Also, water tiles are not land, so always return false
+		if (!bCheckCanals || !MOD_GLOBAL_PASSABLE_FORTS || isWater())
+			return false;
+
+		//check for areas of water connected by canals
+		//starting with the plot itself, we loop through all adjacent plots and add them to a list if they are water tiles
+		//or if there is an owned fort, citadel or city on them
+		//we do this repeatedly until we reach the required amount of plots or until every item of the list is checked
+		std::vector<const CvPlot*> vAccessibleWaterPlots(1, this);
+		TeamTypes eTeam = getTeam();
+		unsigned int iNumPlotsChecked = 0;
+		do
 		{
-			const CvPlot* pAdjacentPlot = aPlotsToCheck[iCount];
-			if (!pAdjacentPlot)
-				continue;
-
-			// If water, must not be unowned ice
-			if (pAdjacentPlot->isWater())
+			const CvPlot* pPlotBeingChecked = vAccessibleWaterPlots[iNumPlotsChecked];
+			CvPlot** aPlotsToCheck = GC.getMap().getNeighborsUnchecked(pPlotBeingChecked);
+			for (int iCount = 0; iCount < NUM_DIRECTION_TYPES; iCount++)
 			{
-				if (pAdjacentPlot->getFeatureType() == FEATURE_ICE && !pAdjacentPlot->isOwned())
-					continue;
-			}
-			//If land, must be owned city, fort or citadel
-			else if (pAdjacentPlot->getTeam()==eTeam)
-			{
-				if (!pAdjacentPlot->isCity() && !(pAdjacentPlot->IsImprovementPassable() && !pAdjacentPlot->IsImprovementPillaged()))
+				const CvPlot* pAdjacentPlot = aPlotsToCheck[iCount];
+				if (!pAdjacentPlot)
 					continue;
 
-				// Must be adjacent to water
-				if (!pAdjacentPlot->isAdjacentToWater())
-					continue;
-			}
-			else
-			{
-				// Land tile not owned by us
-				continue;
-			}
+				// If water, must not be unowned ice
+				if (pAdjacentPlot->isWater())
+				{
+					if (pAdjacentPlot->getFeatureType() == FEATURE_ICE && !pAdjacentPlot->isOwned())
+						continue;
+				}
+				//If land, must be owned city, fort or citadel
+				else if (pAdjacentPlot->getTeam()==eTeam)
+				{
+					if (!pAdjacentPlot->isCity() && !(pAdjacentPlot->IsImprovementPassable() && !pAdjacentPlot->IsImprovementPillaged()))
+						continue;
 
-			// add the plot to the list if it's not already in it
-			if (std::find(vAccessibleWaterPlots.begin(), vAccessibleWaterPlots.end(), pAdjacentPlot) == vAccessibleWaterPlots.end()) 
-			{
-				vAccessibleWaterPlots.push_back(pAdjacentPlot);
-				if (static_cast<int>(vAccessibleWaterPlots.size())-1 >= iMinWaterSize) // minus 1 because the first element in the list is the plot from which we started
-					return true;
+					// Must be adjacent to water
+					if (!pAdjacentPlot->isAdjacentToWater())
+						continue;
+				}
+				else
+				{
+					// Land tile not owned by us
+					continue;
+				}
+
+				// add the plot to the list if it's not already in it
+				if (std::find(vAccessibleWaterPlots.begin(), vAccessibleWaterPlots.end(), pAdjacentPlot) == vAccessibleWaterPlots.end())
+				{
+					vAccessibleWaterPlots.push_back(pAdjacentPlot);
+					if (static_cast<int>(vAccessibleWaterPlots.size())-1 >= iMinWaterSize) // minus 1 because the first element in the list is the plot from which we started
+						return true;
+				}
 			}
-		}
-		iNumPlotsChecked++;
+			iNumPlotsChecked++;
+		} 
+		while (iNumPlotsChecked != vAccessibleWaterPlots.size());
 	}
-	while (iNumPlotsChecked != vAccessibleWaterPlots.size());
-
 	return false;
 }
 
@@ -13382,7 +13382,8 @@ bool CvPlot::canTrain(UnitTypes eUnit) const
 		if (thisUnitDomain == DOMAIN_SEA)
 		{
 			//fast check for ocean (-1)
-			if (!isCoastalLand(-1, true, true) || !isCoastalLand(thisUnitEntry.GetMinAreaSize(), true, true))
+			//check for canals only in Vox Populi
+			if (!isCoastalLand(-1, true, MOD_BALANCE_VP) || !isCoastalLand(thisUnitEntry.GetMinAreaSize(), true, MOD_BALANCE_VP))
 			{
 				return false;
 			}


### PR DESCRIPTION
Fix #9518 
- Cities that are not adjacent to water can't be connected by canals to the ocean
- Canals check is only applied in VP, no longer in CP