### PR TITLE
Heal rate change missing from Ostrog (Fortress UB)

### DIFF
--- a/(2) Vox Populi/Balance Changes/Buildings/CityDefense.sql
+++ b/(2) Vox Populi/Balance Changes/Buildings/CityDefense.sql
@@ -104,6 +104,10 @@ WHERE Type = 'BUILDING_FORTRESS';
 
 UPDATE Buildings
 SET HealRateChange = '5'
+WHERE Type = 'BUILDING_KREPOST';
+
+UPDATE Buildings
+SET HealRateChange = '5'
 WHERE Type = 'BUILDING_ARSENAL';
 
 UPDATE Buildings
@@ -113,4 +117,3 @@ WHERE Type = 'BUILDING_MILITARY_BASE';
 UPDATE Buildings
 SET CityAirStrikeDefense = '5'
 WHERE Type = 'BUILDING_MILITARY_BASE';
-


### PR DESCRIPTION
It seems like Ostrog has missing its +5 HP heal rate for a long time and people didn't notice. It should have it since it's inheriting the same ability as Arsenal (now moved to Fortress) which have +5 HP heal rate.