### PR TITLE
Bugfixes Unit Supply Panel and Conscription

### DIFF
--- a/(2) Vox Populi/LUA/TopPanel.lua
+++ b/(2) Vox Populi/LUA/TopPanel.lua
@@ -1375,39 +1375,31 @@ function UnitSupplyHandler(control)
 	local pPlayer = Players[iPlayerID];
 
 	local iUnitSupplyMod = pPlayer:GetUnitProductionMaintenanceMod();
-	if (iUnitSupplyMod ~= 0) then
-		local iUnitsSupplied = pPlayer:GetNumUnitsSupplied();
-		local iUnitsTotal = pPlayer:GetNumUnitsToSupply();
-		local iPercentPerPop = pPlayer:GetNumUnitsSuppliedByPopulation();
-		local iPerCity = pPlayer:GetNumUnitsSuppliedByCities();
-		local iPerHandicap = pPlayer:GetNumUnitsSuppliedByHandicap();
-		local iWarWearinessReduction = pPlayer:GetWarWeariness();
-		local iWarWearinessActualReduction = pPlayer:GetWarWearinessSupplyReduction();
-		local iTechReduction = pPlayer:GetTechSupplyReduction();
-		local iSupplyFromGreatPeople = pPlayer:GetUnitSupplyFromExpendedGreatPeople();
+	local iUnitsSupplied = pPlayer:GetNumUnitsSupplied();
+	local iUnitsTotal = pPlayer:GetNumUnitsToSupply();
+	local iPercentPerPop = pPlayer:GetNumUnitsSuppliedByPopulation();
+	local iPerCity = pPlayer:GetNumUnitsSuppliedByCities();
+	local iPerHandicap = pPlayer:GetNumUnitsSuppliedByHandicap();
+	local iWarWearinessReduction = pPlayer:GetWarWeariness();
+	local iUnitsOver = pPlayer:GetNumUnitsOutOfSupply();
+	local iWarWearinessActualReduction = pPlayer:GetWarWearinessSupplyReduction();
+	local iTechReduction = pPlayer:GetTechSupplyReduction();
+	local iSupplyFromGreatPeople = pPlayer:GetUnitSupplyFromExpendedGreatPeople();
 
-		local iUnitsOver = pPlayer:GetNumUnitsOutOfSupply();
+	local strUnitSupplyToolTip = "";
+	if(iUnitsOver > 0) then
 		strUnitSupplyToolTip = "[COLOR_NEGATIVE_TEXT]";
 		strUnitSupplyToolTip = strUnitSupplyToolTip .. Locale.ConvertTextKey("TXT_KEY_UNIT_SUPPLY_REACHED_TOOLTIP", iUnitsSupplied, iUnitsOver, -iUnitSupplyMod);
 		strUnitSupplyToolTip = strUnitSupplyToolTip .. "[ENDCOLOR]";
-
-		local strUnitSupplyToolUnderTip = Locale.ConvertTextKey("TXT_KEY_UNIT_SUPPLY_REMAINING_TOOLTIP", iUnitsSupplied, iUnitsTotal, iPercentPerPop, iPerCity, iPerHandicap, (iWarWearinessReduction / 2), iWarWearinessActualReduction, iTechReduction, iWarWearinessReduction, iSupplyFromGreatPeople);
-
-		strUnitSupplyToolTip = strUnitSupplyToolTip .. "[NEWLINE][NEWLINE]" .. strUnitSupplyToolUnderTip;
-	else
-		local iUnitsSupplied = pPlayer:GetNumUnitsSupplied();
-		local iUnitsTotal = pPlayer:GetNumUnitsToSupply();
-		local iPercentPerPop = pPlayer:GetNumUnitsSuppliedByPopulation();
-		local iPerCity = pPlayer:GetNumUnitsSuppliedByCities();
-		local iPerHandicap = pPlayer:GetNumUnitsSuppliedByHandicap();
-		local iWarWearinessReduction = pPlayer:GetWarWeariness();
-		local iWarWearinessActualReduction = pPlayer:GetWarWearinessSupplyReduction();
-		local iTechReduction = pPlayer:GetTechSupplyReduction();
-		local iSupplyFromGreatPeople = pPlayer:GetUnitSupplyFromExpendedGreatPeople();
-
-		strUnitSupplyToolTip = Locale.ConvertTextKey("TXT_KEY_UNIT_SUPPLY_REMAINING_TOOLTIP", iUnitsSupplied, iUnitsTotal, iPercentPerPop, iPerCity, iPerHandicap, iWarWearinessReduction, iWarWearinessActualReduction, iTechReduction, iSupplyFromGreatPeople);
 	end
 
+	local strUnitSupplyToolUnderTip = Locale.ConvertTextKey("TXT_KEY_UNIT_SUPPLY_REMAINING_TOOLTIP", iUnitsSupplied, iUnitsTotal, iPercentPerPop, iPerCity, iPerHandicap, (iWarWearinessReduction / 2), iWarWearinessActualReduction, iTechReduction, iWarWearinessReduction, iSupplyFromGreatPeople);
+
+	if(strUnitSupplyToolTip ~= "") then
+		strUnitSupplyToolTip = strUnitSupplyToolTip .. "[NEWLINE][NEWLINE]" .. strUnitSupplyToolUnderTip;
+	else
+		strUnitSupplyToolTip = strUnitSupplyToolUnderTip;
+	end
 	if(strUnitSupplyToolTip ~= "") then
 		tipControlTable.TopPanelMouseover:SetHide(false);
 		tipControlTable.TooltipLabel:SetText( strUnitSupplyToolTip );

--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -18643,15 +18643,10 @@ void CvCity::setPopulation(int iNewValue, bool bReassignPop /* = true */, bool b
 #if defined(MOD_BALANCE_CORE_POLICIES)
 			if (MOD_BALANCE_CORE_POLICIES && GET_PLAYER(getOwner()).GetXPopulationConscription() > 0 && !IsRazing())
 			{
-				int iDiff = foodDifference(true, true);
-
-				if (iDiff >= 0)
+				int iRemainder = (getPopulation() % GET_PLAYER(getOwner()).GetXPopulationConscription());
+				if (iRemainder == 0)
 				{
-					int iRemainder = (getPopulation() % GET_PLAYER(getOwner()).GetXPopulationConscription());
-					if (iRemainder == 0)
-					{
-						GET_PLAYER(getOwner()).DoXPopulationConscription(this);
-					}
+					GET_PLAYER(getOwner()).DoXPopulationConscription(this);
 				}
 			}
 #endif


### PR DESCRIPTION
- the non-EUI version of TopPanel.lua now uses the same code for the Military Supply Panel as the EUI version, fixing a UI bug where the supply panel wasn't shown in some cases
- fixed that units are only conscripted when the city is not starving (I assume this is a remnant of an old version... At least it's not necessary to prevent cities from conscripting units when losing population, because there's a check `if (getPopulation() > getHighestPopulation())` for that)