### PR TITLE
Fix Barbarian Unit Capture

### DIFF
--- a/(2) Vox Populi/Balance Changes/Barbarians/BarbarianChanges.sql
+++ b/(2) Vox Populi/Balance Changes/Barbarians/BarbarianChanges.sql
@@ -115,12 +115,9 @@ VALUES
 
 CREATE TABLE IF NOT EXISTS Civilization_UnitClassOverrides_BarbarianDisabler (UnitClassType_Temp TEXT NOT NULL);
 
-INSERT INTO Civilization_UnitClassOverrides_BarbarianDisabler (UnitClassType_Temp) VALUES
-	-- Barbarians cannot spawn the unit classes below!
-	-- Civilians
-	('UNITCLASS_SETTLER'),
-	('UNITCLASS_PIONEER'),
-	('UNITCLASS_COLONIST'),
+INSERT INTO Civilization_UnitClassOverrides_BarbarianDisabler (UnitClassType_Temp) VALUE
+	-- Barbarians cannot spawn any civilian units
+	-- The civilian units below also cannot be captured from Barbarians
 	('UNITCLASS_WORKBOAT'),
 	('UNITCLASS_CARAVAN'),
 	('UNITCLASS_CARGO_SHIP'),
@@ -134,13 +131,12 @@ INSERT INTO Civilization_UnitClassOverrides_BarbarianDisabler (UnitClassType_Tem
 	('UNITCLASS_ENGINEER'),
 	('UNITCLASS_ARCHAEOLOGIST'),
 	('UNITCLASS_PROPHET'),
-	('UNITCLASS_MISSIONARY'),
-	('UNITCLASS_INQUISITOR'),
 	('UNITCLASS_SS_COCKPIT'),
 	('UNITCLASS_SS_STASIS_CHAMBER'),
 	('UNITCLASS_SS_ENGINE'),
 	('UNITCLASS_SS_BOOSTER'),
 
+	-- Combat units that cannot be spawned by Barbarians
 	-- Slingers, since they have a unique Archer
 	('UNITCLASS_VP_SLINGER'),
 


### PR DESCRIPTION
It should be possible to capture Barbarian Missionaries, Inquisitors and Settlers (will be converted to workers). The units that can't be captured are great people, trade units, workboats and spaceship parts.