### PR TITLE
Fixes for DOW popup and combat preview screen

### DIFF
--- a/(1) Community Patch/(1) Community Patch (v 111).modinfo
+++ b/(1) Community Patch/(1) Community Patch (v 111).modinfo
@@ -176,6 +176,7 @@
     <File md5="2EDB54EB7721D8240EAF44B71BCE74D6" import="1">Core Files/CoreLua/SaveMenu.lua</File>
     <File md5="FB5ADB053B50EFAC805CCB9EE0425137" import="1">Core Files/CoreLua/SaveMenu.xml</File>
     <File md5="F4BD8D98536B2532C02E1CA4EC1732CF" import="1">Core Files/CoreLua/StagingRoom.lua</File>
+    <File md5="F4630AA3D9462EBDAEC9A2FC5398F0D2" import="1">Core Files/CoreLua/WorldView.lua</File>
     <File md5="8335771F2F933D06C126C246A481A978" import="0">Core Files/PNM Mods DB/API/Achievements.xml</File>
     <File md5="2F0CA9C27CCDF3A00B38107099EC5742" import="0">Core Files/PNM Mods DB/API/Espionage.xml</File>
     <File md5="232B281E961C2031E95F462EA7375099" import="0">Core Files/PNM Mods DB/API/Extensions.sql</File>

--- a/(1) Community Patch/Core Files/CoreLua/EnemyUnitPanel.lua
+++ b/(1) Community Patch/Core Files/CoreLua/EnemyUnitPanel.lua
@@ -3547,7 +3547,7 @@ function OnMouseOverHex( hexX, hexY )
 								pUnit = pPlot:GetUnit(i);
 								if (pUnit ~= nil and not pUnit:IsInvisible(iTeam, false)) then
 
-									local validLandAttack = (pHeadUnit:GetDomainType() == DomainTypes.DOMAIN_LAND) and (pUnit:GetDomainType() == DomainTypes.DOMAIN_LAND);
+									local validLandAttack = (pHeadUnit:GetDomainType() == DomainTypes.DOMAIN_LAND) and not pPlot:IsWater();
 									local validSeaAttack = (pHeadUnit:GetDomainType() == DomainTypes.DOMAIN_SEA) and (pUnit:GetDomainType() == DomainTypes.DOMAIN_SEA or pUnit:IsEmbarked());
 									local validAirAttack = (pHeadUnit:GetDomainType() == DomainTypes.DOMAIN_AIR);
 
@@ -3575,7 +3575,7 @@ function OnMouseOverHex( hexX, hexY )
 					end
 				end
 			-- ranged attack, need to check correct domain etc
-			elseif (pHeadUnit:CanEverRangeStrikeAt(pPlot:GetX(), pPlot:GetY())) then
+			elseif (pHeadUnit:CanEverRangeStrikeAt(pPlot:GetX(), pPlot:GetY()) and not pHeadUnit:IsEmbarked()) then
 
 				local iTeam = Game.GetActiveTeam()
 				local pTeam = Teams[iTeam]

--- a/(1) Community Patch/Core Files/CoreLua/WorldView.lua
+++ b/(1) Community Patch/Core Files/CoreLua/WorldView.lua
@@ -1,65 +1,23 @@
--- modified by bc1 from 1.0.3.144 brave new world code
--- partial fix for sub visibility
 -------------------------------------------------
--- World View
+-- World View 
 -------------------------------------------------
 include( "FLuaVector" );
-local Vector2 = Vector2
-local Vector4 = Vector4
 
-local print = print
-local type = type
-
-local ButtonPopupTypes = ButtonPopupTypes
-local CityUpdateTypes = CityUpdateTypes
-local CommandTypes = CommandTypes
-local ContextPtr = ContextPtr
-local DomainTypes = DomainTypes
-local Events = Events
-local Game = Game
-local GameInfo = GameInfo
-local GameInfoTypes = GameInfoTypes
-local GameMessageTypes = GameMessageTypes
-local InStrategicView = InStrategicView
-local InterfaceModeTypes = InterfaceModeTypes
-local KeyEvents = KeyEvents
-local Keys = Keys
-local Map = Map
-local MissionTypes = MissionTypes
-local MouseEvents = MouseEvents
-local Players = Players
-local TaskTypes = TaskTypes
-local ToGridFromHex = ToGridFromHex
-local ToggleStrategicView = ToggleStrategicView
-local UI = UI
-local UIManager = UIManager
-
-local gk_mode = Game.GetReligionName ~= nil;--bc1
-
+local g_pathFromSelectedUnitToMouse = nil;
 local turn1Color = Vector4( 0, 1, 0, 0.25 );
+local turn2Color = Vector4( 1, 1, 0, 0.25 );
+local turn3PlusColor = Vector4( 0.25, 0, 1, 0.25 );
+local maxRangeColor = Vector4( 1, 1, 1, 0.25 );
 local rButtonDown = false;
 local bEatNextUp = false;
 
 local pathBorderStyle = "MovementRangeBorder";
 local attackPathBorderStyle = "AMRBorder"; -- attack move
-
--- VP/bal : for ctrl + click action
-local WaypointPathColor = Vector4( 1, 1, 0, 1 ); -- Yellow
-
-local buildAcademy = GameInfoTypes["BUILD_ACADEMY"];
-local buildArchaeology = GameInfoTypes["BUILD_ARCHAEOLOGY_DIG"];
-local buildCitadel = GameInfoTypes["BUILD_CITADEL"];
-local buildOrdo = GameInfoTypes["BUILD_MONGOLIA_ORDO"];
-local buildCustomsHouse = GameInfoTypes["BUILD_CUSTOMS_HOUSE"];
-local buildEmbassy = GameInfoTypes["BUILD_EMBASSY"];
-local buildHolySite = GameInfoTypes["BUILD_HOLY_SITE"];
-local buildManufactory = GameInfoTypes["BUILD_MANUFACTORY"];
-local buildRepair = GameInfoTypes["BUILD_REPAIR"];
-
+         
 function UpdatePathFromSelectedUnitToMouse()
 	local interfaceMode = UI.GetInterfaceMode();
 	--Events.ClearHexHighlightStyle(pathBorderStyle);
-	--if interfaceMode == InterfaceModeTypes.INTERFACEMODE_SELECTION and rButtonDown) or (interfaceMode == InterfaceModeTypes.INTERFACEMODE_MOVE_TO then
+	--if (interfaceMode == InterfaceModeTypes.INTERFACEMODE_SELECTION and rButtonDown) or (interfaceMode == InterfaceModeTypes.INTERFACEMODE_MOVE_TO) then
 		--for i, pathNode in ipairs(g_pathFromSelectedUnitToMouse) do
 			--local hexID = ToHexFromGrid( Vector2( pathNode.x, pathNode.y) );
 			--if pathNode.turn == 1 then
@@ -70,38 +28,21 @@ function UpdatePathFromSelectedUnitToMouse()
 				--Events.SerialEventHexHighlight( hexID, true, turn3PlusColor, pathBorderStyle );
 			--end
 		--end
-
+	
 		-- this doesnt work because the size of the array is irrelevant
-		--if #g_pathFromSelectedUnitToMouse > 0 then
+		--if ( #g_pathFromSelectedUnitToMouse > 0 ) then
 			--Events.DisplayMovementIndicator( true );
 		--else
 			--Events.DisplayMovementIndicator( false );
 		--end
 	--end
-
-	if rButtonDown and interfaceMode == InterfaceModeTypes.INTERFACEMODE_SELECTION or interfaceMode == InterfaceModeTypes.INTERFACEMODE_MOVE_TO then
+	
+	if (interfaceMode == InterfaceModeTypes.INTERFACEMODE_SELECTION and rButtonDown) or (interfaceMode == InterfaceModeTypes.INTERFACEMODE_MOVE_TO) then
 		Events.DisplayMovementIndicator( true );
 	else
 		Events.DisplayMovementIndicator( false );
 	end
-
-end
-
-function UpdatePathFromWaypointToMouse()
-    Events.ClearHexHighlights()
-	local pUnit = UI.GetHeadSelectedUnit()
-	local pPlot = Map.GetPlot( UI.GetMouseOverHex() )
-
-	if (pUnit:GetX() ~= pPlot:GetX() or pUnit:GetY() ~= pPlot:GetY()) and rButtonDown then
-		local path = pUnit:GeneratePathToNextWaypoint(pPlot)
-		for i = 1, #path, 1 do 
-			local node = path[i]
---			print("i :"..tostring(i)..", X: "..tostring(node.X)..", Y: "..tostring(node.Y))
-			Events.SerialEventHexHighlight(ToHexFromGrid({x = node.X, y = node.Y}), true, WaypointPathColor)
-		end
---		Events.GameplayFX(hex.x, hex.y, -1);
---		Events.DisplayMovementIndicator( false );
-	end
+	
 end
 
 function ShowMovementRangeIndicator()
@@ -109,7 +50,7 @@ function ShowMovementRangeIndicator()
 	if not unit then
 		return;
 	end
-
+	
 	local iPlayerID = Game.GetActivePlayer();
 
 	Events.ShowMovementRange( iPlayerID, unit:GetID() );
@@ -117,7 +58,7 @@ end
 
 -- Add any interface modes that need special processing to this table
 -- (look at InGame.lua for a bigger example)
-local InterfaceModeMessageHandler =
+local InterfaceModeMessageHandler = 
 {
 	[InterfaceModeTypes.INTERFACEMODE_DEBUG] = {},
 	[InterfaceModeTypes.INTERFACEMODE_SELECTION] = {},
@@ -145,50 +86,50 @@ local DefaultMessageHandler = {};
 
 
 DefaultMessageHandler[KeyEvents.KeyDown] =
-function( wParam )
-	if wParam == Keys.VK_LEFT then
+function( wParam, lParam )
+	if ( wParam == Keys.VK_LEFT ) then
 		Events.SerialEventCameraStopMovingRight();
 		Events.SerialEventCameraStartMovingLeft();
 		return true;
-	elseif wParam == Keys.VK_RIGHT then
+	elseif ( wParam == Keys.VK_RIGHT ) then
 		Events.SerialEventCameraStopMovingLeft();
 		Events.SerialEventCameraStartMovingRight();
 		return true;
-	elseif wParam == Keys.VK_UP then
+	elseif ( wParam == Keys.VK_UP ) then
 		Events.SerialEventCameraStopMovingBack();
 		Events.SerialEventCameraStartMovingForward();
 		return true;
-	elseif wParam == Keys.VK_DOWN then
+	elseif ( wParam == Keys.VK_DOWN ) then
 		Events.SerialEventCameraStopMovingForward();
 		Events.SerialEventCameraStartMovingBack();
 		return true;
-	elseif wParam == Keys.VK_NEXT or wParam == Keys.VK_OEM_MINUS then
+	elseif ( wParam == Keys.VK_NEXT or wParam == Keys.VK_OEM_MINUS ) then
 		Events.SerialEventCameraOut( Vector2(0,0) );
 		return true;
-	elseif wParam == Keys.VK_PRIOR or wParam == Keys.VK_OEM_PLUS then
+	elseif ( wParam == Keys.VK_PRIOR or wParam == Keys.VK_OEM_PLUS ) then
 		Events.SerialEventCameraIn( Vector2(0,0) );
 		return true;
-	elseif wParam == Keys.VK_ESCAPE and InStrategicView() then
+	elseif ( wParam == Keys.VK_ESCAPE and InStrategicView() ) then
 		ToggleStrategicView();
-		return true;
+        return true;
 	end
 end
 
 
 DefaultMessageHandler[KeyEvents.KeyUp] =
-function( wParam )
-	if wParam == Keys.VK_LEFT then
+function( wParam, lParam )
+	if ( wParam == Keys.VK_LEFT ) then
 		Events.SerialEventCameraStopMovingLeft();
-		return true;
-	elseif wParam == Keys.VK_RIGHT then
+        return true;
+	elseif ( wParam == Keys.VK_RIGHT ) then
 		Events.SerialEventCameraStopMovingRight();
-		return true;
-	elseif wParam == Keys.VK_UP then
+        return true;
+	elseif ( wParam == Keys.VK_UP ) then
 		Events.SerialEventCameraStopMovingForward();
-		return true;
-	elseif wParam == Keys.VK_DOWN then
+        return true;
+	elseif ( wParam == Keys.VK_DOWN ) then
 		Events.SerialEventCameraStopMovingBack();
-		return true;
+        return true;
 	end
 	return false;
 end
@@ -196,54 +137,53 @@ end
 
 -- Emergency key up handler
 function KeyUpHandler( wParam )
-	if wParam == Keys.VK_LEFT then
+	if ( wParam == Keys.VK_LEFT ) then
 		Events.SerialEventCameraStopMovingLeft();
-	elseif wParam == Keys.VK_RIGHT then
+	elseif ( wParam == Keys.VK_RIGHT ) then
 		Events.SerialEventCameraStopMovingRight();
-	elseif wParam == Keys.VK_UP then
+	elseif ( wParam == Keys.VK_UP ) then
 		Events.SerialEventCameraStopMovingForward();
-	elseif wParam == Keys.VK_DOWN then
+	elseif ( wParam == Keys.VK_DOWN ) then
 		Events.SerialEventCameraStopMovingBack();
 	end
 end
 Events.KeyUpEvent.Add( KeyUpHandler );
 
 -- INTERFACEMODE_DEBUG
---local g_PlopperSettings, g_UnitPlopper, g_ResourcePlopper, g_ImprovementPlopper, g_CityPlopper
 
 g_UnitPlopper =
 {
 	UnitType = -1,
 	Embarked = false,
-
+	
 	Plop =
 	function(plot)
-		if g_PlopperSettings.Player ~= -1 and g_UnitPlopper.UnitType ~= -1 then
+		if (g_PlopperSettings.Player ~= -1 and g_UnitPlopper.UnitType ~= -1) then
 			local player = Players[g_PlopperSettings.Player];
-			if player then
+			if (player ~= nil) then
 				local unit;
-
+				
 				print(g_UnitPlopper.UnitNameOffset);
 				print(player.InitUnitWithNameOffset);
-				if g_UnitPlopper.UnitNameOffset and player.InitUnitWithNameOffset then
+				if(g_UnitPlopper.UnitNameOffset ~= nil and player.InitUnitWithNameOffset ~= nil) then
 					unit = player:InitUnitWithNameOffset(g_UnitPlopper.UnitType, g_UnitPlopper.UnitNameOffset, plot:GetX(), plot:GetY());
 				else
 					unit = player:InitUnit(g_UnitPlopper.UnitType, plot:GetX(), plot:GetY());
-				end
-
-				if g_UnitPlopper.Embarked then
+				end 
+						
+				if (g_UnitPlopper.Embarked) then
 					unit:Embark();
 				end
 			end
 		end
 	end,
-
+	
 	Deplop =
 	function(plot)
 		local unitCount = plot:GetNumUnits();
 		for i = 0, unitCount - 1 do
 			local unit = plot:GetUnit(i);
-			if unit then
+			if unit ~= nil then
 				unit:Kill(true, -1);
 			end
 		end
@@ -254,14 +194,14 @@ g_ResourcePlopper =
 {
 	ResourceType = -1,
 	ResourceAmount = 1,
-
+	
 	Plop =
 	function(plot)
-		if g_ResourcePlopper.ResourceType ~= -1 then
+		if (g_ResourcePlopper.ResourceType ~= -1) then
 			plot:SetResourceType(g_ResourcePlopper.ResourceType, g_ResourcePlopper.ResourceAmount);
 		end
 	end,
-
+	
 	Deplop =
 	function(plot)
 		plot:SetResourceType(-1);
@@ -273,17 +213,17 @@ g_ImprovementPlopper =
 	ImprovementType = -1,
 	Pillaged = false,
 	HalfBuilt = false,
-
+	
 	Plop =
 	function(plot)
-		if g_ImprovementPlopper.ImprovementType ~= -1 then
+		if (g_ImprovementPlopper.ImprovementType ~= -1) then
 			plot:SetImprovementType(g_ImprovementPlopper.ImprovementType);
-			if g_ImprovementPlopper.Pillaged then
+			if (g_ImprovementPlopper.Pillaged) then
 				plot:SetImprovementPillaged(true);
 			end
 		end
 	end,
-
+	
 	Deplop =
 	function(plot)
 		plot:SetImprovementType(-1);
@@ -294,18 +234,18 @@ g_CityPlopper =
 {
 	Plop =
 	function(plot)
-		if g_PlopperSettings.Player ~= -1 then
+		if (g_PlopperSettings.Player ~= -1) then
 			local player = Players[g_PlopperSettings.Player];
-			if player then
+			if (player ~= nil) then
 				player:InitCity(plot:GetX(), plot:GetY());
 			end
 		end
 	end,
-
+	
 	Deplop =
 	function(plot)
 		local city = plot:GetPlotCity();
-		if city then
+		if (city ~= nil) then
 			city:Kill();
 		end
 	end
@@ -318,47 +258,47 @@ g_PlopperSettings =
 	EnabledWhenInTab = false
 }
 
-InterfaceModeMessageHandler[InterfaceModeTypes.INTERFACEMODE_DEBUG][MouseEvents.LButtonUp] =
-function()
+InterfaceModeMessageHandler[InterfaceModeTypes.INTERFACEMODE_DEBUG][MouseEvents.LButtonUp] = 
+function( wParam, lParam )
 	local plot = Map.GetPlot( UI.GetMouseOverHex() );
 	local plotX = plot:GetX();
 	local plotY = plot:GetY();
 	local pActivePlayer = Players[Game.GetActivePlayer()];
 	local debugItem1 = UI.GetInterfaceModeDebugItemID1();
-
+	
 	-- City
-	if UI.debugItem1 == 0 then
+	if (UI.debugItem1 == 0) then
 		pActivePlayer:InitCity(plotX, plotY);
 	-- Unit
-	elseif debugItem1 == 1 then
+	elseif (debugItem1 == 1) then
 		local iUnitID = UI.GetInterfaceModeDebugItemID2();
 		pActivePlayer:InitUnit(iUnitID, plotX, plotY);
 	-- Improvement
-	elseif debugItem1 == 2 then
+	elseif (debugItem1 == 2) then
 		local iImprovementID = UI.GetInterfaceModeDebugItemID2();
 		plot:SetImprovementType(iImprovementID);
 	-- Route
-	elseif debugItem1 == 3 then
+	elseif (debugItem1 == 3) then
 		local iRouteID = UI.GetInterfaceModeDebugItemID2();
 		plot:SetRouteType(iRouteID);
 	-- Feature
-	elseif debugItem1 == 4 then
+	elseif (debugItem1 == 4) then
 		local iFeatureID = UI.GetInterfaceModeDebugItemID2();
 		plot:SetFeatureType(iFeatureID);
 	-- Resource
-	elseif debugItem1 == 5 then
+	elseif (debugItem1 == 5) then
 		local iResourceID = UI.GetInterfaceModeDebugItemID2();
 		plot:SetResourceType(iResourceID, 5);
 	-- Plopper
 	elseif (debugItem1 == 6 and
-			type(g_PlopperSettings) == "table" and
-			type(g_PlopperSettings.Plopper) == "table" and
-			type(g_PlopperSettings.Plopper.Plop) == "function") then
-
+	        type(g_PlopperSettings) == "table" and
+	        type(g_PlopperSettings.Plopper) == "table" and
+	        type(g_PlopperSettings.Plopper.Plop) == "function") then
+	        
 		g_PlopperSettings.Plopper.Plop(plot);
 		return true; -- Do not allow the interface mode to be set back to INTERFACEMODE_SELECTION
 	end
-
+	
 	UI.SetInterfaceMode(InterfaceModeTypes.INTERFACEMODE_SELECTION);
 	return true;
 end
@@ -367,35 +307,37 @@ end
 -- RIGHT MOUSE BUTTON
 ----------------------------------
 
-InterfaceModeMessageHandler[InterfaceModeTypes.INTERFACEMODE_DEBUG][MouseEvents.RButtonDown] =
-function()
+InterfaceModeMessageHandler[InterfaceModeTypes.INTERFACEMODE_DEBUG][MouseEvents.RButtonDown] = 
+function( wParam, lParam )
 	local plot = Map.GetPlot( UI.GetMouseOverHex() );
+	local plotX = plot:GetX();
+	local plotY = plot:GetY();
 	local debugItem1 = UI.GetInterfaceModeDebugItemID1();
-
+	
 	-- Plopper
 	if (debugItem1 == 6 and
-			type(g_PlopperSettings) == "table" and
-			type(g_PlopperSettings.Plopper) == "table" and
-			type(g_PlopperSettings.Plopper.Deplop) == "function") then
-
+	        type(g_PlopperSettings) == "table" and
+	        type(g_PlopperSettings.Plopper) == "table" and
+	        type(g_PlopperSettings.Plopper.Deplop) == "function") then
+	        
 		g_PlopperSettings.Plopper.Deplop(plot);
 	end
-
+	
 	return true;
 end
 
-InterfaceModeMessageHandler[InterfaceModeTypes.INTERFACEMODE_DEBUG][MouseEvents.RButtonUp] =
-function()
+InterfaceModeMessageHandler[InterfaceModeTypes.INTERFACEMODE_DEBUG][MouseEvents.RButtonUp] = 
+function( wParam, lParam )
 	-- Trap RButtonUp
 	return true;
 end
 
-InterfaceModeMessageHandler[InterfaceModeTypes.INTERFACEMODE_RANGE_ATTACK][KeyEvents.KeyDown] =
+InterfaceModeMessageHandler[InterfaceModeTypes.INTERFACEMODE_RANGE_ATTACK][KeyEvents.KeyDown] = 
 function( wParam, lParam )
-	if wParam == Keys.VK_ESCAPE then
+	if ( wParam == Keys.VK_ESCAPE ) then
 		UI.SetInterfaceMode(InterfaceModeTypes.INTERFACEMODE_SELECTION);
 		return true;
-	elseif wParam == Keys.VK_NUMPAD1 or wParam == Keys.VK_NUMPAD3 or wParam == Keys.VK_NUMPAD4 or wParam == Keys.VK_NUMPAD6 or wParam == Keys.VK_NUMPAD7 or wParam == Keys.VK_NUMPAD8 then
+	elseif (wParam == Keys.VK_NUMPAD1 or wParam == Keys.VK_NUMPAD3 or wParam == Keys.VK_NUMPAD4 or wParam == Keys.VK_NUMPAD6 or wParam == Keys.VK_NUMPAD7 or wParam == Keys.VK_NUMPAD8 ) then
 		UI.SetInterfaceMode(InterfaceModeTypes.INTERFACEMODE_SELECTION);
 		return DefaultMessageHandler[KeyEvents.KeyDown]( wParam, lParam );
 	else
@@ -403,13 +345,13 @@ function( wParam, lParam )
 	end
 end
 
-InterfaceModeMessageHandler[InterfaceModeTypes.INTERFACEMODE_CITY_RANGE_ATTACK][KeyEvents.KeyDown] =
+InterfaceModeMessageHandler[InterfaceModeTypes.INTERFACEMODE_CITY_RANGE_ATTACK][KeyEvents.KeyDown] = 
 function( wParam, lParam )
-	if wParam == Keys.VK_ESCAPE then
+	if ( wParam == Keys.VK_ESCAPE ) then
 		UI.ClearSelectedCities();
 		UI.SetInterfaceMode(InterfaceModeTypes.INTERFACEMODE_SELECTION);
 		return true;
-	elseif wParam == Keys.VK_NUMPAD1 or wParam == Keys.VK_NUMPAD3 or wParam == Keys.VK_NUMPAD4 or wParam == Keys.VK_NUMPAD6 or wParam == Keys.VK_NUMPAD7 or wParam == Keys.VK_NUMPAD8 then
+	elseif (wParam == Keys.VK_NUMPAD1 or wParam == Keys.VK_NUMPAD3 or wParam == Keys.VK_NUMPAD4 or wParam == Keys.VK_NUMPAD6 or wParam == Keys.VK_NUMPAD7 or wParam == Keys.VK_NUMPAD8 ) then
 		UI.ClearSelectedCities();
 		UI.SetInterfaceMode(InterfaceModeTypes.INTERFACEMODE_SELECTION);
 		return DefaultMessageHandler[KeyEvents.KeyDown]( wParam, lParam );
@@ -419,19 +361,24 @@ function( wParam, lParam )
 end
 
 -- this is a default handler for all Interface Modes that correspond to a mission
-function missionTypeLButtonUpHandler()
-	local plot = Map.GetPlot( UI.GetMouseOverHex() )
+function missionTypeLButtonUpHandler( wParam, lParam )
+	local plot = Map.GetPlot( UI.GetMouseOverHex() );
 	if plot then
-		local interfaceMode = UI.GetInterfaceMode()
-		if UI.CanDoInterfaceMode(interfaceMode) then
-			local eInterfaceModeMission = GameInfoTypes[(GameInfo.InterfaceModes[interfaceMode] or {}).Mission]
-			if eInterfaceModeMission and eInterfaceModeMission ~= MissionTypes.NO_MISSION then
-				Game.SelectionListGameNetMessage( GameMessageTypes.GAMEMESSAGE_PUSH_MISSION, eInterfaceModeMission, plot:GetX(), plot:GetY(), 0, false, UIManager:GetShift() )
+		local plotX = plot:GetX();
+		local plotY = plot:GetY();
+		local bShift = UIManager:GetShift();
+		local interfaceMode = UI.GetInterfaceMode();
+		local eInterfaceModeMission = GameInfoTypes[GameInfo.InterfaceModes[interfaceMode].Mission];
+		if eInterfaceModeMission ~= MissionTypes.NO_MISSION then
+			if UI.CanDoInterfaceMode(interfaceMode) then
+				Game.SelectionListGameNetMessage(GameMessageTypes.GAMEMESSAGE_PUSH_MISSION, eInterfaceModeMission, plotX, plotY, 0, false, bShift);
+				UI.SetInterfaceMode(InterfaceModeTypes.INTERFACEMODE_SELECTION);
+				return true;
 			end
 		end
 	end
-	UI.SetInterfaceMode(InterfaceModeTypes.INTERFACEMODE_SELECTION)
-	return true
+	UI.SetInterfaceMode(InterfaceModeTypes.INTERFACEMODE_SELECTION);
+	return true;
 end
 
 InterfaceModeMessageHandler[InterfaceModeTypes.INTERFACEMODE_MOVE_TO][MouseEvents.LButtonUp] = missionTypeLButtonUpHandler;
@@ -445,7 +392,7 @@ InterfaceModeMessageHandler[InterfaceModeTypes.INTERFACEMODE_AIRSTRIKE][MouseEve
 InterfaceModeMessageHandler[InterfaceModeTypes.INTERFACEMODE_AIR_SWEEP][MouseEvents.LButtonUp] = missionTypeLButtonUpHandler;
 InterfaceModeMessageHandler[InterfaceModeTypes.INTERFACEMODE_REBASE][MouseEvents.LButtonUp] = missionTypeLButtonUpHandler;
 
-if UI.IsTouchScreenEnabled() then
+if (UI.IsTouchScreenEnabled()) then
 InterfaceModeMessageHandler[InterfaceModeTypes.INTERFACEMODE_MOVE_TO][MouseEvents.PointerUp] = missionTypeLButtonUpHandler;
 InterfaceModeMessageHandler[InterfaceModeTypes.INTERFACEMODE_MOVE_TO_TYPE][MouseEvents.PointerUp] = missionTypeLButtonUpHandler;
 InterfaceModeMessageHandler[InterfaceModeTypes.INTERFACEMODE_MOVE_TO_ALL][MouseEvents.PointerUp] = missionTypeLButtonUpHandler;
@@ -459,33 +406,34 @@ InterfaceModeMessageHandler[InterfaceModeTypes.INTERFACEMODE_REBASE][MouseEvents
 end
 
 
-function AirStrike()
+function AirStrike( wParam, lParam )
 	local plot = Map.GetPlot( UI.GetMouseOverHex() );
 	local plotX = plot:GetX();
 	local plotY = plot:GetY();
 	local pHeadSelectedUnit = UI.GetHeadSelectedUnit();
 	local bShift = UIManager:GetShift();
-
+	local interfaceMode = InterfaceModeTypes.INTERFACEMODE_RANGE_ATTACK;
+	
 	-- Don't let the user do a ranged attack on a plot that contains some fighting.
 	if plot:IsFighting() then
 		return true;
 	end
-
+		
 	-- should handle the case of units bombarding tiles when they are already at war
 	if pHeadSelectedUnit and pHeadSelectedUnit:CanRangeStrikeAt(plotX, plotY, true, true) then
 		local interfaceMode = UI.GetInterfaceMode();
 		local eInterfaceModeMission = GameInfoTypes[GameInfo.InterfaceModes[interfaceMode].Mission];
 		Game.SelectionListGameNetMessage(GameMessageTypes.GAMEMESSAGE_PUSH_MISSION, eInterfaceModeMission, plotX, plotY, 0, false, bShift);
-		UI.SetInterfaceMode(InterfaceModeTypes.INTERFACEMODE_SELECTION);
+    	UI.SetInterfaceMode(InterfaceModeTypes.INTERFACEMODE_SELECTION);
 		return true;
 	-- Unit Range Strike - special case for declaring war with range strike
 	elseif pHeadSelectedUnit and pHeadSelectedUnit:CanRangeStrikeAt(plotX, plotY, false, true) then
 		-- Is there someone here that we COULD bombard, perhaps?
 		local eRivalTeam = pHeadSelectedUnit:GetDeclareWarRangeStrike(plot);
-		if eRivalTeam ~= -1 then
+		if (eRivalTeam ~= -1) then							
 			UIManager:SetUICursor(0);
-
-			local popupInfo =
+			
+			local popupInfo = 
 			{
 				Type  = ButtonPopupTypes.BUTTONPOPUP_DECLAREWARRANGESTRIKE,
 				Data1 = eRivalTeam,
@@ -493,44 +441,45 @@ function AirStrike()
 				Data3 = plotY
 			};
 			Events.SerialEventGameMessagePopup(popupInfo);
-			UI.SetInterfaceMode(InterfaceModeTypes.INTERFACEMODE_SELECTION);
-			return true;
+        	UI.SetInterfaceMode(InterfaceModeTypes.INTERFACEMODE_SELECTION);
+			return true;	
 		end
 	end
-
+						
 	return true;
 end
 InterfaceModeMessageHandler[InterfaceModeTypes.INTERFACEMODE_AIRSTRIKE][MouseEvents.LButtonUp] = AirStrike;
-if UI.IsTouchScreenEnabled() then
+if (UI.IsTouchScreenEnabled()) then
 	InterfaceModeMessageHandler[InterfaceModeTypes.INTERFACEMODE_AIRSTRIKE][MouseEvents.PointerUp] = AirStrike;
 end
 
 
-function RangeAttack()
+function RangeAttack( wParam, lParam )
 	local plot = Map.GetPlot( UI.GetMouseOverHex() );
 	local plotX = plot:GetX();
 	local plotY = plot:GetY();
 	local pHeadSelectedUnit = UI.GetHeadSelectedUnit();
 	local bShift = UIManager:GetShift();
-
+	local interfaceMode = InterfaceModeTypes.INTERFACEMODE_RANGE_ATTACK;
+	
 	-- Don't let the user do a ranged attack on a plot that contains some fighting.
 	if plot:IsFighting() then
 		return true;
 	end
-
+		
 	-- should handle the case of units bombarding tiles when they are already at war
 	if pHeadSelectedUnit and pHeadSelectedUnit:CanRangeStrikeAt(plotX, plotY, true, true) then
 		Game.SelectionListGameNetMessage(GameMessageTypes.GAMEMESSAGE_PUSH_MISSION, MissionTypes.MISSION_RANGE_ATTACK, plotX, plotY, 0, false, bShift);
-		UI.SetInterfaceMode(InterfaceModeTypes.INTERFACEMODE_SELECTION);
+    	UI.SetInterfaceMode(InterfaceModeTypes.INTERFACEMODE_SELECTION);
 		return true;
 	-- Unit Range Strike - special case for declaring war with range strike
 	elseif pHeadSelectedUnit and pHeadSelectedUnit:CanRangeStrikeAt(plotX, plotY, false, true) then
 		-- Is there someone here that we COULD bombard, perhaps?
 		local eRivalTeam = pHeadSelectedUnit:GetDeclareWarRangeStrike(plot);
-		if eRivalTeam ~= -1 then
+		if (eRivalTeam ~= -1) then		
 			UIManager:SetUICursor(0);
-
-			local popupInfo =
+							
+			local popupInfo = 
 			{
 				Type  = ButtonPopupTypes.BUTTONPOPUP_DECLAREWARRANGESTRIKE,
 				Data1 = eRivalTeam,
@@ -538,32 +487,33 @@ function RangeAttack()
 				Data3 = plotY
 			};
 			Events.SerialEventGameMessagePopup(popupInfo);
-			UI.SetInterfaceMode(InterfaceModeTypes.INTERFACEMODE_SELECTION);
-			return true;
+        	UI.SetInterfaceMode(InterfaceModeTypes.INTERFACEMODE_SELECTION);
+			return true;	
 		end
 	end
-
+						
 	return true;
 end
 
 InterfaceModeMessageHandler[InterfaceModeTypes.INTERFACEMODE_RANGE_ATTACK][MouseEvents.LButtonUp] = RangeAttack;
-if UI.IsTouchScreenEnabled() then
+if (UI.IsTouchScreenEnabled()) then
 	InterfaceModeMessageHandler[InterfaceModeTypes.INTERFACEMODE_RANGE_ATTACK][MouseEvents.PointerUp] = RangeAttack;
 end
-
-function CityBombard()
+function CityBombard( wParam, lParam )
 	local plot = Map.GetPlot( UI.GetMouseOverHex() );
 	local plotX = plot:GetX();
 	local plotY = plot:GetY();
 	local pHeadSelectedCity = UI.GetHeadSelectedCity();
-
+	local bShift = UIManager:GetShift();
+	local interfaceMode = InterfaceModeTypes.INTERFACEMODE_CITY_RANGE_ATTACK;
+	
 	-- Don't let the user do a ranged attack on a plot that contains some fighting.
 	if plot:IsFighting() then
 		UI.ClearSelectedCities();
-		UI.SetInterfaceMode(InterfaceModeTypes.INTERFACEMODE_SELECTION);
+    	UI.SetInterfaceMode(InterfaceModeTypes.INTERFACEMODE_SELECTION);
 		return true;
 	end
-
+		
 	if pHeadSelectedCity and pHeadSelectedCity:CanRangeStrike() then
 		if pHeadSelectedCity:CanRangeStrikeAt(plotX,plotY, true, true) then
 			Game.SelectedCitiesGameNetMessage(GameMessageTypes.GAMEMESSAGE_DO_TASK, TaskTypes.TASK_RANGED_ATTACK, plotX, plotY);
@@ -571,27 +521,27 @@ function CityBombard()
 			Events.SpecificCityInfoDirty( activePlayerID, pHeadSelectedCity:GetID(), CityUpdateTypes.CITY_UPDATE_TYPE_BANNER);
 		end
 		UI.ClearSelectedCities();
-		UI.SetInterfaceMode(InterfaceModeTypes.INTERFACEMODE_SELECTION);
+    	UI.SetInterfaceMode(InterfaceModeTypes.INTERFACEMODE_SELECTION);
 		return true;
-	end
-
+	end	
+	
 	return true;
 end
 InterfaceModeMessageHandler[InterfaceModeTypes.INTERFACEMODE_CITY_RANGE_ATTACK][MouseEvents.LButtonUp] = CityBombard;
-if UI.IsTouchScreenEnabled() then
+if (UI.IsTouchScreenEnabled()) then
 	InterfaceModeMessageHandler[InterfaceModeTypes.INTERFACEMODE_CITY_RANGE_ATTACK][MouseEvents.PointerUp] = CityBombard;
 end
 
 -- If the user presses the right mouse button when in city range attack mode, make sure and clear the
 -- mode and also clear the selection.
-InterfaceModeMessageHandler[InterfaceModeTypes.INTERFACEMODE_CITY_RANGE_ATTACK][MouseEvents.RButtonUp] =
-function ()
+InterfaceModeMessageHandler[InterfaceModeTypes.INTERFACEMODE_CITY_RANGE_ATTACK][MouseEvents.RButtonUp] = 
+function ( wParam, lParam )
 	UI.ClearSelectedCities();
-	UI.SetInterfaceMode(InterfaceModeTypes.INTERFACEMODE_SELECTION);
+   	UI.SetInterfaceMode(InterfaceModeTypes.INTERFACEMODE_SELECTION);
 	return true;
 end
 
-function EmbarkInputHandler()
+function EmbarkInputHandler( wParam, lParam )
 	local plot = Map.GetPlot( UI.GetMouseOverHex() );
 	local plotX = plot:GetX();
 	local plotY = plot:GetY();
@@ -599,22 +549,22 @@ function EmbarkInputHandler()
 	local bShift = UIManager:GetShift();
 
 	if pHeadSelectedUnit then
-		if pHeadSelectedUnit:CanEmbarkOnto(pHeadSelectedUnit:GetPlot(), plot) then
+		if (pHeadSelectedUnit:CanEmbarkOnto(pHeadSelectedUnit:GetPlot(), plot)) then
 			Game.SelectionListGameNetMessage(GameMessageTypes.GAMEMESSAGE_PUSH_MISSION, MissionTypes.MISSION_EMBARK, plotX, plotY, 0, false, bShift);
 		end
 	end
-
+	
 	UI.SetInterfaceMode(InterfaceModeTypes.INTERFACEMODE_SELECTION);
 end
 -- Have either right or left click trigger this
 InterfaceModeMessageHandler[InterfaceModeTypes.INTERFACEMODE_EMBARK][MouseEvents.LButtonUp] = EmbarkInputHandler;
 InterfaceModeMessageHandler[InterfaceModeTypes.INTERFACEMODE_EMBARK][MouseEvents.RButtonUp] = EmbarkInputHandler;
 
-if UI.IsTouchScreenEnabled() then
+if (UI.IsTouchScreenEnabled()) then
 	InterfaceModeMessageHandler[InterfaceModeTypes.INTERFACEMODE_EMBARK][MouseEvents.PointerUp] = EmbarkInputHandler;
 end
 
-function DisembarkInputHandler()
+function DisembarkInputHandler( wParam, lParam )
 	local plot = Map.GetPlot( UI.GetMouseOverHex() );
 	local plotX = plot:GetX();
 	local plotY = plot:GetY();
@@ -622,20 +572,22 @@ function DisembarkInputHandler()
 	local bShift = UIManager:GetShift();
 
 	if pHeadSelectedUnit then
-		if pHeadSelectedUnit:CanDisembarkOnto(plot) then
+		if (pHeadSelectedUnit:CanDisembarkOnto(plot)) then
 			Game.SelectionListGameNetMessage(GameMessageTypes.GAMEMESSAGE_PUSH_MISSION, MissionTypes.MISSION_DISEMBARK, plotX, plotY, 0, false, bShift);
 		end
 	end
-
+	
 	UI.SetInterfaceMode(InterfaceModeTypes.INTERFACEMODE_SELECTION);
 end
 -- Have either right or left click trigger this
 InterfaceModeMessageHandler[InterfaceModeTypes.INTERFACEMODE_DISEMBARK][MouseEvents.LButtonUp] = DisembarkInputHandler;
 InterfaceModeMessageHandler[InterfaceModeTypes.INTERFACEMODE_DISEMBARK][MouseEvents.RButtonUp] = DisembarkInputHandler;
 
-if UI.IsTouchScreenEnabled() then
+if (UI.IsTouchScreenEnabled()) then
 	InterfaceModeMessageHandler[InterfaceModeTypes.INTERFACEMODE_DISEMBARK][MouseEvents.PointerUp] = DisembarkInputHandler;
 end
+
+
 
 
 
@@ -658,25 +610,20 @@ end
 
 
 
-InterfaceModeMessageHandler[InterfaceModeTypes.INTERFACEMODE_SELECTION][MouseEvents.RButtonDown] =
-function()
-	local bShift = UIManager:GetShift();
+InterfaceModeMessageHandler[InterfaceModeTypes.INTERFACEMODE_SELECTION][MouseEvents.RButtonDown] = 
+function( wParam, lParam )
 	ShowMovementRangeIndicator();
 	UI.SendPathfinderUpdate();
-	if bShift then
-		UpdatePathFromWaypointToMouse();
-	else
-		UpdatePathFromSelectedUnitToMouse();
-	end
+	UpdatePathFromSelectedUnitToMouse();
 end
 
-if UI.IsTouchScreenEnabled() then
-InterfaceModeMessageHandler[InterfaceModeTypes.INTERFACEMODE_SELECTION][MouseEvents.LButtonDoubleClick] =
-function()
-	if UI.GetHeadSelectedUnit() then
-		UI.SetInterfaceMode( InterfaceModeTypes.INTERFACEMODE_MOVE_TO );
-		bEatNextUp = true;
-	end
+if (UI.IsTouchScreenEnabled()) then
+InterfaceModeMessageHandler[InterfaceModeTypes.INTERFACEMODE_SELECTION][MouseEvents.LButtonDoubleClick] = 
+function( wParam, lParam )
+    if( UI.GetHeadSelectedUnit() ~= NULL ) then
+	    UI.SetInterfaceMode( InterfaceModeTypes.INTERFACEMODE_MOVE_TO );
+	    bEatNextUp = true;
+    end
 end
 end
 
@@ -685,20 +632,21 @@ function ClearAllHighlights()
 	Events.ClearHexHighlightStyle("");
 	Events.ClearHexHighlightStyle(pathBorderStyle);
 	Events.ClearHexHighlightStyle(attackPathBorderStyle);
---Events.ClearHexHighlightStyle(genericUnitHexBorder);
+	Events.ClearHexHighlightStyle(genericUnitHexBorder);  
 	Events.ClearHexHighlightStyle("FireRangeBorder");
 	Events.ClearHexHighlightStyle("GroupBorder");
 	Events.ClearHexHighlightStyle("ValidFireTargetBorder");
 end
 
-function MovementRButtonUp()
-	if bEatNextUp == true then
-		bEatNextUp = false;
-		return;
-	end
-	if UI.IsTouchScreenEnabled() then
-		UI.SetInterfaceMode( InterfaceModeTypes.INTERFACEMODE_SELECTION );
-	end
+
+function MovementRButtonUp( wParam, lParam )
+    if( bEatNextUp == true ) then
+        bEatNextUp = false;
+        return;
+    end
+    if (UI.IsTouchScreenEnabled()) then
+    	UI.SetInterfaceMode( InterfaceModeTypes.INTERFACEMODE_SELECTION );
+    end
 	local bShift = UIManager:GetShift();
 	local bAlt = UIManager:GetAlt();
 	local bCtrl = UIManager:GetControl();
@@ -706,38 +654,32 @@ function MovementRButtonUp()
 	if not plot then
 		return true;
 	end
-
+	
 	local plotX = plot:GetX();
 	local plotY = plot:GetY();
 	local pHeadSelectedUnit = UI.GetHeadSelectedUnit();
-	local pUnitClass = pHeadSelectedUnit:GetUnitClassType()
-	local pUnitID = pHeadSelectedUnit:GetID()
 	UpdatePathFromSelectedUnitToMouse();
---	if bShift then
---		UpdatePathFromWaypointToMouse();
---	else
---		UpdatePathFromSelectedUnitToMouse();
---	end
-			
+
 	if pHeadSelectedUnit then
-		if UI.IsCameraMoving() and not Game.GetAllowRClickMovementWhileScrolling() then
+		if (UI.IsCameraMoving() and not Game.GetAllowRClickMovementWhileScrolling()) then
 			print("Blocked by moving camera");
 			--Events.ClearHexHighlights();
 			ClearAllHighlights();
 			return;
 		end
-
+	
 		Game.SetEverRightClickMoved(true);
-
+	
 		local bBombardEnemy = false;
 
 		-- Is there someone here that we COULD bombard perhaps?
 		local eRivalTeam = pHeadSelectedUnit:GetDeclareWarRangeStrike(plot);
 		-- Don't bombard if we can move peacefully to the plot
 		if eRivalTeam ~= -1 and not pHeadSelectedUnit:CanMoveOrAttackInto(plot, 1, 1) then
-			UIManager:SetUICursor(0);
 
-			local popupInfo =
+			UIManager:SetUICursor(0);
+										
+			local popupInfo = 
 			{
 				Type  = ButtonPopupTypes.BUTTONPOPUP_DECLAREWARRANGESTRIKE,
 				Data1 = eRivalTeam,
@@ -748,49 +690,29 @@ function MovementRButtonUp()
 			return true;
 		end
 
-		-- rebase with RCLICK
-		if pHeadSelectedUnit:GetDomainType() == DomainTypes.DOMAIN_AIR and pHeadSelectedUnit:CanRebaseAt(0, plotX, plotY) then
-			Game.SelectionListGameNetMessage(GameMessageTypes.GAMEMESSAGE_PUSH_MISSION, MissionTypes.MISSION_REBASE, plotX, plotY);				
-		end
-
 		-- Visible enemy... bombardment?
-		if plot:IsVisibleEnemyUnit(pHeadSelectedUnit:GetOwner()) or plot:IsEnemyCity(pHeadSelectedUnit) then
-
+		if (plot:IsVisibleEnemyUnit(pHeadSelectedUnit:GetOwner()) or plot:IsEnemyCity(pHeadSelectedUnit)) then		
+			
 			local bNoncombatAllowed = false;
-
+			
 			if plot:IsFighting() then
 				return true;		-- Already some combat going on in there, just exit
 			end
-
+			
 			if pHeadSelectedUnit:CanRangeStrikeAt(plotX, plotY, true, bNoncombatAllowed) then
-
+				
 				local iMission;
-				if pHeadSelectedUnit:GetDomainType() == DomainTypes.DOMAIN_AIR then
+				if (pHeadSelectedUnit:GetDomainType() == DomainTypes.DOMAIN_AIR) then
 					iMission = MissionTypes.MISSION_MOVE_TO;		-- Air strikes are moves... yep
 				else
 					iMission = MissionTypes.MISSION_RANGE_ATTACK;
 				end
-
+				
 				Game.SelectionListGameNetMessage(GameMessageTypes.GAMEMESSAGE_PUSH_MISSION, iMission, plotX, plotY, 0, false, bShift);
 				UI.SetInterfaceMode(InterfaceModeTypes.INTERFACEMODE_SELECTION);
 				--Events.ClearHexHighlights();
 				ClearAllHighlights();
 				return true;
-			end
-		end
-
-		if not gk_mode then
-			-- Garrison in a city
-			local city = plot:GetPlotCity();
-			if city and city:GetOwner() == pHeadSelectedUnit:GetOwner() and pHeadSelectedUnit:IsCanAttack() then
-				local cityOwner = Players[city:GetOwner()];
-				if not cityOwner:IsMinorCiv() and city:GetGarrisonedUnit() == nil and pHeadSelectedUnit:GetDomainType() == DomainTypes.DOMAIN_LAND then
-					--print("Garrison attempt");
-					Game.SelectionListGameNetMessage(GameMessageTypes.GAMEMESSAGE_PUSH_MISSION, MissionTypes.MISSION_GARRISON, plotX, plotY, 0, false, bShift);
-					UI.SetInterfaceMode(InterfaceModeTypes.INTERFACEMODE_SELECTION);
-					ClearAllHighlights();
-					return true;
-				end
 			end
 		end
 
@@ -800,67 +722,6 @@ function MovementRButtonUp()
 			if bShift == false and pHeadSelectedUnit:AtPlot(plot) then
 				--print("Game.SelectionListGameNetMessage(GameMessageTypes.GAMEMESSAGE_DO_COMMAND, CommandTypes.COMMAND_CANCEL_ALL);");
 				Game.SelectionListGameNetMessage(GameMessageTypes.GAMEMESSAGE_DO_COMMAND, CommandTypes.COMMAND_CANCEL_ALL);
-
-			-- VP: QoL key+click combinations 
-			elseif bShift and not bCtrl then -- VP/bal: holding down shift queues move orders
-				Game.SelectionListGameNetMessage(GameMessageTypes.GAMEMESSAGE_PUSH_MISSION, MissionTypes.MISSION_MOVE_TO, plotX, plotY, 0, false, true);				
-
-			elseif bCtrl then --VP/bal: ctrl+click gives move&activate orders (e.g. move&alert, move&improve resource). ctrl+shift+click queues 
-				if pHeadSelectedUnit:IsCanAttack() then
-					Game.SelectionListGameNetMessage(GameMessageTypes.GAMEMESSAGE_PUSH_MISSION, MissionTypes.MISSION_MOVE_TO, plotX, plotY, 0, false, bShift);				
-					Game.SelectionListGameNetMessage(GameMessageTypes.GAMEMESSAGE_PUSH_MISSION, MissionTypes.MISSION_ALERT, plotX, plotY, 0, false, true);				
-
-				elseif pUnitClass == GameInfoTypes["UNITCLASS_ARCHAEOLOGIST"] and pHeadSelectedUnit:CanBuild(plot, buildArchaeology) then
-					Game.SelectionListGameNetMessage(GameMessageTypes.GAMEMESSAGE_PUSH_MISSION, MissionTypes.MISSION_MOVE_TO, plotX, plotY, 0, false, bShift);				
-					Game.SelectionListGameNetMessage(GameMessageTypes.GAMEMESSAGE_PUSH_MISSION, MissionTypes.MISSION_BUILD, buildArchaeology, pUnitID, 0, false, true);				
-		
-				elseif pUnitClass == GameInfoTypes["UNITCLASS_WORKER"] or pUnitClass == GameInfoTypes["UNITCLASS_WORKBOAT"] then
-					local build = nil
-					if plot:IsImprovementPillaged() or plot:IsRoutePillaged() then
-						build = buildRepair
-					elseif plot:GetResourceType() ~= NO_RESOURCE then
-						build = plot:GetBuildTypeNeededToImproveResource()
-					end
-					Game.SelectionListGameNetMessage(GameMessageTypes.GAMEMESSAGE_PUSH_MISSION, MissionTypes.MISSION_MOVE_TO, plotX, plotY, 0, false, bShift);				
-					Game.SelectionListGameNetMessage(GameMessageTypes.GAMEMESSAGE_PUSH_MISSION, MissionTypes.MISSION_BUILD, build, pUnitID, 0, false, true);				
-
-				elseif pUnitClass == GameInfoTypes["UNITCLASS_MISSIONARY"] then
-					Game.SelectionListGameNetMessage(GameMessageTypes.GAMEMESSAGE_PUSH_MISSION, MissionTypes.MISSION_MOVE_TO, plotX, plotY, 0, false, bShift);				
-					Game.SelectionListGameNetMessage(GameMessageTypes.GAMEMESSAGE_PUSH_MISSION, MissionTypes.MISSION_SPREAD_RELIGION, plotX, plotY, 0, false, true);				
-
-				elseif pUnitClass == GameInfoTypes["UNITCLASS_INQUISITOR"] then
-					Game.SelectionListGameNetMessage(GameMessageTypes.GAMEMESSAGE_PUSH_MISSION, MissionTypes.MISSION_MOVE_TO, plotX, plotY, 0, false, bShift);				
-					Game.SelectionListGameNetMessage(GameMessageTypes.GAMEMESSAGE_PUSH_MISSION, MissionTypes.MISSION_REMOVE_HERESY, plotX, plotY, 0, false, true);				
-
-				elseif pHeadSelectedUnit:GetUnitCombatType() == GameInfoTypes["UNITCOMBAT_DIPLOMACY"] then
-					Game.SelectionListGameNetMessage(GameMessageTypes.GAMEMESSAGE_PUSH_MISSION, MissionTypes.MISSION_MOVE_TO, plotX, plotY, 0, false, bShift);				
-					Game.SelectionListGameNetMessage(GameMessageTypes.GAMEMESSAGE_PUSH_MISSION, MissionTypes.MISSION_TRADE, plotX, plotY, 0, false, true);				
-
-				elseif pHeadSelectedUnit:IsGreatPerson() then
-					local build = nil
-					if pUnitClass == GameInfoTypes["UNITCLASS_ENGINEER"] then
-						build = buildManufactory
-					elseif pUnitClass == GameInfoTypes["UNITCLASS_SCIENTIST"] then
-						build = buildAcademy
-					elseif pUnitClass == GameInfoTypes["UNITCLASS_PROPHET"] then	
-						build = buildHolySite
-					elseif pUnitClass == GameInfoTypes["UNITCLASS_GREAT_GENERAL"] then
-						if pHeadSelectedUnit:GetUnitType() ==  GameInfoTypes["UNIT_MONGOLIAN_KHAN"] then
-							build = buildOrdo
-						else
-							build = buildCitadel
-						end
-					elseif pUnitClass == GameInfoTypes["UNITCLASS_MERCHANT"] then
-						build = buildCustomsHouse
-					elseif pUnitClass == GameInfoTypes["UNITCLASS_GREAT_DIPLOMAT"] then
-						build = buildEmbassy
-					else
-						Game.SelectionListGameNetMessage(GameMessageTypes.GAMEMESSAGE_PUSH_MISSION, MissionTypes.MISSION_MOVE_TO, plotX, plotY, 0, false, bShift);				
-					end
-					Game.SelectionListGameNetMessage(GameMessageTypes.GAMEMESSAGE_PUSH_MISSION, MissionTypes.MISSION_MOVE_TO, plotX, plotY, 0, false, bShift);				
-					Game.SelectionListGameNetMessage(GameMessageTypes.GAMEMESSAGE_PUSH_MISSION, MissionTypes.MISSION_BUILD, build, pUnitID, 0, false, true);				
-				end -- VP end
-
 			else--if plot == UI.GetGotoPlot() then
 				--print("Game.SelectionListMove(plot,  bAlt, bShift, bCtrl);");
 				Game.SelectionListMove(plot,  bAlt, bShift, bCtrl);
@@ -876,52 +737,54 @@ end
 InterfaceModeMessageHandler[InterfaceModeTypes.INTERFACEMODE_SELECTION][MouseEvents.RButtonUp] = MovementRButtonUp;
 InterfaceModeMessageHandler[InterfaceModeTypes.INTERFACEMODE_MOVE_TO][MouseEvents.RButtonUp] = MovementRButtonUp;
 
-if UI.IsTouchScreenEnabled() then
+if (UI.IsTouchScreenEnabled()) then
 	InterfaceModeMessageHandler[InterfaceModeTypes.INTERFACEMODE_MOVE_TO][MouseEvents.PointerUp] = MovementRButtonUp;
 end
 
 
-function EjectHandler()
+function EjectHandler( wParam, lParam )
 	local plot = Map.GetPlot( UI.GetMouseOverHex() );
+	local plotX = plot:GetX();
+	local plotY = plot:GetY();
 	--print("INTERFACEMODE_PLACE_UNIT");
 
 	local unit = UI.GetPlaceUnit();
-	UI.ClearPlaceUnit();
+	UI.ClearPlaceUnit();	
 	local returnValue = false;
-
-	if unit then
-		local city = unit:GetPlot():GetPlotCity();
-		if city then
+		
+	if (unit ~= nil) then
+		local city = unitPlot:GetPlotCity();
+		if (city ~= nil) then
 			if UI.CanPlaceUnitAt(unit, plot) then
 				--Network.SendCityEjectGarrisonChoice(city:GetID(), plotX, plotY);
-				returnValue =  true;
+				returnValue =  true;					
 			end
 		end
 	end
-
+	
 	UI.SetInterfaceMode(InterfaceModeTypes.INTERFACEMODE_SELECTION);
-
+	
 	return returnValue;
 end
 InterfaceModeMessageHandler[InterfaceModeTypes.INTERFACEMODE_PLACE_UNIT][MouseEvents.LButtonUp] = EjectHandler;
 InterfaceModeMessageHandler[InterfaceModeTypes.INTERFACEMODE_PLACE_UNIT][MouseEvents.RButtonUp] = EjectHandler;
 
-if UI.IsTouchScreenEnabled() then
+if (UI.IsTouchScreenEnabled()) then
 	InterfaceModeMessageHandler[InterfaceModeTypes.INTERFACEMODE_PLACE_UNIT][MouseEvents.PointerUp] = EjectHandler;
 end
 
-function SelectHandler()
+function SelectHandler( wParam, lParam )
 	UI.SetInterfaceMode(InterfaceModeTypes.INTERFACEMODE_SELECTION);
 end
 
 DefaultMessageHandler[MouseEvents.RButtonUp] = SelectHandler;
-if UI.IsTouchScreenEnabled() then
+if (UI.IsTouchScreenEnabled()) then
 	DefaultMessageHandler[MouseEvents.PointerUp] = SelectHandler;
 end
-
-
+    
+    
 ----------------------------------------------------------------
--- Input handling
+-- Input handling 
 ----------------------------------------------------------------
 function InputHandler( uiMsg, wParam, lParam )
 	if uiMsg == MouseEvents.RButtonDown then
@@ -929,12 +792,12 @@ function InputHandler( uiMsg, wParam, lParam )
 	elseif uiMsg == MouseEvents.RButtonUp then
 		rButtonDown = false;
 	end
-	if UI.IsTouchScreenEnabled() and uiMsg == MouseEvents.PointerDown then
-		if UIManager:GetNumPointers() > 1 then
+	if( UI.IsTouchScreenEnabled() and uiMsg == MouseEvents.PointerDown ) then
+	    if( UIManager:GetNumPointers() > 1 ) then
 			UI.SetInterfaceMode(InterfaceModeTypes.INTERFACEMODE_SELECTION);
 	   end
 	end
-
+	
 	local interfaceMode = UI.GetInterfaceMode();
 	local currentInterfaceModeHandler = InterfaceModeMessageHandler[interfaceMode];
 	if currentInterfaceModeHandler and currentInterfaceModeHandler[uiMsg] then
@@ -946,28 +809,21 @@ function InputHandler( uiMsg, wParam, lParam )
 end
 ContextPtr:SetInputHandler( InputHandler );
 
+---------------------------------------------------------------- 
+-- Deal with a new path from the path finder 
+-- this is a place holder implementation to give an example of how to handle it       
 ----------------------------------------------------------------
--- Deal with a new path from the path finder
--- this is a place holder implementation to give an example of how to handle it
-----------------------------------------------------------------
-function OnUIPathFinderUpdate()
---	UpdatePathFromSelectedUnitToMouse();
-	local bShift = UIManager:GetShift();
-	if bShift then
-		UpdatePathFromWaypointToMouse();
-	else
-		UpdatePathFromSelectedUnitToMouse();
-	end
+function OnUIPathFinderUpdate( thePath )
+	--g_pathFromSelectedUnitToMouse = thePath;
+	UpdatePathFromSelectedUnitToMouse();
 end
 Events.UIPathFinderUpdate.Add( OnUIPathFinderUpdate );
 
-function OnMouseMoveHex()
-	local interfaceMode = UI.GetInterfaceMode();
-	local bShift = UIManager:GetShift();
-	if not bShift and rButtonDown and interfaceMode == InterfaceModeTypes.INTERFACEMODE_SELECTION or interfaceMode == InterfaceModeTypes.INTERFACEMODE_MOVE_TO then
+function OnMouseMoveHex( hexX, hexY )
+	--local pPlot = Map.GetPlot( hexX, hexY);
+	local interfaceMode = UI.GetInterfaceMode();	
+	if (interfaceMode == InterfaceModeTypes.INTERFACEMODE_SELECTION and rButtonDown) or (interfaceMode == InterfaceModeTypes.INTERFACEMODE_MOVE_TO) then
 		UI.SendPathfinderUpdate();
-	elseif bShift and rButtonDown and interfaceMode == InterfaceModeTypes.INTERFACEMODE_SELECTION or interfaceMode == InterfaceModeTypes.INTERFACEMODE_MOVE_TO then
-		UpdatePathFromWaypointToMouse()
 	end
 end
 Events.SerialEventMouseOverHex.Add( OnMouseMoveHex );
@@ -984,8 +840,8 @@ function OnStartUnitMoveHexRange()
 end
 Events.StartUnitMoveHexRange.Add( OnStartUnitMoveHexRange );
 
-function OnAddUnitMoveHexRangeHex(i, j, k, attackMove)
-	if attackMove and Map.GetPlot(ToGridFromHex(i, j)):IsVisibleEnemyUnit(Game.GetActivePlayer()) then
+function OnAddUnitMoveHexRangeHex(i, j, k, attackMove, unitID)
+	if attackMove then
 		Events.SerialEventHexHighlight( Vector2( i, j ), true, turn1Color, attackPathBorderStyle );
 	else
 		Events.SerialEventHexHighlight( Vector2( i, j ), true, turn1Color, pathBorderStyle );
@@ -1000,37 +856,41 @@ local g_PerPlayerStrategicViewSettings = {}
 -- 'Active' (local human) player has changed
 ----------------------------------------------------------------
 function OnActivePlayerChanged(iActivePlayer, iPrevActivePlayer)
-
-	if iPrevActivePlayer ~= -1 then
-		g_PerPlayerStrategicViewSettings[ iPrevActivePlayer ] = InStrategicView();
+	
+	if (iPrevActivePlayer ~= -1) then
+		g_PerPlayerStrategicViewSettings[ iPrevActivePlayer + 1 ] = InStrategicView();
 	end
-
-	if iActivePlayer ~= -1 and not g_PerPlayerStrategicViewSettings[ iActivePlayer ] == InStrategicView() then
-		ToggleStrategicView();
+	
+	if (iActivePlayer ~= -1 ) then
+		if (g_PerPlayerStrategicViewSettings[ iActivePlayer + 1] and not InStrategicView()) then
+			ToggleStrategicView();
+		else
+			if (not g_PerPlayerStrategicViewSettings[ iActivePlayer + 1] and InStrategicView()) then
+				ToggleStrategicView();
+			end
+		end
 	end
 end
 Events.GameplaySetActivePlayer.Add(OnActivePlayerChanged);
 
 -------------------------------------------------
-if gk_mode then
-	function OnMultiplayerGameAbandoned(eReason)
-		local popupInfo =
-		{
-			Type  = ButtonPopupTypes.BUTTONPOPUP_KICKED,
-			Data1 = eReason
-		};
+function OnMultiplayerGameAbandoned(eReason)
+	local popupInfo = 
+	{
+		Type  = ButtonPopupTypes.BUTTONPOPUP_KICKED,
+		Data1 = eReason
+	};
 
-		Events.SerialEventGameMessagePopup(popupInfo);
-		UI.SetInterfaceMode(InterfaceModeTypes.INTERFACEMODE_SELECTION);
-	end
-	Events.MultiplayerGameAbandoned.Add( OnMultiplayerGameAbandoned );
+	Events.SerialEventGameMessagePopup(popupInfo);
+    UI.SetInterfaceMode(InterfaceModeTypes.INTERFACEMODE_SELECTION);
 end
+Events.MultiplayerGameAbandoned.Add( OnMultiplayerGameAbandoned );
 
 -------------------------------------------------
 function OnMultiplayerGameLastPlayer()
-	UI.AddPopup( { Type = ButtonPopupTypes.BUTTONPOPUP_TEXT,
-	Data1 = 800,
-	Option1 = true,
+	UI.AddPopup( { Type = ButtonPopupTypes.BUTTONPOPUP_TEXT, 
+	Data1 = 800, 
+	Option1 = true, 
 	Text = "TXT_KEY_MP_LAST_PLAYER" } );
 end
 Events.MultiplayerGameLastPlayer.Add( OnMultiplayerGameLastPlayer );

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -4961,72 +4961,95 @@ bool CvUnit::canEnterTerrain(const CvPlot& enterPlot, int iMoveFlags) const
 TeamTypes CvUnit::GetDeclareWarMove(const CvPlot& plot) const
 {
 	VALIDATE_OBJECT
-	CvAssert(isHuman());
+		CvAssert(isHuman());
 
-	if(getDomainType() != DOMAIN_AIR)
+	if (getDomainType() != DOMAIN_AIR)
 	{
+		// trying to enter foreign territory without open borders?
 		TeamTypes eRevealedTeam = plot.getRevealedTeam(getTeam(), false);
-
-		if(eRevealedTeam != NO_TEAM)
+		if (eRevealedTeam != NO_TEAM)
 		{
-			if(!canEnterTerritory(eRevealedTeam))
+			if (!canEnterTerritory(eRevealedTeam))
 			{
-				if(GET_TEAM(getTeam()).canDeclareWar(plot.getTeam(), getOwner()))
+				if (GET_TEAM(getTeam()).canDeclareWar(plot.getTeam(), getOwner()))
 				{
 					return eRevealedTeam;
 				}
 			}
 		}
 
-		if(plot.getNumUnits() > 0)
+		if (plot.isActiveVisible())
 		{
-			int iPeaceCivilians = 0;
-			bool bWarCity = false;
-			bool bWarUnit = false;
-			if(plot.isCity() && GET_TEAM(GET_PLAYER(plot.getOwner()).getTeam()).isAtWar(getTeam()))
+			TeamTypes eTeamAttack = NO_TEAM;
+			if (plot.isCity())
 			{
-				bWarCity = true;
+				eTeamAttack = plot.getTeam();
 			}
-
-			for(int iUnitLoop = 0; iUnitLoop < plot.getNumUnits(); iUnitLoop++)
+			else
 			{
-				CvUnit* loopUnit = plot.getUnitByIndex(iUnitLoop);
-				if(loopUnit != NULL)
+				//can't attack if not in native domain or plot not accessible
+				if (isNativeDomain(&plot) && canMoveInto(plot, MOVEFLAG_IGNORE_ENEMIES))
 				{
-					if(GET_TEAM(getTeam()).isAtWar(loopUnit->getTeam()))
+					// do not declare war if plot can be entered peacefully
+					if (!canMoveInto(plot, MOVEFLAG_DESTINATION))
 					{
-						bWarUnit = true;
-					}
-					else if(loopUnit->IsCivilianUnit())
-					{
-						iPeaceCivilians++;
+						if (IsCanAttackWithMove())
+						{
+							// check which units are on the tile
+							// there can only be one land unit, one naval unit and one embarked unit on each tile
+							// civilian units are ignored
+							if (plot.getNumUnits() > 0)
+							{
+								TeamTypes eLandUnitTeam = NO_TEAM;
+								TeamTypes eNavalUnitTeam = NO_TEAM;
+								TeamTypes eEmbarkedUnitTeam = NO_TEAM;
+
+								for (int iUnitLoop = 0; iUnitLoop < plot.getNumUnits(); iUnitLoop++)
+								{
+									CvUnit* loopUnit = plot.getUnitByIndex(iUnitLoop);
+									if (loopUnit != NULL)
+									{
+										if (loopUnit->IsCombatUnit())
+										{
+											if (loopUnit->isEmbarked())
+											{
+												eEmbarkedUnitTeam = loopUnit->getTeam();
+											}
+											else if (loopUnit->getDomainType() == DOMAIN_LAND)
+											{
+												eLandUnitTeam = loopUnit->getTeam();
+											}
+											else
+											{
+												eNavalUnitTeam = loopUnit->getTeam();
+											}
+										}
+									}
+								}
+
+								// attack priority: first land unit, than naval unit, than embarked unit
+								if (eLandUnitTeam != NO_TEAM) {
+									eTeamAttack = eLandUnitTeam;
+								}
+								else
+								{
+									if (eNavalUnitTeam != NO_TEAM) {
+										eTeamAttack = eNavalUnitTeam;
+									}
+									else
+									{
+										eTeamAttack = eEmbarkedUnitTeam;
+									}
+								}
+							}
+						}
 					}
 				}
 			}
-
-			//If there is a civlian and an enemy unit here (or this is an enemy city), but we're at peace with that civilian
-			//return NO_TEAM (don't need to declare war again!)
-			if(iPeaceCivilians > 0 && (bWarCity || bWarUnit))
-			{
-				return NO_TEAM;
-			}
-
-			//If there are only civilians here, don't require a declaration of war (can do so manually if intended)
-			if (iPeaceCivilians==plot.getNumUnits())
-			{
-				return NO_TEAM;
-			}
-		}
-
-		if(plot.isActiveVisible())
-		{
-			if(canMoveInto(plot, MOVEFLAG_ATTACK))
-			{
-				const CvUnit* pUnit = plot.plotCheck(PUF_canDeclareWar, getOwner(), isAlwaysHostile(plot), NO_PLAYER, NO_TEAM, PUF_isVisible, getOwner());
-
-				if(pUnit != NULL)
+			if (eTeamAttack != NO_TEAM) {
+				if (GET_TEAM(getTeam()).canDeclareWar(eTeamAttack, getOwner()))
 				{
-					return pUnit->getTeam();
+					return eTeamAttack;
 				}
 			}
 		}
@@ -5040,67 +5063,71 @@ TeamTypes CvUnit::GetDeclareWarMove(const CvPlot& plot) const
 TeamTypes CvUnit::GetDeclareWarRangeStrike(const CvPlot& plot) const
 {
 	VALIDATE_OBJECT
-	CvAssert(isHuman());
+		CvAssert(isHuman());
 
-	if(plot.isActiveVisible())
+	if (plot.isActiveVisible())
 	{
-		if(canRangeStrikeAt(plot.getX(), plot.getY(), false))
+		if (canRangeStrikeAt(plot.getX(), plot.getY(), false))
 		{
-			if(plot.getNumUnits() > 0)
+			TeamTypes eTeamAttack = NO_TEAM;
+			if (plot.isCity())
 			{
-				const CvUnit* pUnit = NULL;
-				int iPeaceUnits = 0;
-				bool bWarCity = false;
-				if(plot.isCity() && GET_TEAM(GET_PLAYER(plot.getOwner()).getTeam()).isAtWar(getTeam()))
-				{
-					bWarCity = true;
-				}
-				for(int iUnitLoop = 0; iUnitLoop < plot.getNumUnits(); iUnitLoop++)
-				{
-					CvUnit* loopUnit = plot.getUnitByIndex(iUnitLoop);
-
-					//If we're at war with a civ, and they've got a unit here, let's return that unit instead of the civilian unit on this space.
-					if(loopUnit != NULL)
-					{
-						if(loopUnit->IsCombatUnit())
-						{
-							if(GET_TEAM(getTeam()).isAtWar(loopUnit->getTeam()))
-							{
-								//There can be only one military unit on a tile, so one check is good enough.
-								pUnit = plot.getUnitByIndex(iUnitLoop);
-							}
-						}
-						else if(loopUnit->IsCivilianUnit())
-						{
-							//Only need one to trigger.
-							if(!GET_TEAM(getTeam()).isAtWar(loopUnit->getTeam()))
-							{
-								iPeaceUnits++;
-							}
-						}
-					}
-				}
-				//If there is a civlian and an enemy unit here (or this is an enemy city), but we're at peace with that civilian, return NO_TEAM.
-				if((iPeaceUnits > 0) && (bWarCity || (pUnit != NULL)))
-				{
-					return NO_TEAM;
-				}
+				eTeamAttack = plot.getTeam();
 			}
-
-			CvUnit* pUnit = plot.plotCheck(PUF_canDeclareWar, getOwner(), isAlwaysHostile(plot), NO_PLAYER, NO_TEAM, PUF_isVisible, getOwner());
-			if(pUnit != NULL)
-			{
-				return pUnit->getTeam();
-			}
-			// Check for City as well
 			else
 			{
-				if(plot.isCity())
+				// check which units are on the tile
+				// there can only be one land unit, one naval unit and one embarked unit on each tile
+				// civilian units are ignored
+				if (plot.getNumUnits() > 0)
 				{
-					if(GET_TEAM(getTeam()).canDeclareWar(plot.getTeam(), getOwner()))
+					TeamTypes eLandUnitTeam = NO_TEAM;
+					TeamTypes eNavalUnitTeam = NO_TEAM;
+					TeamTypes eEmbarkedUnitTeam = NO_TEAM;
+
+					for (int iUnitLoop = 0; iUnitLoop < plot.getNumUnits(); iUnitLoop++)
 					{
-						return plot.getTeam();
+						CvUnit* loopUnit = plot.getUnitByIndex(iUnitLoop);
+						if (loopUnit != NULL)
+						{
+							if (loopUnit->IsCombatUnit())
+							{
+								if (loopUnit->isEmbarked())
+								{
+									eEmbarkedUnitTeam = loopUnit->getTeam();
+								}
+								else if (loopUnit->getDomainType() == DOMAIN_LAND)
+								{
+									eLandUnitTeam = loopUnit->getTeam();
+								}
+								else
+								{
+									eNavalUnitTeam = loopUnit->getTeam();
+								}
+							}
+						}
 					}
+
+					// attack priority: first land unit, than naval unit, than embarked unit
+					if (eLandUnitTeam != NO_TEAM) {
+						eTeamAttack = eLandUnitTeam;
+					}
+					else
+					{
+						if (eNavalUnitTeam != NO_TEAM) {
+							eTeamAttack = eNavalUnitTeam;
+						}
+						else
+						{
+							eTeamAttack = eEmbarkedUnitTeam;
+						}
+					}
+				}
+			}
+			if (eTeamAttack != NO_TEAM) {
+				if (GET_TEAM(getTeam()).canDeclareWar(eTeamAttack, getOwner()))
+				{
+					return eTeamAttack;
 				}
 			}
 		}
@@ -29175,48 +29202,49 @@ bool CvUnit::VerifyCachedPath(const CvPlot* pDestPlot, int iFlags, int iMaxTurns
 	return IsCachedPathValid();
 }
 
-bool CvUnit::CheckDOWNeededForMove(int iX, int iY)
+bool CvUnit::CheckDOWNeededForMove(int iX, int iY, bool bPopup)
 {
 	CvMap& kMap = GC.getMap();
 	CvPlot* pDestPlot = kMap.plot(iX, iY);
 
 	// Important
-	if (at(iX,iY))
+	if (at(iX, iY))
 		return false;
 
 	// No war declarations from automated units
-	if(IsAutomated())
+	if (IsAutomated())
 		return false;
 
 	// Test if this attack requires war to be declared first
-	if(pDestPlot && isHuman() && getOwner() == GC.getGame().getActivePlayer() && pDestPlot->isVisible(getTeam()))
+	if (pDestPlot && isHuman() && getOwner() == GC.getGame().getActivePlayer() && pDestPlot->isVisible(getTeam()))
 	{
 		TeamTypes eRivalTeam = GetDeclareWarMove(*pDestPlot);
 
-		if(eRivalTeam != NO_TEAM)
+		if (eRivalTeam != NO_TEAM)
 		{
-			CvPopupInfo kPopup(BUTTONPOPUP_DECLAREWARMOVE);
-			kPopup.iData1 = eRivalTeam;
-			kPopup.iData2 = pDestPlot->getX();
-			kPopup.iData3 = pDestPlot->getY();
-			kPopup.bOption1 = false;
-			kPopup.bOption2 = pDestPlot->getTeam() != eRivalTeam;
-			if(pDestPlot->isCity())
-			{
-				kPopup.iFlags = DOW_MOVE_ONTO_CITY;
+			if (bPopup) {
+				CvPopupInfo kPopup(BUTTONPOPUP_DECLAREWARMOVE);
+				kPopup.iData1 = eRivalTeam;
+				kPopup.iData2 = pDestPlot->getX();
+				kPopup.iData3 = pDestPlot->getY();
+				kPopup.bOption1 = false;
+				kPopup.bOption2 = pDestPlot->getTeam() != eRivalTeam;
+				if (pDestPlot->isCity())
+				{
+					kPopup.iFlags = DOW_MOVE_ONTO_CITY;
+				}
+				// If a unit was present, put up the standard DOW message
+				else if (pDestPlot->isVisibleOtherUnit(m_eOwner))
+				{
+					kPopup.iFlags = DOW_MOVE_ONTO_UNIT;
+				}
+				// Otherwise put out one about entering enemy territory
+				else
+				{
+					kPopup.iFlags = DOW_MOVE_INTO_TERRITORY;
+				}
+				DLLUI->AddPopup(kPopup);
 			}
-			// If a unit was present, put up the standard DOW message
-			else if(pDestPlot->isVisibleOtherUnit(m_eOwner))
-			{
-				kPopup.iFlags = DOW_MOVE_ONTO_UNIT;
-			}
-			// Otherwise put out one about entering enemy territory
-			else
-			{
-				kPopup.iFlags = DOW_MOVE_INTO_TERRITORY;
-			}
-			DLLUI->AddPopup(kPopup);
-
 			return true;
 		}
 	}

--- a/CvGameCoreDLL_Expansion2/CvUnit.h
+++ b/CvGameCoreDLL_Expansion2/CvUnit.h
@@ -1996,7 +1996,7 @@ protected:
 	void PublishQueuedVisualizationMoves();
 
 	bool EmergencyRebase();
-	bool CheckDOWNeededForMove(int iX, int iY);
+	bool CheckDOWNeededForMove(int iX, int iY, bool bPopup = true);
 	MoveResult UnitAttackWithMove(int iX, int iY, int iFlags);
 	int UnitPathTo(int iX, int iY, int iFlags);
 	bool UnitMove(CvPlot* pPlot, bool bCombat, CvUnit* pCombatUnit, bool bEndMove = false);

--- a/CvGameCoreDLL_Expansion2/CvUnitMission.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnitMission.cpp
@@ -480,8 +480,9 @@ void CvUnitMission::ContinueMission(CvUnit* hUnit, int iSteps)
 
 			if(kMissionData.eMissionType == CvTypes::getMISSION_MOVE_TO())
 			{
-				//need to declare war first
-				if(hUnit->CheckDOWNeededForMove(pkMissionData->iData1, pkMissionData->iData2))
+				// check if we need to declare war first
+				// show a DOW popup only if the enemy unit is visible when the move order is given
+				if(hUnit->CheckDOWNeededForMove(pkMissionData->iData1, pkMissionData->iData2, iSteps == 0 && pkMissionData->iPushTurn == GC.getGame().getGameTurn()))
 				{
 					hUnit->ClearMissionQueue();
 					return;
@@ -1486,10 +1487,9 @@ void CvUnitMission::StartMission(CvUnit* hUnit)
 			{
 				//make sure the path cache is current (not for air units, their movement is actually an airstrike)
 				CvPlot* pDestPlot = GC.getMap().plot(pkQueueData->iData1, pkQueueData->iData2);
-				if (hUnit->getDomainType()!=DOMAIN_AIR && !hUnit->GeneratePath(pDestPlot, pkQueueData->iFlags))
+				if (hUnit->getDomainType()!=DOMAIN_AIR)
 				{
-					//uh? problem ... abort mission
-					bDelete = true;
+					hUnit->GeneratePath(pDestPlot, pkQueueData->iFlags);
 				}
 
 				if(pkQueueData->eMissionType == CvTypes::getMISSION_ROUTE_TO())


### PR DESCRIPTION
Changes in CvUnit:
- the popup "does this mean WAR?" does not appear if it is possible to enter a tile peacefully (tile blocked by civilians or embarked unit moving on a tile with a ship etc., fix for issue #9508 )
- when determining which player to show in the DOW popup, unit precedence is taken into account: if present on the tile, the land unit is attacked, else the naval unit, else the embarked unit (fix for issue #9513 )

Changes in CvUnitMission:
- move orders for which no path can be calculated are no longer immediately canceled (this was the reason why there was no DOW popup when trying to enter foreign territory or a tile blocked by a neutral unit)
- if a move order is given to a tile that is not visible, and it turns out during the move that the tile is blocked then no DOW popup is shown

Changes in the LUA files:
- when a ranged unit is selected and a right click is done on a tile on which the ranged unit can move although there is a neutral unit on it (e.g. a tile with a ship but no embarked unit), then the default action is movement, not declaring war. this makes the default action consistent with the UI interface, which also shows a movement path (a white circle with a number and not a red one) in those cases 
- no combat preview screen is shown for embarked ranged units and for land units moving on a water tile with a unit (no attacks possible in both cases)
- a combat preview screen is shown for land units attacking a naval unit on land (in a fort/citadel)

@RecursiveVision I want to add a file to the mod here. What exactly has to be done besides including it in the modinfo-file?