### PR TITLE
More city shortcuts

### DIFF
--- a/(2) Vox Populi/Balance Changes/Text/en_US/UIShortcutsCivolopedia_en_US.xml
+++ b/(2) Vox Populi/Balance Changes/Text/en_US/UIShortcutsCivolopedia_en_US.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Created by ModBuddy on 6/23/2015 12:21:44 AM -->
+<GameData>
+	<Concepts>
+		<Row>
+			<Type>CONCEPT_SHORTCUTS_INTRODUCTION</Type>
+			<Topic>TXT_KEY_TOPIC_SHORTCUT_INTRODUCTION</Topic>
+			<Description>TXT_KEY_SHORTCUT_INTRODUCTION_TITLE</Description>
+			<Summary>TXT_KEY_SHORTCUT_INTRODUCTION_BODY</Summary>
+			<CivilopediaHeaderType>HEADER_SHORTCUTS</CivilopediaHeaderType>
+			<Advisor>ECONOMIC</Advisor>
+		</Row>
+		<Row>
+			<Type>CONCEPT_SHORTCUTS_CITY_VIEW</Type>
+			<Topic>TXT_KEY_TOPIC_SHORTCUT_CITY_VIEW</Topic>
+			<Description>TXT_KEY_SHORTCUT_CITY_VIEW_TITLE</Description>
+			<Summary>TXT_KEY_SHORTCUT_CITY_VIEW_BODY</Summary>
+			<CivilopediaHeaderType>HEADER_SHORTCUTS</CivilopediaHeaderType>
+			<Advisor>ECONOMIC</Advisor>
+		</Row>
+		<Row>
+			<Type>CONCEPT_SHORTCUTS_WORLD_VIEW</Type>
+			<Topic>TXT_KEY_TOPIC_SHORTCUT_WORLD_VIEW</Topic>
+			<Description>TXT_KEY_SHORTCUT_WORLD_VIEW_TITLE</Description>
+			<Summary>TXT_KEY_SHORTCUT_WORLD_VIEW_BODY</Summary>
+			<CivilopediaHeaderType>HEADER_SHORTCUTS</CivilopediaHeaderType>
+			<Advisor>ECONOMIC</Advisor>
+		</Row>
+	</Concepts>
+	<Language_en_US>
+		<Row Tag="TXT_KEY_GAME_CONCEPT_SECTION_28">
+			<Text>[COLOR_GREEN]Input Shortcuts[ENDCOLOR]</Text>
+		</Row>
+		<Row Tag="TXT_KEY_TOPIC_SHORTCUT_INTRODUCTION">
+			<Text>Input Shortcuts</Text>
+		</Row>
+		<Row Tag="TXT_KEY_SHORTCUT_INTRODUCTION_TITLE">
+			<Text>[COLOR_GREEN]{TXT_KEY_TOPIC_SHORTCUT_INTRODUCTION}[ENDCOLOR]</Text>
+		</Row>
+		<Row Tag="TXT_KEY_SHORTCUT_INTRODUCTION_BODY">
+			<Text>A number of mouse and keyboard shortcuts are available in Vox Populi to streamline many tasks! See [COLOR_GREEN]{TXT_KEY_TOPIC_SHORTCUT_WORLD_VIEW}[ENDCOLOR] for shortcuts pertaining to unit control in the main map view. See [COLOR_GREEN]{TXT_KEY_TOPIC_SHORTCUT_CITY_VIEW}[ENDCOLOR] for shortcuts related to building construction and city management. </Text>
+		</Row>
+
+		<Row Tag="TXT_KEY_TOPIC_SHORTCUT_CITY_VIEW">
+			<Text>City View Shortcuts</Text>
+		</Row>
+		<Row Tag="TXT_KEY_SHORTCUT_CITY_VIEW_TITLE">
+			<Text>[COLOR_GREEN]{TXT_KEY_TOPIC_SHORTCUT_CITY_VIEW}[ENDCOLOR]</Text>
+		</Row>
+		<Row Tag="TXT_KEY_SHORTCUT_CITY_VIEW_BODY">
+			<Text>
+				[COLOR_POSITIVE_TEXT]Building Construction Modifiers:[ENDCOLOR] While left-clicking a building will place it at the bottom of the current cities construction queue, other actions can be accomplished with the use of modifier keys.[NEWLINE]
+				[ICON_BULLET][COLOR_CYAN]Insert Top[ENDCOLOR]: [COLOR_YELLOW]CTRL+LCLICK[ENDCOLOR] an item to add it to the top of the current cities construction queue.[NEWLINE]
+				[ICON_BULLET][COLOR_CYAN]Replace[ENDCOLOR]: [COLOR_YELLOW]SHIFT+LCLICK[ENDCOLOR] an item to replace the current cities construction queue with this item.[NEWLINE]
+				[ICON_BULLET][COLOR_CYAN]Repeat[ENDCOLOR]: [COLOR_YELLOW]ALT+LCLICK[ENDCOLOR] an item to repeat production of that item.[NEWLINE]
+				[ICON_BULLET][COLOR_CYAN]Insert Bottom All[ENDCOLOR]: [COLOR_YELLOW]SHIFT+ALT+LCLICK[ENDCOLOR] an item to add it to the bottom of every eligible cities construction queues.[NEWLINE]
+				[ICON_BULLET][COLOR_CYAN]Insert Top All[ENDCOLOR]: [COLOR_YELLOW]SHIFT+CTRL+LCLICK[ENDCOLOR] an item to add it to the top of every eligible owned cities construction queues.[NEWLINE]
+				[ICON_BULLET][COLOR_CYAN]Invest All[ENDCOLOR]: [COLOR_YELLOW]SHIFT+LCLICK[ENDCOLOR] a buildings invest button to invest in every copy of this building in any cities active construction queue.[NEWLINE]
+			</Text>
+		</Row>
+
+		<Row Tag="TXT_KEY_TOPIC_SHORTCUT_WORLD_VIEW">
+			<Text>World View Shortcuts</Text>
+		</Row>
+		<Row Tag="TXT_KEY_SHORTCUT_WORLD_VIEW_TITLE">
+			<Text>[COLOR_GREEN]{TXT_KEY_TOPIC_SHORTCUT_WORLD_VIEW}[ENDCOLOR]</Text>
+		</Row>
+		<Row Tag="TXT_KEY_SHORTCUT_WORLD_VIEW_BODY">
+			<Text>
+				[COLOR_POSITIVE_TEXT]Special Movement Actions:[ENDCOLOR] Most special movement actions such as rebasing can be executed by selecting the unit and [COLOR_YELLOW]right-clicking[ENDCOLOR] on a valid destination tile.[NEWLINE]
+				[ICON_BULLET][COLOR_CYAN]Airlift[ENDCOLOR]: With a land unit eligible to airlift selected, right click on an eligible airlift destination tile to airlift.[NEWLINE]
+				[ICON_BULLET][COLOR_CYAN]Change Home City[ENDCOLOR]: With a trade unit selected, right click on a city to change home city.[NEWLINE]
+				[ICON_BULLET][COLOR_CYAN]Change Port[ENDCOLOR]: With a Great Admiral in a city selected, right click on a coastal city to change port.[NEWLINE]
+				[ICON_BULLET][COLOR_CYAN]Rebase[ENDCOLOR]: With an air unit selected, right click on an eligible airlift destination tile to perform an airlift action.[NEWLINE]
+
+				[NEWLINE][COLOR_POSITIVE_TEXT]Move and Act Orders:[ENDCOLOR] [COLOR_YELLOW]CTRL+RCLICK[ENDCOLOR] issues a 'Move and Act' order, instructing a unit to move to the destination tile then perform their action.[NEWLINE]
+				[ICON_BULLET][COLOR_CYAN]Archaeologists[ENDCOLOR]: Archeological Dig.[NEWLINE]
+				[ICON_BULLET][COLOR_CYAN]Combat Units[ENDCOLOR]: Alert/Fortify Mode.[NEWLINE]
+				[ICON_BULLET][COLOR_CYAN]Diplomatic Units[ENDCOLOR]: Conduct Diplomatic Mission.[NEWLINE]
+				[ICON_BULLET][COLOR_CYAN]Great People[ENDCOLOR]: Construct Tile Improvement.[NEWLINE]
+				[ICON_BULLET][COLOR_CYAN]Inquisitors[ENDCOLOR]: Remove Heresy.[NEWLINE]
+				[ICON_BULLET][COLOR_CYAN]Missionaries[ENDCOLOR]: Spread Religion.[NEWLINE]
+				[ICON_BULLET][COLOR_CYAN]Workers/Workboats[ENDCOLOR]: Repair/Improve Resources.[NEWLINE]
+
+				[NEWLINE][COLOR_POSITIVE_TEXT]Queued Movement:[ENDCOLOR] Issue move orders with [COLOR_YELLOW]SHIFT+RCLICK[ENDCOLOR] to create waypoints.[NEWLINE]
+
+				[NEWLINE][COLOR_POSITIVE_TEXT]Aircraft Group Commands:[ENDCOLOR] With an aircraft unit selected, modifier keys can be used to issue commands to all aircraft of the same type in the same airbase.[NEWLINE]
+				[ICON_BULLET][COLOR_CYAN]Massed Forward Rebase[ENDCOLOR]: [COLOR_YELLOW]SHIFT+RCLICK[ENDCOLOR] on an airbase will move all aircraft to that airbase until no more slots are available or all aircraft have rebased. Higher HP aircraft are prioritized, with ties broken by unit level.[NEWLINE]
+				[ICON_BULLET][COLOR_CYAN]Massed Fallback Rebase[ENDCOLOR]: [COLOR_YELLOW]ALT+RCLICK[ENDCOLOR] on an airbase will move all damaged aircraft to target airbase until no more slots are available or all aircraft have rebased. Lower HP aircraft are prioritized.[NEWLINE]
+				[ICON_BULLET][COLOR_CYAN]Massed Strike Mode[ENDCOLOR]: [COLOR_YELLOW]SHIFT+RCLICK[ENDCOLOR] on an enemy will air strike the unit on the target hex until all aircraft have attacked or the target is dead. Attack order prioritizes higher HP aircraft, with ties being broken by unit level. Aircraft that can attack twice will do so before the next aircraft begins attacking. [NEWLINE]
+			</Text>
+		</Row>
+	</Language_en_US>
+</GameData>

--- a/(2) Vox Populi/Balance Changes/Text/en_US/VPUI_tips_en_us.xml
+++ b/(2) Vox Populi/Balance Changes/Text/en_US/VPUI_tips_en_us.xml
@@ -104,5 +104,8 @@
 		<Row Tag="TXT_KEY_VPUI_TIP_32">
 			<Text>Check the Monopoly Overview before building the East India Company. An extra luxury from the right city might give you a new monopoly.</Text>
 		</Row>
+		<Row Tag="TXT_KEY_VPUI_TIP_33">
+			<Text>Vox Populi has many shortcuts to simplify repetitive tasks! Check the Civilopedia Game Concepts "Input Shortcuts" section to learn more.</Text>
+		</Row>
 	</Language_en_US>
 </GameData>

--- a/(2) Vox Populi/Core Files/CoreLua/CivilopediaScreen.lua
+++ b/(2) Vox Populi/Core Files/CoreLua/CivilopediaScreen.lua
@@ -194,14 +194,14 @@ function SetSelectedCategory( thisCategory )
 	-- get first entry from list (this will be a special page)
 	if CivilopediaCategory[selectedCategory].DisplayHomePage then
 		CivilopediaCategory[selectedCategory].DisplayHomePage();
-	end	
+	end
 	Controls.ScrollPanel:CalculateInternalSize();
 	Controls.LeftScrollPanel:CalculateInternalSize();
 end
 
 -- CBP (adds to table that stores entries related to its civilization in a table (cannot be nil))
 function AppendCivRelationshipTable( relationshipTable, searchTable, typeColumnName, civColumnName )
-	for row in searchTable do	
+	for row in searchTable do
 		if row[typeColumnName] ~= nil and row[civColumnName] ~= nil then
 			relationshipTable[row[civColumnName]] = row[typeColumnName];
 		end
@@ -264,13 +264,13 @@ CivilopediaCategory[CategoryCorporations].labelString = Locale.Lookup("TXT_KEY_P
 
 CivilopediaCategory[CategoryHomePage].PopulateList = function()
 	sortedList[CategoryHomePage] = {};
-	
-	sortedList[CategoryHomePage][1] = {}; -- there is only one section 
-	local tableid = 1;		
-	
+
+	sortedList[CategoryHomePage][1] = {}; -- there is only one section
+	local tableid = 1;
+
 		-- for each major category
- 		for i=1, numCategories,1 do  
- 		
+ 		for i=1, numCategories,1 do
+
 			-- add an entry to a list (localized name, tag, etc.)
  			local article = {};
  			local compoundName = "TXT_KEY_PEDIA_CATEGORY_" .. tostring(i) .. "_LABEL" ;
@@ -281,7 +281,7 @@ CivilopediaCategory[CategoryHomePage].PopulateList = function()
 
 			sortedList[CategoryHomePage][1][tableid] = article;
 			tableid = tableid + 1;
-			
+
 			-- index by various keys
 			searchableList[Locale.ToLower(name)] = article;
 			searchableTextKeyList[compoundName] = article;
@@ -292,7 +292,7 @@ end
 CivilopediaCategory[CategoryGameConcepts].PopulateList = function()
 	sortedList[CategoryGameConcepts] = {};
 	local GameConceptsList = sortedList[CategoryGameConcepts];
-	
+
 	local conceptSections = {
 		HEADER_CITIES = 1,
 		HEADER_COMBAT = 2,
@@ -321,20 +321,21 @@ CivilopediaCategory[CategoryGameConcepts].PopulateList = function()
 		HEADER_WORLDCONGRESS = 25,
 -- CBP
 		HEADER_VASSALAGE = 26,
-		HEADER_CORPORATIONS = 27
+		HEADER_CORPORATIONS = 27,
+		HEADER_SHORTCUTS = 28
 -- END
 	}
-	
+
 	-- Create table.
 	for i,v in pairs(conceptSections) do
 		GameConceptsList[v] = {
 			headingOpen = false,
-		}; 
-	end	
-	
+		};
+	end
+
 	-- for each concept
 	for thisConcept in GameInfo.Concepts() do
-		
+
 		local sectionID = conceptSections[thisConcept.CivilopediaHeaderType];
 		if(sectionID ~= nil) then
 			-- add an article to the list (localized name, unit tag, etc.)
@@ -348,20 +349,20 @@ CivilopediaCategory[CategoryGameConcepts].PopulateList = function()
 			article.Type = thisConcept.Type;
 
 			table.insert(GameConceptsList[sectionID], article);
-			
+
 			-- index by various keys
 			searchableList[Locale.ToLower(name)] = article;
 			searchableTextKeyList[thisConcept.Description] = article;
 			categorizedList[(CategoryGameConcepts * absurdlyLargeNumTopicsInCategory) + thisConcept.ID] = article;
 		end
 	end
-	
+
 	-- In order to maintain the original order as best as possible,
 	-- we assign "InsertBefore" values to all items that lack any insert.
 	for _, conceptList in ipairs(GameConceptsList) do
 		for i = #conceptList, 1, -1 do
 			local concept = conceptList[i];
-			
+
 			if(concept.InsertBefore == nil and concept.InsertAfter == nil) then
 				for ii = i - 1, 1, -1 do
 					local previousConcept = conceptList[ii];
@@ -373,40 +374,40 @@ CivilopediaCategory[CategoryGameConcepts].PopulateList = function()
 			end
 		end
 	end
-	
-	
+
+
 	-- sort the articles by their dependencies.
 	function DependencySort(articles)
-		
+
 		-- index articles by Topic
 		local articlesByType= {};
 		local dependencies = {};
-		
+
 		for i,v in ipairs(articles) do
 			articlesByType[v.Type] = v;
 			dependencies[v] = {};
 		end
-		
+
 		for i,v in ipairs(articles) do
-			
+
 			local insertBefore = v.InsertBefore;
 			if(insertBefore ~= nil) then
 				local article = articlesByType[insertBefore];
 				dependencies[article][v] = true;
 			end
-			
+
 			local insertAfter = v.InsertAfter;
 			if(insertAfter ~= nil) then
 				local article = articlesByType[insertAfter];
 				dependencies[v][article] = true;
 			end
 		end
-		
+
 		local sortedList = {};
-		
+
 		local articleCount = #articles;
 		while(#sortedList < articleCount) do
-			
+
 			-- Attempt to find a node with 0 dependencies
 			local article;
 			for i,a in ipairs(articles) do
@@ -415,15 +416,15 @@ CivilopediaCategory[CategoryGameConcepts].PopulateList = function()
 					break;
 				end
 			end
-			
+
 			if(article == nil) then
 				print("Failed to sort articles topologically!! There are dependency cycles.");
 				return nil;
 			else
-			
+
 				-- Insert Node
 				table.insert(sortedList, article);
-				
+
 				-- Remove node
 				dependencies[article] = nil;
 				for a,d in pairs(dependencies) do
@@ -431,57 +432,57 @@ CivilopediaCategory[CategoryGameConcepts].PopulateList = function()
 				end
 			end
 		end
-		
+
 		return sortedList;
 	end
-		
+
 	for i,v in ipairs(GameConceptsList) do
 		local oldList = v;
 		local newList = DependencySort(v);
-	
+
 		if(newList == nil) then
 			newList = oldList;
 		else
 			newList.headingOpen = false;
 		end
-		
+
 		GameConceptsList[i] = newList;
 	end
 end
 
 CivilopediaCategory[CategoryTech].PopulateList = function()
 	-- add the instances of the tech entries
-	
+
 	sortedList[CategoryTech] = {};
-	
+
 	-- for each era
 	-- Infixo GameInfo.Eras is not updated after mods are loaded
 	--for era in GameInfo.Eras() do
 	for era in DB.Query("SELECT ID, Type FROM Eras ORDER BY ID") do
-	
+
 		local eraID = era.ID;
-	
+
 		sortedList[CategoryTech][eraID] = {};
 		local tableid = 1;
-	
+
 		-- for each tech in this era
  		for tech in GameInfo.Technologies("Era = '" .. era.Type .. "'") do
- 		
+
 			-- add a tech entry to a list (localized name, unit tag, etc.)
  			local article = {};
  			local name = Locale.ConvertTextKey( tech.Description )
  			article.entryName = name;
  			article.entryID = tech.ID;
-			article.entryCategory = CategoryTech;			
-			article.tooltipTextureOffset, article.tooltipTexture = IconLookup( tech.PortraitIndex, buttonSize, tech.IconAtlas );				
+			article.entryCategory = CategoryTech;
+			article.tooltipTextureOffset, article.tooltipTexture = IconLookup( tech.PortraitIndex, buttonSize, tech.IconAtlas );
 			if not article.tooltipTextureOffset then
 				article.tooltipTexture = defaultErrorTextureSheet;
 				article.tooltipTextureOffset = nullOffset;
-			end				
-			
+			end
+
 			sortedList[CategoryTech][eraID][tableid] = article;
 			tableid = tableid + 1;
-			
+
 			-- index by various keys
 			searchableList[Locale.ToLower(name)] = article;
 			searchableTextKeyList[tech.Description] = article;
@@ -490,37 +491,37 @@ CivilopediaCategory[CategoryTech].PopulateList = function()
 
 		-- sort this list alphabetically by localized name
 		table.sort(sortedList[CategoryTech][eraID], Alphabetically);
-	
+
 	end
-		
+
 end
 
 CivilopediaCategory[CategoryUnits].PopulateList = function()
 	-- add the instances of the unit entries
 	sortedList[CategoryUnits] = {};
 
-	function AddArticle(categoryID, entryID, unit)	
+	function AddArticle(categoryID, entryID, unit)
 		local article = {};
 		local name = Locale.ConvertTextKey( unit.Description )
 		article.entryName = name;
 		article.entryID = unit.ID;
 		article.entryCategory = CategoryUnits;
-		article.tooltipTextureOffset, article.tooltipTexture = IconLookup( unit.PortraitIndex, buttonSize, unit.IconAtlas );				
+		article.tooltipTextureOffset, article.tooltipTexture = IconLookup( unit.PortraitIndex, buttonSize, unit.IconAtlas );
 		if not article.tooltipTextureOffset then
 			article.tooltipTexture = defaultErrorTextureSheet;
 			article.tooltipTextureOffset = nullOffset;
-		end				
-		
+		end
+
 		sortedList[CategoryUnits][categoryID][entryID] = article;
-		
+
 		-- index by various keys
 		searchableList[Locale.ToLower(name)] = article;
 		searchableTextKeyList[unit.Description] = article;
 		categorizedList[(CategoryUnits * absurdlyLargeNumTopicsInCategory) + unit.ID] = article;
 	end
-	
+
 	local sectionID = 0;
-	
+
 	-- Add units which cost faith to a "Faith" category first.
 	if(Game == nil or not Game.IsOption(GameOptionTypes.GAMEOPTION_NO_RELIGION)) then
 		local faithUnits = {};
@@ -532,52 +533,52 @@ CivilopediaCategory[CategoryUnits].PopulateList = function()
 		end
 		sectionID = sectionID + 1;
 	end
-	
+
 	-- for each era
 	local sql = [[
-		SELECT Units.ID, Units.Description, Units.PortraitIndex, Units.IconAtlas 
-		FROM Units INNER JOIN Technologies on PreReqTech = Technologies.Type 
+		SELECT Units.ID, Units.Description, Units.PortraitIndex, Units.IconAtlas
+		FROM Units INNER JOIN Technologies on PreReqTech = Technologies.Type
 		WHERE (Units.FaithCost = 0 or RequiresFaithPurchaseEnabled or Units.Cost >= 0) and Units.ShowInPedia = 1 and Technologies.Era = ?;]];
-						
+
 	local UnitsByEra = DB.CreateQuery(sql);
-	
+
 	local bFirstEra = true;
 	-- Infixo GameInfo.Eras is not updated after mods are loaded
 	--for era in GameInfo.Eras() do
 	for era in DB.Query("SELECT ID, Type FROM Eras ORDER BY ID") do
-	
+
 		local eraID = era.ID + sectionID;
-	
+
 		sortedList[CategoryUnits][eraID] = {};
 		local tableid = 1;
-	
+
 		for unit in UnitsByEra(era.Type) do
 			AddArticle(eraID, tableid, unit);
 			tableid = tableid + 1;
 		end
-			
+
 		-- put in all of the units that do not have tech requirements in the Ancient Era for lack of a better place
 		if(bFirstEra == true) then
 			for unit in DB.Query("SELECT Units.ID, Units.Description, Units.PortraitIndex, Units.IconAtlas From Units where PreReqTech is NULL and Special is NULL and (Units.FaithCost = 0 or RequiresFaithPurchaseEnabled or Units.Cost >= 0) and Units.ShowInPedia = 1") do
 				AddArticle(eraID, tableid, unit);
 				tableid = tableid + 1;
 			end
-		end	
-		
+		end
+
 		bFirstEra = false;
 	end
-	
+
 	-- sort this list alphabetically by localized name
 	for k,v in pairs(sortedList[CategoryUnits]) do
 		table.sort(v, Alphabetically);
-	end	
+	end
 end
 
 
 CivilopediaCategory[CategoryPromotions].PopulateList = function()
 	-- add the instances of the promotion entries
 	sortedList[CategoryPromotions] = {};
-	
+
 	-- Infixo more categories
 	for iSection, sPediaType in ipairs(UnitPromotionsPediaTypes) do
 		sortedList[CategoryPromotions][iSection] = {};
@@ -599,11 +600,11 @@ CivilopediaCategory[CategoryPromotions].PopulateList = function()
 			end
 		end -- unit promos
 	end -- pedia types
-	
+
 	--[[ Infixo more categories
-	sortedList[CategoryPromotions][1] = {}; 
+	sortedList[CategoryPromotions][1] = {};
 	local tableid = 1;
-	
+
 	-- for each promotion
 	for thisPromotion in GameInfo.UnitPromotions() do
 		if thisPromotion.PediaType == "PEDIA_MELEE" then
@@ -616,15 +617,15 @@ CivilopediaCategory[CategoryPromotions].PopulateList = function()
 
 			sortedList[CategoryPromotions][1][tableid] = article;
 			tableid = tableid + 1;
-			
+
 			-- index by various keys
 			searchableList[Locale.ToLower(name)] = article;
 			searchableTextKeyList[thisPromotion.Description] = article;
 			categorizedList[(CategoryPromotions * absurdlyLargeNumTopicsInCategory) + thisPromotion.ID] = article;
 		end
 	end
-	
-	sortedList[CategoryPromotions][2] = {}; 
+
+	sortedList[CategoryPromotions][2] = {};
 	local tableid = 1;
 	for thisPromotion in GameInfo.UnitPromotions() do
 		if thisPromotion.PediaType == "PEDIA_RANGED" then
@@ -637,15 +638,15 @@ CivilopediaCategory[CategoryPromotions].PopulateList = function()
 
 			sortedList[CategoryPromotions][2][tableid] = article;
 			tableid = tableid + 1;
-			
+
 			-- index by various keys
 			searchableList[Locale.ToLower(name)] = article;
 			searchableTextKeyList[thisPromotion.Description] = article;
 			categorizedList[(CategoryPromotions * absurdlyLargeNumTopicsInCategory) + thisPromotion.ID] = article;
 		end
 	end
-	
-	sortedList[CategoryPromotions][3] = {}; 
+
+	sortedList[CategoryPromotions][3] = {};
 	local tableid = 1;
 	for thisPromotion in GameInfo.UnitPromotions() do
 		if thisPromotion.PediaType == "PEDIA_NAVAL" then
@@ -658,15 +659,15 @@ CivilopediaCategory[CategoryPromotions].PopulateList = function()
 
 			sortedList[CategoryPromotions][3][tableid] = article;
 			tableid = tableid + 1;
-			
+
 			-- index by various keys
 			searchableList[Locale.ToLower(name)] = article;
 			searchableTextKeyList[thisPromotion.Description] = article;
 			categorizedList[(CategoryPromotions * absurdlyLargeNumTopicsInCategory) + thisPromotion.ID] = article;
 		end
 	end
-		
-	sortedList[CategoryPromotions][4] = {}; 
+
+	sortedList[CategoryPromotions][4] = {};
 	local tableid = 1;
 	for thisPromotion in GameInfo.UnitPromotions() do
 		if thisPromotion.PediaType == "PEDIA_HEAL" then
@@ -679,15 +680,15 @@ CivilopediaCategory[CategoryPromotions].PopulateList = function()
 
 			sortedList[CategoryPromotions][4][tableid] = article;
 			tableid = tableid + 1;
-			
+
 			-- index by various keys
 			searchableList[Locale.ToLower(name)] = article;
 			searchableTextKeyList[thisPromotion.Description] = article;
 			categorizedList[(CategoryPromotions * absurdlyLargeNumTopicsInCategory) + thisPromotion.ID] = article;
 		end
 	end
-	
-	sortedList[CategoryPromotions][5] = {}; 
+
+	sortedList[CategoryPromotions][5] = {};
 	local tableid = 1;
 	for thisPromotion in GameInfo.UnitPromotions() do
 		if thisPromotion.PediaType == "PEDIA_SCOUTING" then
@@ -700,15 +701,15 @@ CivilopediaCategory[CategoryPromotions].PopulateList = function()
 
 			sortedList[CategoryPromotions][5][tableid] = article;
 			tableid = tableid + 1;
-			
+
 			-- index by various keys
 			searchableList[Locale.ToLower(name)] = article;
 			searchableTextKeyList[thisPromotion.Description] = article;
 			categorizedList[(CategoryPromotions * absurdlyLargeNumTopicsInCategory) + thisPromotion.ID] = article;
 		end
 	end
-	
-	sortedList[CategoryPromotions][6] = {}; 
+
+	sortedList[CategoryPromotions][6] = {};
 	local tableid = 1;
 	for thisPromotion in GameInfo.UnitPromotions() do
 		if thisPromotion.PediaType == "PEDIA_AIR" then
@@ -721,7 +722,7 @@ CivilopediaCategory[CategoryPromotions].PopulateList = function()
 
 			sortedList[CategoryPromotions][6][tableid] = article;
 			tableid = tableid + 1;
-			
+
 			-- index by various keys
 			searchableList[Locale.ToLower(name)] = article;
 			searchableTextKeyList[thisPromotion.Description] = article;
@@ -729,7 +730,7 @@ CivilopediaCategory[CategoryPromotions].PopulateList = function()
 		end
 	end
 
-	sortedList[CategoryPromotions][7] = {}; 
+	sortedList[CategoryPromotions][7] = {};
 	local tableid = 1;
 	for thisPromotion in GameInfo.UnitPromotions() do
 		if thisPromotion.PediaType == "PEDIA_SHARED" then
@@ -742,15 +743,15 @@ CivilopediaCategory[CategoryPromotions].PopulateList = function()
 
 			sortedList[CategoryPromotions][7][tableid] = article;
 			tableid = tableid + 1;
-			
+
 			-- index by various keys
 			searchableList[Locale.ToLower(name)] = article;
 			searchableTextKeyList[thisPromotion.Description] = article;
 			categorizedList[(CategoryPromotions * absurdlyLargeNumTopicsInCategory) + thisPromotion.ID] = article;
 		end
 	end
-	
-	sortedList[CategoryPromotions][8] = {}; 
+
+	sortedList[CategoryPromotions][8] = {};
 	local tableid = 1;
 	for thisPromotion in GameInfo.UnitPromotions() do
 		if thisPromotion.PediaType == "PEDIA_ATTRIBUTES" then
@@ -763,7 +764,7 @@ CivilopediaCategory[CategoryPromotions].PopulateList = function()
 
 			sortedList[CategoryPromotions][8][tableid] = article;
 			tableid = tableid + 1;
-			
+
 			-- index by various keys
 			searchableList[Locale.ToLower(name)] = article;
 			searchableTextKeyList[thisPromotion.Description] = article;
@@ -776,47 +777,47 @@ CivilopediaCategory[CategoryPromotions].PopulateList = function()
 	--for section = 1,8,1 do
 	for section,_ in ipairs(UnitPromotionsPediaTypes) do
 		table.sort(sortedList[CategoryPromotions][section], Alphabetically);
-	end		
+	end
 end
 
 
 CivilopediaCategory[CategoryBuildings].PopulateList = function()
 	-- add the instances of the building entries
-	
+
 	sortedList[CategoryBuildings] = {};
-	
+
 	function AddArticle(categoryID, entryID, building)
 		local article = {};
 		local name = Locale.ConvertTextKey( building.Description )
 		article.entryName = name;
 		article.entryID = building.ID;
 		article.entryCategory = CategoryBuildings;
-		article.tooltipTextureOffset, article.tooltipTexture = IconLookup( building.PortraitIndex, buttonSize, building.IconAtlas );				
+		article.tooltipTextureOffset, article.tooltipTexture = IconLookup( building.PortraitIndex, buttonSize, building.IconAtlas );
 		if not article.tooltipTextureOffset then
 			article.tooltipTexture = defaultErrorTextureSheet;
 			article.tooltipTextureOffset = nullOffset;
 		end
-		
+
 		sortedList[CategoryBuildings][categoryID][entryID] = article;
-		
+
 		-- index by various keys
 		searchableList[Locale.ToLower(name)] = article;
 		searchableTextKeyList[building.Description] = article;
 		categorizedList[(CategoryBuildings * absurdlyLargeNumTopicsInCategory) + building.ID] = article;
 	end
-	
+
 	local sectionID = 0;
 	if(Game == nil or not Game.IsOption(GameOptionTypes.GAMEOPTION_NO_RELIGION)) then
 		--Add Faith Buildings first
 		local tableid = 1;
-		sortedList[CategoryBuildings][sectionID] = {};	
+		sortedList[CategoryBuildings][sectionID] = {};
 		for building in DB.Query("SELECT Buildings.ID, Buildings.Description, Buildings.PortraitIndex, Buildings.IconAtlas from Buildings inner join  BuildingClasses on Buildings.BuildingClass = BuildingClasses.Type where Buildings.FaithCost > 0 and Buildings.ShowInPedia == 1 and Buildings.Cost == -1 and BuildingClasses.MaxGlobalInstances < 0 and (BuildingClasses.MaxPlayerInstances <> 1 or Buildings.SpecialistCount > 0) and BuildingClasses.MaxTeamInstances < 0;") do
 			AddArticle(sectionID, tableid, building); -- FIXED Infixo changed 0 to sectionID
 			tableid = tableid + 1;
 		end
 		sectionID = sectionID + 1;
 	end
-	
+
 	--CORPS
 	--Add Corporation Buildings Second
 	local tableid = 1;
@@ -826,50 +827,50 @@ CivilopediaCategory[CategoryBuildings].PopulateList = function()
 		tableid = tableid + 1;
 	end
 	sectionID = sectionID + 1;
-	
+
 	local sql = [[
-		SELECT Buildings.ID, Buildings.Description, Buildings.PortraitIndex, Buildings.IconAtlas 
-		FROM Buildings 
-		INNER JOIN BuildingClasses ON Buildings.BuildingClass = BuildingClasses.Type 
-		INNER JOIN Technologies ON Buildings.PrereqTech = Technologies.Type 
+		SELECT Buildings.ID, Buildings.Description, Buildings.PortraitIndex, Buildings.IconAtlas
+		FROM Buildings
+		INNER JOIN BuildingClasses ON Buildings.BuildingClass = BuildingClasses.Type
+		INNER JOIN Technologies ON Buildings.PrereqTech = Technologies.Type
 		WHERE (FaithCost == 0 or Buildings.Cost >= 0) AND Buildings.IsCorporation == 0 AND Buildings.ShowInPedia == 1 AND BuildingClasses.MaxGlobalInstances < 0 AND BuildingClasses.MaxPlayerInstances <> 1 AND BuildingClasses.MaxTeamInstances < 0 AND Technologies.Era = ?;]];
-	
+
 	local BuildingsByEra = DB.CreateQuery(sql);
-	
-	
+
+
 	-- for each era
 	local bFirstEra = true;
 	-- Infixo GameInfo.Eras is not updated after mods are loaded
 	--for era in GameInfo.Eras() do
 	for era in DB.Query("SELECT ID, Type FROM Eras ORDER BY ID") do
-	
+
 		local eraID = era.ID + sectionID;
-	
+
 		sortedList[CategoryBuildings][eraID] = {};
 		local tableid = 1;
-		
+
 		for building in BuildingsByEra(era.Type) do
 			AddArticle(eraID, tableid, building);
 			tableid = tableid + 1;
 		end
-	
+
 		-- put in all of the buildings that do not have tech requirements in the first Era for lack of a better place
 		if(bFirstEra) then
 			local sql = [[
-				SELECT Buildings.ID, Buildings.Description, Buildings.PortraitIndex, Buildings.IconAtlas 
-				FROM Buildings 
-				INNER JOIN BuildingClasses ON Buildings.BuildingClass = BuildingClasses.Type 
+				SELECT Buildings.ID, Buildings.Description, Buildings.PortraitIndex, Buildings.IconAtlas
+				FROM Buildings
+				INNER JOIN BuildingClasses ON Buildings.BuildingClass = BuildingClasses.Type
 				WHERE Buildings.PrereqTech IS NULL AND (Buildings.FaithCost == 0 or Buildings.Cost >= 0) AND Buildings.ShowInPedia == 1 AND Buildings.IsCorporation == 0 AND BuildingClasses.MaxGlobalInstances < 0 AND (BuildingClasses.MaxPlayerInstances <> 1 or Buildings.SpecialistCount > 0) AND BuildingClasses.MaxTeamInstances < 0;]];
-		
+
 			for building in DB.Query(sql) do
 				AddArticle(eraID, tableid, building);
 				tableid = tableid + 1;
 			end
 		end
-		
+
 		bFirstEra = false;
 	end
-		
+
 	for k,v in pairs(sortedList[CategoryBuildings]) do
 		table.sort(v, Alphabetically);
 	end
@@ -878,15 +879,15 @@ end
 
 CivilopediaCategory[CategoryWonders].PopulateList = function()
 	-- add the instances of the Wonder, National Wonder, Team Wonder, and Project entries
-	
+
 	sortedList[CategoryWonders] = {};
-	
+
 	-- first Wonders
 	sortedList[CategoryWonders][1] = {};
 	local tableid = 1;
 
-	for building in GameInfo.Buildings() do	
-		-- exclude wonders etc.				
+	for building in GameInfo.Buildings() do
+		-- exclude wonders etc.
 		local thisBuildingClass = GameInfo.BuildingClasses[building.BuildingClass];
 		if thisBuildingClass.MaxGlobalInstances > 0 and building.IsCorporation == 0 then
 			local article = {};
@@ -894,30 +895,30 @@ CivilopediaCategory[CategoryWonders].PopulateList = function()
 			article.entryName = name;
 			article.entryID = building.ID;
 			article.entryCategory = CategoryWonders;
-			article.tooltipTextureOffset, article.tooltipTexture = IconLookup( building.PortraitIndex, buttonSize, building.IconAtlas );				
+			article.tooltipTextureOffset, article.tooltipTexture = IconLookup( building.PortraitIndex, buttonSize, building.IconAtlas );
 			if not article.tooltipTextureOffset then
 				article.tooltipTexture = defaultErrorTextureSheet;
 				article.tooltipTextureOffset = nullOffset;
-			end				
-			
+			end
+
 			sortedList[CategoryWonders][1][tableid] = article;
 			tableid = tableid + 1;
-			
+
 			-- index by various keys
 			searchableList[Locale.ToLower(name)] = article;
 			searchableTextKeyList[building.Description] = article;
 			categorizedList[(CategoryWonders * absurdlyLargeNumTopicsInCategory) + building.ID] = article;
 		end
 	end
-	
+
 	-- sort this list alphabetically by localized name
 	table.sort(sortedList[CategoryWonders][1], Alphabetically);
-			
+
 	-- next National Wonders
 	sortedList[CategoryWonders][2] = {};
 	tableid = 1;
 
-	for building in GameInfo.Buildings() do	
+	for building in GameInfo.Buildings() do
 		local thisBuildingClass = GameInfo.BuildingClasses[building.BuildingClass];
 		if thisBuildingClass.MaxPlayerInstances == 1 then
 			local article = {};
@@ -925,62 +926,62 @@ CivilopediaCategory[CategoryWonders].PopulateList = function()
 			article.entryName = name;
 			article.entryID = building.ID;
 			article.entryCategory = CategoryWonders;
-			article.tooltipTextureOffset, article.tooltipTexture = IconLookup( building.PortraitIndex, buttonSize, building.IconAtlas );				
+			article.tooltipTextureOffset, article.tooltipTexture = IconLookup( building.PortraitIndex, buttonSize, building.IconAtlas );
 			if not article.tooltipTextureOffset then
 				article.tooltipTexture = defaultErrorTextureSheet;
 				article.tooltipTextureOffset = nullOffset;
-			end				
-			
+			end
+
 			sortedList[CategoryWonders][2][tableid] = article;
 			tableid = tableid + 1;
-			
+
 			-- index by various keys
 			searchableList[Locale.ToLower(name)] = article;
 			searchableTextKeyList[building.Description] = article;
 			categorizedList[(CategoryWonders * absurdlyLargeNumTopicsInCategory) + building.ID] = article;
 		end
 	end
-	
+
 	-- sort this list alphabetically by localized name
 	table.sort(sortedList[CategoryWonders][2], Alphabetically);
-	
+
 	-- finally Projects
 	sortedList[CategoryWonders][3] = {};
 	tableid = 1;
 
 	for building in GameInfo.Projects() do
-		local bIgnore = projectsToIgnore[building.Type];	
+		local bIgnore = projectsToIgnore[building.Type];
 		if(bIgnore ~= true) then
 			local article = {};
 			local name = Locale.ConvertTextKey( building.Description )
 			article.entryName = name;
 			article.entryID = building.ID + 1000;
 			article.entryCategory = CategoryWonders;
-			article.tooltipTextureOffset, article.tooltipTexture = IconLookup( building.PortraitIndex, buttonSize, building.IconAtlas );				
+			article.tooltipTextureOffset, article.tooltipTexture = IconLookup( building.PortraitIndex, buttonSize, building.IconAtlas );
 			if not article.tooltipTextureOffset then
 				article.tooltipTexture = defaultErrorTextureSheet;
 				article.tooltipTextureOffset = nullOffset;
-			end				
-			
+			end
+
 			sortedList[CategoryWonders][3][tableid] = article;
 			tableid = tableid + 1;
-			
+
 			-- index by various keys
 			searchableList[Locale.ToLower(name)] = article;
 			searchableTextKeyList[building.Description] = article;
 			categorizedList[(CategoryWonders * absurdlyLargeNumTopicsInCategory) + building.ID + 1000] = article;
 		end
 	end
-	
+
 	-- sort this list alphabetically by localized name
 	table.sort(sortedList[CategoryWonders][3], Alphabetically);
-	
+
 		-- fourth Corporations
 	sortedList[CategoryWonders][4] = {};
 	local tableid = 1;
 
-	for building in GameInfo.Buildings() do	
-		-- exclude wonders etc.				
+	for building in GameInfo.Buildings() do
+		-- exclude wonders etc.
 		local thisBuildingClass = GameInfo.BuildingClasses[building.BuildingClass];
 		if thisBuildingClass.MaxGlobalInstances > 0 and building.IsCorporation > 0 then
 			local article = {};
@@ -988,40 +989,40 @@ CivilopediaCategory[CategoryWonders].PopulateList = function()
 			article.entryName = name;
 			article.entryID = building.ID;
 			article.entryCategory = CategoryWonders;
-			article.tooltipTextureOffset, article.tooltipTexture = IconLookup( building.PortraitIndex, buttonSize, building.IconAtlas );				
+			article.tooltipTextureOffset, article.tooltipTexture = IconLookup( building.PortraitIndex, buttonSize, building.IconAtlas );
 			if not article.tooltipTextureOffset then
 				article.tooltipTexture = defaultErrorTextureSheet;
 				article.tooltipTextureOffset = nullOffset;
-			end				
-			
+			end
+
 			sortedList[CategoryWonders][4][tableid] = article;
 			tableid = tableid + 1;
-			
+
 			-- index by various keys
 			searchableList[Locale.ToLower(name)] = article;
 			searchableTextKeyList[building.Description] = article;
 			categorizedList[(CategoryWonders * absurdlyLargeNumTopicsInCategory) + building.ID] = article;
 		end
 	end
-	
+
 	-- sort this list alphabetically by localized name
 	table.sort(sortedList[CategoryWonders][4], Alphabetically);
-					
+
 end
 
 CivilopediaCategory[CategoryPolicies].PopulateList = function()
 	-- add the instances of the policy entries
-	
+
 	sortedList[CategoryPolicies] = {};
-	
+
 	-- for each policy branch
 	for branch in GameInfo.PolicyBranchTypes() do
-	
+
 		local branchID = branch.ID;
-	
+
 		sortedList[CategoryPolicies][branchID] = {};
 		local tableid = 1;
-	
+
 		-- for each policy in this branch
  		for policy in GameInfo.Policies("PolicyBranchType = '" .. branch.Type .. "'") do
 			local article = {};
@@ -1029,21 +1030,21 @@ CivilopediaCategory[CategoryPolicies].PopulateList = function()
 			article.entryName = name;
 			article.entryID = policy.ID;
 			article.entryCategory = CategoryPolicies;
-			article.tooltipTextureOffset, article.tooltipTexture = IconLookup( policy.PortraitIndex, buttonSize, policy.IconAtlas );				
+			article.tooltipTextureOffset, article.tooltipTexture = IconLookup( policy.PortraitIndex, buttonSize, policy.IconAtlas );
 			if not article.tooltipTextureOffset then
 				article.tooltipTexture = defaultErrorTextureSheet;
 				article.tooltipTextureOffset = nullOffset;
-			end				
-			
+			end
+
 			sortedList[CategoryPolicies][branchID][tableid] = article;
 			tableid = tableid + 1;
-			
+
 			-- index by various keys
 			searchableList[Locale.ToLower(name)] = article;
 			searchableTextKeyList[policy.Description] = article;
 			categorizedList[(CategoryPolicies * absurdlyLargeNumTopicsInCategory) + policy.ID] = article;
 		end
-		
+
 		-- put in free policies that belong to this branch in here
 		if (branch.FreePolicy ~= nil) then
 			local freePolicy = GameInfo.Policies[branch.FreePolicy];
@@ -1052,15 +1053,15 @@ CivilopediaCategory[CategoryPolicies].PopulateList = function()
 			article.entryName = name;
 			article.entryID = freePolicy.ID;
 			article.entryCategory = CategoryPolicies;
-			article.tooltipTextureOffset, article.tooltipTexture = IconLookup( freePolicy.PortraitIndex, buttonSize, freePolicy.IconAtlas );				
+			article.tooltipTextureOffset, article.tooltipTexture = IconLookup( freePolicy.PortraitIndex, buttonSize, freePolicy.IconAtlas );
 			if not article.tooltipTextureOffset then
 				article.tooltipTexture = defaultErrorTextureSheet;
 				article.tooltipTextureOffset = nullOffset;
-			end				
-		
+			end
+
 			sortedList[CategoryPolicies][branchID][tableid] = article;
 			tableid = tableid + 1;
-		
+
 			-- index by various keys
 			searchableList[Locale.ToLower(name)] = article;
 			searchableTextKeyList[freePolicy.Description] = article;
@@ -1069,44 +1070,44 @@ CivilopediaCategory[CategoryPolicies].PopulateList = function()
 
 		-- sort this list alphabetically by localized name
 		table.sort(sortedList[CategoryPolicies][branchID], Alphabetically);
-	
+
 	end
-		
+
 end
 
 CivilopediaCategory[CategoryPeople].PopulateList = function()
 	-- add the instances of the Specialists and Great People entries
-	
+
 	sortedList[CategoryPeople] = {};
-	
+
 	-- first Specialists
 	sortedList[CategoryPeople][1] = {};
 	local tableid = 1;
 
-	for person in GameInfo.Specialists() do	
+	for person in GameInfo.Specialists() do
 		local article = {};
 		local name = Locale.ConvertTextKey( person.Description )
 		article.entryName = name;
 		article.entryID = person.ID;
 		article.entryCategory = CategoryPeople;
-		article.tooltipTextureOffset, article.tooltipTexture = IconLookup( person.PortraitIndex, buttonSize, person.IconAtlas );				
+		article.tooltipTextureOffset, article.tooltipTexture = IconLookup( person.PortraitIndex, buttonSize, person.IconAtlas );
 		if not article.tooltipTextureOffset then
 			article.tooltipTexture = defaultErrorTextureSheet;
 			article.tooltipTextureOffset = nullOffset;
-		end				
+		end
 
 		sortedList[CategoryPeople][1][tableid] = article;
 		tableid = tableid + 1;
-		
+
 		-- index by various keys
 		searchableList[Locale.ToLower(name)] = article;
 		searchableTextKeyList[person.Description] = article;
 		categorizedList[(CategoryPeople * absurdlyLargeNumTopicsInCategory) + person.ID] = article; -- add a fudge factor
 	end
-	
+
 	-- sort this list alphabetically by localized name
 	table.sort(sortedList[CategoryPeople][1], Alphabetically);
-			
+
 	-- next Great People
 	sortedList[CategoryPeople][2] = {};
 	tableid = 1;
@@ -1118,15 +1119,15 @@ CivilopediaCategory[CategoryPeople].PopulateList = function()
 			article.entryName = name;
 			article.entryID = unit.ID + 1000;
 			article.entryCategory = CategoryPeople;
-			article.tooltipTextureOffset, article.tooltipTexture = IconLookup( unit.PortraitIndex, buttonSize, unit.IconAtlas );				
+			article.tooltipTextureOffset, article.tooltipTexture = IconLookup( unit.PortraitIndex, buttonSize, unit.IconAtlas );
 			if not article.tooltipTextureOffset then
 				article.tooltipTexture = defaultErrorTextureSheet;
 				article.tooltipTextureOffset = nullOffset;
-			end				
-			
+			end
+
 			sortedList[CategoryPeople][2][tableid] = article;
 			tableid = tableid + 1;
-			
+
 			-- index by various keys
 			searchableList[Locale.ToLower(name)] = article;
 			searchableTextKeyList[unit.Description] = article;
@@ -1136,14 +1137,14 @@ CivilopediaCategory[CategoryPeople].PopulateList = function()
 
 	-- sort this list alphabetically by localized name
 	table.sort(sortedList[CategoryPeople][2], Alphabetically);
-					
+
 end
 
 CivilopediaCategory[CategoryCivilizations].PopulateList = function()
 	-- add the instances of the Civilization and Leader entries
-	
+
 	sortedList[CategoryCivilizations] = {};
-	
+
 	-- first Civilizations
 	sortedList[CategoryCivilizations][1] = {};
 	local tableid = 1;
@@ -1155,30 +1156,30 @@ CivilopediaCategory[CategoryCivilizations].PopulateList = function()
 			article.entryName = name;
 			article.entryID = row.ID;
 			article.entryCategory = CategoryCivilizations;
-			article.tooltipTextureOffset, article.tooltipTexture = IconLookup( row.PortraitIndex, buttonSize, row.IconAtlas );				
+			article.tooltipTextureOffset, article.tooltipTexture = IconLookup( row.PortraitIndex, buttonSize, row.IconAtlas );
 			if not article.tooltipTextureOffset then
 				article.tooltipTexture = defaultErrorTextureSheet;
 				article.tooltipTextureOffset = nullOffset;
-			end				
+			end
 
 			sortedList[CategoryCivilizations][1][tableid] = article;
 			tableid = tableid + 1;
-			
+
 			-- index by various keys
 			searchableList[Locale.ToLower(name)] = article;
 			searchableTextKeyList[row.ShortDescription] = article;
 			categorizedList[(CategoryCivilizations * absurdlyLargeNumTopicsInCategory) + row.ID] = article;
 		end
 	end
-	
+
 	-- sort this list alphabetically by localized name
 	table.sort(sortedList[CategoryCivilizations][1], Alphabetically);
-			
+
 	-- next Leaders
 	sortedList[CategoryCivilizations][2] = {};
 	local tableid = 1;
 
-	for row in GameInfo.Civilizations() do	
+	for row in GameInfo.Civilizations() do
 		if row.Type ~= "CIVILIZATION_MINOR" and row.Type ~= "CIVILIZATION_BARBARIAN" then
 			local leader = GameInfo.Leaders[GameInfo.Civilization_Leaders( "CivilizationType = '" .. row.Type .. "'" )().LeaderheadType];
 			local article = {};
@@ -1186,53 +1187,53 @@ CivilopediaCategory[CategoryCivilizations].PopulateList = function()
 			article.entryName = name;
 			article.entryID = row.ID + 1000;
 			article.entryCategory = CategoryCivilizations;
-			article.tooltipTextureOffset, article.tooltipTexture = IconLookup( leader.PortraitIndex, buttonSize, leader.IconAtlas );				
+			article.tooltipTextureOffset, article.tooltipTexture = IconLookup( leader.PortraitIndex, buttonSize, leader.IconAtlas );
 			if not article.tooltipTextureOffset then
 				article.tooltipTexture = defaultErrorTextureSheet;
 				article.tooltipTextureOffset = nullOffset;
-			end				
+			end
 
 			sortedList[CategoryCivilizations][2][tableid] = article;
 			tableid = tableid + 1;
-			
+
 			-- index by various keys
 			searchableList[Locale.ToLower(name)] = article;
 			searchableTextKeyList[leader.Description] = article;
 			categorizedList[(CategoryCivilizations * absurdlyLargeNumTopicsInCategory) + row.ID + 1000] = article;
 		end
 	end
-	
+
 	-- sort this list alphabetically by localized name
 	table.sort(sortedList[CategoryCivilizations][2], Alphabetically);
-					
+
 end
 
 CivilopediaCategory[CategoryCityStates].PopulateList = function()
 	-- add the instances of the City States entries
-	
+
 	sortedList[CategoryCityStates] = {};
-	
+
 	-- for each trait
 	for trait in GameInfo.MinorCivTraits() do
-	
+
 		local traitID = trait.ID;
-	
+
 		sortedList[CategoryCityStates][traitID] = {};
 		local tableid = 1;
-	
+
 		-- for each city state that has this trait
  		for cityState in GameInfo.MinorCivilizations("MinorCivTrait = '" .. trait.Type .. "'") do
- 		
+
 			-- add a tech entry to a list (localized name, tag, etc.)
  			local article = {};
  			local name = Locale.ConvertTextKey( cityState.Description )
  			article.entryName = name;
  			article.entryID = cityState.ID;
 			article.entryCategory = CategoryCityStates;
-			
+
 			sortedList[CategoryCityStates][traitID][tableid] = article;
 			tableid = tableid + 1;
-			
+
 			-- index by various keys
 			searchableList[Locale.ToLower(name)] = article;
 			searchableTextKeyList[cityState.Description] = article;
@@ -1241,63 +1242,63 @@ CivilopediaCategory[CategoryCityStates].PopulateList = function()
 
 		-- sort this list alphabetically by localized name
 		table.sort(sortedList[CategoryCityStates][traitID], Alphabetically);
-	
+
 	end
-					
+
 end
 
 CivilopediaCategory[CategoryTerrain].PopulateList = function()
 	-- add the instances of the Terrain and Features entries
-	
+
 	sortedList[CategoryTerrain] = {};
-	
+
 	-- first Specialists
 	sortedList[CategoryTerrain][1] = {};
 	local tableid = 1;
 
-	for row in GameInfo.Terrains() do	
+	for row in GameInfo.Terrains() do
 		local article = {};
 		local name = Locale.ConvertTextKey( row.Description )
 		article.entryName = name;
 		article.entryID = row.ID;
 		article.entryCategory = CategoryTerrain;
-		article.tooltipTextureOffset, article.tooltipTexture = IconLookup( row.PortraitIndex, buttonSize, row.IconAtlas );				
+		article.tooltipTextureOffset, article.tooltipTexture = IconLookup( row.PortraitIndex, buttonSize, row.IconAtlas );
 		if not article.tooltipTextureOffset then
 			article.tooltipTexture = defaultErrorTextureSheet;
 			article.tooltipTextureOffset = nullOffset;
-		end				
+		end
 
 		sortedList[CategoryTerrain][1][tableid] = article;
 		tableid = tableid + 1;
-		
+
 		-- index by various keys
 		searchableList[Locale.ToLower(name)] = article;
 		searchableTextKeyList[row.Description] = article;
 		categorizedList[(CategoryTerrain * absurdlyLargeNumTopicsInCategory) + row.ID] = article; -- add a fudge factor
 	end
-	
+
 	-- sort this list alphabetically by localized name
 	table.sort(sortedList[CategoryTerrain][1], Alphabetically);
-			
+
 	-- next Features
 	sortedList[CategoryTerrain][2] = {};
 	tableid = 1;
 
-	for row in GameInfo.Features() do	
+	for row in GameInfo.Features() do
 		local article = {};
 		local name = Locale.ConvertTextKey( row.Description )
 		article.entryName = name;
 		article.entryID = row.ID + 1000;
 		article.entryCategory = CategoryTerrain;
-		article.tooltipTextureOffset, article.tooltipTexture = IconLookup( row.PortraitIndex, buttonSize, row.IconAtlas );				
+		article.tooltipTextureOffset, article.tooltipTexture = IconLookup( row.PortraitIndex, buttonSize, row.IconAtlas );
 		if not article.tooltipTextureOffset then
 			article.tooltipTexture = defaultErrorTextureSheet;
 			article.tooltipTextureOffset = nullOffset;
-		end				
+		end
 
 		sortedList[CategoryTerrain][2][tableid] = article;
 		tableid = tableid + 1;
-		
+
 		-- index by various keys
 		searchableList[Locale.ToLower(name)] = article;
 		searchableTextKeyList[row.Description] = article;
@@ -1305,21 +1306,21 @@ CivilopediaCategory[CategoryTerrain].PopulateList = function()
 	end
 
 	-- now for the fake features (river and lake)
-	for row in GameInfo.FakeFeatures() do	
+	for row in GameInfo.FakeFeatures() do
 		local article = {};
 		local name = Locale.ConvertTextKey( row.Description )
 		article.entryName = name;
 		article.entryID = row.ID + 2000;
 		article.entryCategory = CategoryTerrain;
-		article.tooltipTextureOffset, article.tooltipTexture = IconLookup( row.PortraitIndex, buttonSize, row.IconAtlas );				
+		article.tooltipTextureOffset, article.tooltipTexture = IconLookup( row.PortraitIndex, buttonSize, row.IconAtlas );
 		if not article.tooltipTextureOffset then
 			article.tooltipTexture = defaultErrorTextureSheet;
 			article.tooltipTextureOffset = nullOffset;
-		end				
+		end
 
 		sortedList[CategoryTerrain][2][tableid] = article;
 		tableid = tableid + 1;
-		
+
 		-- index by various keys
 		searchableList[Locale.ToLower(name)] = article;
 		searchableTextKeyList[row.Description] = article;
@@ -1328,38 +1329,38 @@ CivilopediaCategory[CategoryTerrain].PopulateList = function()
 
 	-- sort this list alphabetically by localized name
 	table.sort(sortedList[CategoryTerrain][2], Alphabetically);
-					
+
 end
 
 CivilopediaCategory[CategoryResources].PopulateList = function()
 	-- add the instances of the resource entries
-	
+
 	sortedList[CategoryResources] = {};
-	
+
 	-- for each type of resource
 	for resourceType = 0, 2, 1 do
-		
+
 		sortedList[CategoryResources][resourceType] = {};
 		local tableid = 1;
-	
+
 		-- for each type of resource
  		for resource in GameInfo.Resources( "ResourceUsage = '" .. resourceType .. "'" ) do
- 		
+
 			-- add a tech entry to a list (localized name, tag, etc.)
  			local article = {};
  			local name = Locale.ConvertTextKey( resource.Description )
  			article.entryName = name;
  			article.entryID = resource.ID;
 			article.entryCategory = CategoryResources;
-			article.tooltipTextureOffset, article.tooltipTexture = IconLookup( resource.PortraitIndex, buttonSize, resource.IconAtlas );				
+			article.tooltipTextureOffset, article.tooltipTexture = IconLookup( resource.PortraitIndex, buttonSize, resource.IconAtlas );
 			if not article.tooltipTextureOffset then
 				article.tooltipTexture = defaultErrorTextureSheet;
 				article.tooltipTextureOffset = nullOffset;
-			end				
-			
+			end
+
 			sortedList[CategoryResources][resourceType][tableid] = article;
 			tableid = tableid + 1;
-			
+
 			-- index by various keys
 			searchableList[Locale.ToLower(name)] = article;
 			searchableTextKeyList[resource.Description] = article;
@@ -1368,21 +1369,21 @@ CivilopediaCategory[CategoryResources].PopulateList = function()
 
 		-- sort this list alphabetically by localized name
 		table.sort(sortedList[CategoryResources][resourceType], Alphabetically);
-	
+
 	end
-					
+
 end
 
 CivilopediaCategory[CategoryImprovements].PopulateList = function()
 	-- add the instances of the improvement entries
-	
+
 	sortedList[CategoryImprovements] = {};
-	
+
 	sortedList[CategoryImprovements][1] = {}; -- there is only one section (for now)
 	local tableid = 1;
-	
+
 	-- for each improvement
-	for row in GameInfo.Improvements() do	
+	for row in GameInfo.Improvements() do
 		if not row.GraphicalOnly then
 			-- add an article to the list (localized name, unit tag, etc.)
 			local article = {};
@@ -1390,22 +1391,22 @@ CivilopediaCategory[CategoryImprovements].PopulateList = function()
 			article.entryName = name;
 			article.entryID = row.ID;
 			article.entryCategory = CategoryImprovements;
-			article.tooltipTextureOffset, article.tooltipTexture = IconLookup( row.PortraitIndex, buttonSize, row.IconAtlas );				
+			article.tooltipTextureOffset, article.tooltipTexture = IconLookup( row.PortraitIndex, buttonSize, row.IconAtlas );
 			if not article.tooltipTextureOffset then
 				article.tooltipTexture = defaultErrorTextureSheet;
 				article.tooltipTextureOffset = nullOffset;
-			end				
-			
+			end
+
 			sortedList[CategoryImprovements][1][tableid] = article;
 			tableid = tableid + 1;
-			
+
 			-- index by various keys
 			searchableList[Locale.ToLower(name)] = article;
 			searchableTextKeyList[row.Description] = article;
 			categorizedList[(CategoryImprovements * absurdlyLargeNumTopicsInCategory) + row.ID] = article;
 		end
 	end
-	
+
 	--add railroads and roads
 	for row in GameInfo.Routes() do
 		local article = {};
@@ -1413,15 +1414,15 @@ CivilopediaCategory[CategoryImprovements].PopulateList = function()
 		article.entryName = name;
 		article.entryID = row.ID + 1000;
 		article.entryCategory = CategoryImprovements;
-		article.tooltipTextureOffset, article.tooltipTexture = IconLookup( row.PortraitIndex, buttonSize, row.IconAtlas );				
+		article.tooltipTextureOffset, article.tooltipTexture = IconLookup( row.PortraitIndex, buttonSize, row.IconAtlas );
 		if not article.tooltipTextureOffset then
 			article.tooltipTexture = defaultErrorTextureSheet;
 			article.tooltipTextureOffset = nullOffset;
-		end				
-		
+		end
+
 		sortedList[CategoryImprovements][1][tableid] = article;
 		tableid = tableid + 1;
-		
+
 		-- index by various keys
 		searchableList[Locale.ToLower(name)] = article;
 		searchableTextKeyList[row.Description] = article;
@@ -1430,37 +1431,37 @@ CivilopediaCategory[CategoryImprovements].PopulateList = function()
 
 	-- sort this list alphabetically by localized name
 	table.sort(sortedList[CategoryImprovements][1], Alphabetically);
-			
+
 end
 
 CivilopediaCategory[CategoryBeliefs].PopulateList = function()
-	
+
 	sortedList[CategoryBeliefs] = {};
-	
+
 	do
 		local section = {};
 		for religion in GameInfo.Religions("Type <> 'RELIGION_PANTHEON'") do
-	 		
+
 			-- add a tech entry to a list (localized name, tag, etc.)
 			local article = {};
 			local name = Locale.ConvertTextKey(religion.Description)
 			article.entryName = name;
 			article.entryID = {"Religions", religion.ID};
-			article.entryCategory = CategoryBeliefs;			
-			
+			article.entryCategory = CategoryBeliefs;
+
 			table.insert(section, article);
-			
+
 			-- index by various keys
 			searchableList[Locale.ToLower(name)] = article;
 			searchableTextKeyList[religion.Description] = article;
 			categorizedList[(CategoryBeliefs * absurdlyLargeNumTopicsInCategory) + religion.ID] = article;
 		end
-		
+
 		-- sort this list alphabetically by localized name
 		table.sort(section, Alphabetically);
 		table.insert(sortedList[CategoryBeliefs], section);
 	end
-	
+
 	-- for each type of resource
 	local sectionConditions = {
 		"Pantheon = 1",
@@ -1469,23 +1470,23 @@ CivilopediaCategory[CategoryBeliefs].PopulateList = function()
 		"Enhancer = 1",
 		"Reformation = 1"
 	};
-	
+
 	local numReligions = #GameInfo.Religions;
 	for i,condition in ipairs(sectionConditions) do
-		
+
 		local section = {};
-	
+
  		for belief in GameInfo.Beliefs(condition) do
- 		
+
 			-- add a tech entry to a list (localized name, tag, etc.)
  			local article = {};
  			local name = Locale.ConvertTextKey( belief.ShortDescription )
  			article.entryName = name;
  			article.entryID = {"Beliefs", belief.ID};
-			article.entryCategory = CategoryBeliefs;			
-			
+			article.entryCategory = CategoryBeliefs;
+
 			table.insert(section, article);
-			
+
 			-- index by various keys
 			searchableList[Locale.ToLower(name)] = article;
 			searchableTextKeyList[belief.ShortDescription] = article;
@@ -1495,57 +1496,57 @@ CivilopediaCategory[CategoryBeliefs].PopulateList = function()
 		-- sort this list alphabetically by localized name
 		table.sort(section, Alphabetically);
 		table.insert(sortedList[CategoryBeliefs], section);
-	
-	end			
+
+	end
 end
 
 CivilopediaCategory[CategoryWorldCongress].PopulateList = function()
-	
+
 	sortedList[CategoryWorldCongress] = {};
-	
+
 	do
 		local section = {};
 		for resolution in GameInfo.Resolutions() do
-	 		
+
 			-- add a resolution entry to a list (localized name, tag, etc.)
 			local article = {};
 			local name = Locale.ConvertTextKey(resolution.Description)
 			article.entryName = name;
 			article.entryID = {"Resolutions", resolution.ID};
-			article.entryCategory = CategoryWorldCongress;			
-			
+			article.entryCategory = CategoryWorldCongress;
+
 			table.insert(section, article);
-			
+
 			-- index by various keys
 			searchableList[Locale.ToLower(name)] = article;
 			searchableTextKeyList[resolution.Description] = article;
 			categorizedList[(CategoryWorldCongress * absurdlyLargeNumTopicsInCategory) + resolution.ID] = article;
 		end
-		
+
 		-- sort this list alphabetically by localized name
 		table.sort(section, Alphabetically);
 		table.insert(sortedList[CategoryWorldCongress], section);
 	end
-	
+
 	do
 		local section = {};
 		for leagueProject in GameInfo.LeagueProjects() do
-	 		
+
 			-- add a league project entry to a list (localized name, tag, etc.)
 			local article = {};
 			local name = Locale.ConvertTextKey(leagueProject.Description)
 			article.entryName = name;
 			article.entryID = {"LeagueProjects", leagueProject.ID};
-			article.entryCategory = CategoryWorldCongress;			
-			
+			article.entryCategory = CategoryWorldCongress;
+
 			table.insert(section, article);
-			
+
 			-- index by various keys
 			searchableList[Locale.ToLower(name)] = article;
 			searchableTextKeyList[leagueProject.Description] = article;
 			categorizedList[(CategoryWorldCongress * absurdlyLargeNumTopicsInCategory) + leagueProject.ID] = article;
 		end
-		
+
 		-- sort this list alphabetically by localized name
 		table.sort(section, Alphabetically);
 		table.insert(sortedList[CategoryWorldCongress], section);
@@ -1555,10 +1556,10 @@ end
 CivilopediaCategory[CategoryCorporations].PopulateList = function()
 
 	sortedList[CategoryCorporations] = {};
-	
+
 	sortedList[CategoryCorporations][1] = {}; -- there is only one section (for now)
 	local tableid = 1;
-	
+
 	for corporation in GameInfo.Corporations() do
 		-- add a corporation entry to a list (localized name, tag, etc.)
 		local article = {};
@@ -1566,16 +1567,16 @@ CivilopediaCategory[CategoryCorporations].PopulateList = function()
 		article.entryName = name;
 		article.entryID = corporation.ID;
 		article.entryCategory = CategoryCorporations;
-		
+
 		sortedList[CategoryCorporations][1][tableid] = article;
 		tableid = tableid + 1;
-		
+
 		-- index by various keys
 		searchableList[Locale.ToLower(name)] = article;
 		searchableTextKeyList[corporation.Description] = article;
 		categorizedList[(CategoryCorporations * absurdlyLargeNumTopicsInCategory) + corporation.ID] = article;
 	end
-	
+
 	-- sort this list alphabetically by localized name
 	table.sort(sortedList[CategoryCorporations][1], Alphabetically);
 
@@ -1609,8 +1610,8 @@ end
 CivilopediaCategory[CategoryHomePage].DisplayHomePage = function()
 
 	ClearArticle();
-	Controls.ArticleID:SetText( Locale.ConvertTextKey("TXT_KEY_PEDIA_HOME_PAGE_LABEL") );	
-	
+	Controls.ArticleID:SetText( Locale.ConvertTextKey("TXT_KEY_PEDIA_HOME_PAGE_LABEL") );
+
 	-- Update some circle logo
 	if IconHookup( 20, portraitSize, "TERRAIN_ATLAS", Controls.Portrait ) then
 		Controls.PortraitFrame:SetHide( false );
@@ -1619,25 +1620,25 @@ CivilopediaCategory[CategoryHomePage].DisplayHomePage = function()
 	end
 
 	g_BBTextManager:ResetInstances();
-	
+
 	--Welcome and insert 1st manual paragraph
 	UpdateTextBlock( Locale.ConvertTextKey( "TXT_KEY_PEDIA_HOME_PAGE_BLURB_TEXT" ), Controls.HomePageBlurbLabel, Controls.HomePageBlurbInnerFrame, Controls.HomePageBlurbFrame );
 
-	--How to use the Pedia	
+	--How to use the Pedia
 	local thisBBTextInstance = g_BBTextManager:GetInstance();
 	if thisBBTextInstance then
 		thisBBTextInstance.BBTextHeader:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_HOME_PAGE_HELP_LABEL" ));
 		UpdateSuperWideTextBlock( Locale.ConvertTextKey( "TXT_KEY_PEDIA_HOME_PAGE_HELP_TEXT" ), thisBBTextInstance.BBTextLabel, thisBBTextInstance.BBTextInnerFrame, thisBBTextInstance.BBTextFrame );
-	end	
-	
-	Controls.BBTextStack:SetHide( false );	
+	end
+
+	Controls.BBTextStack:SetHide( false );
 	ResizeEtc();
 end;
 
 CivilopediaCategory[CategoryGameConcepts].DisplayHomePage = function()
 	ClearArticle();
-	Controls.ArticleID:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_GAME_CONCEPT_PAGE_LABEL" ));	
-	
+	Controls.ArticleID:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_GAME_CONCEPT_PAGE_LABEL" ));
+
 	-- Update Some kind of circle logo
 	if IconHookup( 47, portraitSize, "TECH_ATLAS_1", Controls.Portrait ) then
 		Controls.PortraitFrame:SetHide( false );
@@ -1646,326 +1647,326 @@ CivilopediaCategory[CategoryGameConcepts].DisplayHomePage = function()
 	end
 
 	UpdateTextBlock( Locale.ConvertTextKey( "TXT_KEY_PEDIA_QUOTE_BLOCK_GCONCEPTS" ), Controls.HomePageBlurbLabel, Controls.HomePageBlurbInnerFrame, Controls.HomePageBlurbFrame );
-	
+
 	g_BBTextManager:ResetInstances();
 
-	--Basic Sectional Infos	
+	--Basic Sectional Infos
 	local thisBBTextInstance = g_BBTextManager:GetInstance();
 	if thisBBTextInstance then
 		thisBBTextInstance.BBTextHeader:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_GAME_CONCEPT_PAGE_LABEL" ));
 		UpdateSuperWideTextBlock( Locale.ConvertTextKey( "TXT_KEY_PEDIA_GAME_CONCEPT_HELP_TEXT" ), thisBBTextInstance.BBTextLabel, thisBBTextInstance.BBTextInnerFrame, thisBBTextInstance.BBTextFrame );
-	end	
-	
+	end
+
 	Controls.BBTextStack:SetHide( false );
-	
+
 	--Did you know fact/tip of the day? Can be taken from rando advisor text.  Or link to random page or modding
 	ResizeEtc();
 end;
 
 CivilopediaCategory[CategoryTech].DisplayHomePage = function()
 	ClearArticle();
-	Controls.ArticleID:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_TECH_PAGE_LABEL" ));	
-	
+	Controls.ArticleID:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_TECH_PAGE_LABEL" ));
+
 	local portraitIndex = 48;
 	local portraitAtlas = "TECH_ATLAS_1";
-		
+
 	for row in DB.Query("SELECT PortraitIndex, IconAtlas from Technologies ORDER By Random() LIMIT 1") do
 		portraitIndex = row.PortraitIndex;
 		portraitAtlas = row.IconAtlas;
-	end	
-	
+	end
+
 	if IconHookup( portraitIndex, portraitSize, portraitAtlas, Controls.Portrait ) then
 		Controls.PortraitFrame:SetHide( false );
 	else
 		Controls.PortraitFrame:SetHide( true );
 	end
-	
+
 	UpdateTextBlock( Locale.ConvertTextKey( "TXT_KEY_PEDIA_QUOTE_BLOCK_TECHS" ), Controls.HomePageBlurbLabel, Controls.HomePageBlurbInnerFrame, Controls.HomePageBlurbFrame );
-	
+
 	g_BBTextManager:ResetInstances();
-	
-	--Basic Sectional Infos	
+
+	--Basic Sectional Infos
 	local thisBBTextInstance = g_BBTextManager:GetInstance();
 	if thisBBTextInstance then
 		thisBBTextInstance.BBTextHeader:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_TECH_PAGE_LABEL" ));
 		UpdateSuperWideTextBlock( Locale.ConvertTextKey( "TXT_KEY_PEDIA_TECHNOLOGIES_HELP_TEXT" ), thisBBTextInstance.BBTextLabel, thisBBTextInstance.BBTextInnerFrame, thisBBTextInstance.BBTextFrame );
-	end	
-	
+	end
+
 	Controls.BBTextStack:SetHide( false );
 	ResizeEtc();
 end;
 
 CivilopediaCategory[CategoryUnits].DisplayHomePage = function()
 	ClearArticle();
-	Controls.ArticleID:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_UNITS_PAGE_LABEL" ));	
-	
+	Controls.ArticleID:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_UNITS_PAGE_LABEL" ));
+
 	local portraitIndex = 26;
 	local portraitAtlas = "UNIT_ATLAS_1";
-		
+
 	for row in DB.Query("SELECT PortraitIndex, IconAtlas from Units ORDER By Random() LIMIT 1") do
 		portraitIndex = row.PortraitIndex;
 		portraitAtlas = row.IconAtlas;
-	end	
-	
+	end
+
 	if IconHookup( portraitIndex, portraitSize, portraitAtlas, Controls.Portrait ) then
 		Controls.PortraitFrame:SetHide( false );
 	else
 		Controls.PortraitFrame:SetHide( true );
 	end
-	
+
 	UpdateTextBlock( Locale.ConvertTextKey( "TXT_KEY_PEDIA_QUOTE_BLOCK_UNITS" ), Controls.HomePageBlurbLabel, Controls.HomePageBlurbInnerFrame, Controls.HomePageBlurbFrame );
-	
+
 	g_BBTextManager:ResetInstances();
-	
-	--Basic Sectional Infos	
+
+	--Basic Sectional Infos
 	local thisBBTextInstance = g_BBTextManager:GetInstance();
 	if thisBBTextInstance then
 		thisBBTextInstance.BBTextHeader:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_UNITS_PAGE_LABEL" ));
 		UpdateSuperWideTextBlock( Locale.ConvertTextKey( "TXT_KEY_PEDIA_UNITS_HELP_TEXT" ), thisBBTextInstance.BBTextLabel, thisBBTextInstance.BBTextInnerFrame, thisBBTextInstance.BBTextFrame );
-	end	
+	end
 	Controls.BBTextStack:SetHide( false );
 	ResizeEtc();
 end;
 
 CivilopediaCategory[CategoryPromotions].DisplayHomePage = function()
 	ClearArticle();
-	Controls.ArticleID:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_PROMOTIONS_PAGE_LABEL" ));	
-	
+	Controls.ArticleID:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_PROMOTIONS_PAGE_LABEL" ));
+
 	local portraitIndex = 16;
 	local portraitAtlas = "PROMOTION_ATLAS";
-		
+
 	for row in DB.Query("SELECT PortraitIndex, IconAtlas from UnitPromotions ORDER By Random() LIMIT 1") do
 		portraitIndex = row.PortraitIndex;
 		portraitAtlas = row.IconAtlas;
-	end	
-	
+	end
+
 	if IconHookup( portraitIndex, portraitSize, portraitAtlas, Controls.Portrait ) then
 		Controls.PortraitFrame:SetHide( false );
 	else
 		Controls.PortraitFrame:SetHide( true );
 	end
-	
+
 	UpdateTextBlock( Locale.ConvertTextKey( "TXT_KEY_PEDIA_QUOTE_BLOCK_PROMOTIONS" ), Controls.HomePageBlurbLabel, Controls.HomePageBlurbInnerFrame, Controls.HomePageBlurbFrame );
-	
+
 	g_BBTextManager:ResetInstances();
-			
-	--Basic Sectional Infos	
+
+	--Basic Sectional Infos
 	local thisBBTextInstance = g_BBTextManager:GetInstance();
 	if thisBBTextInstance then
 		thisBBTextInstance.BBTextHeader:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_PROMOTIONS_PAGE_LABEL" ));
 		UpdateSuperWideTextBlock( Locale.ConvertTextKey( "TXT_KEY_PEDIA_PROMOTIONS_HELP_TEXT" ), thisBBTextInstance.BBTextLabel, thisBBTextInstance.BBTextInnerFrame, thisBBTextInstance.BBTextFrame );
-	end	
+	end
 	Controls.BBTextStack:SetHide( false );
 	ResizeEtc();
 end;
 
 CivilopediaCategory[CategoryBuildings].DisplayHomePage = function()
 	ClearArticle();
-	Controls.ArticleID:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_BUILDINGS_PAGE_LABEL" ));	
-	
+	Controls.ArticleID:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_BUILDINGS_PAGE_LABEL" ));
+
 	local portraitIndex = 24;
 	local portraitAtlas = "BW_ATLAS_1";
-		
+
 	for row in DB.Query("SELECT PortraitIndex, IconAtlas from Buildings where WonderSplashImage IS NULL ORDER By Random() LIMIT 1") do
 		portraitIndex = row.PortraitIndex;
 		portraitAtlas = row.IconAtlas;
-	end	
-	
+	end
+
 	if IconHookup( portraitIndex, portraitSize, portraitAtlas, Controls.Portrait ) then
 		Controls.PortraitFrame:SetHide( false );
 	else
 		Controls.PortraitFrame:SetHide( true );
 	end
-	
+
 	UpdateTextBlock( Locale.ConvertTextKey( "TXT_KEY_PEDIA_QUOTE_BLOCK_BUILDINGS" ), Controls.HomePageBlurbLabel, Controls.HomePageBlurbInnerFrame, Controls.HomePageBlurbFrame );
-	
+
 	g_BBTextManager:ResetInstances();
-			
-	--Basic Sectional Infos	
+
+	--Basic Sectional Infos
 	local thisBBTextInstance = g_BBTextManager:GetInstance();
 	if thisBBTextInstance then
 		thisBBTextInstance.BBTextHeader:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_BUILDINGS_PAGE_LABEL" ));
 		UpdateSuperWideTextBlock( Locale.ConvertTextKey( "TXT_KEY_PEDIA_BUILDINGS_HELP_TEXT" ), thisBBTextInstance.BBTextLabel, thisBBTextInstance.BBTextInnerFrame, thisBBTextInstance.BBTextFrame );
-	end	
+	end
 	Controls.BBTextStack:SetHide( false );
 	ResizeEtc();
 end;
 
 CivilopediaCategory[CategoryWonders].DisplayHomePage = function()
 	ClearArticle();
-	Controls.ArticleID:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_WONDERS_PAGE_LABEL" ));	
-	
+	Controls.ArticleID:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_WONDERS_PAGE_LABEL" ));
+
 	local portraitIndex = 2;
 	local portraitAtlas = "BW_ATLAS_2";
-		
+
 	for row in DB.Query("SELECT PortraitIndex, IconAtlas from Buildings Where WonderSplashImage IS NOT NULL ORDER By Random() LIMIT 1") do
 		portraitIndex = row.PortraitIndex;
 		portraitAtlas = row.IconAtlas;
-	end	
-	
+	end
+
 	if IconHookup( portraitIndex, portraitSize, portraitAtlas, Controls.Portrait ) then
 		Controls.PortraitFrame:SetHide( false );
 	else
 		Controls.PortraitFrame:SetHide( true );
 	end
-	
+
 	UpdateTextBlock( Locale.ConvertTextKey( "TXT_KEY_PEDIA_QUOTE_BLOCK_WONDERS" ), Controls.HomePageBlurbLabel, Controls.HomePageBlurbInnerFrame, Controls.HomePageBlurbFrame );
-	
+
 	g_BBTextManager:ResetInstances();
-	
-	--Basic Sectional Infos	
+
+	--Basic Sectional Infos
 	local thisBBTextInstance = g_BBTextManager:GetInstance();
 	if thisBBTextInstance then
 		thisBBTextInstance.BBTextHeader:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_WONDERS_PAGE_LABEL" ));
 		UpdateSuperWideTextBlock( Locale.ConvertTextKey( "TXT_KEY_PEDIA_WONDERS_HELP_TEXT" ), thisBBTextInstance.BBTextLabel, thisBBTextInstance.BBTextInnerFrame, thisBBTextInstance.BBTextFrame );
-	end	
+	end
 	Controls.BBTextStack:SetHide( false );
 	ResizeEtc();
 end;
 
 CivilopediaCategory[CategoryPolicies].DisplayHomePage = function()
 	ClearArticle();
-	Controls.ArticleID:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_POLICIES_PAGE_LABEL" ));	
-	
+	Controls.ArticleID:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_POLICIES_PAGE_LABEL" ));
+
 	local portraitIndex = 25;
 	local portraitAtlas = "POLICY_ATLAS";
-		
+
 	for row in DB.Query("SELECT PortraitIndex, IconAtlas from Policies Where IconAtlas IS NOT NULL ORDER By Random() LIMIT 1") do
 		portraitIndex = row.PortraitIndex;
 		portraitAtlas = row.IconAtlas;
-	end	
-	
+	end
+
 	if IconHookup( portraitIndex, portraitSize, portraitAtlas, Controls.Portrait ) then
 		Controls.PortraitFrame:SetHide( false );
 	else
 		Controls.PortraitFrame:SetHide( true );
 	end
-	
+
 	UpdateTextBlock( Locale.ConvertTextKey( "TXT_KEY_PEDIA_QUOTE_BLOCK_POLICIES" ), Controls.HomePageBlurbLabel, Controls.HomePageBlurbInnerFrame, Controls.HomePageBlurbFrame );
-	
+
 	g_BBTextManager:ResetInstances();
-	
-	--Basic Sectional Infos	
+
+	--Basic Sectional Infos
 	local thisBBTextInstance = g_BBTextManager:GetInstance();
 	if thisBBTextInstance then
 		thisBBTextInstance.BBTextHeader:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_POLICIES_PAGE_LABEL" ));
 		UpdateSuperWideTextBlock( Locale.ConvertTextKey( "TXT_KEY_PEDIA_SOCIAL_POL_HELP_TEXT" ), thisBBTextInstance.BBTextLabel, thisBBTextInstance.BBTextInnerFrame, thisBBTextInstance.BBTextFrame );
-	end	
+	end
 	Controls.BBTextStack:SetHide( false );
 	ResizeEtc();
 end;
 
 CivilopediaCategory[CategoryPeople].DisplayHomePage = function()
 	ClearArticle();
-	Controls.ArticleID:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_PEOPLE_PAGE_LABEL" ));	
+	Controls.ArticleID:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_PEOPLE_PAGE_LABEL" ));
 
 	if IconHookup( 47, portraitSize, "UNIT_ATLAS_2", Controls.Portrait ) then
 		Controls.PortraitFrame:SetHide( false );
 	else
 		Controls.PortraitFrame:SetHide( true );
 	end
-	
+
 	UpdateTextBlock( Locale.ConvertTextKey( "TXT_KEY_PEDIA_QUOTE_BLOCK_PEOPLE" ), Controls.HomePageBlurbLabel, Controls.HomePageBlurbInnerFrame, Controls.HomePageBlurbFrame );
-	
+
 	g_BBTextManager:ResetInstances();
-		
-	--Basic Sectional Infos	
+
+	--Basic Sectional Infos
 	local thisBBTextInstance = g_BBTextManager:GetInstance();
 	if thisBBTextInstance then
 		thisBBTextInstance.BBTextHeader:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_PEOPLE_PAGE_LABEL" ));
 		UpdateSuperWideTextBlock( Locale.ConvertTextKey( "TXT_KEY_PEDIA_SPEC_HELP_TEXT" ), thisBBTextInstance.BBTextLabel, thisBBTextInstance.BBTextInnerFrame, thisBBTextInstance.BBTextFrame );
-	end	
+	end
 	Controls.BBTextStack:SetHide( false );
 	ResizeEtc();
 end;
 
 CivilopediaCategory[CategoryCivilizations].DisplayHomePage = function()
 	ClearArticle();
-	Controls.ArticleID:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_CIVILIZATIONS_PAGE_LABEL" ));	
-	
+	Controls.ArticleID:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_CIVILIZATIONS_PAGE_LABEL" ));
+
 	local portraitIndex = 7;
 	local portraitAtlas = "LEADER_ATLAS";
-		
+
 	for row in DB.Query("SELECT PortraitIndex, IconAtlas from Leaders where Type <> \"LEADER_BARBARIAN\" ORDER By Random() LIMIT 1") do
 		portraitIndex = row.PortraitIndex;
 		portraitAtlas = row.IconAtlas;
-	end	
-	
+	end
+
 	if IconHookup( portraitIndex, portraitSize, portraitAtlas, Controls.Portrait ) then
 		Controls.PortraitFrame:SetHide( false );
 	else
 		Controls.PortraitFrame:SetHide( true );
 	end
-	
-	
-	
+
+
+
 	UpdateTextBlock( Locale.ConvertTextKey( "TXT_KEY_PEDIA_QUOTE_BLOCK_CIVS" ), Controls.HomePageBlurbLabel, Controls.HomePageBlurbInnerFrame, Controls.HomePageBlurbFrame );
-	
+
 	g_BBTextManager:ResetInstances();
-			
-	--Basic Sectional Infos	
+
+	--Basic Sectional Infos
 	local thisBBTextInstance = g_BBTextManager:GetInstance();
 	if thisBBTextInstance then
 		thisBBTextInstance.BBTextHeader:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_CIVILIZATIONS_PAGE_LABEL" ));
 		UpdateSuperWideTextBlock( Locale.ConvertTextKey( "TXT_KEY_PEDIA_CIVS_HELP_TEXT" ), thisBBTextInstance.BBTextLabel, thisBBTextInstance.BBTextInnerFrame, thisBBTextInstance.BBTextFrame );
-	end	
+	end
 	Controls.BBTextStack:SetHide( false );
 	ResizeEtc();
 end;
 
 CivilopediaCategory[CategoryCityStates].DisplayHomePage = function()
 	ClearArticle();
-	Controls.ArticleID:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_CITY_STATES_PAGE_LABEL" ));	
-	
+	Controls.ArticleID:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_CITY_STATES_PAGE_LABEL" ));
+
 	if IconHookup( 44, portraitSize, "UNIT_ATLAS_2", Controls.Portrait ) then
 		Controls.PortraitFrame:SetHide( false );
 	else
 		Controls.PortraitFrame:SetHide( true );
 	end
-	
+
 	UpdateTextBlock( Locale.ConvertTextKey( "TXT_KEY_PEDIA_QUOTE_BLOCK_CITYSTATES" ), Controls.HomePageBlurbLabel, Controls.HomePageBlurbInnerFrame, Controls.HomePageBlurbFrame );
-	
+
 	g_BBTextManager:ResetInstances();
-			
-	--Basic Sectional Infos	
+
+	--Basic Sectional Infos
 	local thisBBTextInstance = g_BBTextManager:GetInstance();
 	if thisBBTextInstance then
 		thisBBTextInstance.BBTextHeader:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_CITY_STATES_PAGE_LABEL" ));
 		UpdateSuperWideTextBlock( Locale.ConvertTextKey( "TXT_KEY_PEDIA_CSTATES_HELP_TEXT" ), thisBBTextInstance.BBTextLabel, thisBBTextInstance.BBTextInnerFrame, thisBBTextInstance.BBTextFrame );
-	end	
+	end
 	Controls.BBTextStack:SetHide( false );
 	ResizeEtc();
 end;
 
 CivilopediaCategory[CategoryTerrain].DisplayHomePage = function()
 	ClearArticle();
-	Controls.ArticleID:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_TERRAIN_PAGE_LABEL" ));	
-	
+	Controls.ArticleID:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_TERRAIN_PAGE_LABEL" ));
+
 	local portraitIndex = 9;
 	local portraitAtlas = "TERRAIN_ATLAS";
-		
+
 	for row in DB.Query("SELECT PortraitIndex, IconAtlas from Terrains ORDER By Random() LIMIT 1") do
 		portraitIndex = row.PortraitIndex;
 		portraitAtlas = row.IconAtlas;
-	end	
-	
-	
+	end
+
+
 	if IconHookup( portraitIndex, portraitSize, portraitAtlas, Controls.Portrait ) then
 		Controls.PortraitFrame:SetHide( false );
 	else
 		Controls.PortraitFrame:SetHide( true );
 	end
-	
+
 	UpdateTextBlock( Locale.ConvertTextKey( "TXT_KEY_PEDIA_QUOTE_BLOCK_TERRAIN" ), Controls.HomePageBlurbLabel, Controls.HomePageBlurbInnerFrame, Controls.HomePageBlurbFrame );
-	
+
 	g_BBTextManager:ResetInstances();
-			
-	--Basic Sectional Infos	
+
+	--Basic Sectional Infos
 	local thisBBTextInstance = g_BBTextManager:GetInstance();
 	if thisBBTextInstance then
 		thisBBTextInstance.BBTextHeader:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_TERRAIN_LABEL" ));
-		UpdateSuperWideTextBlock( Locale.ConvertTextKey( "TXT_KEY_PEDIA_TERRAIN_HELP_TEXT" ), thisBBTextInstance.BBTextLabel, thisBBTextInstance.BBTextInnerFrame, thisBBTextInstance.BBTextFrame );	
-	end	
+		UpdateSuperWideTextBlock( Locale.ConvertTextKey( "TXT_KEY_PEDIA_TERRAIN_HELP_TEXT" ), thisBBTextInstance.BBTextLabel, thisBBTextInstance.BBTextInnerFrame, thisBBTextInstance.BBTextFrame );
+	end
 	Controls.BBTextStack:SetHide( false );
 	local thisBBTextInstance = g_BBTextManager:GetInstance();
 	if thisBBTextInstance then
@@ -1977,145 +1978,145 @@ end;
 
 CivilopediaCategory[CategoryResources].DisplayHomePage = function()
 	ClearArticle();
-	Controls.ArticleID:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_RESOURCES_PAGE_LABEL" ));	
-	
+	Controls.ArticleID:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_RESOURCES_PAGE_LABEL" ));
+
 	local portraitIndex = 6;
 	local portraitAtlas = "RESOURCE_ATLAS";
-		
+
 	for row in DB.Query("SELECT PortraitIndex, IconAtlas from Resources ORDER By Random() LIMIT 1") do
 		portraitIndex = row.PortraitIndex;
 		portraitAtlas = row.IconAtlas;
-	end	
-	
+	end
+
 	if IconHookup( portraitIndex, portraitSize, portraitAtlas, Controls.Portrait ) then
 		Controls.PortraitFrame:SetHide( false );
 	else
 		Controls.PortraitFrame:SetHide( true );
 	end
-	
+
 	UpdateTextBlock( Locale.ConvertTextKey( "TXT_KEY_PEDIA_QUOTE_BLOCK_RESOURCES" ), Controls.HomePageBlurbLabel, Controls.HomePageBlurbInnerFrame, Controls.HomePageBlurbFrame );
-	
+
 	g_BBTextManager:ResetInstances();
-			
-	--Basic Sectional Infos	
+
+	--Basic Sectional Infos
 	local thisBBTextInstance = g_BBTextManager:GetInstance();
 	if thisBBTextInstance then
 		thisBBTextInstance.BBTextHeader:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_RESOURCES_PAGE_LABEL" ));
 		UpdateSuperWideTextBlock( Locale.ConvertTextKey( "TXT_KEY_PEDIA_RESOURCES_HELP_TEXT" ), thisBBTextInstance.BBTextLabel, thisBBTextInstance.BBTextInnerFrame, thisBBTextInstance.BBTextFrame );
-	end	
+	end
 	Controls.BBTextStack:SetHide( false );
 	ResizeEtc();
 end;
 
 CivilopediaCategory[CategoryImprovements].DisplayHomePage = function()
 	ClearArticle();
-	Controls.ArticleID:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_IMPROVEMENTS_PAGE_LABEL" ));	
-	
+	Controls.ArticleID:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_IMPROVEMENTS_PAGE_LABEL" ));
+
 	--eventually make random?
 	local portraitIndex = 1;
 	local portraitAtlas = "BW_ATLAS_1";
-		
+
 	for row in DB.Query("SELECT PortraitIndex, IconAtlas from Improvements ORDER By Random() LIMIT 1") do
 		portraitIndex = row.PortraitIndex;
 		portraitAtlas = row.IconAtlas;
-	end	
-	
+	end
+
 	if IconHookup( portraitIndex, portraitSize, portraitAtlas, Controls.Portrait ) then
 		Controls.PortraitFrame:SetHide( false );
 	else
 		Controls.PortraitFrame:SetHide( true );
 	end
-	
+
 	UpdateTextBlock( Locale.ConvertTextKey( "TXT_KEY_PEDIA_QUOTE_BLOCK_IMPROVEMENTS" ), Controls.HomePageBlurbLabel, Controls.HomePageBlurbInnerFrame, Controls.HomePageBlurbFrame );
-	
+
 	g_BBTextManager:ResetInstances();
-			
-	--Basic Sectional Infos	
+
+	--Basic Sectional Infos
 	local thisBBTextInstance = g_BBTextManager:GetInstance();
 	if thisBBTextInstance then
 		thisBBTextInstance.BBTextHeader:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_IMPROVEMENTS_PAGE_LABEL" ));
 		UpdateSuperWideTextBlock( Locale.ConvertTextKey( "TXT_KEY_PEDIA_IMPROVEMENT_HELP_TEXT" ), thisBBTextInstance.BBTextLabel, thisBBTextInstance.BBTextInnerFrame, thisBBTextInstance.BBTextFrame );
-	end	
+	end
 	Controls.BBTextStack:SetHide( false );
 	ResizeEtc();
 end;
 
 CivilopediaCategory[CategoryBeliefs].DisplayHomePage = function()
 	ClearArticle();
-	Controls.ArticleID:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_BELIEFS_PAGE_LABEL" ));	
-	
+	Controls.ArticleID:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_BELIEFS_PAGE_LABEL" ));
+
 	Controls.Portrait:SetTexture("Religion256.dds");
 	Controls.Portrait:SetTextureOffsetVal(0,0);
 	Controls.Portrait:SetHide(false);
-	
+
 	Controls.PortraitFrame:SetHide(false);
-	
+
 	UpdateTextBlock( Locale.ConvertTextKey( "TXT_KEY_PEDIA_BELIEFS_HOMEPAGE_BLURB" ), Controls.HomePageBlurbLabel, Controls.HomePageBlurbInnerFrame, Controls.HomePageBlurbFrame );
-	
+
 	g_BBTextManager:ResetInstances();
-			
-	--Basic Sectional Infos	
+
+	--Basic Sectional Infos
 	local thisBBTextInstance = g_BBTextManager:GetInstance();
 	if thisBBTextInstance then
 		thisBBTextInstance.BBTextHeader:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_BELIEFS_HOMEPAGE_LABEL1" ));
 		UpdateSuperWideTextBlock( Locale.ConvertTextKey( "TXT_KEY_PEDIA_BELIEFS_HOMEPAGE_TEXT1" ), thisBBTextInstance.BBTextLabel, thisBBTextInstance.BBTextInnerFrame, thisBBTextInstance.BBTextFrame );
-	end	
+	end
 	Controls.BBTextStack:SetHide( false );
 	ResizeEtc();
 end;
 
 CivilopediaCategory[CategoryWorldCongress].DisplayHomePage = function()
 	ClearArticle();
-	Controls.ArticleID:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_WORLD_CONGRESS_PAGE_LABEL" ));	
-	
+	Controls.ArticleID:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_WORLD_CONGRESS_PAGE_LABEL" ));
+
 	Controls.Portrait:SetTexture("WorldCongressPortrait256_EXP2.dds");
 	Controls.Portrait:SetTextureOffsetVal(0,0);
 	Controls.Portrait:SetHide(false);
-	
+
 	Controls.PortraitFrame:SetHide(false);
-	
+
 	UpdateTextBlock( Locale.ConvertTextKey( "TXT_KEY_PEDIA_WORLD_CONGRESS_HOMEPAGE_BLURB" ), Controls.HomePageBlurbLabel, Controls.HomePageBlurbInnerFrame, Controls.HomePageBlurbFrame );
-	
+
 	g_BBTextManager:ResetInstances();
-			
-	--Basic Sectional Infos	
+
+	--Basic Sectional Infos
 	local thisBBTextInstance = g_BBTextManager:GetInstance();
 	if thisBBTextInstance then
 		thisBBTextInstance.BBTextHeader:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_WORLD_CONGRESS_HOMEPAGE_LABEL1" ));
 		UpdateSuperWideTextBlock( Locale.ConvertTextKey( "TXT_KEY_PEDIA_WORLD_CONGRESS_HOMEPAGE_TEXT1" ), thisBBTextInstance.BBTextLabel, thisBBTextInstance.BBTextInnerFrame, thisBBTextInstance.BBTextFrame );
-	end	
+	end
 	Controls.BBTextStack:SetHide( false );
 	ResizeEtc();
 end;
 
 CivilopediaCategory[CategoryCorporations].DisplayHomePage = function()
 	ClearArticle();
-	Controls.ArticleID:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_CORPORATIONS_PAGE_LABEL" ));	
-	
+	Controls.ArticleID:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_CORPORATIONS_PAGE_LABEL" ));
+
 	local portraitIndex = 6;
 	local portraitAtlas = "CORP_ATLAS";
-		
+
 	for row in DB.Query("SELECT PortraitIndex, IconAtlas from Corporations ORDER By Random() LIMIT 1") do
 		portraitIndex = row.PortraitIndex;
 		portraitAtlas = row.IconAtlas;
-	end	
-	
+	end
+
 	if IconHookup( portraitIndex, portraitSize, portraitAtlas, Controls.Portrait ) then
 		Controls.PortraitFrame:SetHide( false );
 	else
 		Controls.PortraitFrame:SetHide( true );
 	end
-	
+
 	UpdateTextBlock( Locale.ConvertTextKey( "TXT_KEY_PEDIA_CORPORATIONS_HOMEPAGE_BLURB" ), Controls.HomePageBlurbLabel, Controls.HomePageBlurbInnerFrame, Controls.HomePageBlurbFrame );
-	
+
 	g_BBTextManager:ResetInstances();
-			
-	--Basic Sectional Infos	
+
+	--Basic Sectional Infos
 	local thisBBTextInstance = g_BBTextManager:GetInstance();
 	if thisBBTextInstance then
 		thisBBTextInstance.BBTextHeader:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_CORPORATIONS_HOMEPAGE_LABEL1" ));
 		UpdateSuperWideTextBlock( Locale.ConvertTextKey( "TXT_KEY_PEDIA_CORPORATIONS_HOMEPAGE_TEXT1" ), thisBBTextInstance.BBTextLabel, thisBBTextInstance.BBTextInnerFrame, thisBBTextInstance.BBTextFrame );
-	end	
+	end
 	Controls.BBTextStack:SetHide( false );
 	ResizeEtc();
 end;
@@ -2179,21 +2180,21 @@ function UpdateButtonFrame( numButtonsAdded, innerFrame, outerFrame )
 		outerFrame:SetSize( frameSize );
 		outerFrame:SetHide( false );
 	end
-end	
+end
 
 function UpdateSmallButton( buttonAdded, image, button, textureSheet, textureOffset, category, localizedText, buttonId )
-	
+
 	if(textureSheet ~= nil) then
 		image:SetTexture( textureSheet );
 	end
-	
+
 	if(textureOffset ~= nil) then
-		image:SetTextureOffset( textureOffset );	
+		image:SetTextureOffset( textureOffset );
 	end
-	
-	button:SetOffsetVal( (buttonAdded % numberOfButtonsPerRow) * buttonSize + buttonPadding, math.floor(buttonAdded / numberOfButtonsPerRow) * buttonSize + buttonPadding );				
+
+	button:SetOffsetVal( (buttonAdded % numberOfButtonsPerRow) * buttonSize + buttonPadding, math.floor(buttonAdded / numberOfButtonsPerRow) * buttonSize + buttonPadding );
 	button:SetToolTipString( localizedText );
-	
+
 	if(category ~= nil) then
 		button:SetVoids( buttonId, addToList );
 		button:RegisterCallback( Mouse.eLClick, CivilopediaCategory[category].SelectArticle );
@@ -2211,17 +2212,17 @@ end
 function AnalyzeObjectField(tObject, sField, sSuffix, sAddText)
 	--dprint("   ...field", sField, type(tObject[sField]), tObject[sField]);
 	if tObject[sField] == nil then return ""; end
-	if type(tObject[sField]) == "boolean" then 
+	if type(tObject[sField]) == "boolean" then
 		if tObject[sField] then return "[NEWLINE][ICON_BULLET]"..sField;
 		else                    return ""; 	end
 	end
-	if type(tObject[sField]) == "string" then 
+	if type(tObject[sField]) == "string" then
 		if tObject[sField] == nil then return ""; end
 		if sSuffix == nil then return "[NEWLINE][ICON_BULLET]"..sField..string.format(" %s", tObject[sField]); end
 		-- sSuffix is reference table
 		return "[NEWLINE][ICON_BULLET]"..sAddText.." [COLOR_CYAN]"..Locale.Lookup(GameInfo[sSuffix][tObject[sField]].Description).."[ENDCOLOR]";
 	end
-	if type(tObject[sField]) == "number" then 
+	if type(tObject[sField]) == "number" then
 		if tObject[sField] == 0 or tObject[sField] == -1 then return ""; end
 		local suffix = "%";
 		if sSuffix ~= nil then suffix = " "..sSuffix; end
@@ -2236,9 +2237,9 @@ end
 
 
 CivilopediaCategory[CategoryHomePage].SelectArticle = function( pageID, shouldAddToList )
-	
+
 	ClearArticle();
-	
+
 	if pageID == 1 then
 		if selectedCategory ~= CategoryHomePage then
 		SetSelectedCategory(CategoryHomePage);
@@ -2268,12 +2269,12 @@ CivilopediaCategory[CategoryHomePage].SelectArticle = function( pageID, shouldAd
 		if selectedCategory ~= CategoryBuildings then
 		SetSelectedCategory(CategoryBuildings);
 		end
-		CivilopediaCategory[CategoryBuildings].DisplayHomePage(); 
+		CivilopediaCategory[CategoryBuildings].DisplayHomePage();
 	elseif pageID == 7 then
 		if selectedCategory ~= CategoryWonders then
 		SetSelectedCategory(CategoryWonders);
 		end
-		CivilopediaCategory[CategoryWonders].DisplayHomePage(); 
+		CivilopediaCategory[CategoryWonders].DisplayHomePage();
 	elseif pageID == 8 then
 		if selectedCategory ~= CategoryPolicies then
 		SetSelectedCategory(CategoryPolicies);
@@ -2298,7 +2299,7 @@ CivilopediaCategory[CategoryHomePage].SelectArticle = function( pageID, shouldAd
 		if selectedCategory ~= CategoryTerrain then
 		SetSelectedCategory(CategoryTerrain);
 		end
-		CivilopediaCategory[CategoryTerrain].DisplayHomePage();	
+		CivilopediaCategory[CategoryTerrain].DisplayHomePage();
 	elseif pageID == 13 then
 		if selectedCategory ~= CategoryResources then
 		SetSelectedCategory(CategoryResources);
@@ -2327,9 +2328,9 @@ CivilopediaCategory[CategoryHomePage].SelectArticle = function( pageID, shouldAd
 	else
 		print("couldn't find category home page");
 	end
-	
+
 	ResizeEtc();
-	
+
 end
 
 CivilopediaCategory[CategoryGameConcepts].SelectArticle = function( conceptID, shouldAddToList )
@@ -2337,9 +2338,9 @@ CivilopediaCategory[CategoryGameConcepts].SelectArticle = function( conceptID, s
 	if selectedCategory ~= CategoryGameConcepts then
 		SetSelectedCategory(CategoryGameConcepts);
 	end
-	
+
 	ClearArticle();
-	
+
 	if shouldAddToList == addToList then
 		currentTopic = currentTopic + 1;
 		listOfTopicsViewed[currentTopic] = categorizedList[(CategoryGameConcepts * absurdlyLargeNumTopicsInCategory) + conceptID];
@@ -2348,40 +2349,40 @@ CivilopediaCategory[CategoryGameConcepts].SelectArticle = function( conceptID, s
 		end
 		endTopic = currentTopic;
 	end
-	
+
 	if conceptID ~= -1 then
 		local thisConcept = GameInfo.Concepts[conceptID];
-		
+
 		if thisConcept then
-		
+
 			-- update the name
-			local name = Locale.ConvertTextKey( thisConcept.Description ); 	
+			local name = Locale.ConvertTextKey( thisConcept.Description );
 			Controls.ArticleID:SetText( name );
-			
+
 			-- portrait
-			
+
 			-- update the summary
 			if thisConcept.Summary then
 				UpdateTextBlock( Locale.ConvertTextKey( thisConcept.Summary ), Controls.SummaryLabel, Controls.SummaryInnerFrame, Controls.SummaryFrame );
 			end
-			
+
 			-- update the extended article
 			if thisConcept.Extended then
 				UpdateTextBlock( Locale.ConvertTextKey( thisConcept.Extended ), Controls.ExtendedLabel, Controls.ExtendedInnerFrame, Controls.ExtendedFrame );
 			end
-			
+
 			-- update the Designer's Notes
 			if thisConcept.DesignNotes then
 				UpdateTextBlock( Locale.ConvertTextKey( thisConcept.DesignNotes ), Controls.DNotesLabel, Controls.DNotesInnerFrame, Controls.DNotesFrame );
 			end
-			
+
 			-- related images
-			
+
 			-- related concepts
-		
+
 		end
 
-	end	
+	end
 
 	ResizeEtc();
 
@@ -2394,9 +2395,9 @@ CivilopediaCategory[CategoryTech].SelectArticle = function( techID, shouldAddToL
 	if selectedCategory ~= CategoryTech then
 		SetSelectedCategory(CategoryTech);
 	end
-	
+
 	ClearArticle();
-	
+
 	if shouldAddToList == addToList then
 		currentTopic = currentTopic + 1;
 		listOfTopicsViewed[currentTopic] = categorizedList[(CategoryTech * absurdlyLargeNumTopicsInCategory) + techID];
@@ -2405,11 +2406,11 @@ CivilopediaCategory[CategoryTech].SelectArticle = function( techID, shouldAddToL
 		end
 		endTopic = currentTopic;
 	end
-	
+
 	if techID ~= -1 then
 		local thisTech = GameInfo.Technologies[techID];
-					
-		local name = Locale.ConvertTextKey( thisTech.Description ); 	
+
+		local name = Locale.ConvertTextKey( thisTech.Description );
 		Controls.ArticleID:SetText( name );
 
 		-- if we have one, update the tech picture
@@ -2418,7 +2419,7 @@ CivilopediaCategory[CategoryTech].SelectArticle = function( techID, shouldAddToL
 		else
 			Controls.PortraitFrame:SetHide( true );
 		end
-		
+
 		-- update the cost
 		Controls.CostFrame:SetHide( false );
 
@@ -2427,7 +2428,7 @@ CivilopediaCategory[CategoryTech].SelectArticle = function( techID, shouldAddToL
 			local pPlayer = Players[Game.GetActivePlayer()];
 			local pTeam = Teams[pPlayer:GetTeam()];
 			local pTeamTechs = pTeam:GetTeamTechs();
-			cost = pTeamTechs:GetResearchCost(techID);		
+			cost = pTeamTechs:GetResearchCost(techID);
 		end
 
 		if (cost > 0) then
@@ -2435,7 +2436,7 @@ CivilopediaCategory[CategoryTech].SelectArticle = function( techID, shouldAddToL
 		else
 			Controls.CostLabel:SetText( Locale.ConvertTextKey( "TXT_KEY_FREE" ) );
 		end
-		
+
  		local contentSize;
  		local frameSize = {};
 		local buttonAdded = 0;
@@ -2453,14 +2454,14 @@ CivilopediaCategory[CategoryTech].SelectArticle = function( techID, shouldAddToL
 			local prereq = GameInfo.Technologies[row.PrereqTech];
 			local thisPrereqInstance = g_PrereqTechManager:GetInstance();
 			if thisPrereqInstance then
-				local textureOffset, textureSheet = IconLookup( prereq.PortraitIndex, buttonSize, prereq.IconAtlas );				
+				local textureOffset, textureSheet = IconLookup( prereq.PortraitIndex, buttonSize, prereq.IconAtlas );
 				if textureOffset == nil then
 					textureSheet = defaultErrorTextureSheet;
 					textureOffset = nullOffset;
-				end				
+				end
 				UpdateSmallButton( buttonAdded, thisPrereqInstance.PrereqTechImage, thisPrereqInstance.PrereqTechButton, textureSheet, textureOffset, CategoryTech, Locale.ConvertTextKey( prereq.Description ), prereq.ID );
 				buttonAdded = buttonAdded + 1;
-			end			
+			end
 		end
 		UpdateButtonFrame( buttonAdded, Controls.PrereqTechInnerFrame, Controls.PrereqTechFrame );
 
@@ -2471,14 +2472,14 @@ CivilopediaCategory[CategoryTech].SelectArticle = function( techID, shouldAddToL
 			local leadsTo = GameInfo.Technologies[row.TechType];
 			local thisLeadsToInstance = g_LeadsToTechManager:GetInstance();
 			if thisLeadsToInstance then
-				local textureOffset, textureSheet = IconLookup( leadsTo.PortraitIndex, buttonSize, leadsTo.IconAtlas );				
+				local textureOffset, textureSheet = IconLookup( leadsTo.PortraitIndex, buttonSize, leadsTo.IconAtlas );
 				if textureOffset == nil then
 					textureSheet = defaultErrorTextureSheet;
 					textureOffset = nullOffset;
-				end				
+				end
 				UpdateSmallButton( buttonAdded, thisLeadsToInstance.LeadsToTechImage, thisLeadsToInstance.LeadsToTechButton, textureSheet, textureOffset, CategoryTech, Locale.ConvertTextKey( leadsTo.Description ), leadsTo.ID );
 				buttonAdded = buttonAdded + 1;
-			end			
+			end
 		end
 		UpdateButtonFrame( buttonAdded, Controls.LeadsToTechInnerFrame, Controls.LeadsToTechFrame );
 
@@ -2489,18 +2490,18 @@ CivilopediaCategory[CategoryTech].SelectArticle = function( techID, shouldAddToL
 			if thisUnitInfo.ShowInPedia then
 				local thisUnitInstance = g_UnlockedUnitsManager:GetInstance();
 				if thisUnitInstance then
-					local textureOffset, textureSheet = IconLookup( thisUnitInfo.PortraitIndex, buttonSize, thisUnitInfo.IconAtlas );				
+					local textureOffset, textureSheet = IconLookup( thisUnitInfo.PortraitIndex, buttonSize, thisUnitInfo.IconAtlas );
 					if textureOffset == nil then
 						textureSheet = defaultErrorTextureSheet;
 						textureOffset = nullOffset;
-					end				
+					end
 					UpdateSmallButton( buttonAdded, thisUnitInstance.UnlockedUnitImage, thisUnitInstance.UnlockedUnitButton, textureSheet, textureOffset, CategoryUnits, Locale.ConvertTextKey( thisUnitInfo.Description ), thisUnitInfo.ID );
 					buttonAdded = buttonAdded + 1;
 				end
 			end
 		end
 		UpdateButtonFrame( buttonAdded, Controls.UnlockedUnitsInnerFrame, Controls.UnlockedUnitsFrame );
-		
+
 		-- update the buildings unlocked
 		g_UnlockedBuildingsManager:ResetInstances();
 		buttonAdded = 0;
@@ -2516,7 +2517,7 @@ CivilopediaCategory[CategoryTech].SelectArticle = function( techID, shouldAddToL
 
 					--move this button
 					thisBuildingInstance.UnlockedBuildingButton:SetOffsetVal( (buttonAdded % numberOfButtonsPerRow) * buttonSize + buttonPadding, math.floor(buttonAdded / numberOfButtonsPerRow) * buttonSize + buttonPadding );
-					
+
 					thisBuildingInstance.UnlockedBuildingButton:SetToolTipString( Locale.ConvertTextKey( thisBuildingInfo.Description ) );
 					thisBuildingInstance.UnlockedBuildingButton:SetVoids( thisBuildingInfo.ID, addToList );
 					local thisBuildingClass = GameInfo.BuildingClasses[thisBuildingInfo.BuildingClass];
@@ -2530,28 +2531,28 @@ CivilopediaCategory[CategoryTech].SelectArticle = function( techID, shouldAddToL
 			end
 		end
 		UpdateButtonFrame( buttonAdded, Controls.UnlockedBuildingsInnerFrame, Controls.UnlockedBuildingsFrame );
-		
+
 		-- update the projects unlocked
 		g_UnlockedProjectsManager:ResetInstances();
 		buttonAdded = 0;
 		for thisProjectInfo in GameInfo.Projects( otherPrereqCondition ) do
-		
+
 			local bIgnore = projectsToIgnore[thisProjectInfo.Type];
 			if(bIgnore ~= true) then
 				local thisProjectInstance = g_UnlockedProjectsManager:GetInstance();
 				if thisProjectInstance then
-					local textureOffset, textureSheet = IconLookup( thisProjectInfo.PortraitIndex, buttonSize, thisProjectInfo.IconAtlas );				
+					local textureOffset, textureSheet = IconLookup( thisProjectInfo.PortraitIndex, buttonSize, thisProjectInfo.IconAtlas );
 					if textureOffset == nil then
 						textureSheet = defaultErrorTextureSheet;
 						textureOffset = nullOffset;
-					end				
+					end
 					UpdateSmallButton( buttonAdded, thisProjectInstance.UnlockedProjectImage, thisProjectInstance.UnlockedProjectButton, textureSheet, textureOffset, CategoryWonders, Locale.ConvertTextKey( thisProjectInfo.Description ), thisProjectInfo.ID + 1000);
 					buttonAdded = buttonAdded + 1;
 				end
 			end
 		end
 		UpdateButtonFrame( buttonAdded, Controls.UnlockedProjectsInnerFrame, Controls.UnlockedProjectsFrame );
-		
+
 		-- update the resources revealed
 		g_RevealedResourcesManager:ResetInstances();
 		buttonAdded = 0;
@@ -2580,28 +2581,28 @@ CivilopediaCategory[CategoryTech].SelectArticle = function( techID, shouldAddToL
 						break;
 					end
 				end
-				
+
 				if isAltTech == false then
-					local textureOffset, textureSheet = IconLookup( revealedResource.PortraitIndex, buttonSize, revealedResource.IconAtlas );				
+					local textureOffset, textureSheet = IconLookup( revealedResource.PortraitIndex, buttonSize, revealedResource.IconAtlas );
 					if textureOffset == nil then
 						textureSheet = defaultErrorTextureSheet;
 						textureOffset = nullOffset;
-					end				
+					end
 					UpdateSmallButton( buttonAdded, thisRevealedResourceInstance.RevealedResourceImage, thisRevealedResourceInstance.RevealedResourceButton, textureSheet, textureOffset, CategoryResources, Locale.ConvertTextKey( revealedResource.Description ), revealedResource.ID );
 					buttonAdded = buttonAdded + 1;
 				end
-			end			
+			end
 		end
 		-- alternate reveal tech specific to this leader
 		for altRevealedResource in GameInfo.Trait_AlternateResourceTechs( "TraitType = '" .. traitType .. "'AND " .. revealCondition ) do
 			for resource in GameInfo.Resources( "Type = '" .. altRevealedResource.ResourceType .. "'" ) do
 				local thisRevealedResourceInstance = g_RevealedResourcesManager:GetInstance();
 				if thisRevealedResourceInstance then
-					local textureOffset, textureSheet = IconLookup( resource.PortraitIndex, buttonSize, resource.IconAtlas );				
+					local textureOffset, textureSheet = IconLookup( resource.PortraitIndex, buttonSize, resource.IconAtlas );
 					if textureOffset == nil then
 						textureSheet = defaultErrorTextureSheet;
 						textureOffset = nullOffset;
-					end				
+					end
 					UpdateSmallButton( buttonAdded, thisRevealedResourceInstance.RevealedResourceImage, thisRevealedResourceInstance.RevealedResourceButton, textureSheet, textureOffset, CategoryResources, Locale.ConvertTextKey( resource.Description ), resource.ID );
 					buttonAdded = buttonAdded + 1;
 				end
@@ -2615,7 +2616,7 @@ CivilopediaCategory[CategoryTech].SelectArticle = function( techID, shouldAddToL
 		for thisBuildInfo in GameInfo.Builds{PrereqTech = techType, ShowInPedia = 1} do
 			local thisWorkerActionInstance = g_WorkerActionsManager:GetInstance();
 			if thisWorkerActionInstance then
-				local textureOffset, textureSheet = IconLookup( thisBuildInfo.IconIndex, buttonSize, thisBuildInfo.IconAtlas );				
+				local textureOffset, textureSheet = IconLookup( thisBuildInfo.IconIndex, buttonSize, thisBuildInfo.IconAtlas );
 				if textureOffset == nil then
 					textureSheet = defaultErrorTextureSheet;
 					textureOffset = nullOffset;
@@ -2628,17 +2629,17 @@ CivilopediaCategory[CategoryTech].SelectArticle = function( techID, shouldAddToL
 					UpdateSmallButton( buttonAdded, thisWorkerActionInstance.WorkerActionImage, thisWorkerActionInstance.WorkerActionButton, textureSheet, textureOffset, CategoryGameConcepts, Locale.ConvertTextKey( thisBuildInfo.Description ), GameInfo.Concepts["CONCEPT_WORKERS_CLEARINGLAND"].ID );-- add fudge factor
 				end
 				buttonAdded = buttonAdded + 1;
-			end			
+			end
 		end
 		UpdateButtonFrame( buttonAdded, Controls.WorkerActionsInnerFrame, Controls.WorkerActionsFrame );
-		
+
 		-- update the related articles
 		Controls.RelatedArticlesFrame:SetHide( true ); -- todo: figure out how this should be implemented
 
 		-- update the game info
 		if (thisTech.Help) then
 			--CBP
-			UpdateTextBlock( GetHelpTextForTech(thisTech.ID, false), Controls.GameInfoLabel, Controls.GameInfoInnerFrame, Controls.GameInfoFrame )		
+			UpdateTextBlock( GetHelpTextForTech(thisTech.ID, false), Controls.GameInfoLabel, Controls.GameInfoInnerFrame, Controls.GameInfoFrame )
 			--END
 			--UpdateTextBlock( Locale.ConvertTextKey( thisTech.Help ), Controls.GameInfoLabel, Controls.GameInfoInnerFrame, Controls.GameInfoFrame );
 		end
@@ -2668,31 +2669,31 @@ CivilopediaCategory[CategoryTech].SelectArticle = function( techID, shouldAddToL
 			abilitiesString = abilitiesString .. Locale.ConvertTextKey("TXT_KEY_CIVILOPEDIA_SPECIALABILITIES_MOVEMENT", GameInfo.Routes[row.RouteType].Description);
 			numAbilities = numAbilities + 1;
 		end
-		
+
 		for row in GameInfo.Build_TechTimeChanges( condition ) do
 			if numAbilities > 0 then
 				 abilitiesString = abilitiesString .. "[NEWLINE]";
 			end
 			abilitiesString = abilitiesString .. Locale.ConvertTextKey("TXT_KEY_BUILD_COST_REDUCTION", GameInfo.Builds[row.BuildType].Description, row.TimeChange/100);
 			numAbilities = numAbilities + 1;
-		end	
-	
+		end
+
 		for row in GameInfo.Improvement_TechYieldChanges( condition ) do
 			if numAbilities > 0 then
 				 abilitiesString = abilitiesString .. "[NEWLINE]";
 			end
 			abilitiesString = abilitiesString .. Locale.ConvertTextKey("TXT_KEY_CIVILOPEDIA_SPECIALABILITIES_YIELDCHANGES", GameInfo.Improvements[row.ImprovementType].Description, GameInfo.Yields[row.YieldType].Description, row.Yield, Locale.ConvertTextKey(GameInfo.Yields[row.YieldType].IconString));
 			numAbilities = numAbilities + 1;
-		end	
+		end
 
 		for row in GameInfo.Improvement_TechNoFreshWaterYieldChanges( condition ) do
 			if numAbilities > 0 then
 				 abilitiesString = abilitiesString .. "[NEWLINE]";
 			end
-			
+
 			abilitiesString = abilitiesString .. Locale.ConvertTextKey("TXT_KEY_CIVILOPEDIA_SPECIALABILITIES_NOFRESHWATERYIELDCHANGES", GameInfo.Improvements[row.ImprovementType].Description, GameInfo.Yields[row.YieldType].Description, row.Yield, Locale.ConvertTextKey(GameInfo.Yields[row.YieldType].IconString));
 			numAbilities = numAbilities + 1;
-		end	
+		end
 
 		for row in GameInfo.Improvement_TechFreshWaterYieldChanges( condition ) do
 			if numAbilities > 0 then
@@ -2700,7 +2701,7 @@ CivilopediaCategory[CategoryTech].SelectArticle = function( techID, shouldAddToL
 			end
 			abilitiesString = abilitiesString .. Locale.ConvertTextKey("TXT_KEY_CIVILOPEDIA_SPECIALABILITIES_FRESHWATERYIELDCHANGES", GameInfo.Improvements[row.ImprovementType].Description, GameInfo.Yields[row.YieldType].Description, row.Yield, Locale.ConvertTextKey(GameInfo.Yields[row.YieldType].IconString));
 			numAbilities = numAbilities + 1;
-		end	
+		end
 
 		if thisTech.EmbarkedMoveChange > 0 then
 			if numAbilities > 0 then
@@ -2709,7 +2710,7 @@ CivilopediaCategory[CategoryTech].SelectArticle = function( techID, shouldAddToL
 			abilitiesString = abilitiesString .. Locale.ConvertTextKey( "TXT_KEY_ABLTY_FAST_EMBARK_STRING" );
 			numAbilities = numAbilities + 1;
 		end
-	
+
 		if thisTech.AllowsEmbarking then
 			if numAbilities > 0 then
 				 abilitiesString = abilitiesString .. "[NEWLINE]";
@@ -2717,7 +2718,7 @@ CivilopediaCategory[CategoryTech].SelectArticle = function( techID, shouldAddToL
 			abilitiesString = abilitiesString .. Locale.ConvertTextKey( "TXT_KEY_ALLOWS_EMBARKING" );
 			numAbilities = numAbilities + 1;
 		end
-	
+
 		if thisTech.AllowsDefensiveEmbarking then
 			if numAbilities > 0 then
 				 abilitiesString = abilitiesString .. "[NEWLINE]";
@@ -2725,7 +2726,7 @@ CivilopediaCategory[CategoryTech].SelectArticle = function( techID, shouldAddToL
 			abilitiesString = abilitiesString .. Locale.ConvertTextKey( "TXT_KEY_ABLTY_DEFENSIVE_EMBARK_STRING" );
 			numAbilities = numAbilities + 1;
 		end
-	
+
 		if thisTech.EmbarkedAllWaterPassage then
 			if numAbilities > 0 then
 				 abilitiesString = abilitiesString .. "[NEWLINE]";
@@ -2782,8 +2783,8 @@ CivilopediaCategory[CategoryTech].SelectArticle = function( techID, shouldAddToL
 			end
 			abilitiesString = abilitiesString .. Locale.ConvertTextKey("TXT_KEY_SPECIALIST_YIELD_CHANGE", GameInfo.Specialists[row.SpecialistType].Description , GameInfo.Yields[row.YieldType].Description, row.Yield, Locale.ConvertTextKey(GameInfo.Yields[row.YieldType].IconString));
 			numAbilities = numAbilities + 1;
-		end	
--- END	
+		end
+-- END
 -- Putmalk: If this tech grants Research Agreements, and Research Agreements are enabled, then display it on the tech info page
 		if (thisTech.ResearchAgreementTradingAllowed and g_bResearchAgreementTrading) then
 			if numAbilities > 0 then
@@ -2792,7 +2793,7 @@ CivilopediaCategory[CategoryTech].SelectArticle = function( techID, shouldAddToL
 			abilitiesString = abilitiesString .. Locale.ConvertTextKey( "TXT_KEY_ABLTY_R_PACT_STRING" );
 			numAbilities = numAbilities + 1;
 		end
-	
+
 		-- Putmalk: If this tech grants Map Trading then display it on the tech info page
 		if thisTech.MapTrading then
 			if numAbilities > 0 then
@@ -2801,7 +2802,7 @@ CivilopediaCategory[CategoryTech].SelectArticle = function( techID, shouldAddToL
 			abilitiesString = abilitiesString .. Locale.ConvertTextKey( "TXT_KEY_ABLTY_MAP_TRADING_STRING" );
 			numAbilities = numAbilities + 1;
 		end
-	
+
 		-- Putmalk: If this tech grants Tech Trading, and Tech trading is active, then display it on the tech info page
 		if (thisTech.TechTrading and g_bTechTrading) then
 			if numAbilities > 0 then
@@ -2810,7 +2811,7 @@ CivilopediaCategory[CategoryTech].SelectArticle = function( techID, shouldAddToL
 			abilitiesString = abilitiesString .. Locale.ConvertTextKey( "TXT_KEY_ABLTY_TECH_TRADING_STRING" );
 			numAbilities = numAbilities + 1;
 		end
-	
+
 		-- Putmalk: If this tech grants vassalage, and vassalage isn't disabled, then display it on the tech info page
 		if (thisTech.VassalageTradingAllowed and not g_bNoVassalage) then
 			if numAbilities > 0 then
@@ -2819,7 +2820,7 @@ CivilopediaCategory[CategoryTech].SelectArticle = function( techID, shouldAddToL
 			abilitiesString = abilitiesString .. Locale.ConvertTextKey( "TXT_KEY_ABLTY_VASSALAGE_STRING" );
 			numAbilities = numAbilities + 1;
 		end
--- END		
+-- END
 		if thisTech.AllowEmbassyTradingAllowed then
 			if numAbilities > 0 then
 				abilitiesString = abilitiesString .. "[NEWLINE]";
@@ -2827,7 +2828,7 @@ CivilopediaCategory[CategoryTech].SelectArticle = function( techID, shouldAddToL
 			abilitiesString = abilitiesString .. Locale.ConvertTextKey( "TXT_KEY_ABLTY_ALLOW_EMBASSY_STRING" );
 			numAbilities = numAbilities + 1;
 		end
-	
+
 		if thisTech.OpenBordersTradingAllowed then
 			if numAbilities > 0 then
 				 abilitiesString = abilitiesString .. "[NEWLINE]";
@@ -2835,7 +2836,7 @@ CivilopediaCategory[CategoryTech].SelectArticle = function( techID, shouldAddToL
 			abilitiesString = abilitiesString .. Locale.ConvertTextKey( "TXT_KEY_ABLTY_OPEN_BORDER_STRING" );
 			numAbilities = numAbilities + 1;
 		end
-	
+
 		if thisTech.DefensivePactTradingAllowed then
 			if numAbilities > 0 then
 				 abilitiesString = abilitiesString .. "[NEWLINE]";
@@ -2843,7 +2844,7 @@ CivilopediaCategory[CategoryTech].SelectArticle = function( techID, shouldAddToL
 			abilitiesString = abilitiesString .. Locale.ConvertTextKey( "TXT_KEY_ABLTY_D_PACT_STRING" );
 			numAbilities = numAbilities + 1;
 		end
-	
+
 		if thisTech.ResearchAgreementTradingAllowed then
 			if numAbilities > 0 then
 				 abilitiesString = abilitiesString .. "[NEWLINE]";
@@ -2851,7 +2852,7 @@ CivilopediaCategory[CategoryTech].SelectArticle = function( techID, shouldAddToL
 			abilitiesString = abilitiesString .. Locale.ConvertTextKey( "TXT_KEY_ABLTY_R_PACT_STRING" );
 			numAbilities = numAbilities + 1;
 		end
-	
+
 		if thisTech.BridgeBuilding then
 			if numAbilities > 0 then
 				 abilitiesString = abilitiesString .. "[NEWLINE]";
@@ -2863,19 +2864,19 @@ CivilopediaCategory[CategoryTech].SelectArticle = function( techID, shouldAddToL
 		if numAbilities > 0 then
 			UpdateTextBlock( Locale.ConvertTextKey( abilitiesString ), Controls.AbilitiesLabel, Controls.AbilitiesInnerFrame, Controls.AbilitiesFrame );
 		else
-			Controls.AbilitiesFrame:SetHide( true );			
+			Controls.AbilitiesFrame:SetHide( true );
 		end
-		
+
 		-- update the historical info
 		if (thisTech.Civilopedia) then
 			UpdateTextBlock( Locale.ConvertTextKey( thisTech.Civilopedia ), Controls.HistoryLabel, Controls.HistoryInnerFrame, Controls.HistoryFrame );
 		end
-		
+
 		-- update the related images
 		Controls.RelatedImagesFrame:SetHide( true );
-		
+
 	end
-	
+
 	ResizeEtc();
 
 end
@@ -2885,9 +2886,9 @@ CivilopediaCategory[CategoryUnits].SelectArticle = function( unitID, shouldAddTo
 	if selectedCategory ~= CategoryUnits then
 		SetSelectedCategory(CategoryUnits);
 	end
-	
+
 	ClearArticle();
-	
+
 	if shouldAddToList == addToList then
 		currentTopic = currentTopic + 1;
 		listOfTopicsViewed[currentTopic] = categorizedList[(CategoryUnits * absurdlyLargeNumTopicsInCategory) + unitID];
@@ -2896,12 +2897,12 @@ CivilopediaCategory[CategoryUnits].SelectArticle = function( unitID, shouldAddTo
 		end
 		endTopic = currentTopic;
 	end
-	
+
 	if unitID ~= -1 then
 		local thisUnit = GameInfo.Units[unitID];
-					
+
 		-- update the name
-		local name = Locale.ConvertTextKey( thisUnit.Description ); 	
+		local name = Locale.ConvertTextKey( thisUnit.Description );
 		Controls.ArticleID:SetText( name );
 
 		-- update the portrait
@@ -2913,24 +2914,24 @@ CivilopediaCategory[CategoryUnits].SelectArticle = function( unitID, shouldAddTo
 
 		-- update the cost
 		Controls.CostFrame:SetHide( false );
-		
+
 		local costString = "";
-		
+
 		local cost = thisUnit.Cost;
-		
+
 		local faithCost = thisUnit.FaithCost;
-		
+
 		if(Game and not Game.IsOption(GameOptionTypes.GAMEOPTION_NO_RELIGION)) then
 			faithCost = Game.GetFaithCost(unitID);
 		end
-		
+
 		if(Game ~= nil) then
 			cost = Players[Game.GetActivePlayer()]:GetUnitProductionNeeded( unitID );
 		end
-		
+
 		if(cost == 1 and faithCost > 0) then
 			costString = tostring(faithCost) .. " [ICON_PEACE]";
-			
+
 		elseif(cost > 0 and faithCost > 0) then
 			costString = Locale.Lookup("TXT_KEY_PEDIA_A_OR_B", tostring(cost) .. " [ICON_PRODUCTION]", tostring(faithCost) .. " [ICON_PEACE");
 		else
@@ -2940,42 +2941,42 @@ CivilopediaCategory[CategoryUnits].SelectArticle = function( unitID, shouldAddTo
 				costString = tostring(faithCost) .. " [ICON_PEACE]";
 			else
 				costString = Locale.Lookup("TXT_KEY_FREE");
-				
+
 				if(thisUnit.Type == "UNIT_SETTLER") then
 					Controls.CostFrame:SetHide(true);
 				end
 			end
 		end
-				
+
 		Controls.CostLabel:SetText(costString);
-		
+
 		-- update the Combat value
 		local combat = thisUnit.Combat;
 		if combat > 0 then
 			Controls.CombatLabel:SetText( tostring(combat).." [ICON_STRENGTH]" );
 			Controls.CombatFrame:SetHide( false );
 		end
-		
+
 		-- update the Ranged Combat value
 		local rangedCombat = thisUnit.RangedCombat;
 		if rangedCombat > 0 then
 			Controls.RangedCombatLabel:SetText( tostring(rangedCombat).." [ICON_RANGE_STRENGTH]" );
 			Controls.RangedCombatFrame:SetHide( false );
 		end
-		
+
 		-- update the Ranged Combat value
 		local rangedCombatRange = thisUnit.Range;
 		if rangedCombatRange > 0 then
 			Controls.RangedCombatRangeLabel:SetText( tostring(rangedCombatRange) );
 			Controls.RangedCombatRangeFrame:SetHide( false );
 		end
-		
+
 		-- update the Combat Type value
 		if thisUnit.CombatClass then
 			Controls.CombatTypeLabel:SetText( Locale.ConvertTextKey( GameInfo.UnitCombatInfos[thisUnit.CombatClass].Description ) );
 			Controls.CombatTypeFrame:SetHide( false );
 		end
-		
+
 		-- update the Movement value
 		local movementRange = thisUnit.Moves;
 		if movementRange > 0 then
@@ -2992,12 +2993,12 @@ CivilopediaCategory[CategoryUnits].SelectArticle = function( unitID, shouldAddTo
 			Controls.AirDefenseFrame:SetHide( false );
 		end
 
-		
-		
+
+
  		local contentSize;
  		local frameSize = {};
 		local buttonAdded = 0;
- 		
+
  		-- update the free promotions
 		g_PromotionsManager:ResetInstances();
 		buttonAdded = 0;
@@ -3008,15 +3009,15 @@ CivilopediaCategory[CategoryUnits].SelectArticle = function( unitID, shouldAddTo
 			if promotion then
 				local thisPromotionInstance = g_PromotionsManager:GetInstance();
 				if thisPromotionInstance then
-					local textureOffset, textureSheet = IconLookup( promotion.PortraitIndex, buttonSize, promotion.IconAtlas );				
+					local textureOffset, textureSheet = IconLookup( promotion.PortraitIndex, buttonSize, promotion.IconAtlas );
 					if textureOffset == nil then
 						textureSheet = defaultErrorTextureSheet;
 						textureOffset = nullOffset;
-					end				
+					end
 					UpdateSmallButton( buttonAdded, thisPromotionInstance.PromotionImage, thisPromotionInstance.PromotionButton, textureSheet, textureOffset, CategoryPromotions, Locale.ConvertTextKey( promotion.Description ), promotion.ID );
 					buttonAdded = buttonAdded + 1;
 				end
-			end	
+			end
 		end
 		UpdateButtonFrame( buttonAdded, Controls.FreePromotionsInnerFrame, Controls.FreePromotionsFrame );
 
@@ -3032,15 +3033,15 @@ CivilopediaCategory[CategoryUnits].SelectArticle = function( unitID, shouldAddTo
 			if requiredResource then
 				local thisRequiredResourceInstance = g_RequiredResourcesManager:GetInstance();
 				if thisRequiredResourceInstance then
-					local textureOffset, textureSheet = IconLookup( requiredResource.PortraitIndex, buttonSize, requiredResource.IconAtlas );				
+					local textureOffset, textureSheet = IconLookup( requiredResource.PortraitIndex, buttonSize, requiredResource.IconAtlas );
 					if textureOffset == nil then
 						textureSheet = defaultErrorTextureSheet;
 						textureOffset = nullOffset;
-					end				
+					end
 					UpdateSmallButton( buttonAdded, thisRequiredResourceInstance.RequiredResourceImage, thisRequiredResourceInstance.RequiredResourceButton, textureSheet, textureOffset, CategoryResources, Locale.ConvertTextKey( requiredResource.Description ), requiredResource.ID );
 					buttonAdded = buttonAdded + 1;
 				end
-			end		
+			end
 		end
 		UpdateButtonFrame( buttonAdded, Controls.RequiredResourcesInnerFrame, Controls.RequiredResourcesFrame );
 
@@ -3053,16 +3054,16 @@ CivilopediaCategory[CategoryUnits].SelectArticle = function( unitID, shouldAddTo
 			if prereq then
 				local thisPrereqInstance = g_PrereqTechManager:GetInstance();
 				if thisPrereqInstance then
-					local textureOffset, textureSheet = IconLookup( prereq.PortraitIndex, buttonSize, prereq.IconAtlas );				
+					local textureOffset, textureSheet = IconLookup( prereq.PortraitIndex, buttonSize, prereq.IconAtlas );
 					if textureOffset == nil then
 						textureSheet = defaultErrorTextureSheet;
 						textureOffset = nullOffset;
-					end				
+					end
 					UpdateSmallButton( buttonAdded, thisPrereqInstance.PrereqTechImage, thisPrereqInstance.PrereqTechButton, textureSheet, textureOffset, CategoryTech, Locale.ConvertTextKey( prereq.Description ), prereq.ID );
 					buttonAdded = buttonAdded + 1;
-				end	
+				end
 			end
-		end	
+		end
 		UpdateButtonFrame( buttonAdded, Controls.PrereqTechInnerFrame, Controls.PrereqTechFrame );
 
 		-- update the obsolete techs
@@ -3074,22 +3075,22 @@ CivilopediaCategory[CategoryUnits].SelectArticle = function( unitID, shouldAddTo
 			if obs then
 				local thisTechInstance = g_ObsoleteTechManager:GetInstance();
 				if thisTechInstance then
-					local textureOffset, textureSheet = IconLookup( obs.PortraitIndex, buttonSize, obs.IconAtlas );				
+					local textureOffset, textureSheet = IconLookup( obs.PortraitIndex, buttonSize, obs.IconAtlas );
 					if textureOffset == nil then
 						textureSheet = defaultErrorTextureSheet;
 						textureOffset = nullOffset;
-					end				
+					end
 					UpdateSmallButton( buttonAdded, thisTechInstance.ObsoleteTechImage, thisTechInstance.ObsoleteTechButton, textureSheet, textureOffset, CategoryTech, Locale.ConvertTextKey( obs.Description ), obs.ID );
 					buttonAdded = buttonAdded + 1;
-				end	
+				end
 			end
-		end	
+		end
 		UpdateButtonFrame( buttonAdded, Controls.ObsoleteTechInnerFrame, Controls.ObsoleteTechFrame );
 
 		-- update the Upgrade units
 		g_UpgradeManager:ResetInstances();
 		buttonAdded = 0;
-		
+
 		if(Game ~= nil) then
 			local iUnitUpgrade = Game.GetUnitUpgradesTo(unitID);
 			if iUnitUpgrade ~= nil and iUnitUpgrade ~= -1 then
@@ -3097,58 +3098,58 @@ CivilopediaCategory[CategoryUnits].SelectArticle = function( unitID, shouldAddTo
 				if obs then
 					local thisUpgradeInstance = g_UpgradeManager:GetInstance();
 					if thisUpgradeInstance then
-						local textureOffset, textureSheet = IconLookup( obs.PortraitIndex, buttonSize, obs.IconAtlas );				
+						local textureOffset, textureSheet = IconLookup( obs.PortraitIndex, buttonSize, obs.IconAtlas );
 						if textureOffset == nil then
 							textureSheet = defaultErrorTextureSheet;
 							textureOffset = nullOffset;
-						end				
+						end
 						UpdateSmallButton( buttonAdded, thisUpgradeInstance.UpgradeImage, thisUpgradeInstance.UpgradeButton, textureSheet, textureOffset, CategoryUnits, Locale.ConvertTextKey( obs.Description ), obs.ID );
 						buttonAdded = buttonAdded + 1;
-					end	
+					end
 				end
-			end	
+			end
 		else
-			for row in GameInfo.Unit_ClassUpgrades{UnitType = thisUnit.Type} do	
+			for row in GameInfo.Unit_ClassUpgrades{UnitType = thisUnit.Type} do
 				local unitClass = GameInfo.UnitClasses[row.UnitClassType];
 				local upgradeUnit = GameInfo.Units[unitClass.DefaultUnit];
 				if (upgradeUnit) then
 					local thisUpgradeInstance = g_UpgradeManager:GetInstance();
 					if thisUpgradeInstance then
-						local textureOffset, textureSheet = IconLookup( upgradeUnit.PortraitIndex, buttonSize, upgradeUnit.IconAtlas );				
+						local textureOffset, textureSheet = IconLookup( upgradeUnit.PortraitIndex, buttonSize, upgradeUnit.IconAtlas );
 						if textureOffset == nil then
 							textureSheet = defaultErrorTextureSheet;
 							textureOffset = nullOffset;
-						end				
+						end
 						UpdateSmallButton( buttonAdded, thisUpgradeInstance.UpgradeImage, thisUpgradeInstance.UpgradeButton, textureSheet, textureOffset, CategoryUnits, Locale.ConvertTextKey( upgradeUnit.Description ), upgradeUnit.ID );
 						buttonAdded = buttonAdded + 1;
-					end	
-				end		
+					end
+				end
 			end
 		end
-		
+
 		UpdateButtonFrame( buttonAdded, Controls.UpgradeInnerFrame, Controls.UpgradeFrame );
-		
+
 		-- Are we a unique unit?  If so, who do I replace?
 		local replacesUnitClass = {};
 		local specificCivs = {};
-		
+
 		local classOverrideCondition = string.format("UnitType='%s' and CivilizationType <> 'CIVILIZATION_BARBARIAN' and CivilizationType <> 'CIVILIZATION_MINOR'", thisUnit.Type);
 		for row in GameInfo.Civilization_UnitClassOverrides(classOverrideCondition) do
 			specificCivs[row.CivilizationType] = 1;
 			replacesUnitClass[row.UnitClassType] = 1;
 		end
-		 	
+
 		g_ReplacesManager:ResetInstances();
 		buttonAdded = 0;
 		for unitClassType, _ in pairs(replacesUnitClass) do
 			for replacedUnit in DB.Query("SELECT u.ID, u.Description, u.PortraitIndex, u.IconAtlas from Units as u inner join UnitClasses as uc on u.Type = uc.DefaultUnit where uc.Type = ?", unitClassType) do
 				local thisUnitInstance = g_ReplacesManager:GetInstance();
 				if thisUnitInstance then
-					local textureOffset, textureSheet = IconLookup( replacedUnit.PortraitIndex, buttonSize, replacedUnit.IconAtlas );				
+					local textureOffset, textureSheet = IconLookup( replacedUnit.PortraitIndex, buttonSize, replacedUnit.IconAtlas );
 					if textureOffset == nil then
 						textureSheet = defaultErrorTextureSheet;
 						textureOffset = nullOffset;
-					end				
+					end
 					UpdateSmallButton( buttonAdded, thisUnitInstance.ReplaceImage, thisUnitInstance.ReplaceButton, textureSheet, textureOffset, CategoryUnits, Locale.ConvertTextKey( replacedUnit.Description ), replacedUnit.ID );
 					buttonAdded = buttonAdded + 1;
 				end
@@ -3159,19 +3160,19 @@ CivilopediaCategory[CategoryUnits].SelectArticle = function( unitID, shouldAddTo
 		g_CivilizationsManager:ResetInstances();
 		buttonAdded = 0;
 		for civilizationType, _ in pairs(specificCivs) do
-		
+
 			local civ = GameInfo.Civilizations[civilizationType];
 			if(civ ~= nil) then
 				local thisCivInstance = g_CivilizationsManager:GetInstance();
 				if thisCivInstance then
-					local textureOffset, textureSheet = IconLookup( civ.PortraitIndex, buttonSize, civ.IconAtlas );				
+					local textureOffset, textureSheet = IconLookup( civ.PortraitIndex, buttonSize, civ.IconAtlas );
 					if textureOffset == nil then
 						textureSheet = defaultErrorTextureSheet;
 						textureOffset = nullOffset;
-					end				
+					end
 					UpdateSmallButton( buttonAdded, thisCivInstance.CivilizationImage, thisCivInstance.CivilizationButton, textureSheet, textureOffset, CategoryCivilizations, Locale.ConvertTextKey( civ.ShortDescription ), civ.ID );
 					buttonAdded = buttonAdded + 1;
-				end	
+				end
 			end
 		end
 		UpdateButtonFrame( buttonAdded, Controls.CivilizationsInnerFrame, Controls.CivilizationsFrame );
@@ -3180,20 +3181,20 @@ CivilopediaCategory[CategoryUnits].SelectArticle = function( unitID, shouldAddTo
 		if thisUnit.Help then
 			UpdateTextBlock( Locale.ConvertTextKey( thisUnit.Help ), Controls.GameInfoLabel, Controls.GameInfoInnerFrame, Controls.GameInfoFrame );
 		end
-				
+
 		-- update the strategy info
 		if thisUnit.Strategy then
 			UpdateTextBlock( Locale.ConvertTextKey( thisUnit.Strategy ), Controls.StrategyLabel, Controls.StrategyInnerFrame, Controls.StrategyFrame );
 		end
-		
+
 		-- update the historical info
 		if thisUnit.Civilopedia then
 			UpdateTextBlock( Locale.ConvertTextKey( thisUnit.Civilopedia ), Controls.HistoryLabel, Controls.HistoryInnerFrame, Controls.HistoryFrame );
 		end
-		
+
 		-- update the related images
 		Controls.RelatedImagesFrame:SetHide( true );
-		
+
 		-- Infixo Extended info
 		local sText = "[COLOR_CYAN]Abilities[ENDCOLOR] of this unit:"; -- change to TXT_KEY_ later
 		local function AnalyzeUnit(...)
@@ -3337,7 +3338,7 @@ CivilopediaCategory[CategoryUnits].SelectArticle = function( unitID, shouldAddTo
 		UpdateTextBlock( sText, Controls.ExtendedLabel,  Controls.ExtendedInnerFrame,  Controls.ExtendedFrame );
 		-- end Infixo
 	end
-	
+
 	ResizeEtc();
 
 end
@@ -3349,9 +3350,9 @@ CivilopediaCategory[CategoryPromotions].SelectArticle = function( promotionID, s
 	if selectedCategory ~= CategoryPromotions then
 		SetSelectedCategory(CategoryPromotions);
 	end
-	
+
 	ClearArticle();
-	
+
 	if shouldAddToList == addToList then
 		currentTopic = currentTopic + 1;
 		listOfTopicsViewed[currentTopic] = categorizedList[(CategoryPromotions * absurdlyLargeNumTopicsInCategory) + promotionID];
@@ -3360,42 +3361,42 @@ CivilopediaCategory[CategoryPromotions].SelectArticle = function( promotionID, s
 		end
 		endTopic = currentTopic;
 	end
-	
+
 	if promotionID ~= -1 then
 		local thisPromotion = GameInfo.UnitPromotions[promotionID];
-		
+
 		-- update the name
-		local name = Locale.ConvertTextKey( thisPromotion.Description ); 	
+		local name = Locale.ConvertTextKey( thisPromotion.Description );
 		Controls.ArticleID:SetText( name );
-		
+
 		-- portrait
 		if IconHookup( thisPromotion.PortraitIndex, portraitSize, thisPromotion.IconAtlas, Controls.Portrait ) then
 			Controls.PortraitFrame:SetHide( false );
 		else
 			Controls.PortraitFrame:SetHide( true );
 		end
-		
+
  		local contentSize;
  		local frameSize = {};
 		local buttonAdded = 0;
- 		
+
  		-- required promotions
 		g_RequiredPromotionsManager:ResetInstances();
-		
+
 		local function CheckPromotionPrereqOr(sFieldName)
 			if thisPromotion[sFieldName] == nil then return; end -- field is empty
 			local thisReq = GameInfo.UnitPromotions[thisPromotion[sFieldName]];
 			if thisReq == nil then return; end -- cannot find that promotion
 			local thisRequiredPromotionInstance = g_RequiredPromotionsManager:GetInstance();
 			if thisRequiredPromotionInstance then
-				local textureOffset, textureSheet = IconLookup( thisReq.PortraitIndex, buttonSize, thisReq.IconAtlas );				
+				local textureOffset, textureSheet = IconLookup( thisReq.PortraitIndex, buttonSize, thisReq.IconAtlas );
 				if textureOffset == nil then
 					textureSheet = defaultErrorTextureSheet;
 					textureOffset = nullOffset;
-				end				
+				end
 				UpdateSmallButton( buttonAdded, thisRequiredPromotionInstance.RequiredPromotionImage, thisRequiredPromotionInstance.RequiredPromotionButton, textureSheet, textureOffset, CategoryPromotions, Locale.ConvertTextKey( thisReq.Description ), thisReq.ID );
 				buttonAdded = buttonAdded + 1;
-			end	
+			end
 		end
 		CheckPromotionPrereqOr("PromotionPrereqOr1");
 		CheckPromotionPrereqOr("PromotionPrereqOr2");
@@ -3409,44 +3410,44 @@ CivilopediaCategory[CategoryPromotions].SelectArticle = function( promotionID, s
 			if thisReq then
 				local thisRequiredPromotionInstance = g_RequiredPromotionsManager:GetInstance();
 				if thisRequiredPromotionInstance then
-					local textureOffset, textureSheet = IconLookup( thisReq.PortraitIndex, buttonSize, thisReq.IconAtlas );				
+					local textureOffset, textureSheet = IconLookup( thisReq.PortraitIndex, buttonSize, thisReq.IconAtlas );
 					if textureOffset == nil then
 						textureSheet = defaultErrorTextureSheet;
 						textureOffset = nullOffset;
-					end				
+					end
 					UpdateSmallButton( buttonAdded, thisRequiredPromotionInstance.RequiredPromotionImage, thisRequiredPromotionInstance.RequiredPromotionButton, textureSheet, textureOffset, CategoryPromotions, Locale.ConvertTextKey( thisReq.Description ), thisReq.ID );
 					buttonAdded = buttonAdded + 1;
-				end	
+				end
 			end
-		end	
+		end
 		if thisPromotion.PromotionPrereqOr2 then
 			local thisReq = GameInfo.UnitPromotions[thisPromotion.PromotionPrereqOr2];
 			if thisReq then
 				local thisRequiredPromotionInstance = g_RequiredPromotionsManager:GetInstance();
 				if thisRequiredPromotionInstance then
-					local textureOffset, textureSheet = IconLookup( thisReq.PortraitIndex, buttonSize, thisReq.IconAtlas );				
+					local textureOffset, textureSheet = IconLookup( thisReq.PortraitIndex, buttonSize, thisReq.IconAtlas );
 					if textureOffset == nil then
 						textureSheet = defaultErrorTextureSheet;
 						textureOffset = nullOffset;
-					end				
+					end
 					UpdateSmallButton( buttonAdded, thisRequiredPromotionInstance.RequiredPromotionImage, thisRequiredPromotionInstance.RequiredPromotionButton, textureSheet, textureOffset, CategoryPromotions, Locale.ConvertTextKey( thisReq.Description ), thisReq.ID );
 					buttonAdded = buttonAdded + 1;
-				end	
+				end
 			end
-		end	
+		end
 		if thisPromotion.PromotionPrereqOr3 then
 			local thisReq = GameInfo.UnitPromotions[thisPromotion.PromotionPrereqOr3];
 			if thisReq then
 				local thisRequiredPromotionInstance = g_RequiredPromotionsManager:GetInstance();
 				if thisRequiredPromotionInstance then
-					local textureOffset, textureSheet = IconLookup( thisReq.PortraitIndex, buttonSize, thisReq.IconAtlas );				
+					local textureOffset, textureSheet = IconLookup( thisReq.PortraitIndex, buttonSize, thisReq.IconAtlas );
 					if textureOffset == nil then
 						textureSheet = defaultErrorTextureSheet;
 						textureOffset = nullOffset;
-					end				
+					end
 					UpdateSmallButton( buttonAdded, thisRequiredPromotionInstance.RequiredPromotionImage, thisRequiredPromotionInstance.RequiredPromotionButton, textureSheet, textureOffset, CategoryPromotions, Locale.ConvertTextKey( thisReq.Description ), thisReq.ID );
 					buttonAdded = buttonAdded + 1;
-				end	
+				end
 			end
 		end
 		if thisPromotion.PromotionPrereqOr4 then
@@ -3454,46 +3455,46 @@ CivilopediaCategory[CategoryPromotions].SelectArticle = function( promotionID, s
 			if thisReq then
 				local thisRequiredPromotionInstance = g_RequiredPromotionsManager:GetInstance();
 				if thisRequiredPromotionInstance then
-					local textureOffset, textureSheet = IconLookup( thisReq.PortraitIndex, buttonSize, thisReq.IconAtlas );				
+					local textureOffset, textureSheet = IconLookup( thisReq.PortraitIndex, buttonSize, thisReq.IconAtlas );
 					if textureOffset == nil then
 						textureSheet = defaultErrorTextureSheet;
 						textureOffset = nullOffset;
-					end				
+					end
 					UpdateSmallButton( buttonAdded, thisRequiredPromotionInstance.RequiredPromotionImage, thisRequiredPromotionInstance.RequiredPromotionButton, textureSheet, textureOffset, CategoryPromotions, Locale.ConvertTextKey( thisReq.Description ), thisReq.ID );
 					buttonAdded = buttonAdded + 1;
-				end	
+				end
 			end
-		end		
+		end
 		if thisPromotion.PromotionPrereqOr5 then
 			local thisReq = GameInfo.UnitPromotions[thisPromotion.PromotionPrereqOr5];
 			if thisReq then
 				local thisRequiredPromotionInstance = g_RequiredPromotionsManager:GetInstance();
 				if thisRequiredPromotionInstance then
-					local textureOffset, textureSheet = IconLookup( thisReq.PortraitIndex, buttonSize, thisReq.IconAtlas );				
+					local textureOffset, textureSheet = IconLookup( thisReq.PortraitIndex, buttonSize, thisReq.IconAtlas );
 					if textureOffset == nil then
 						textureSheet = defaultErrorTextureSheet;
 						textureOffset = nullOffset;
-					end				
+					end
 					UpdateSmallButton( buttonAdded, thisRequiredPromotionInstance.RequiredPromotionImage, thisRequiredPromotionInstance.RequiredPromotionButton, textureSheet, textureOffset, CategoryPromotions, Locale.ConvertTextKey( thisReq.Description ), thisReq.ID );
 					buttonAdded = buttonAdded + 1;
-				end	
+				end
 			end
-		end	
+		end
 		if thisPromotion.PromotionPrereqOr6 then
 			local thisReq = GameInfo.UnitPromotions[thisPromotion.PromotionPrereqOr6];
 			if thisReq then
 				local thisRequiredPromotionInstance = g_RequiredPromotionsManager:GetInstance();
 				if thisRequiredPromotionInstance then
-					local textureOffset, textureSheet = IconLookup( thisReq.PortraitIndex, buttonSize, thisReq.IconAtlas );				
+					local textureOffset, textureSheet = IconLookup( thisReq.PortraitIndex, buttonSize, thisReq.IconAtlas );
 					if textureOffset == nil then
 						textureSheet = defaultErrorTextureSheet;
 						textureOffset = nullOffset;
-					end				
+					end
 					UpdateSmallButton( buttonAdded, thisRequiredPromotionInstance.RequiredPromotionImage, thisRequiredPromotionInstance.RequiredPromotionButton, textureSheet, textureOffset, CategoryPromotions, Locale.ConvertTextKey( thisReq.Description ), thisReq.ID );
 					buttonAdded = buttonAdded + 1;
-				end	
+				end
 			end
-		end	
+		end
 		--]]
 		UpdateButtonFrame( buttonAdded, Controls.RequiredPromotionsInnerFrame, Controls.RequiredPromotionsFrame );
 
@@ -3501,7 +3502,7 @@ CivilopediaCategory[CategoryPromotions].SelectArticle = function( promotionID, s
 		if thisPromotion.Help then
 			UpdateTextBlock( Locale.ConvertTextKey( thisPromotion.Help ), Controls.GameInfoLabel, Controls.GameInfoInnerFrame, Controls.GameInfoFrame );
 		end
-		
+
 		-- Infixo more info
 		local sText = "[COLOR_CYAN]Abilities[ENDCOLOR] of this promotion:"; -- change to TXT_KEY_ later
 		-- Generic info from main table
@@ -3798,7 +3799,7 @@ CivilopediaCategory[CategoryPromotions].SelectArticle = function( promotionID, s
 		end
 		UpdateTextBlock( sText, Controls.ExtendedLabel,  Controls.ExtendedInnerFrame,  Controls.ExtendedFrame );
 		-- end Infixo
-	end	
+	end
 
 	ResizeEtc();
 
@@ -3812,7 +3813,7 @@ function AddRequiredBuildingFrame( thisBuilding )
 	g_RequiredBuildingsManager:ResetInstances();
 	local buttonAdded = 0;
 	local thisBuildingTable = AppendCivRelationshipTable( {}, GameInfo.Buildings( "Type = '" .. thisBuilding.Type .. "'" ), "Type", "CivilizationRequired" );
-	thisBuildingTable = AppendCivRelationshipTable( thisBuildingTable, GameInfo.Civilization_BuildingClassOverrides( "BuildingType = '" .. thisBuilding.Type .. "'" ), "BuildingType", "CivilizationType" ); 
+	thisBuildingTable = AppendCivRelationshipTable( thisBuildingTable, GameInfo.Civilization_BuildingClassOverrides( "BuildingType = '" .. thisBuilding.Type .. "'" ), "BuildingType", "CivilizationType" );
 	local thisRelatedBuildingTable = AppendCivRelationshipTable( {}, GameInfo.Buildings( "BuildingClass = '" .. thisBuilding.BuildingClass .. "'" ), "Type", "CivilizationRequired");
 	thisRelatedBuildingTable = AppendCivRelationshipTable( thisRelatedBuildingTable, GameInfo.Civilization_BuildingClassOverrides( "BuildingClassType = '" .. thisBuilding.BuildingClass .. "'" ), "BuildingType", "CivilizationType");
 	-- add the leads to button if its info exists
@@ -3827,10 +3828,10 @@ function AddRequiredBuildingFrame( thisBuilding )
 						thisBuildingInstance.RequiredBuildingImage:SetTexture( defaultErrorTextureSheet );
 						thisBuildingInstance.RequiredBuildingImage:SetTextureOffset( nullOffset );
 					end
-					
+
 					--move this button
 					thisBuildingInstance.RequiredBuildingButton:SetOffsetVal( (buttonAdded % numberOfButtonsPerRow) * buttonSize + buttonPadding, math.floor(buttonAdded / numberOfButtonsPerRow) * buttonSize + buttonPadding );
-					
+
 					thisBuildingInstance.RequiredBuildingButton:SetToolTipString( Locale.ConvertTextKey( thisBuildingInfo.Description ) );
 					thisBuildingInstance.RequiredBuildingButton:SetVoids( thisBuildingInfo.ID, addToList );
 					local thisBuildingClass = GameInfo.BuildingClasses[thisBuildingInfo.BuildingClass];
@@ -3876,22 +3877,22 @@ function AddRequiredBuildingFrame( thisBuilding )
 			AddRequiredBuildingButton( GameInfo.BuildingClasses[reqClassType].DefaultBuilding );
 		end
 	end
-	
+
 	-- search through the building classes to find potential required buildings
-	local thisBuildingCondition = "BuildingType = '" .. thisBuilding.Type .. "'";	
+	local thisBuildingCondition = "BuildingType = '" .. thisBuilding.Type .. "'";
 	for reqClassRow in GameInfo.Building_ClassesNeededInCity( thisBuildingCondition ) do
 		AddRequiredBuildingInstance( reqClassRow.BuildingClassType );
 	end
 	for reqClassRow in GameInfo.Building_ClassNeededAnywhere( thisBuildingCondition ) do
 		AddRequiredBuildingInstance( reqClassRow.BuildingClassType );
 	end
-	
+
 	UpdateButtonFrame( buttonAdded, Controls.RequiredBuildingsInnerFrame, Controls.RequiredBuildingsFrame );
 end
 -- leads to buildings
 function AddLeadsToBuildingFrame( thisBuilding )
 	local thisBuildingTable = AppendCivRelationshipTable( {}, GameInfo.Buildings( "Type = '" .. thisBuilding.Type .. "'" ), "Type", "CivilizationRequired" );
-	thisBuildingTable = AppendCivRelationshipTable( thisBuildingTable, GameInfo.Civilization_BuildingClassOverrides( "BuildingType = '" .. thisBuilding.Type .. "'" ), "BuildingType", "CivilizationType" ); 
+	thisBuildingTable = AppendCivRelationshipTable( thisBuildingTable, GameInfo.Civilization_BuildingClassOverrides( "BuildingType = '" .. thisBuilding.Type .. "'" ), "BuildingType", "CivilizationType" );
 	local thisRelatedBuildingTable = AppendCivRelationshipTable( {}, GameInfo.Buildings( "BuildingClass = '" .. thisBuilding.BuildingClass .. "'" ), "Type", "CivilizationRequired");
 	thisRelatedBuildingTable = AppendCivRelationshipTable( thisRelatedBuildingTable, GameInfo.Civilization_BuildingClassOverrides( "BuildingClassType = '" .. thisBuilding.BuildingClass .. "'" ), "BuildingType", "CivilizationType");
 	g_LeadsToBuildingsManager:ResetInstances();
@@ -3908,10 +3909,10 @@ function AddLeadsToBuildingFrame( thisBuilding )
 						thisBuildingInstance.LeadsToBuildingImage:SetTexture( defaultErrorTextureSheet );
 						thisBuildingInstance.LeadsToBuildingImage:SetTextureOffset( nullOffset );
 					end
-					
+
 					--move this button
 					thisBuildingInstance.LeadsToBuildingButton:SetOffsetVal( (buttonAdded % numberOfButtonsPerRow) * buttonSize + buttonPadding, math.floor(buttonAdded / numberOfButtonsPerRow) * buttonSize + buttonPadding );
-					
+
 					thisBuildingInstance.LeadsToBuildingButton:SetToolTipString( Locale.ConvertTextKey( thisBuildingInfo.Description ) );
 					thisBuildingInstance.LeadsToBuildingButton:SetVoids( thisBuildingInfo.ID, addToList );
 					local thisBuildingClass = GameInfo.BuildingClasses[thisBuildingInfo.BuildingClass];
@@ -3970,7 +3971,7 @@ function AddLeadsToBuildingFrame( thisBuilding )
 			AddLeadsToBuildingButton( nextBuildingType );
 		end
 	end
-	
+
 	local thisBuildingClassCondition = "BuildingClassType = '" .. thisBuilding.BuildingClass .. "'";
 	for nextBuildingRow in GameInfo.Building_ClassesNeededInCity( thisBuildingClassCondition ) do
 		AddLeadsToBuildingInstance( nextBuildingRow.BuildingType );
@@ -3985,9 +3986,9 @@ end
 function SelectBuildingOrWonderArticle( buildingID )
 	if buildingID ~= -1 then
 		local thisBuilding = GameInfo.Buildings[buildingID];
-					
+
 		-- update the name
-		local name = Locale.ConvertTextKey( thisBuilding.Description ); 	
+		local name = Locale.ConvertTextKey( thisBuilding.Description );
 		Controls.ArticleID:SetText( name );
 
 		-- update the portrait
@@ -3996,21 +3997,21 @@ function SelectBuildingOrWonderArticle( buildingID )
 		else
 			Controls.PortraitFrame:SetHide( true );
 		end
-		
+
 		-- update the cost
 		Controls.CostFrame:SetHide( false );
 		local costString = "";
-		
+
 		local cost = thisBuilding.Cost;
 		if(Game ~= nil) then
 			cost = Players[Game.GetActivePlayer()]:GetBuildingProductionNeeded( buildingID );
 		end
-		
+
 		local faithCost = thisBuilding.FaithCost;
 		if(Game and Game.IsOption(GameOptionTypes.GAMEOPTION_NO_RELIGION)) then
 			faithCost = 0;
 		end
-		
+
 		local costPerPlayer = 0;
 		for tLeagueProject in GameInfo.LeagueProjects() do
 			if (tLeagueProject ~= nil) then
@@ -4032,7 +4033,7 @@ function SelectBuildingOrWonderArticle( buildingID )
 				end
 			end
 		end
-		
+
 		if(costPerPlayer > 0) then
 			costString = Locale.ConvertTextKey("TXT_KEY_LEAGUE_PROJECT_COST_PER_PLAYER", costPerPlayer);
 		elseif(cost == 1 and faithCost > 0) then
@@ -4048,9 +4049,9 @@ function SelectBuildingOrWonderArticle( buildingID )
 				costString = Locale.Lookup("TXT_KEY_FREE");
 			end
 		end
-		
+
 		Controls.CostLabel:SetText(costString);
-		
+
 		-- update the maintenance
 		local perTurnCost = thisBuilding.GoldMaintenance;
 		if perTurnCost > 0 then
@@ -4069,11 +4070,11 @@ function SelectBuildingOrWonderArticle( buildingID )
 				if (row.HeadquartersBuildingClass == buildingClass.Type or row.OfficeBuildingClass == buildingClass.Type or row.FranchiseBuildingClass == buildingClass.Type) then
 					local thisCorporationInstance = g_CorporationsManager:GetInstance();
 					if thisCorporationInstance then
-						local textureOffset, textureSheet = IconLookup( row.PortraitIndex, buttonSize, row.IconAtlas );				
+						local textureOffset, textureSheet = IconLookup( row.PortraitIndex, buttonSize, row.IconAtlas );
 						if textureOffset == nil then
 							textureSheet = defaultErrorTextureSheet;
 							textureOffset = nullOffset;
-						end				
+						end
 						UpdateSmallButton( 0, thisCorporationInstance.CorporationImage, thisCorporationInstance.CorporationButton, textureSheet, textureOffset, CategoryCorporations, Locale.ConvertTextKey( row.Description ), row.ID );
 						iCorp = iCorp + 1;
 						-- find the first one
@@ -4090,7 +4091,7 @@ function SelectBuildingOrWonderArticle( buildingID )
 			Controls.CorporationFrame:SetHide(true);
 			Controls.CorporationInnerFrame:SetHide(true);
 		end
-		
+
 		-- update the Happiness
 		local iHappiness = thisBuilding.Happiness;
 		if iHappiness > 0 then
@@ -4114,10 +4115,10 @@ function SelectBuildingOrWonderArticle( buildingID )
 				for row in GameInfo.Building_YieldChanges{BuildingType = buildingType, YieldType = yieldType} do
 					yieldModifier = yieldModifier + row.Yield;
 				end
-				
+
 				return yieldModifier;
 			end
-		
+
 		end
 
 		-- update the Culture
@@ -4140,19 +4141,19 @@ function SelectBuildingOrWonderArticle( buildingID )
 		if iDefense > 0 then
 			table.insert(defenseEntries, tostring(iDefense / 100).." [ICON_STRENGTH]");
 		end
-		
+
 		local iExtraHitPoints = thisBuilding.ExtraCityHitPoints;
 		if(iExtraHitPoints > 0) then
 			table.insert(defenseEntries, Locale.Lookup("TXT_KEY_PEDIA_DEFENSE_HITPOINTS", iExtraHitPoints));
 		end
-		
+
 		if(#defenseEntries > 0) then
 			Controls.DefenseLabel:SetText(table.concat(defenseEntries, ", "));
 			Controls.DefenseFrame:SetHide(false);
 		else
 			Controls.DefenseFrame:SetHide(true);
 		end
-		
+
 		local GetBuildingYieldModifier = function(buildingID, yieldType)
 			if(Game ~= nil) then
 				return Game.GetBuildingYieldModifier(buildingID, YieldTypes[yieldType]);
@@ -4162,12 +4163,12 @@ function SelectBuildingOrWonderArticle( buildingID )
 				for row in GameInfo.Building_YieldModifiers{BuildingType = buildingType, YieldType = yieldType} do
 					yieldModifier = yieldModifier + row.Yield;
 				end
-				
+
 				return yieldModifier;
 			end
-			
+
 		end
-		
+
 		-- Use Game to calculate Yield Changes and modifiers.
 		-- update the Food Change
 		local iFood = GetBuildingYieldChange(buildingID, "YIELD_FOOD");
@@ -4196,13 +4197,13 @@ function SelectBuildingOrWonderArticle( buildingID )
 		if(iScience > 0) then
 			table.insert(scienceItems, "+" .. tostring(iScience).."% [ICON_RESEARCH]" );
 		end
-		
+
 		-- update the Science Change
 		local iScience = GetBuildingYieldChange(buildingID, "YIELD_SCIENCE");
 		if(iScience > 0) then
 			table.insert(scienceItems, "+" .. tostring(iScience).." [ICON_RESEARCH]" );
 		end
-		
+
 		if(#scienceItems > 0) then
 			Controls.ScienceLabel:SetText( table.concat(scienceItems, ", ") );
 			Controls.ScienceFrame:SetHide( false );
@@ -4214,13 +4215,13 @@ function SelectBuildingOrWonderArticle( buildingID )
 		if(iProduction > 0) then
 			table.insert(productionItems, "+" .. tostring(iProduction).."% [ICON_PRODUCTION]");
 		end
-        
+
 		-- update the Production
 		local iProduction = GetBuildingYieldChange(buildingID, "YIELD_PRODUCTION");
 		if(iProduction > 0) then
 			table.insert(productionItems, "+" .. tostring(iProduction).." [ICON_PRODUCTION]");
 		end
-        
+
 		if(#productionItems > 0) then
 			Controls.ProductionLabel:SetText( table.concat(productionItems, ", ") );
 			Controls.ProductionFrame:SetHide( false );
@@ -4264,16 +4265,16 @@ function SelectBuildingOrWonderArticle( buildingID )
 			if prereq then
 				local thisPrereqInstance = g_PrereqTechManager:GetInstance();
 				if thisPrereqInstance then
-					local textureOffset, textureSheet = IconLookup( prereq.PortraitIndex, buttonSize, prereq.IconAtlas );				
+					local textureOffset, textureSheet = IconLookup( prereq.PortraitIndex, buttonSize, prereq.IconAtlas );
 					if textureOffset == nil then
 						textureSheet = defaultErrorTextureSheet;
 						textureOffset = nullOffset;
-					end				
+					end
 					UpdateSmallButton( buttonAdded, thisPrereqInstance.PrereqTechImage, thisPrereqInstance.PrereqTechButton, textureSheet, textureOffset, CategoryTech, Locale.ConvertTextKey( prereq.Description ), prereq.ID );
 					buttonAdded = buttonAdded + 1;
-				end	
+				end
 			end
-		end	
+		end
 		UpdateButtonFrame( buttonAdded, Controls.PrereqTechInnerFrame, Controls.PrereqTechFrame );
 
 		local condition = "BuildingType = '" .. thisBuilding.Type .. "'";
@@ -4288,27 +4289,27 @@ function SelectBuildingOrWonderArticle( buildingID )
 				for i = 1, thisBuilding.SpecialistCount, 1 do
 					local thisSpecialistInstance = g_SpecialistsManager:GetInstance();
 					if thisSpecialistInstance then
-						local textureOffset, textureSheet = IconLookup( thisSpec.PortraitIndex, buttonSize, thisSpec.IconAtlas );				
+						local textureOffset, textureSheet = IconLookup( thisSpec.PortraitIndex, buttonSize, thisSpec.IconAtlas );
 						if textureOffset == nil then
 							textureSheet = defaultErrorTextureSheet;
 							textureOffset = nullOffset;
-						end				
+						end
 						UpdateSmallButton( buttonAdded, thisSpecialistInstance.SpecialistImage, thisSpecialistInstance.SpecialistButton, textureSheet, textureOffset, CategoryPeople, Locale.ConvertTextKey( thisSpec.Description ), thisSpec.ID );
 						buttonAdded = buttonAdded + 1;
-					end	
+					end
 				end
 			end
-		end	
+		end
 		UpdateButtonFrame( buttonAdded, Controls.SpecialistsInnerFrame, Controls.SpecialistsFrame );
-		
+
 		-- CBP
 		-- required buildings (CBP, now shows civ override buildings if relevant)
 		AddRequiredBuildingFrame( thisBuilding );
-		
+
 		-- Leads to Building (CBP now shows civ override buildings if relevant)
 		AddLeadsToBuildingFrame( thisBuilding );
 		-- END
-		
+
 		-- needed local resources
 		local condition = "BuildingType = '" .. thisBuilding.Type .. "'";
 		g_LocalResourcesManager:ResetInstances();
@@ -4319,18 +4320,18 @@ function SelectBuildingOrWonderArticle( buildingID )
 			if requiredResource then
 				local thisLocalResourceInstance = g_LocalResourcesManager:GetInstance();
 				if thisLocalResourceInstance then
-					local textureOffset, textureSheet = IconLookup( requiredResource.PortraitIndex, buttonSize, requiredResource.IconAtlas );				
+					local textureOffset, textureSheet = IconLookup( requiredResource.PortraitIndex, buttonSize, requiredResource.IconAtlas );
 					if textureOffset == nil then
 						textureSheet = defaultErrorTextureSheet;
 						textureOffset = nullOffset;
-					end				
+					end
 					UpdateSmallButton( buttonAdded, thisLocalResourceInstance.LocalResourceImage, thisLocalResourceInstance.LocalResourceButton, textureSheet, textureOffset, CategoryResources, Locale.ConvertTextKey( requiredResource.Description ), requiredResource.ID );
 					buttonAdded = buttonAdded + 1;
 				end
-			end		
+			end
 		end
 		UpdateButtonFrame( buttonAdded, Controls.LocalResourcesInnerFrame, Controls.LocalResourcesFrame );
-		
+
 		-- CBP
 		g_MonopolyResourcesManager:ResetInstances();
 		buttonAdded = 0;
@@ -4340,20 +4341,20 @@ function SelectBuildingOrWonderArticle( buildingID )
 			if requiredResource then
 				local thisLocalResourceInstance = g_MonopolyResourcesManager:GetInstance();
 				if thisLocalResourceInstance then
-					local textureOffset, textureSheet = IconLookup( requiredResource.PortraitIndex, buttonSize, requiredResource.IconAtlas );				
+					local textureOffset, textureSheet = IconLookup( requiredResource.PortraitIndex, buttonSize, requiredResource.IconAtlas );
 					if textureOffset == nil then
 						textureSheet = defaultErrorTextureSheet;
 						textureOffset = nullOffset;
-					end				
+					end
 					UpdateSmallButton( buttonAdded, thisLocalResourceInstance.MonopolyResourceImage, thisLocalResourceInstance.MonopolyResourceButton, textureSheet, textureOffset, CategoryResources, Locale.ConvertTextKey( requiredResource.Description ), requiredResource.ID );
 					buttonAdded = buttonAdded + 1;
 				end
-			end		
+			end
 		end
 		UpdateButtonFrame( buttonAdded, Controls.MonopolyResourcesInnerFrame, Controls.MonopolyResourcesFrame );
-	
+
 		--END
-		
+
 		-- update the required resources
 		Controls.RequiredResourcesLabel:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_REQ_RESRC_LABEL" ) );
 		g_RequiredResourcesManager:ResetInstances();
@@ -4364,15 +4365,15 @@ function SelectBuildingOrWonderArticle( buildingID )
 			if requiredResource then
 				local thisRequiredResourceInstance = g_RequiredResourcesManager:GetInstance();
 				if thisRequiredResourceInstance then
-					local textureOffset, textureSheet = IconLookup( requiredResource.PortraitIndex, buttonSize, requiredResource.IconAtlas );				
+					local textureOffset, textureSheet = IconLookup( requiredResource.PortraitIndex, buttonSize, requiredResource.IconAtlas );
 					if textureOffset == nil then
 						textureSheet = defaultErrorTextureSheet;
 						textureOffset = nullOffset;
-					end				
+					end
 					UpdateSmallButton( buttonAdded, thisRequiredResourceInstance.RequiredResourceImage, thisRequiredResourceInstance.RequiredResourceButton, textureSheet, textureOffset, CategoryResources, Locale.ConvertTextKey( requiredResource.Description ), requiredResource.ID );
 					buttonAdded = buttonAdded + 1;
 				end
-			end		
+			end
 		end
 		UpdateButtonFrame( buttonAdded, Controls.RequiredResourcesInnerFrame, Controls.RequiredResourcesFrame );
 
@@ -4403,11 +4404,11 @@ function SelectBuildingOrWonderArticle( buildingID )
 		if defaultBuilding then
 			local thisBuildingInstance = g_ReplacesManager:GetInstance();
 			if thisBuildingInstance then
-				local textureOffset, textureSheet = IconLookup( defaultBuilding.PortraitIndex, buttonSize, defaultBuilding.IconAtlas );				
+				local textureOffset, textureSheet = IconLookup( defaultBuilding.PortraitIndex, buttonSize, defaultBuilding.IconAtlas );
 				if textureOffset == nil then
 					textureSheet = defaultErrorTextureSheet;
 					textureOffset = nullOffset;
-				end				
+				end
 				UpdateSmallButton( buttonAdded, thisBuildingInstance.ReplaceImage, thisBuildingInstance.ReplaceButton, textureSheet, textureOffset, CategoryBuildings, Locale.ConvertTextKey( defaultBuilding.Description ), defaultBuilding.ID );
 				buttonAdded = buttonAdded + 1;
 			end
@@ -4419,17 +4420,17 @@ function SelectBuildingOrWonderArticle( buildingID )
 			g_CivilizationsManager:ResetInstances();
 			local thisCivInstance = g_CivilizationsManager:GetInstance();
 			if thisCivInstance then
-				local textureOffset, textureSheet = IconLookup( thisCiv.PortraitIndex, buttonSize, thisCiv.IconAtlas );				
+				local textureOffset, textureSheet = IconLookup( thisCiv.PortraitIndex, buttonSize, thisCiv.IconAtlas );
 				if textureOffset == nil then
 					textureSheet = defaultErrorTextureSheet;
 					textureOffset = nullOffset;
-				end				
+				end
 				UpdateSmallButton( buttonAdded, thisCivInstance.CivilizationImage, thisCivInstance.CivilizationButton, textureSheet, textureOffset, CategoryCivilizations, Locale.ConvertTextKey( thisCiv.ShortDescription ), thisCiv.ID );
 				buttonAdded = buttonAdded + 1;
-			end	
+			end
 		end
 		UpdateButtonFrame( buttonAdded, Controls.CivilizationsInnerFrame, Controls.CivilizationsFrame );
-		
+
 		-- update the great works box
 		buttonAdded = 0;
 		g_GreatWorksManager:ResetInstances();
@@ -4437,14 +4438,14 @@ function SelectBuildingOrWonderArticle( buildingID )
 			for i = 1, thisBuilding.GreatWorkCount, 1 do
 				local greatWorkSlot = GameInfo.GreatWorkSlots[thisBuilding.GreatWorkSlotType];
 				local emptyTexture = greatWorkSlot.EmptyIcon;
-			
+
 				local thisGreatWorksInstance = g_GreatWorksManager:GetInstance();
-				
-				
+
+
 				UpdateSmallButton( buttonAdded, thisGreatWorksInstance.GreatWorksImage, thisGreatWorksInstance.GreatWorksButton, emptyTexture, nil, nil, Locale.Lookup(greatWorkSlot.EmptyToolTipText), nil);
-				buttonAdded = buttonAdded + 1;			
+				buttonAdded = buttonAdded + 1;
 			end
-		end	
+		end
 		UpdateButtonFrame( buttonAdded, Controls.GreatWorksInnerFrame, Controls.GreatWorksFrame );
 
 		-- update the game info
@@ -4454,17 +4455,17 @@ function SelectBuildingOrWonderArticle( buildingID )
 				UpdateTextBlock( Locale.ConvertTextKey( thisBuilding.Help ), Controls.GameInfoLabel, Controls.GameInfoInnerFrame, Controls.GameInfoFrame );
 			end
 		end
-				
+
 		-- update the strategy info
 		if thisBuilding.Strategy then
 			UpdateTextBlock( Locale.ConvertTextKey( thisBuilding.Strategy ), Controls.StrategyLabel, Controls.StrategyInnerFrame, Controls.StrategyFrame );
 		end
-		
+
 		-- update the historical info
 		if thisBuilding.Civilopedia then
 			UpdateTextBlock( Locale.ConvertTextKey( thisBuilding.Civilopedia ), Controls.HistoryLabel, Controls.HistoryInnerFrame, Controls.HistoryFrame );
 		end
-		
+
 		if thisBuilding.Quote then
 			UpdateTextBlock( Locale.ConvertTextKey( thisBuilding.Quote ), Controls.SilentQuoteLabel, Controls.SilentQuoteInnerFrame, Controls.SilentQuoteFrame );
 		end
@@ -4727,7 +4728,7 @@ function SelectBuildingOrWonderArticle( buildingID )
 			--INNER JOIN [sRefTable] ON [sTable].[sFieldName] = [sRefTable].Type
 			--WHERE [sTable].BuildingType = ?
 			--ORDER BY YieldType" -]]
-			if sRefTable == "" then 
+			if sRefTable == "" then
 				local sql = string.format(
 					"SELECT %s.Yield%s as Yield, Yields.IconString FROM %s INNER JOIN Yields ON %s.YieldType = Yields.Type WHERE %s.BuildingType = ? ORDER BY YieldType",
 					sTable, sFlags, sTable, sTable, sTable);
@@ -4745,7 +4746,7 @@ function SelectBuildingOrWonderArticle( buildingID )
 					if sGroup == "" then
 						sLocText = sLocText..string.format("[NEWLINE][ICON_BULLET]%+d%s ", row.Yield, row.IconString);
 						sGroup = row.Description;
-					elseif row.Description == sGroup then 
+					elseif row.Description == sGroup then
 						sLocText = sLocText..string.format("%+d%s ", row.Yield, row.IconString);
 					else
 						sLocText = sLocText.."from "..Locale.Lookup(sGroup);
@@ -4794,9 +4795,9 @@ CivilopediaCategory[CategoryBuildings].SelectArticle = function( buildingID, sho
 	if selectedCategory ~= CategoryBuildings then
 		SetSelectedCategory(CategoryBuildings);
 	end
-	
+
 	ClearArticle();
-	
+
 	if shouldAddToList == addToList then
 		currentTopic = currentTopic + 1;
 		listOfTopicsViewed[currentTopic] = categorizedList[(CategoryBuildings * absurdlyLargeNumTopicsInCategory) + buildingID];
@@ -4805,7 +4806,7 @@ CivilopediaCategory[CategoryBuildings].SelectArticle = function( buildingID, sho
 		end
 		endTopic = currentTopic;
 	end
-	
+
 	SelectBuildingOrWonderArticle( buildingID );
 
 	ResizeEtc();
@@ -4818,9 +4819,9 @@ CivilopediaCategory[CategoryWonders].SelectArticle = function( wonderID, shouldA
 	if selectedCategory ~= CategoryWonders then
 		SetSelectedCategory(CategoryWonders);
 	end
-	
+
 	ClearArticle();
-	
+
 	if shouldAddToList == addToList then
 		currentTopic = currentTopic + 1;
 		listOfTopicsViewed[currentTopic] = categorizedList[(CategoryWonders * absurdlyLargeNumTopicsInCategory) + wonderID];
@@ -4829,17 +4830,17 @@ CivilopediaCategory[CategoryWonders].SelectArticle = function( wonderID, shouldA
 		end
 		endTopic = currentTopic;
 	end
-	
+
 	if wonderID < 1000 then
 		SelectBuildingOrWonderArticle( wonderID );
 	else
 		local projectID = wonderID - 1000;
 		if projectID ~= -1 then
-		
+
 			local thisProject = GameInfo.Projects[projectID];
-						
+
 			-- update the name
-			local name = Locale.ConvertTextKey( thisProject.Description ); 	
+			local name = Locale.ConvertTextKey( thisProject.Description );
 			Controls.ArticleID:SetText( name );
 
 			-- update the portrait
@@ -4848,14 +4849,14 @@ CivilopediaCategory[CategoryWonders].SelectArticle = function( wonderID, shouldA
 			else
 				Controls.PortraitFrame:SetHide( true );
 			end
-			
+
 			-- update the cost
 			Controls.CostFrame:SetHide( false );
 			local cost = thisProject.Cost;
 			if(cost > 0 and Game ~= nil) then
 				cost = Players[Game.GetActivePlayer()]:GetProjectProductionNeeded( projectID );
 			end
-			
+
 			if(cost > 0) then
 				Controls.CostLabel:SetText( tostring(cost).." [ICON_PRODUCTION]" );
 			elseif(cost == 0) then
@@ -4863,7 +4864,7 @@ CivilopediaCategory[CategoryWonders].SelectArticle = function( wonderID, shouldA
 			else
 				Controls.CostFrame:SetHide(true);
 			end
-	
+
  			local contentSize;
  			local frameSize = {};
 			local buttonAdded = 0;
@@ -4877,20 +4878,20 @@ CivilopediaCategory[CategoryWonders].SelectArticle = function( wonderID, shouldA
 				if prereq then
 					local thisPrereqInstance = g_PrereqTechManager:GetInstance();
 					if thisPrereqInstance then
-						local textureOffset, textureSheet = IconLookup( prereq.PortraitIndex, buttonSize, prereq.IconAtlas );				
+						local textureOffset, textureSheet = IconLookup( prereq.PortraitIndex, buttonSize, prereq.IconAtlas );
 						if textureOffset == nil then
 							textureSheet = defaultErrorTextureSheet;
 							textureOffset = nullOffset;
-						end				
+						end
 						UpdateSmallButton( buttonAdded, thisPrereqInstance.PrereqTechImage, thisPrereqInstance.PrereqTechButton, textureSheet, textureOffset, CategoryTech, Locale.ConvertTextKey( prereq.Description ), prereq.ID );
 						buttonAdded = buttonAdded + 1;
-					end	
+					end
 				end
-			end	
+			end
 			UpdateButtonFrame( buttonAdded, Controls.PrereqTechInnerFrame, Controls.PrereqTechFrame );
 
 			local condition = "BuildingType = '" .. thisProject.Type .. "'";
-			
+
 			-- required buildings
 			g_RequiredBuildingsManager:ResetInstances();
 			buttonAdded = 0;
@@ -4906,10 +4907,10 @@ CivilopediaCategory[CategoryWonders].SelectArticle = function( wonderID, shouldA
 								thisBuildingInstance.RequiredBuildingImage:SetTexture( defaultErrorTextureSheet );
 								thisBuildingInstance.RequiredBuildingImage:SetTextureOffset( nullOffset );
 							end
-							
+
 							--move this button
 							thisBuildingInstance.RequiredBuildingButton:SetOffsetVal( (buttonAdded % numberOfButtonsPerRow) * buttonSize + buttonPadding, math.floor(buttonAdded / numberOfButtonsPerRow) * buttonSize + buttonPadding );
-							
+
 							thisBuildingInstance.RequiredBuildingButton:SetToolTipString( Locale.ConvertTextKey( thisBuildingInfo.Description ) );
 							thisBuildingInstance.RequiredBuildingButton:SetVoids( thisBuildingInfo.ID, addToList );
 							local thisBuildingClass = GameInfo.BuildingClasses[thisBuildingInfo.BuildingClass];
@@ -4924,22 +4925,22 @@ CivilopediaCategory[CategoryWonders].SelectArticle = function( wonderID, shouldA
 				end
 			end
 			UpdateButtonFrame( buttonAdded, Controls.RequiredBuildingsInnerFrame, Controls.RequiredBuildingsFrame );
-			
+
 			-- update the game info
 			if thisProject.Help then
 				UpdateTextBlock( Locale.ConvertTextKey( thisProject.Help ), Controls.GameInfoLabel, Controls.GameInfoInnerFrame, Controls.GameInfoFrame );
 			end
-					
+
 			-- update the strategy info
 			if (thisProject.Strategy) then
 				UpdateTextBlock( Locale.ConvertTextKey( thisProject.Strategy ), Controls.StrategyLabel, Controls.StrategyInnerFrame, Controls.StrategyFrame );
 			end
-			
+
 			-- update the historical info
 			if (thisProject.Civilopedia) then
 				UpdateTextBlock( Locale.ConvertTextKey( thisProject.Civilopedia ), Controls.HistoryLabel, Controls.HistoryInnerFrame, Controls.HistoryFrame );
 			end
-					
+
 			-- update the related images
 			Controls.RelatedImagesFrame:SetHide( true );
 		end
@@ -4954,9 +4955,9 @@ CivilopediaCategory[CategoryPolicies].SelectArticle = function( policyID, should
 	if selectedCategory ~= CategoryPolicies then
 		SetSelectedCategory(CategoryPolicies);
 	end
-	
+
 	ClearArticle();
-	
+
 	if shouldAddToList == addToList then
 		currentTopic = currentTopic + 1;
 		listOfTopicsViewed[currentTopic] = categorizedList[(CategoryPolicies * absurdlyLargeNumTopicsInCategory) + policyID];
@@ -4965,13 +4966,13 @@ CivilopediaCategory[CategoryPolicies].SelectArticle = function( policyID, should
 		end
 		endTopic = currentTopic;
 	end
-	
+
 	if policyID ~= -1 then
-	
+
 		local thisPolicy = GameInfo.Policies[policyID];
-					
+
 		-- update the name
-		local name = Locale.ConvertTextKey( thisPolicy.Description ); 	
+		local name = Locale.ConvertTextKey( thisPolicy.Description );
 		Controls.ArticleID:SetText( name );
 
 		-- update the portrait
@@ -4980,26 +4981,26 @@ CivilopediaCategory[CategoryPolicies].SelectArticle = function( policyID, should
 		else
 			Controls.PortraitFrame:SetHide( true );
 		end
-		
+
 		-- update the policy branch
 		if thisPolicy.PolicyBranchType then
 			local branch = GameInfo.PolicyBranchTypes[thisPolicy.PolicyBranchType];
 			if branch then
-				local branchName = Locale.ConvertTextKey( branch.Description ); 	
+				local branchName = Locale.ConvertTextKey( branch.Description );
 				Controls.PolicyBranchLabel:SetText( branchName );
 				Controls.PolicyBranchFrame:SetHide( false );
 				-- update the prereq era
 				if branch.EraPrereq then
 					local era = GameInfo.Eras[branch.EraPrereq];
 					if era then
-						local eraName = Locale.ConvertTextKey( era.Description ); 	
+						local eraName = Locale.ConvertTextKey( era.Description );
 						Controls.PrereqEraLabel:SetText( eraName );
 						Controls.PrereqEraFrame:SetHide( false );
 					end
 				end
 			end
 		end
-				
+
 		local contentSize;
 		local frameSize = {};
 		local buttonAdded = 0;
@@ -5015,46 +5016,46 @@ CivilopediaCategory[CategoryPolicies].SelectArticle = function( policyID, should
 			if requiredPolicy then
 				local thisRequiredPolicyInstance = g_RequiredPoliciesManager:GetInstance();
 				if thisRequiredPolicyInstance then
-					local textureOffset, textureSheet = IconLookup( requiredPolicy.PortraitIndex, buttonSize, requiredPolicy.IconAtlas );				
+					local textureOffset, textureSheet = IconLookup( requiredPolicy.PortraitIndex, buttonSize, requiredPolicy.IconAtlas );
 					if textureOffset == nil then
 						textureSheet = defaultErrorTextureSheet;
 						textureOffset = nullOffset;
-					end				
+					end
 					UpdateSmallButton( buttonAdded, thisRequiredPolicyInstance.RequiredPolicyImage, thisRequiredPolicyInstance.RequiredPolicyButton, textureSheet, textureOffset, CategoryPolicies, Locale.ConvertTextKey( requiredPolicy.Description ), requiredPolicy.ID );
 					buttonAdded = buttonAdded + 1;
 				end
-			end		
+			end
 		end
 		UpdateButtonFrame( buttonAdded, Controls.RequiredPoliciesInnerFrame, Controls.RequiredPoliciesFrame );
-		
+
 		local tenetLevelLabels = {
 			"TXT_KEY_POLICYSCREEN_L1_TENET",
 			"TXT_KEY_POLICYSCREEN_L2_TENET",
 			"TXT_KEY_POLICYSCREEN_L3_TENET",
 		}
-		
+
 		local tenetLevel = tonumber(thisPolicy.Level);
 		if(tenetLevel ~= nil and tenetLevel > 0) then
 			Controls.TenetLevelLabel:LocalizeAndSetText(tenetLevelLabels[tenetLevel]);
-			Controls.TenetLevelFrame:SetHide(false);	
+			Controls.TenetLevelFrame:SetHide(false);
 		else
 			Controls.TenetLevelFrame:SetHide(true);
 		end
-		
+
 
 		-- update the game info
 		if thisPolicy.Help then
 			UpdateTextBlock( Locale.ConvertTextKey( thisPolicy.Help ), Controls.GameInfoLabel, Controls.GameInfoInnerFrame, Controls.GameInfoFrame );
 		end
-				
+
 		-- update the strategy info
 		--UpdateTextBlock( Locale.ConvertTextKey( thisPolicy.Strategy ), Controls.StrategyLabel, Controls.StrategyInnerFrame, Controls.StrategyFrame );
-		
+
 		-- update the historical info
 		if (thisPolicy.Civilopedia) then
 			UpdateTextBlock( Locale.ConvertTextKey( thisPolicy.Civilopedia ), Controls.HistoryLabel, Controls.HistoryInnerFrame, Controls.HistoryFrame );
 		end
-		
+
 		-- update the related images
 		Controls.RelatedImagesFrame:SetHide( true );
 	end
@@ -5069,9 +5070,9 @@ CivilopediaCategory[CategoryPeople].SelectArticle =  function( rawPeopleID, shou
 	if selectedCategory ~= CategoryPeople then
 		SetSelectedCategory(CategoryPeople);
 	end
-	
+
 	ClearArticle();
-	
+
 	if shouldAddToList == addToList then
 		currentTopic = currentTopic + 1;
 		listOfTopicsViewed[currentTopic] = categorizedList[(CategoryPeople * absurdlyLargeNumTopicsInCategory) + rawPeopleID];
@@ -5080,14 +5081,14 @@ CivilopediaCategory[CategoryPeople].SelectArticle =  function( rawPeopleID, shou
 		end
 		endTopic = currentTopic;
 	end
-	
+
 	if rawPeopleID < 1000 then
 		if rawPeopleID ~= -1 then
-		
+
 			local thisPerson = GameInfo.Specialists[rawPeopleID];
-						
+
 			-- update the name
-			local name = Locale.ConvertTextKey( thisPerson.Description ); 	
+			local name = Locale.ConvertTextKey( thisPerson.Description );
 			Controls.ArticleID:SetText( name );
 
 			if IconHookup( thisPerson.PortraitIndex, portraitSize, thisPerson.IconAtlas, Controls.Portrait ) then
@@ -5104,24 +5105,24 @@ CivilopediaCategory[CategoryPeople].SelectArticle =  function( rawPeopleID, shou
 			if thisPerson.Help then
 				UpdateTextBlock( Locale.ConvertTextKey( thisPerson.Help ), Controls.GameInfoLabel, Controls.GameInfoInnerFrame, Controls.GameInfoFrame );
 			end
-					
+
 			-- update the strategy info
 			if thisPerson.Strategy then
 				UpdateTextBlock( Locale.ConvertTextKey( thisPerson.Strategy ), Controls.StrategyLabel, Controls.StrategyInnerFrame, Controls.StrategyFrame );
 			end
-			
+
 			-- update the historical info
 			if thisPerson.Civilopedia then
 				UpdateTextBlock( Locale.ConvertTextKey( thisPerson.Civilopedia ), Controls.HistoryLabel, Controls.HistoryInnerFrame, Controls.HistoryFrame );
 			end
-					
+
 			-- update the related images
 			Controls.RelatedImagesFrame:SetHide( true );
 
 			-- Infixo Extended info
 			local sText = "[COLOR_CYAN]Buildings[ENDCOLOR] with this specialist:"; -- change to TXT_KEY_ later
 			for row in GameInfo.Buildings() do
-				if row.SpecialistType == thisPerson.Type and row.SpecialistCount > 0 then 
+				if row.SpecialistType == thisPerson.Type and row.SpecialistCount > 0 then
 					sText = sText.."[NEWLINE][ICON_BULLET]"..Locale.Lookup(row.Description)..string.format(" %d[ICON_SPY]", row.SpecialistCount);
 				end
 			end
@@ -5157,11 +5158,11 @@ CivilopediaCategory[CategoryPeople].SelectArticle =  function( rawPeopleID, shou
 	else
 		local greatPersonID = rawPeopleID - 1000;
 		if greatPersonID ~= -1 then
-		
+
 			local thisPerson = GameInfo.Units[greatPersonID];
-						
+
 			-- update the name
-			local name = Locale.ConvertTextKey( thisPerson.Description ); 	
+			local name = Locale.ConvertTextKey( thisPerson.Description );
 			Controls.ArticleID:SetText( name );
 
 			-- update the portrait
@@ -5170,29 +5171,29 @@ CivilopediaCategory[CategoryPeople].SelectArticle =  function( rawPeopleID, shou
 			else
 				Controls.PortraitFrame:SetHide( true );
 			end
-						
+
 			local buttonAdded = 0;
 
 			-- list the buildings that can spawn this unit
-				
+
 			-- update the game info
 			if thisPerson.Help then
 				UpdateTextBlock( Locale.ConvertTextKey( thisPerson.Help ), Controls.GameInfoLabel, Controls.GameInfoInnerFrame, Controls.GameInfoFrame );
 			end
-					
+
 			-- update the strategy info
 			if (thisPerson.Strategy) then
 				UpdateTextBlock( Locale.ConvertTextKey( thisPerson.Strategy ), Controls.StrategyLabel, Controls.StrategyInnerFrame, Controls.StrategyFrame );
 			end
-			
+
 			-- update the historical info
 			if (thisPerson.Civilopedia) then
 				UpdateTextBlock( Locale.ConvertTextKey( thisPerson.Civilopedia ), Controls.HistoryLabel, Controls.HistoryInnerFrame, Controls.HistoryFrame );
 			end
-					
+
 			-- update the related images
 			Controls.RelatedImagesFrame:SetHide( true );
-			
+
 			-- Infixo Extended info
 			local sSpecialistType = "";
 			for row in DB.Query("SELECT Type FROM Specialists WHERE GreatPeopleUnitClass = ?", thisPerson.Class) do
@@ -5203,7 +5204,7 @@ CivilopediaCategory[CategoryPeople].SelectArticle =  function( rawPeopleID, shou
 				local sText = "[COLOR_CYAN]Buildings[ENDCOLOR] that generate [ICON_GREAT_PEOPLE] for this person:"; -- change to TXT_KEY_ later
 				local bShow = false;
 				for row in GameInfo.Buildings() do
-					if row.SpecialistType == sSpecialistType and row.GreatPeopleRateChange > 0 then 
+					if row.SpecialistType == sSpecialistType and row.GreatPeopleRateChange > 0 then
 						sText = sText.."[NEWLINE][ICON_BULLET]"..Locale.Lookup(row.Description)..string.format(" %+d[ICON_GREAT_PEOPLE]", row.GreatPeopleRateChange);
 					end
 				end
@@ -5211,9 +5212,9 @@ CivilopediaCategory[CategoryPeople].SelectArticle =  function( rawPeopleID, shou
 			end
 			-- end Infixo
 		end
-	
+
 	end
-	
+
 	ResizeEtc();
 
 end
@@ -5224,9 +5225,9 @@ CivilopediaCategory[CategoryCivilizations].SelectArticle = function( rawCivID, s
 	if selectedCategory ~= CategoryCivilizations then
 		SetSelectedCategory(CategoryCivilizations);
 	end
-	
+
 	ClearArticle();
-	
+
 	if shouldAddToList == addToList then
 		currentTopic = currentTopic + 1;
 		listOfTopicsViewed[currentTopic] = categorizedList[(CategoryCivilizations * absurdlyLargeNumTopicsInCategory) + rawCivID];
@@ -5238,10 +5239,10 @@ CivilopediaCategory[CategoryCivilizations].SelectArticle = function( rawCivID, s
 
 	if rawCivID < 1000 then
 		if rawCivID ~= -1 then
-		
+
 			local thisCiv = GameInfo.Civilizations[rawCivID];
 			if thisCiv and thisCiv.Type ~= "CIVILIZATION_MINOR" and thisCiv.Type ~= "CIVILIZATION_BARBARIAN" then
-							
+
 				-- update the name
 				local name = Locale.ConvertTextKey( thisCiv.ShortDescription )
 				Controls.ArticleID:SetText( name );
@@ -5255,24 +5256,24 @@ CivilopediaCategory[CategoryCivilizations].SelectArticle = function( rawCivID, s
 
 				local buttonAdded = 0;
 		 		local condition = "CivilizationType = '" .. thisCiv.Type .. "'";
-				
+
 				-- add a list of leaders
 				g_LeadersManager:ResetInstances();
 				buttonAdded = 0;
-					
+
 				local leader = GameInfo.Leaders[GameInfo.Civilization_Leaders( "CivilizationType = '" .. thisCiv.Type .. "'" )().LeaderheadType]; -- todo: add support for multiple leaders
 				local thisLeaderInstance = g_LeadersManager:GetInstance();
 				if thisLeaderInstance then
-					local textureOffset, textureSheet = IconLookup( leader.PortraitIndex, buttonSize, leader.IconAtlas );				
+					local textureOffset, textureSheet = IconLookup( leader.PortraitIndex, buttonSize, leader.IconAtlas );
 					if textureOffset == nil then
 						textureSheet = defaultErrorTextureSheet;
 						textureOffset = nullOffset;
-					end				
+					end
 					UpdateSmallButton( buttonAdded, thisLeaderInstance.LeaderImage, thisLeaderInstance.LeaderButton, textureSheet, textureOffset, CategoryCivilizations, Locale.ConvertTextKey( leader.Description ), thisCiv.ID + 1000 );
 					buttonAdded = buttonAdded + 1;
-				end	
+				end
 				UpdateButtonFrame( buttonAdded, Controls.LeadersInnerFrame, Controls.LeadersFrame );
-				
+
 				-- list of UUs
  				g_UniqueUnitsManager:ResetInstances();
 				buttonAdded = 0;
@@ -5282,12 +5283,12 @@ CivilopediaCategory[CategoryCivilizations].SelectArticle = function( rawCivID, s
 						if thisUnitInfo then
 							local thisUnitInstance = g_UniqueUnitsManager:GetInstance();
 							if thisUnitInstance then
-								local textureOffset, textureSheet = IconLookup( thisUnitInfo.PortraitIndex, buttonSize, thisUnitInfo.IconAtlas );				
+								local textureOffset, textureSheet = IconLookup( thisUnitInfo.PortraitIndex, buttonSize, thisUnitInfo.IconAtlas );
 								if textureOffset == nil then
 									textureSheet = defaultErrorTextureSheet;
 									textureOffset = nullOffset;
-								end			
-								
+								end
+
 								local unitCategory = CategoryUnits;
 								local unitEntryID = thisUnitInfo.ID;
 								--if(thisUnitInfo.Special == "SPECIALUNIT_PEOPLE") then
@@ -5302,18 +5303,18 @@ CivilopediaCategory[CategoryCivilizations].SelectArticle = function( rawCivID, s
 									--end
 									--
 									--if(bIsSpecialist == false) then
-										--unitEntryID = unitEntryID + 1000;	
+										--unitEntryID = unitEntryID + 1000;
 									--end
 								--end
-									
+
 								UpdateSmallButton( buttonAdded, thisUnitInstance.UniqueUnitImage, thisUnitInstance.UniqueUnitButton, textureSheet, textureOffset, unitCategory, Locale.ConvertTextKey( thisUnitInfo.Description ), unitEntryID);
 								buttonAdded = buttonAdded + 1;
 							end
 						end
 					end
 				end
-				UpdateButtonFrame( buttonAdded, Controls.UniqueUnitsInnerFrame, Controls.UniqueUnitsFrame );	 	  
-				
+				UpdateButtonFrame( buttonAdded, Controls.UniqueUnitsInnerFrame, Controls.UniqueUnitsFrame );
+
 				-- list of UBs
 				g_UniqueBuildingsManager:ResetInstances();
 				buttonAdded = 0;
@@ -5328,10 +5329,10 @@ CivilopediaCategory[CategoryCivilizations].SelectArticle = function( rawCivID, s
 									thisBuildingInstance.UniqueBuildingImage:SetTexture( defaultErrorTextureSheet );
 									thisBuildingInstance.UniqueBuildingImage:SetTextureOffset( nullOffset );
 								end
-								
+
 								--move this button
 								thisBuildingInstance.UniqueBuildingButton:SetOffsetVal( (buttonAdded % numberOfButtonsPerRow) * buttonSize + buttonPadding, math.floor(buttonAdded / numberOfButtonsPerRow) * buttonSize + buttonPadding );
-								
+
 								thisBuildingInstance.UniqueBuildingButton:SetToolTipString( Locale.ConvertTextKey( thisBuildingInfo.Description ) );
 								thisBuildingInstance.UniqueBuildingButton:SetVoids( thisBuildingInfo.ID, addToList );
 								local thisBuildingClass = GameInfo.BuildingClasses[thisBuildingInfo.BuildingClass];
@@ -5347,8 +5348,8 @@ CivilopediaCategory[CategoryCivilizations].SelectArticle = function( rawCivID, s
 					end
 				end
 				UpdateButtonFrame( buttonAdded, Controls.UniqueBuildingsInnerFrame, Controls.UniqueBuildingsFrame );
-				
-				-- list of unique improvements	 	  
+
+				-- list of unique improvements
 				g_UniqueImprovementsManager:ResetInstances();
 				buttonAdded = 0;
 				for thisImprovement in GameInfo.Improvements( condition ) do
@@ -5359,10 +5360,10 @@ CivilopediaCategory[CategoryCivilizations].SelectArticle = function( rawCivID, s
 							thisImprovementInstance.UniqueImprovementImage:SetTexture( defaultErrorTextureSheet );
 							thisImprovementInstance.UniqueImprovementImage:SetTextureOffset( nullOffset );
 						end
-						
+
 						--move this button
 						thisImprovementInstance.UniqueImprovementButton:SetOffsetVal( (buttonAdded % numberOfButtonsPerRow) * buttonSize + buttonPadding, math.floor(buttonAdded / numberOfButtonsPerRow) * buttonSize + buttonPadding );
-						
+
 						thisImprovementInstance.UniqueImprovementButton:SetToolTipString( Locale.ConvertTextKey( thisImprovement.Description ) );
 						thisImprovementInstance.UniqueImprovementButton:SetVoids( thisImprovement.ID, addToList );
 						thisImprovementInstance.UniqueImprovementButton:RegisterCallback( Mouse.eLClick, CivilopediaCategory[CategoryImprovements].SelectArticle );
@@ -5371,13 +5372,13 @@ CivilopediaCategory[CategoryCivilizations].SelectArticle = function( rawCivID, s
 					end
 				end
 				UpdateButtonFrame( buttonAdded, Controls.UniqueImprovementsInnerFrame, Controls.UniqueImprovementsFrame );
-				
+
 				-- list of special abilities
 				buttonAdded = 0;
-				
+
 				-- add the free form text
 				g_FreeFormTextManager:ResetInstances();
-				
+
 				local tagString = thisCiv.CivilopediaTag;
 				if tagString then
 					local headerString = tagString .. "_HEADING_";
@@ -5394,7 +5395,7 @@ CivilopediaCategory[CategoryCivilizations].SelectArticle = function( rawCivID, s
 								UpdateTextBlock( Locale.ConvertTextKey( bodyTag ), thisFreeFormTextInstance.FFTextLabel, thisFreeFormTextInstance.FFTextInnerFrame, thisFreeFormTextInstance.FFTextFrame );
 							end
 						else
-							notFound = true;		
+							notFound = true;
 						end
 						i = i + 1;
 					until notFound;
@@ -5408,7 +5409,7 @@ CivilopediaCategory[CategoryCivilizations].SelectArticle = function( rawCivID, s
 							UpdateTextBlock( Locale.ConvertTextKey( factoidBodyString ), thisFreeFormTextInstance.FFTextLabel, thisFreeFormTextInstance.FFTextInnerFrame, thisFreeFormTextInstance.FFTextFrame );
 						end
 					end
-					
+
 					Controls.FFTextStack:SetHide( false );
 
 				end
@@ -5420,10 +5421,10 @@ CivilopediaCategory[CategoryCivilizations].SelectArticle = function( rawCivID, s
 	else
 		local civID = rawCivID - 1000;
 		if civID ~= -1 then
-		
+
 			local thisCiv = GameInfo.Civilizations[civID];
 			if thisCiv and thisCiv.Type ~= "CIVILIZATION_MINOR" and thisCiv.Type ~= "CIVILIZATION_BARBARIAN" then
-							
+
 				local leader = GameInfo.Leaders[GameInfo.Civilization_Leaders( "CivilizationType = '" .. thisCiv.Type .. "'" )().LeaderheadType];
 
 				-- update the name
@@ -5446,7 +5447,7 @@ CivilopediaCategory[CategoryCivilizations].SelectArticle = function( rawCivID, s
 				end
 
 				local buttonAdded = 0;
-				
+
 				-- add titles etc.
 				if tagString then
 					Controls.LivedLabel:SetText( Locale.ConvertTextKey( tagString.."_LIVED" ) );
@@ -5466,7 +5467,7 @@ CivilopediaCategory[CategoryCivilizations].SelectArticle = function( rawCivID, s
 							numTitles = numTitles + 1;
 							titles = titles .. Locale.ConvertTextKey( titlesTag );
 						else
-							notFound = true;		
+							notFound = true;
 						end
 						i = i + 1;
 					until notFound;
@@ -5476,7 +5477,7 @@ CivilopediaCategory[CategoryCivilizations].SelectArticle = function( rawCivID, s
 				end
 
  				local condition = "LeaderType = '" .. leader.Type .. "'";
- 	
+
 				-- list of traits
  				--g_TraitsManager:ResetInstances();
 				--buttonAdded = 0;
@@ -5494,23 +5495,23 @@ CivilopediaCategory[CategoryCivilizations].SelectArticle = function( rawCivID, s
 						--end
 					--end
 				--end
-				--UpdateButtonFrame( buttonAdded, Controls.TraitsInnerFrame, Controls.TraitsFrame );	 	  
+				--UpdateButtonFrame( buttonAdded, Controls.TraitsInnerFrame, Controls.TraitsFrame );
 								--
 				-- add the civ icon
 				g_CivilizationsManager:ResetInstances();
 				buttonAdded = 0;
 				local thisCivInstance = g_CivilizationsManager:GetInstance();
 				if thisCivInstance then
-					local textureOffset, textureSheet = IconLookup( thisCiv.PortraitIndex, buttonSize, thisCiv.IconAtlas );				
+					local textureOffset, textureSheet = IconLookup( thisCiv.PortraitIndex, buttonSize, thisCiv.IconAtlas );
 					if textureOffset == nil then
 						textureSheet = defaultErrorTextureSheet;
 						textureOffset = nullOffset;
-					end				
+					end
 					UpdateSmallButton( buttonAdded, thisCivInstance.CivilizationImage, thisCivInstance.CivilizationButton, textureSheet, textureOffset, CategoryCivilizations, Locale.ConvertTextKey( thisCiv.ShortDescription ), thisCiv.ID );
 					buttonAdded = buttonAdded + 1;
-				end	
+				end
 				UpdateButtonFrame( buttonAdded, Controls.CivilizationsInnerFrame, Controls.CivilizationsFrame );
-						
+
 				-- update the game info
 				local leaderTrait = GameInfo.Leader_Traits(condition)();
 				if leaderTrait then
@@ -5518,7 +5519,7 @@ CivilopediaCategory[CategoryCivilizations].SelectArticle = function( rawCivID, s
 					local traitString = Locale.ConvertTextKey( GameInfo.Traits[trait].ShortDescription ).."[NEWLINE][NEWLINE]"..Locale.ConvertTextKey( GameInfo.Traits[trait].Description );
 					UpdateTextBlock( traitString, Controls.GameInfoLabel, Controls.GameInfoInnerFrame, Controls.GameInfoFrame );
 				end
-										
+
 				-- add the free form text
 				g_FreeFormTextManager:ResetInstances();
 				if tagString then
@@ -5536,11 +5537,11 @@ CivilopediaCategory[CategoryCivilizations].SelectArticle = function( rawCivID, s
 								UpdateTextBlock( Locale.ConvertTextKey( bodyTag ), thisFreeFormTextInstance.FFTextLabel, thisFreeFormTextInstance.FFTextInnerFrame, thisFreeFormTextInstance.FFTextFrame );
 							end
 						else
-							notFound = true;		
+							notFound = true;
 						end
 						i = i + 1;
 					until notFound;
-					
+
 					notFound = false;
 					i = 1;
 					repeat
@@ -5553,15 +5554,15 @@ CivilopediaCategory[CategoryCivilizations].SelectArticle = function( rawCivID, s
 								UpdateTextBlock( Locale.ConvertTextKey( bodyTag ), thisFreeFormTextInstance.FFTextLabel, thisFreeFormTextInstance.FFTextInnerFrame, thisFreeFormTextInstance.FFTextFrame );
 							end
 						else
-							notFound = true;		
+							notFound = true;
 						end
 						i = i + 1;
 					until notFound;
-											
+
 					Controls.FFTextStack:SetHide( false );
 
 				end
-				
+
 				-- update the related images
 				Controls.RelatedImagesFrame:SetHide( true );
 
@@ -5578,9 +5579,9 @@ CivilopediaCategory[CategoryCityStates].SelectArticle = function( cityStateID, s
 	if selectedCategory ~= CategoryCityStates then
 		SetSelectedCategory(CategoryCityStates);
 	end
-	
+
 	ClearArticle();
-	
+
 	if shouldAddToList == addToList then
 		currentTopic = currentTopic + 1;
 		listOfTopicsViewed[currentTopic] = categorizedList[(CategoryCityStates * absurdlyLargeNumTopicsInCategory) + cityStateID];
@@ -5589,29 +5590,29 @@ CivilopediaCategory[CategoryCityStates].SelectArticle = function( cityStateID, s
 		end
 		endTopic = currentTopic;
 	end
-	
+
 	if cityStateID ~= -1 then
 		local thisCityState = GameInfo.MinorCivilizations[cityStateID];
-		
+
 		-- update the name
-		local name = Locale.ConvertTextKey( thisCityState.Description ); 	
+		local name = Locale.ConvertTextKey( thisCityState.Description );
 		Controls.ArticleID:SetText( name );
-		
+
 		-- portrait -- need to update this once they're in.
 		--Controls.PortraitFrame:SetHide( false );
-		
+
  		local contentSize;
  		local frameSize = {};
 		local buttonAdded = 0;
- 		
+
 		-- update the game info
-		
+
 		-- update the historical info
 		if (thisCityState.Civilopedia) then
 			UpdateTextBlock( Locale.ConvertTextKey( thisCityState.Civilopedia ), Controls.HistoryLabel, Controls.HistoryInnerFrame, Controls.HistoryFrame );
 		end
-				
-	end	
+
+	end
 
 	ResizeEtc();
 
@@ -5623,9 +5624,9 @@ CivilopediaCategory[CategoryTerrain].SelectArticle = function( rawTerrainID, sho
 	if selectedCategory ~= CategoryTerrain then
 		SetSelectedCategory(CategoryTerrain);
 	end
-	
+
 	ClearArticle();
-	
+
 	if shouldAddToList == addToList then
 		currentTopic = currentTopic + 1;
 		listOfTopicsViewed[currentTopic] = categorizedList[(CategoryTerrain * absurdlyLargeNumTopicsInCategory) + rawTerrainID];
@@ -5638,7 +5639,7 @@ CivilopediaCategory[CategoryTerrain].SelectArticle = function( rawTerrainID, sho
 	if rawTerrainID < 1000 then
 		local terrainId = rawTerrainID;
 		if terrainId ~= -1 then
-		
+
 			local thisTerrain = GameInfo.Terrains[terrainId];
 			if thisTerrain then
 
@@ -5655,7 +5656,7 @@ CivilopediaCategory[CategoryTerrain].SelectArticle = function( rawTerrainID, sho
 
 				local buttonAdded = 0;
 		 		local condition = "TerrainType = '" .. thisTerrain.Type .. "'";
-				
+
 				-- City Yield
 				Controls.YieldFrame:SetHide( false );
 				local numYields = 0;
@@ -5680,13 +5681,13 @@ CivilopediaCategory[CategoryTerrain].SelectArticle = function( rawTerrainID, sho
 					numYields = 1;
 					yieldString = "2 [ICON_PRODUCTION]"
 				end
-				
+
 				if numYields == 0 then
 					Controls.YieldLabel:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_NO_YIELD" ) );
 				else
 					Controls.YieldLabel:SetText( Locale.ConvertTextKey( yieldString ) );
 				end
-				
+
 				-- Movement
 				Controls.MovementCostFrame:SetHide( false );
 				local moveCost = thisTerrain.Movement;
@@ -5725,17 +5726,17 @@ CivilopediaCategory[CategoryTerrain].SelectArticle = function( rawTerrainID, sho
 					if thisFeature then
 						local thisFeatureInstance = g_FeaturesManager:GetInstance();
 						if thisFeatureInstance then
-							local textureOffset, textureSheet = IconLookup( thisFeature.PortraitIndex, buttonSize, thisFeature.IconAtlas );				
+							local textureOffset, textureSheet = IconLookup( thisFeature.PortraitIndex, buttonSize, thisFeature.IconAtlas );
 							if textureOffset == nil then
 								textureSheet = defaultErrorTextureSheet;
 								textureOffset = nullOffset;
-							end				
+							end
 							UpdateSmallButton( buttonAdded, thisFeatureInstance.FeatureImage, thisFeatureInstance.FeatureButton, textureSheet, textureOffset, CategoryTerrain, Locale.ConvertTextKey( thisFeature.Description ), thisFeature.ID + 1000 ); -- todo: add a fudge factor
 							buttonAdded = buttonAdded + 1;
 						end
 					end
 				end
-				UpdateButtonFrame( buttonAdded, Controls.FeaturesInnerFrame, Controls.FeaturesFrame );	 	  
+				UpdateButtonFrame( buttonAdded, Controls.FeaturesInnerFrame, Controls.FeaturesFrame );
 
 				-- Resources that can exist on this terrain
 				Controls.ResourcesFoundLabel:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_RESOURCESFOUND_LABEL" ) );
@@ -5746,11 +5747,11 @@ CivilopediaCategory[CategoryTerrain].SelectArticle = function( rawTerrainID, sho
 					if thisResource then
 						local thisResourceInstance = g_ResourcesFoundManager:GetInstance();
 						if thisResourceInstance then
-							local textureOffset, textureSheet = IconLookup( thisResource.PortraitIndex, buttonSize, thisResource.IconAtlas );				
+							local textureOffset, textureSheet = IconLookup( thisResource.PortraitIndex, buttonSize, thisResource.IconAtlas );
 							if textureOffset == nil then
 								textureSheet = defaultErrorTextureSheet;
 								textureOffset = nullOffset;
-							end				
+							end
 							UpdateSmallButton( buttonAdded, thisResourceInstance.ResourceFoundImage, thisResourceInstance.ResourceFoundButton, textureSheet, textureOffset, CategoryResources, Locale.ConvertTextKey( thisResource.Description ), thisResource.ID );
 							buttonAdded = buttonAdded + 1;
 						end
@@ -5762,24 +5763,24 @@ CivilopediaCategory[CategoryTerrain].SelectArticle = function( rawTerrainID, sho
 						if thisResource and thisResource.Hills then
 							local thisResourceInstance = g_ResourcesFoundManager:GetInstance();
 							if thisResourceInstance then
-								local textureOffset, textureSheet = IconLookup( thisResource.PortraitIndex, buttonSize, thisResource.IconAtlas );				
+								local textureOffset, textureSheet = IconLookup( thisResource.PortraitIndex, buttonSize, thisResource.IconAtlas );
 								if textureOffset == nil then
 									textureSheet = defaultErrorTextureSheet;
 									textureOffset = nullOffset;
-								end				
+								end
 								UpdateSmallButton( buttonAdded, thisResourceInstance.ResourceFoundImage, thisResourceInstance.ResourceFoundButton, textureSheet, textureOffset, CategoryResources, Locale.ConvertTextKey( thisResource.Description ), thisResource.ID );
 								buttonAdded = buttonAdded + 1;
 							end
 						end
 					end
 				end
-				UpdateButtonFrame( buttonAdded, Controls.ResourcesFoundInnerFrame, Controls.ResourcesFoundFrame );	 	  
+				UpdateButtonFrame( buttonAdded, Controls.ResourcesFoundInnerFrame, Controls.ResourcesFoundFrame );
 
 				-- generic text
 				if (thisTerrain.Civilopedia) then
 					UpdateTextBlock( Locale.ConvertTextKey( thisTerrain.Civilopedia ), Controls.GameInfoLabel, Controls.GameInfoInnerFrame, Controls.GameInfoFrame );
 				end
-				
+
 				-- update the related images
 				Controls.RelatedImagesFrame:SetHide( true );
 			end
@@ -5787,7 +5788,7 @@ CivilopediaCategory[CategoryTerrain].SelectArticle = function( rawTerrainID, sho
 	else
 		local featureID = rawTerrainID - 1000;
 		if featureID ~= -1 then
-		
+
 			local thisFeature;
 			if featureID < 1000 then
 				thisFeature = GameInfo.Features[featureID];
@@ -5809,7 +5810,7 @@ CivilopediaCategory[CategoryTerrain].SelectArticle = function( rawTerrainID, sho
 
 				local buttonAdded = 0;
 		 		local condition = "FeatureType = '" .. thisFeature.Type .. "'";
-				
+
 				-- City Yield
 				Controls.YieldFrame:SetHide( false );
 				local numYields = 0;
@@ -5818,7 +5819,7 @@ CivilopediaCategory[CategoryTerrain].SelectArticle = function( rawTerrainID, sho
 					numYields = numYields + 1;
 					yieldString = yieldString..tostring(row.Yield).." ";
 					yieldString = yieldString..GameInfo.Yields[row.YieldType].IconString.." ";
-				end				
+				end
 				-- add happiness since it is a quasi-yield
 				if thisFeature.InBorderHappiness and thisFeature.InBorderHappiness ~= 0 then
 					numYields = numYields + 1;
@@ -5830,7 +5831,7 @@ CivilopediaCategory[CategoryTerrain].SelectArticle = function( rawTerrainID, sho
 				else
 					Controls.YieldLabel:SetText( Locale.ConvertTextKey( yieldString ) );
 				end
-				
+
 				-- Movement
 				Controls.MovementCostFrame:SetHide( false );
 				local moveCost = thisFeature.Movement;
@@ -5858,17 +5859,17 @@ CivilopediaCategory[CategoryTerrain].SelectArticle = function( rawTerrainID, sho
 					if thisTerrain then
 						local thisTerrainInstance = g_FeaturesManager:GetInstance();
 						if thisTerrainInstance then
-							local textureOffset, textureSheet = IconLookup( thisTerrain.PortraitIndex, buttonSize, thisTerrain.IconAtlas );				
+							local textureOffset, textureSheet = IconLookup( thisTerrain.PortraitIndex, buttonSize, thisTerrain.IconAtlas );
 							if textureOffset == nil then
 								textureSheet = defaultErrorTextureSheet;
 								textureOffset = nullOffset;
-							end				
+							end
 							UpdateSmallButton( buttonAdded, thisTerrainInstance.FeatureImage, thisTerrainInstance.FeatureButton, textureSheet, textureOffset, CategoryTerrain, Locale.ConvertTextKey( thisTerrain.Description ), thisTerrain.ID );
 							buttonAdded = buttonAdded + 1;
 						end
 					end
 				end
-				UpdateButtonFrame( buttonAdded, Controls.TerrainsInnerFrame, Controls.TerrainsFrame );	 	  
+				UpdateButtonFrame( buttonAdded, Controls.TerrainsInnerFrame, Controls.TerrainsFrame );
 
 				-- Resources that can exist on this feature
 				Controls.ResourcesFoundLabel:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_RESOURCESFOUND_LABEL" ) );
@@ -5879,33 +5880,33 @@ CivilopediaCategory[CategoryTerrain].SelectArticle = function( rawTerrainID, sho
 					if thisResource then
 						local thisResourceInstance = g_ResourcesFoundManager:GetInstance();
 						if thisResourceInstance then
-							local textureOffset, textureSheet = IconLookup( thisResource.PortraitIndex, buttonSize, thisResource.IconAtlas );				
+							local textureOffset, textureSheet = IconLookup( thisResource.PortraitIndex, buttonSize, thisResource.IconAtlas );
 							if textureOffset == nil then
 								textureSheet = defaultErrorTextureSheet;
 								textureOffset = nullOffset;
-							end				
+							end
 							UpdateSmallButton( buttonAdded, thisResourceInstance.ResourceFoundImage, thisResourceInstance.ResourceFoundButton, textureSheet, textureOffset, CategoryResources, Locale.ConvertTextKey( thisResource.Description ), thisResource.ID );
 							buttonAdded = buttonAdded + 1;
 						end
 					end
 				end
-				UpdateButtonFrame( buttonAdded, Controls.ResourcesFoundInnerFrame, Controls.ResourcesFoundFrame );	 	  
+				UpdateButtonFrame( buttonAdded, Controls.ResourcesFoundInnerFrame, Controls.ResourcesFoundFrame );
 
 				if(featureID < 1000) then
 					-- generic text
 					if (thisFeature.Help) then
 						UpdateTextBlock( Locale.ConvertTextKey( thisFeature.Help ), Controls.GameInfoLabel, Controls.GameInfoInnerFrame, Controls.GameInfoFrame );
 					end
-					
+
 					if (thisFeature.Civilopedia) then
 						UpdateTextBlock( Locale.ConvertTextKey( thisFeature.Civilopedia ), Controls.HistoryLabel, Controls.HistoryInnerFrame, Controls.HistoryFrame );
-					end			
+					end
 				else
 					if (thisFeature.Civilopedia) then
 						UpdateTextBlock( Locale.ConvertTextKey( thisFeature.Civilopedia ), Controls.GameInfoLabel, Controls.GameInfoInnerFrame, Controls.GameInfoFrame );
-					end				
+					end
 				end
-				
+
 				-- update the related images
 				Controls.RelatedImagesFrame:SetHide( true );
 			end
@@ -5923,9 +5924,9 @@ CivilopediaCategory[CategoryResources].SelectArticle = function( resourceID, sho
 	if selectedCategory ~= CategoryResources then
 		SetSelectedCategory(CategoryResources);
 	end
-	
+
 	ClearArticle();
-	
+
 	if shouldAddToList == addToList then
 		currentTopic = currentTopic + 1;
 		listOfTopicsViewed[currentTopic] = categorizedList[(CategoryResources * absurdlyLargeNumTopicsInCategory) + resourceID];
@@ -5950,7 +5951,7 @@ CivilopediaCategory[CategoryResources].SelectArticle = function( resourceID, sho
 	end
 
 	if resourceID ~= -1 then
-	
+
 		local thisResource = GameInfo.Resources[resourceID];
 		if thisResource then
 
@@ -5967,7 +5968,7 @@ CivilopediaCategory[CategoryResources].SelectArticle = function( resourceID, sho
 
 			local buttonAdded = 0;
 	 		local condition = "ResourceType = '" .. thisResource.Type .. "'";
-			
+
 			-- tech visibility
 			g_RevealTechsManager:ResetInstances();
 			buttonAdded = 0;
@@ -5988,16 +5989,16 @@ CivilopediaCategory[CategoryResources].SelectArticle = function( resourceID, sho
 			if techReveal then
 				local prereq = GameInfo.Technologies[techReveal];
 				local thisPrereqInstance = g_RevealTechsManager:GetInstance();
-				
+
 				if thisPrereqInstance then
-					local textureOffset, textureSheet = IconLookup( prereq.PortraitIndex, buttonSize, prereq.IconAtlas );				
+					local textureOffset, textureSheet = IconLookup( prereq.PortraitIndex, buttonSize, prereq.IconAtlas );
 					if textureOffset == nil then
 						textureSheet = defaultErrorTextureSheet;
 						textureOffset = nullOffset;
-					end				
+					end
 					UpdateSmallButton( buttonAdded, thisPrereqInstance.RevealTechImage, thisPrereqInstance.RevealTechButton, textureSheet, textureOffset, CategoryTech, Locale.ConvertTextKey( prereq.Description ), prereq.ID );
 					buttonAdded = buttonAdded + 1;
-				end			
+				end
 				UpdateButtonFrame( buttonAdded, Controls.RevealTechsInnerFrame, Controls.RevealTechsFrame );
 			end
 
@@ -6027,17 +6028,17 @@ CivilopediaCategory[CategoryResources].SelectArticle = function( resourceID, sho
 				if thisFeature then
 					local thisFeatureInstance = g_ResourcesFoundManager:GetInstance();
 					if thisFeatureInstance then
-						local textureOffset, textureSheet = IconLookup( thisFeature.PortraitIndex, buttonSize, thisFeature.IconAtlas );				
+						local textureOffset, textureSheet = IconLookup( thisFeature.PortraitIndex, buttonSize, thisFeature.IconAtlas );
 						if textureOffset == nil then
 							textureSheet = defaultErrorTextureSheet;
 							textureOffset = nullOffset;
-						end				
+						end
 						UpdateSmallButton( buttonAdded, thisFeatureInstance.ResourceFoundImage, thisFeatureInstance.ResourceFoundButton, textureSheet, textureOffset, CategoryTerrain, Locale.ConvertTextKey( thisFeature.Description ), thisFeature.ID + 1000 ); -- todo: add a fudge factor
 						buttonAdded = buttonAdded + 1;
 					end
 				end
 			end
-			
+
 			local bAlreadyShowingHills = false;
 			for row in GameInfo.Resource_TerrainBooleans( condition ) do
 				local thisTerrain = GameInfo.Terrains[row.TerrainType];
@@ -6047,12 +6048,12 @@ CivilopediaCategory[CategoryResources].SelectArticle = function( resourceID, sho
 						if(row.TerrainType == "TERRAIN_HILL") then
 							bAlreadyShowingHills = true;
 						end
-					
-						local textureOffset, textureSheet = IconLookup( thisTerrain.PortraitIndex, buttonSize, thisTerrain.IconAtlas );				
+
+						local textureOffset, textureSheet = IconLookup( thisTerrain.PortraitIndex, buttonSize, thisTerrain.IconAtlas );
 						if textureOffset == nil then
 							textureSheet = defaultErrorTextureSheet;
 							textureOffset = nullOffset;
-						end				
+						end
 						UpdateSmallButton( buttonAdded, thisTerrainInstance.ResourceFoundImage, thisTerrainInstance.ResourceFoundButton, textureSheet, textureOffset, CategoryTerrain, Locale.ConvertTextKey( thisTerrain.Description ), thisTerrain.ID );
 						buttonAdded = buttonAdded + 1;
 					end
@@ -6063,17 +6064,17 @@ CivilopediaCategory[CategoryResources].SelectArticle = function( resourceID, sho
 				local thisTerrain = GameInfo.Terrains["TERRAIN_HILL"];
 				local thisTerrainInstance = g_ResourcesFoundManager:GetInstance();
 				if thisTerrainInstance then
-					local textureOffset, textureSheet = IconLookup( thisTerrain.PortraitIndex, buttonSize, thisTerrain.IconAtlas );				
+					local textureOffset, textureSheet = IconLookup( thisTerrain.PortraitIndex, buttonSize, thisTerrain.IconAtlas );
 					if textureOffset == nil then
 						textureSheet = defaultErrorTextureSheet;
 						textureOffset = nullOffset;
-					end				
+					end
 					UpdateSmallButton( buttonAdded, thisTerrainInstance.ResourceFoundImage, thisTerrainInstance.ResourceFoundButton, textureSheet, textureOffset, CategoryTerrain, Locale.ConvertTextKey( thisTerrain.Description ), thisTerrain.ID );
 					buttonAdded = buttonAdded + 1;
 				end
 			end
-			UpdateButtonFrame( buttonAdded, Controls.ResourcesFoundInnerFrame, Controls.ResourcesFoundFrame );	 	  
-			
+			UpdateButtonFrame( buttonAdded, Controls.ResourcesFoundInnerFrame, Controls.ResourcesFoundFrame );
+
 			-- improvement
 			g_ImprovementsManager:ResetInstances();
 			buttonAdded = 0;
@@ -6083,19 +6084,19 @@ CivilopediaCategory[CategoryResources].SelectArticle = function( resourceID, sho
 					if thisImprovement then
 						local thisImprovementInstance = g_ImprovementsManager:GetInstance();
 						if thisImprovementInstance then
-							local textureOffset, textureSheet = IconLookup( thisImprovement.PortraitIndex, buttonSize, thisImprovement.IconAtlas );				
+							local textureOffset, textureSheet = IconLookup( thisImprovement.PortraitIndex, buttonSize, thisImprovement.IconAtlas );
 							if textureOffset == nil then
 								textureSheet = defaultErrorTextureSheet;
 								textureOffset = nullOffset;
-							end				
+							end
 							UpdateSmallButton( buttonAdded, thisImprovementInstance.ImprovementImage, thisImprovementInstance.ImprovementButton, textureSheet, textureOffset, CategoryImprovements, Locale.ConvertTextKey( thisImprovement.Description ), thisImprovement.ID );
 							buttonAdded = buttonAdded + 1;
 						end
 					end
 				end
 			end
-			UpdateButtonFrame( buttonAdded, Controls.ImprovementsInnerFrame, Controls.ImprovementsFrame );	 	  
-			
+			UpdateButtonFrame( buttonAdded, Controls.ImprovementsInnerFrame, Controls.ImprovementsFrame );
+
 			--CBP
 			numYields = 0;
 			yieldString = "";
@@ -6103,7 +6104,7 @@ CivilopediaCategory[CategoryResources].SelectArticle = function( resourceID, sho
 			local numImprovement = 0;
 
 			for row in GameInfo.Improvement_ResourceType_Yields( condition ) do
-				numYields = numYields + 1;			
+				numYields = numYields + 1;
 				local thisImprovement = GameInfo.Improvements[row.ImprovementType];
 				if thisImprovement then
 					if numImprovement > 0 then
@@ -6135,15 +6136,15 @@ CivilopediaCategory[CategoryResources].SelectArticle = function( resourceID, sho
 				UpdateTextBlock( Locale.ConvertTextKey( thisResource.Civilopedia ), Controls.HistoryLabel, Controls.HistoryInnerFrame, Controls.HistoryFrame );
 			end
 
-			
-			
+
+
 			-- update the related images
 			Controls.RelatedImagesFrame:SetHide( true );
-			
+
 			-- Infixo Extended info
 			--local sText = "[COLOR_CYAN]Buildings[ENDCOLOR] with this specialist:"; -- change to TXT_KEY_ later
 			--for row in GameInfo.Buildings() do
-			--	if row.SpecialistType == thisPerson.Type and row.SpecialistCount > 0 then 
+			--	if row.SpecialistType == thisPerson.Type and row.SpecialistCount > 0 then
 			--		sText = sText.."[NEWLINE][ICON_BULLET]"..Locale.Lookup(row.Description)..string.format(" %d[ICON_SPY]", row.SpecialistCount);
 			--	end
 			--end
@@ -6165,7 +6166,7 @@ CivilopediaCategory[CategoryResources].SelectArticle = function( resourceID, sho
 			--end
 			UpdateTextBlock( sText, Controls.ExtendedLabel,  Controls.ExtendedInnerFrame,  Controls.ExtendedFrame );
 			-- end Infixo
-			
+
 		end
 	end
 
@@ -6179,9 +6180,9 @@ CivilopediaCategory[CategoryImprovements].SelectArticle = function( improvementI
 	if selectedCategory ~= CategoryImprovements then
 		SetSelectedCategory(CategoryImprovements);
 	end
-	
+
 	ClearArticle();
-	
+
 	if shouldAddToList == addToList then
 		currentTopic = currentTopic + 1;
 		listOfTopicsViewed[currentTopic] = categorizedList[(CategoryImprovements * absurdlyLargeNumTopicsInCategory) + improvementID];
@@ -6192,7 +6193,7 @@ CivilopediaCategory[CategoryImprovements].SelectArticle = function( improvementI
 	end
 
 	if improvementID ~= -1 and improvementID < 1000 then
-	
+
 		local thisImprovement = GameInfo.Improvements[improvementID];
 		if thisImprovement then
 
@@ -6209,7 +6210,7 @@ CivilopediaCategory[CategoryImprovements].SelectArticle = function( improvementI
 
 			local buttonAdded = 0;
 	 		local condition = "ImprovementType = '" .. thisImprovement.Type .. "'";
-			
+
 			-- tech visibility
 			g_PrereqTechManager:ResetInstances();
 			buttonAdded = 0;
@@ -6220,15 +6221,15 @@ CivilopediaCategory[CategoryImprovements].SelectArticle = function( improvementI
 					prereq = GameInfo.Technologies[row.PrereqTech];
 				end
 			end
-			
+
 			if prereq then
 				local thisPrereqInstance = g_PrereqTechManager:GetInstance();
 				if thisPrereqInstance then
-					local textureOffset, textureSheet = IconLookup( prereq.PortraitIndex, buttonSize, prereq.IconAtlas );				
+					local textureOffset, textureSheet = IconLookup( prereq.PortraitIndex, buttonSize, prereq.IconAtlas );
 					if textureOffset == nil then
 						textureSheet = defaultErrorTextureSheet;
 						textureOffset = nullOffset;
-					end				
+					end
 					UpdateSmallButton( buttonAdded, thisPrereqInstance.PrereqTechImage, thisPrereqInstance.PrereqTechButton, textureSheet, textureOffset, CategoryTech, Locale.ConvertTextKey( prereq.Description ), prereq.ID );
 					buttonAdded = buttonAdded + 1;
 					UpdateButtonFrame( buttonAdded, Controls.PrereqTechInnerFrame, Controls.PrereqTechFrame );
@@ -6251,7 +6252,7 @@ CivilopediaCategory[CategoryImprovements].SelectArticle = function( improvementI
 				Controls.YieldLabel:SetText( Locale.ConvertTextKey( yieldString ) );
 				Controls.YieldFrame:SetHide( false );
 			end
-			
+
 			-- add in mountain adjacency yield
 			numYields = 0;
 			yieldString = "";
@@ -6414,7 +6415,7 @@ CivilopediaCategory[CategoryImprovements].SelectArticle = function( improvementI
 				Controls.AdjacentImprovYieldFrame:SetHide( false );
 			end
 			--END
-			
+
 			buttonAdded = 0;
 			if thisImprovement.CivilizationType then
 				local thisCiv = GameInfo.Civilizations[thisImprovement.CivilizationType];
@@ -6422,18 +6423,18 @@ CivilopediaCategory[CategoryImprovements].SelectArticle = function( improvementI
 					g_CivilizationsManager:ResetInstances();
 					local thisCivInstance = g_CivilizationsManager:GetInstance();
 					if thisCivInstance then
-						local textureOffset, textureSheet = IconLookup( thisCiv.PortraitIndex, buttonSize, thisCiv.IconAtlas );				
+						local textureOffset, textureSheet = IconLookup( thisCiv.PortraitIndex, buttonSize, thisCiv.IconAtlas );
 						if textureOffset == nil then
 							textureSheet = defaultErrorTextureSheet;
 							textureOffset = nullOffset;
-						end				
+						end
 						UpdateSmallButton( buttonAdded, thisCivInstance.CivilizationImage, thisCivInstance.CivilizationButton, textureSheet, textureOffset, CategoryCivilizations, Locale.ConvertTextKey( thisCiv.ShortDescription ), thisCiv.ID );
 						buttonAdded = buttonAdded + 1;
-					end	
+					end
 				end
 			end
 			UpdateButtonFrame( buttonAdded, Controls.CivilizationsInnerFrame, Controls.CivilizationsFrame );
-			
+
 			-- found on
 			Controls.ResourcesFoundLabel:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_FOUNDON_LABEL" ) );
 			g_ResourcesFoundManager:ResetInstances(); -- okay, this is supposed to be a resource, but for now a round button is a round button
@@ -6443,11 +6444,11 @@ CivilopediaCategory[CategoryImprovements].SelectArticle = function( improvementI
 				if thisFeature then
 					local thisFeatureInstance = g_ResourcesFoundManager:GetInstance();
 					if thisFeatureInstance then
-						local textureOffset, textureSheet = IconLookup( thisFeature.PortraitIndex, buttonSize, thisFeature.IconAtlas );				
+						local textureOffset, textureSheet = IconLookup( thisFeature.PortraitIndex, buttonSize, thisFeature.IconAtlas );
 						if textureOffset == nil then
 							textureSheet = defaultErrorTextureSheet;
 							textureOffset = nullOffset;
-						end				
+						end
 						UpdateSmallButton( buttonAdded, thisFeatureInstance.ResourceFoundImage, thisFeatureInstance.ResourceFoundButton, textureSheet, textureOffset, CategoryTerrain, Locale.ConvertTextKey( thisFeature.Description ), thisFeature.ID + 1000 ); -- todo: add a fudge factor
 						buttonAdded = buttonAdded + 1;
 					end
@@ -6458,11 +6459,11 @@ CivilopediaCategory[CategoryImprovements].SelectArticle = function( improvementI
 				if thisTerrain then
 					local thisTerrainInstance = g_ResourcesFoundManager:GetInstance();
 					if thisTerrainInstance then
-						local textureOffset, textureSheet = IconLookup( thisTerrain.PortraitIndex, buttonSize, thisTerrain.IconAtlas );				
+						local textureOffset, textureSheet = IconLookup( thisTerrain.PortraitIndex, buttonSize, thisTerrain.IconAtlas );
 						if textureOffset == nil then
 							textureSheet = defaultErrorTextureSheet;
 							textureOffset = nullOffset;
-						end				
+						end
 						UpdateSmallButton( buttonAdded, thisTerrainInstance.ResourceFoundImage, thisTerrainInstance.ResourceFoundButton, textureSheet, textureOffset, CategoryTerrain, Locale.ConvertTextKey( thisTerrain.Description ), thisTerrain.ID );
 						buttonAdded = buttonAdded + 1;
 					end
@@ -6481,8 +6482,8 @@ CivilopediaCategory[CategoryImprovements].SelectArticle = function( improvementI
 					--buttonAdded = buttonAdded + 1;
 				--end
 			--end
-			UpdateButtonFrame( buttonAdded, Controls.ResourcesFoundInnerFrame, Controls.ResourcesFoundFrame );	 	  
-			
+			UpdateButtonFrame( buttonAdded, Controls.ResourcesFoundInnerFrame, Controls.ResourcesFoundFrame );
+
 			Controls.RequiredResourcesLabel:SetText( Locale.ConvertTextKey( "TXT_KEY_PEDIA_IMPROVES_RESRC_LABEL" ) );
 			g_RequiredResourcesManager:ResetInstances();
 			buttonAdded = 0;
@@ -6492,11 +6493,11 @@ CivilopediaCategory[CategoryImprovements].SelectArticle = function( improvementI
 					if requiredResource then
 						local thisRequiredResourceInstance = g_RequiredResourcesManager:GetInstance();
 						if thisRequiredResourceInstance then
-							local textureOffset, textureSheet = IconLookup( requiredResource.PortraitIndex, buttonSize, requiredResource.IconAtlas );				
+							local textureOffset, textureSheet = IconLookup( requiredResource.PortraitIndex, buttonSize, requiredResource.IconAtlas );
 							if textureOffset == nil then
 								textureSheet = defaultErrorTextureSheet;
 								textureOffset = nullOffset;
-							end				
+							end
 							UpdateSmallButton( buttonAdded, thisRequiredResourceInstance.RequiredResourceImage, thisRequiredResourceInstance.RequiredResourceButton, textureSheet, textureOffset, CategoryResources, Locale.ConvertTextKey( requiredResource.Description ), requiredResource.ID );
 							buttonAdded = buttonAdded + 1;
 						end
@@ -6515,11 +6516,11 @@ CivilopediaCategory[CategoryImprovements].SelectArticle = function( improvementI
 					if requiredResource then
 						local thisRequiredResourceInstance = g_LocalResourcesManager:GetInstance();
 						if thisRequiredResourceInstance then
-							local textureOffset, textureSheet = IconLookup( requiredResource.PortraitIndex, buttonSize, requiredResource.IconAtlas );				
+							local textureOffset, textureSheet = IconLookup( requiredResource.PortraitIndex, buttonSize, requiredResource.IconAtlas );
 							if textureOffset == nil then
 								textureSheet = defaultErrorTextureSheet;
 								textureOffset = nullOffset;
-							end				
+							end
 							UpdateSmallButton( buttonAdded, thisRequiredResourceInstance.LocalResourceImage, thisRequiredResourceInstance.LocalResourceButton, textureSheet, textureOffset, CategoryResources, Locale.ConvertTextKey( requiredResource.Description ), requiredResource.ID );
 							buttonAdded = buttonAdded + 1;
 						end
@@ -6537,13 +6538,13 @@ CivilopediaCategory[CategoryImprovements].SelectArticle = function( improvementI
 			if (thisImprovement.Civilopedia) then
 				UpdateTextBlock( Locale.ConvertTextKey( thisImprovement.Civilopedia ), Controls.GameInfoLabel, Controls.GameInfoInnerFrame, Controls.GameInfoFrame );
 			end
-			
+
 			-- update the related images
 			Controls.RelatedImagesFrame:SetHide( true );
 		end
 	--Roads and Railroads
 	elseif improvementID ~= -1 then
-	
+
 		improvementID = improvementID - 1000;
 		local thisImprovement = GameInfo.Routes[improvementID];
 		if thisImprovement then
@@ -6560,7 +6561,7 @@ CivilopediaCategory[CategoryImprovements].SelectArticle = function( improvementI
 
 			local buttonAdded = 0;
 	 		local condition = "RouteType = '" .. thisImprovement.Type .. "'";
-			
+
 			-- tech visibility
 			g_PrereqTechManager:ResetInstances();
 			buttonAdded = 0;
@@ -6571,15 +6572,15 @@ CivilopediaCategory[CategoryImprovements].SelectArticle = function( improvementI
 					prereq = GameInfo.Technologies[row.PrereqTech];
 				end
 			end
-			
+
 			if prereq then
 				local thisPrereqInstance = g_PrereqTechManager:GetInstance();
 				if thisPrereqInstance then
-					local textureOffset, textureSheet = IconLookup( prereq.PortraitIndex, buttonSize, prereq.IconAtlas );				
+					local textureOffset, textureSheet = IconLookup( prereq.PortraitIndex, buttonSize, prereq.IconAtlas );
 					if textureOffset == nil then
 						textureSheet = defaultErrorTextureSheet;
 						textureOffset = nullOffset;
-					end				
+					end
 					UpdateSmallButton( buttonAdded, thisPrereqInstance.PrereqTechImage, thisPrereqInstance.PrereqTechButton, textureSheet, textureOffset, CategoryTech, Locale.ConvertTextKey( prereq.Description ), prereq.ID );
 					buttonAdded = buttonAdded + 1;
 					UpdateButtonFrame( buttonAdded, Controls.PrereqTechInnerFrame, Controls.PrereqTechFrame );
@@ -6590,7 +6591,7 @@ CivilopediaCategory[CategoryImprovements].SelectArticle = function( improvementI
 			if (thisImprovement.Civilopedia) then
 				UpdateTextBlock( Locale.ConvertTextKey( thisImprovement.Civilopedia ), Controls.GameInfoLabel, Controls.GameInfoInnerFrame, Controls.GameInfoFrame );
 			end
-			
+
 			-- update the related images
 			Controls.RelatedImagesFrame:SetHide( true );
 		end
@@ -6603,16 +6604,16 @@ CivilopediaCategory[CategoryBeliefs].SelectArticle = function(entryID, shouldAdd
 	if selectedCategory ~= CategoryBeliefs then
 		SetSelectedCategory(CategoryBeliefs);
 	end
-	
+
 	ClearArticle();
-	
+
 	local offset = 0;
 	if(entryID[1] == "Beliefs") then
 		offset = #GameInfo.Religions;
 	end
-	
+
 	offset = offset + entryID[2];
-	
+
 	if shouldAddToList == addToList then
 		currentTopic = currentTopic + 1;
 		listOfTopicsViewed[currentTopic] = categorizedList[(CategoryBeliefs * absurdlyLargeNumTopicsInCategory) + offset];
@@ -6621,42 +6622,42 @@ CivilopediaCategory[CategoryBeliefs].SelectArticle = function(entryID, shouldAdd
 		end
 		endTopic = currentTopic;
 	end
-	
+
 	if (entryID ~= nil) then
-	
+
 		local t = entryID[1];
 		local id = entryID[2];
-		
+
 		if(t == "Religions") then
-		
+
 			local thisReligion = GameInfo[t][id];
-		
+
 			if (thisReligion ~= nil) then
-			
-				-- update the name	
+
+				-- update the name
 				Controls.ArticleID:LocalizeAndSetText(thisReligion.Description);
-				
+
 				-- update the summary
 				if (thisReligion.Civilopedia ~= nil) then
 					UpdateTextBlock( Locale.ConvertTextKey( thisReligion.Civilopedia ), Controls.SummaryLabel, Controls.SummaryInnerFrame, Controls.SummaryFrame );
-				end		
+				end
 			end
-		
+
 		else
 			local thisBelief = GameInfo[t][id];
-		
+
 			if (thisBelief ~= nil) then
-			
+
 				-- update the name
 				Controls.ArticleID:LocalizeAndSetText(thisBelief.ShortDescription);
-				
+
 				-- update the summary
 				if (thisBelief.Description ~= nil) then
 					UpdateTextBlock( Locale.ConvertTextKey( thisBelief.Description ), Controls.SummaryLabel, Controls.SummaryInnerFrame, Controls.SummaryFrame );
-				end		
+				end
 			end
 		end
-	end	
+	end
 
 	ResizeEtc();
 
@@ -6666,12 +6667,12 @@ CivilopediaCategory[CategoryWorldCongress].SelectArticle = function(entryID, sho
 	if selectedCategory ~= CategoryWorldCongress then
 		SetSelectedCategory(CategoryWorldCongress);
 	end
-	
+
 	ClearArticle();
-	
-	local offset = 0;	
+
+	local offset = 0;
 	offset = offset + entryID[2];
-	
+
 	if shouldAddToList == addToList then
 		currentTopic = currentTopic + 1;
 		listOfTopicsViewed[currentTopic] = categorizedList[(CategoryWorldCongress * absurdlyLargeNumTopicsInCategory) + offset];
@@ -6680,53 +6681,53 @@ CivilopediaCategory[CategoryWorldCongress].SelectArticle = function(entryID, sho
 		end
 		endTopic = currentTopic;
 	end
-	
+
 	if (entryID ~= nil) then
-	
+
 		local t = entryID[1];
 		local id = entryID[2];
-		
+
 		if(t == "Resolutions") then
-		
+
 			local thisResolution = GameInfo[t][id];
-		
+
 			if (thisResolution ~= nil) then
-			
+
 				Controls.Portrait:SetTexture("WorldCongressPortrait256_EXP2.dds");
 				Controls.Portrait:SetTextureOffsetVal(0,0);
 				Controls.PortraitFrame:SetHide(false);
-				
-				-- update the name	
+
+				-- update the name
 				Controls.ArticleID:LocalizeAndSetText(thisResolution.Description);
-				
+
 				-- update the summary
 				if (thisResolution.Help ~= nil) then
 					UpdateTextBlock( Locale.ConvertTextKey( thisResolution.Help ), Controls.SummaryLabel, Controls.SummaryInnerFrame, Controls.SummaryFrame );
-				end		
+				end
 			end
-		
+
 		elseif(t == "LeagueProjects") then
-			
+
 			local thisLeagueProject = GameInfo[t][id];
-			
+
 			if (thisLeagueProject ~= nil) then
-			
+
 				-- update the portrait
 				if IconHookup( thisLeagueProject.PortraitIndex, portraitSize, thisLeagueProject.IconAtlas, Controls.Portrait ) then
 					Controls.PortraitFrame:SetHide( false );
 				else
 					Controls.PortraitFrame:SetHide( true );
 				end
-				
-				-- update the name	
+
+				-- update the name
 				Controls.ArticleID:LocalizeAndSetText(thisLeagueProject.Description);
-				
+
 				-- update the summary
 				local sSummary = GetLeagueProjectPediaText(id);
 				if (sSummary ~= nil and sSummary ~= "") then
 					UpdateTextBlock( sSummary , Controls.SummaryLabel, Controls.SummaryInnerFrame, Controls.SummaryFrame );
 				end
-				
+
 				-- update the cost
 				local cost = thisLeagueProject.CostPerPlayer;
 				if(Game ~= nil and Game.GetNumActiveLeagues() > 0) then
@@ -6741,20 +6742,20 @@ CivilopediaCategory[CategoryWorldCongress].SelectArticle = function(entryID, sho
 				end
 			end
 		end
-	end	
+	end
 
 	ResizeEtc();
 end
 
 function GetLeagueProjectPediaText(iLeagueProjectID)
 	local s = "";
-	
+
 	local TrophyIcons = {
 		"[ICON_TROPHY_BRONZE]",
 		"[ICON_TROPHY_SILVER]",
 		"[ICON_TROPHY_GOLD]",
 	};
-	
+
 	local tProject = GameInfo.LeagueProjects[iLeagueProjectID];
 	if (tProject ~= nil) then
 		for i = 3, 1, -1 do
@@ -6767,13 +6768,13 @@ function GetLeagueProjectPediaText(iLeagueProjectID)
 					end
 				end
 			end
-				
+
 			if (i > 1) then
 				s = s .. "[NEWLINE][NEWLINE]";
 			end
 		end
 	end
-	
+
 	return s;
 end
 
@@ -6781,11 +6782,11 @@ CivilopediaCategory[CategoryCorporations].SelectArticle = function(corporationID
 	if selectedCategory ~= CategoryCorporations then
 		SetSelectedCategory(CategoryCorporations);
 	end
-	
+
 	ClearArticle();
-	
+
 	local buttonAdded = 0;
-	
+
 	if shouldAddToList == addToList then
 		currentTopic = currentTopic + 1;
 		listOfTopicsViewed[currentTopic] = categorizedList[(CategoryCorporations * absurdlyLargeNumTopicsInCategory) + corporationID];
@@ -6794,63 +6795,63 @@ CivilopediaCategory[CategoryCorporations].SelectArticle = function(corporationID
 		end
 		endTopic = currentTopic;
 	end
-	
-	if (corporationID ~= -1 and corporationID < 1000) then	
+
+	if (corporationID ~= -1 and corporationID < 1000) then
 		local thisCorporation = GameInfo.Corporations[corporationID];
-	
+
 		if (thisCorporation ~= nil) then
-		
+
 			if IconHookup( thisCorporation.PortraitIndex, portraitSize, thisCorporation.IconAtlas, Controls.Portrait ) then
 				Controls.PortraitFrame:SetHide( false );
 			else
 				Controls.PortraitFrame:SetHide( true );
 			end
-			
-			-- update the name	
+
+			-- update the name
 			Controls.ArticleID:LocalizeAndSetText(thisCorporation.Description);
-			
+
 			local helpStr = "";
 			if(thisCorporation.Help ~= nil) then
 				helpStr = helpStr .. Locale.ConvertTextKey(thisCorporation.Help);
 			end
-			
+
 			local numFreeResources = 0;
 			local condition = "CorporationType = '" .. thisCorporation.Type .. "'";
-			for row in GameInfo.Corporation_NumFreeResource( condition ) do	
+			for row in GameInfo.Corporation_NumFreeResource( condition ) do
 				local freeResource = GameInfo.Resources[row.ResourceType];
-				if freeResource then	
+				if freeResource then
 					if(numFreeResources == 0) then
 						helpStr = helpStr .. "[NEWLINE]";
-					end	
+					end
 					helpStr = helpStr .. "[NEWLINE]" .. Locale.ConvertTextKey( "TXT_KEY_PEDIA_CORPORATIONS_FREE_RESOURCE", row.NumResource, freeResource.IconString, freeResource.Description );
 					numFreeResources = numFreeResources + 1;
 				end
 			end
-			
+
 			-- update the summary
 			if (helpStr ~= nil) then
 				UpdateTextBlock( helpStr, Controls.SummaryLabel, Controls.SummaryInnerFrame, Controls.SummaryFrame );
 			end
-			
+
 			if(thisCorporation.ResourceBonusHelp ~= nil) then
 				UpdateTextBlock( Locale.ConvertTextKey( thisCorporation.ResourceBonusHelp ), Controls.CorporationResourceBonusLabel, Controls.CorpResourceBonusInnerFrame, Controls.CorporationResourceBonusFrame );
 			end
-			
+
 			if(thisCorporation.OfficeBonusHelp ~= nil) then
 				UpdateTextBlock( Locale.ConvertTextKey( thisCorporation.OfficeBonusHelp ), Controls.CorporationOfficeBonusLabel, Controls.CorpOfficeBonusInnerFrame, Controls.CorporationOfficeBonusFrame);
 			end
-			
+
 			if(thisCorporation.TradeRouteBonusHelp ~= nil) then
 				UpdateTextBlock( Locale.ConvertTextKey( thisCorporation.TradeRouteBonusHelp ), Controls.CorporationTRBonusLabel, Controls.CorporationTRBonusInnerFrame, Controls.CorporationTRBonusFrame);
 			end
-			
+
 			-- update free trade routes
 			local freeTRs = thisCorporation.NumFreeTradeRoutes;
 			if(freeTRs > 0) then
 				Controls.FreeTRFrame:SetHide(false);
 				Controls.FreeTRLabel:SetText(freeTRs .. " [ICON_INTERNATIONAL_TRADE]");
 			end
-			
+
 			g_MonopolyResourcesManager:ResetInstances();
 			buttonAdded = 0;
 
@@ -6860,22 +6861,22 @@ CivilopediaCategory[CategoryCorporations].SelectArticle = function(corporationID
 				if requiredResource then
 					local thisLocalResourceInstance = g_MonopolyResourcesManager:GetInstance();
 					if thisLocalResourceInstance then
-						local textureOffset, textureSheet = IconLookup( requiredResource.PortraitIndex, buttonSize, requiredResource.IconAtlas );				
+						local textureOffset, textureSheet = IconLookup( requiredResource.PortraitIndex, buttonSize, requiredResource.IconAtlas );
 						if textureOffset == nil then
 							textureSheet = defaultErrorTextureSheet;
 							textureOffset = nullOffset;
-						end				
+						end
 						UpdateSmallButton( buttonAdded, thisLocalResourceInstance.MonopolyResourceImage, thisLocalResourceInstance.MonopolyResourceButton, textureSheet, textureOffset, CategoryResources, Locale.ConvertTextKey( requiredResource.Description ), requiredResource.ID );
 						buttonAdded = buttonAdded + 1;
 					end
-				end		
+				end
 			end
 			UpdateButtonFrame( buttonAdded, Controls.MonopolyResourcesInnerFrame, Controls.MonopolyResourcesFrame );
-			
+
 			g_CorpHeadquartersManager:ResetInstances();
 			g_CorpOfficeManager:ResetInstances();
 			g_CorpFranchiseManager:ResetInstances();
-			
+
 			local headquarters = GameInfo.BuildingClasses[thisCorporation.HeadquartersBuildingClass];
 			if(headquarters) then
 				local buildingInfo = GameInfo.Buildings[headquarters.DefaultBuilding];
@@ -6886,13 +6887,13 @@ CivilopediaCategory[CategoryCorporations].SelectArticle = function(corporationID
 							instance.CorporationBuildingImage:SetTexture( defaultErrorTextureSheet );
 							instance.CorporationBuildingImage:SetTextureOffset( nullOffset );
 						end
-						
+
 						--move this button
 						instance.CorporationBuildingButton:SetOffsetVal( buttonPadding, buttonPadding );
-						
+
 						instance.CorporationBuildingButton:SetToolTipString( Locale.ConvertTextKey( buildingInfo.Description ) );
 						instance.CorporationBuildingButton:SetVoids( buildingInfo.ID, addToList );
-						
+
 						if headquarters.MaxGlobalInstances > 0 or (headquarters.MaxPlayerInstances == 1 and headquarters.SpecialistCount == 0) or headquarters.MaxTeamInstances > 0 then
 							instance.CorporationBuildingButton:RegisterCallback( Mouse.eLClick, CivilopediaCategory[CategoryWonders].SelectArticle );
 						else
@@ -6901,7 +6902,7 @@ CivilopediaCategory[CategoryCorporations].SelectArticle = function(corporationID
 					end
 				end
 			end
-			
+
 			local office = GameInfo.BuildingClasses[thisCorporation.OfficeBuildingClass];
 			if(office ~= nil) then
 				local buildingInfo = GameInfo.Buildings[office.DefaultBuilding];
@@ -6912,13 +6913,13 @@ CivilopediaCategory[CategoryCorporations].SelectArticle = function(corporationID
 							instance.CorporationBuildingImage:SetTexture( defaultErrorTextureSheet );
 							instance.CorporationBuildingImage:SetTextureOffset( nullOffset );
 						end
-							
+
 						--move this button
 						instance.CorporationBuildingButton:SetOffsetVal( buttonPadding, buttonPadding );
-						
+
 						instance.CorporationBuildingButton:SetToolTipString( Locale.ConvertTextKey( buildingInfo.Description ) );
 						instance.CorporationBuildingButton:SetVoids( buildingInfo.ID, addToList );
-						
+
 						if office.MaxGlobalInstances > 0 or (office.MaxPlayerInstances == 1 and office.SpecialistCount == 0) or office.MaxTeamInstances > 0 then
 							instance.CorporationBuildingButton:RegisterCallback( Mouse.eLClick, CivilopediaCategory[CategoryWonders].SelectArticle );
 						else
@@ -6927,7 +6928,7 @@ CivilopediaCategory[CategoryCorporations].SelectArticle = function(corporationID
 					end
 				end
 			end
-			
+
 			local franchise = GameInfo.BuildingClasses[thisCorporation.FranchiseBuildingClass];
 			if(franchise ~= nil) then
 				local buildingInfo = GameInfo.Buildings[franchise.DefaultBuilding];
@@ -6938,13 +6939,13 @@ CivilopediaCategory[CategoryCorporations].SelectArticle = function(corporationID
 							instance.CorporationBuildingImage:SetTexture( defaultErrorTextureSheet );
 							instance.CorporationBuildingImage:SetTextureOffset( nullOffset );
 						end
-							
+
 						--move this button
 						instance.CorporationBuildingButton:SetOffsetVal( buttonPadding, buttonPadding );
-						
+
 						instance.CorporationBuildingButton:SetToolTipString( Locale.ConvertTextKey( buildingInfo.Description ) );
 						instance.CorporationBuildingButton:SetVoids( buildingInfo.ID, addToList );
-						
+
 						if franchise.MaxGlobalInstances > 0 or (franchise.MaxPlayerInstances == 1 and franchise.SpecialistCount == 0) or franchise.MaxTeamInstances > 0 then
 							instance.CorporationBuildingButton:RegisterCallback( Mouse.eLClick, CivilopediaCategory[CategoryWonders].SelectArticle );
 						else
@@ -6958,7 +6959,7 @@ CivilopediaCategory[CategoryCorporations].SelectArticle = function(corporationID
 			UpdateButtonFrame( 1, Controls.CorpOfficeInnerFrame, Controls.CorpOfficeFrame );
 			UpdateButtonFrame( 1, Controls.CorpFranchiseInnerFrame, Controls.CorpFranchiseFrame );
 		end
-	end	
+	end
 
 	ResizeEtc();
 end
@@ -6970,8 +6971,8 @@ function SortFunction( a, b )
 
     local aVal = otherSortedList[ tostring( a ) ];
     local bVal = otherSortedList[ tostring( b ) ];
-    
-    if (aVal == nil) or (bVal == nil) then 
+
+    if (aVal == nil) or (bVal == nil) then
 		--print("nil : "..tostring( a ).." = "..tostring(aVal).." : "..tostring( b ).." = "..tostring(bVal))
 		if aVal and (bVal == nil) then
 			return false;
@@ -7006,7 +7007,7 @@ CivilopediaCategory[CategoryHomePage].SelectHeading = function( selectedEraID, d
 	--	thisListInstance.ListItemButton:SetToolTipCallback( TipHandler );
 	--	otherSortedList[tostring( thisListInstance.ListItemButton )] = sortOrder;
 	--end
-	
+
 	Controls.ListOfArticles:CalculateSize();
 	Controls.ScrollPanel:CalculateInternalSize();
 end
@@ -7031,9 +7032,9 @@ CivilopediaCategory[CategoryGameConcepts].SelectHeading = function( selectedEraI
 		thisListInstance.ListItemButton:SetToolTipCallback( TipHandler );
 		otherSortedList[tostring( thisListInstance.ListItemButton )] = sortOrder;
 	end
-	
+
 	local numConcepts = #sortedList[CategoryGameConcepts];
-	for section = 1, numConcepts, 1 do	
+	for section = 1, numConcepts, 1 do
 		-- add a section header
 		local thisHeaderInstance = g_ListHeadingManager:GetInstance();
 		if thisHeaderInstance then
@@ -7050,9 +7051,9 @@ CivilopediaCategory[CategoryGameConcepts].SelectHeading = function( selectedEraI
 			thisHeaderInstance.ListHeadingButton:SetVoids( section, 0 );
 			thisHeaderInstance.ListHeadingButton:RegisterCallback( Mouse.eLClick, CivilopediaCategory[CategoryGameConcepts].SelectHeading );
 			otherSortedList[tostring( thisHeaderInstance.ListHeadingButton )] = sortOrder;
-		end	
-		
-		-- for each element of the sorted list		
+		end
+
+		-- for each element of the sorted list
 		if sortedList[CategoryGameConcepts][section].headingOpen then
 			for i, v in ipairs(sortedList[CategoryGameConcepts][section]) do
 				local thisListInstance = g_ListItemManager:GetInstance();
@@ -7067,7 +7068,7 @@ CivilopediaCategory[CategoryGameConcepts].SelectHeading = function( selectedEraI
 			end
 		end
 	end
-	
+
 	Controls.ListOfArticles:SortChildren( SortFunction );
 	ResizeEtc();
 end
@@ -7078,7 +7079,7 @@ CivilopediaCategory[CategoryTech].SelectHeading = function( selectedEraID, dummy
 	g_ListItemManager:ResetInstances();
 
 	sortedList[CategoryTech][selectedEraID].headingOpen = not sortedList[CategoryTech][selectedEraID].headingOpen; -- ain't lua great
-	
+
 	local sortOrder = 0;
 	otherSortedList = {};
 
@@ -7096,7 +7097,7 @@ CivilopediaCategory[CategoryTech].SelectHeading = function( selectedEraID, dummy
 	-- Infixo GameInfo.Eras is not updated after mods are loaded
 	--for era in GameInfo.Eras() do
 	for era in DB.Query("SELECT ID, Description FROM Eras ORDER BY ID") do
-	
+
 		local eraID = era.ID;
 		-- add an era header
 		local thisEraInstance = g_ListHeadingManager:GetInstance();
@@ -7114,9 +7115,9 @@ CivilopediaCategory[CategoryTech].SelectHeading = function( selectedEraID, dummy
 			thisEraInstance.ListHeadingButton:SetVoids( eraID, 0 );
 			thisEraInstance.ListHeadingButton:RegisterCallback( Mouse.eLClick, CivilopediaCategory[CategoryTech].SelectHeading );
 			otherSortedList[tostring( thisEraInstance.ListHeadingButton )] = sortOrder;
-		end	
-		
-		-- for each element of the sorted list		
+		end
+
+		-- for each element of the sorted list
 		if sortedList[CategoryTech][eraID].headingOpen then
 			for i, v in ipairs(sortedList[CategoryTech][eraID]) do
 				local thisListInstance = g_ListItemManager:GetInstance();
@@ -7131,11 +7132,11 @@ CivilopediaCategory[CategoryTech].SelectHeading = function( selectedEraID, dummy
 			end
 		end
 
-	end	
-	
+	end
+
 	Controls.ListOfArticles:SortChildren( SortFunction );
 	ResizeEtc();
-		
+
 end
 
 CivilopediaCategory[CategoryUnits].SelectHeading = function( selectedEraID, dummy )
@@ -7144,7 +7145,7 @@ CivilopediaCategory[CategoryUnits].SelectHeading = function( selectedEraID, dumm
 	g_ListItemManager:ResetInstances();
 
 	sortedList[CategoryUnits][selectedEraID].headingOpen = not sortedList[CategoryUnits][selectedEraID].headingOpen; -- ain't lua great
-	
+
 	local sortOrder = 0;
 	otherSortedList = {};
 
@@ -7173,9 +7174,9 @@ CivilopediaCategory[CategoryUnits].SelectHeading = function( selectedEraID, dumm
 			thisEraInstance.ListHeadingButton:SetVoids( categoryID, 0 );
 			thisEraInstance.ListHeadingButton:RegisterCallback( Mouse.eLClick, CivilopediaCategory[CategoryUnits].SelectHeading );
 			otherSortedList[tostring( thisEraInstance.ListHeadingButton )] = sortOrder;
-		end	
-		
-		-- for each element of the sorted list		
+		end
+
+		-- for each element of the sorted list
 		if sortedList[CategoryUnits][categoryID].headingOpen then
 			for i, v in ipairs(sortedList[CategoryUnits][categoryID]) do
 				local thisListInstance = g_ListItemManager:GetInstance();
@@ -7190,8 +7191,8 @@ CivilopediaCategory[CategoryUnits].SelectHeading = function( selectedEraID, dumm
 			end
 		end
 	end
-	
-	
+
+
 	local sectionID = 0;
 	if(Game == nil or not Game.IsOption(GameOptionTypes.GAMEOPTION_NO_RELIGION)) then
 		PopulateHeaderAndItems(sectionID, "TXT_KEY_PEDIA_RELIGIOUS");
@@ -7205,10 +7206,10 @@ CivilopediaCategory[CategoryUnits].SelectHeading = function( selectedEraID, dumm
 		local headingName = era.Description;
 		PopulateHeaderAndItems(sectionID, headingName);
 		sectionID = sectionID + 1;
-	end	
-	
+	end
+
 	Controls.ListOfArticles:SortChildren( SortFunction );
-	ResizeEtc();	
+	ResizeEtc();
 end
 
 CivilopediaCategory[CategoryPromotions].SelectHeading = function( selectedSection, dummy )
@@ -7231,9 +7232,9 @@ CivilopediaCategory[CategoryPromotions].SelectHeading = function( selectedSectio
 		thisListInstance.ListItemButton:SetToolTipCallback( TipHandler );
 		otherSortedList[tostring( thisListInstance.ListItemButton )] = sortOrder;
 	end
-	
+
 	-- Infixo more categories
-	--for section = 1, 8, 1 do	
+	--for section = 1, 8, 1 do
 	for section,sPediaType in ipairs(UnitPromotionsPediaTypes) do
 		-- add a section header
 		local thisHeaderInstance = g_ListHeadingManager:GetInstance();
@@ -7261,9 +7262,9 @@ CivilopediaCategory[CategoryPromotions].SelectHeading = function( selectedSectio
 			thisHeaderInstance.ListHeadingButton:SetVoids( section, 0 );
 			thisHeaderInstance.ListHeadingButton:RegisterCallback( Mouse.eLClick, CivilopediaCategory[CategoryPromotions].SelectHeading );
 			otherSortedList[tostring( thisHeaderInstance.ListHeadingButton )] = sortOrder;
-		end	
-		
-		-- for each element of the sorted list		
+		end
+
+		-- for each element of the sorted list
 		if sortedList[CategoryPromotions][section].headingOpen then
 			for i, v in ipairs(sortedList[CategoryPromotions][section]) do
 				local thisListInstance = g_ListItemManager:GetInstance();
@@ -7278,7 +7279,7 @@ CivilopediaCategory[CategoryPromotions].SelectHeading = function( selectedSectio
 			end
 		end
 	end
-	
+
 	Controls.ListOfArticles:SortChildren( SortFunction );
 	ResizeEtc();
 
@@ -7290,7 +7291,7 @@ CivilopediaCategory[CategoryBuildings].SelectHeading = function( selectedEraID, 
 	g_ListItemManager:ResetInstances();
 
 	sortedList[CategoryBuildings][selectedEraID].headingOpen = not sortedList[CategoryBuildings][selectedEraID].headingOpen; -- ain't lua great
-	
+
 	local sortOrder = 0;
 	otherSortedList = {};
 
@@ -7304,9 +7305,9 @@ CivilopediaCategory[CategoryBuildings].SelectHeading = function( selectedEraID, 
 		thisListInstance.ListItemButton:SetToolTipCallback( TipHandler );
 		otherSortedList[tostring( thisListInstance.ListItemButton )] = sortOrder;
 	end
-	
+
 	function PopulateAndAdd(categoryID, headingName)
-	
+
 		-- add an era header
 		local thisEraInstance = g_ListHeadingManager:GetInstance();
 		if thisEraInstance then
@@ -7321,9 +7322,9 @@ CivilopediaCategory[CategoryBuildings].SelectHeading = function( selectedEraID, 
 			thisEraInstance.ListHeadingButton:SetVoids( categoryID, 0 );
 			thisEraInstance.ListHeadingButton:RegisterCallback( Mouse.eLClick, CivilopediaCategory[CategoryBuildings].SelectHeading );
 			otherSortedList[tostring( thisEraInstance.ListHeadingButton )] = sortOrder;
-		end	
-		
-		-- for each element of the sorted list		
+		end
+
+		-- for each element of the sorted list
 		if sortedList[CategoryBuildings][categoryID].headingOpen then
 			for i, v in ipairs(sortedList[CategoryBuildings][categoryID]) do
 				local thisListInstance = g_ListItemManager:GetInstance();
@@ -7344,7 +7345,7 @@ CivilopediaCategory[CategoryBuildings].SelectHeading = function( selectedEraID, 
 		PopulateAndAdd(sectionID, "TXT_KEY_PEDIA_RELIGIOUS");
 		sectionID = sectionID + 1;
 	end
-	
+
 	PopulateAndAdd(sectionID, "TXT_KEY_TOPIC_CORPORATION");
 	sectionID = sectionID + 1;
 
@@ -7355,10 +7356,10 @@ CivilopediaCategory[CategoryBuildings].SelectHeading = function( selectedEraID, 
 		local headingName = era.Description;
 		PopulateAndAdd(sectionID, headingName);
 		sectionID = sectionID + 1;
-	end	
-	
+	end
+
 	Controls.ListOfArticles:SortChildren( SortFunction );
-	ResizeEtc();	
+	ResizeEtc();
 end
 
 
@@ -7368,7 +7369,7 @@ CivilopediaCategory[CategoryWonders].SelectHeading = function( selectedSectionID
 	g_ListItemManager:ResetInstances();
 
 	sortedList[CategoryWonders][selectedSectionID].headingOpen = not sortedList[CategoryWonders][selectedSectionID].headingOpen; -- ain't lua great
-	
+
 	local sortOrder = 0;
 	otherSortedList = {};
 
@@ -7383,7 +7384,7 @@ CivilopediaCategory[CategoryWonders].SelectHeading = function( selectedSectionID
 		otherSortedList[tostring( thisListInstance.ListItemButton )] = sortOrder;
 	end
 
-	for section = 1, 4, 1 do	
+	for section = 1, 4, 1 do
 		-- add a section header
 		local thisHeaderInstance = g_ListHeadingManager:GetInstance();
 		if thisHeaderInstance then
@@ -7400,9 +7401,9 @@ CivilopediaCategory[CategoryWonders].SelectHeading = function( selectedSectionID
 			thisHeaderInstance.ListHeadingButton:SetVoids( section, 0 );
 			thisHeaderInstance.ListHeadingButton:RegisterCallback( Mouse.eLClick, CivilopediaCategory[CategoryWonders].SelectHeading );
 			otherSortedList[tostring( thisHeaderInstance.ListHeadingButton )] = sortOrder;
-		end	
-		
-		-- for each element of the sorted list		
+		end
+
+		-- for each element of the sorted list
 		if sortedList[CategoryWonders][section].headingOpen then
 			for i, v in ipairs(sortedList[CategoryWonders][section]) do
 				local thisListInstance = g_ListItemManager:GetInstance();
@@ -7417,11 +7418,11 @@ CivilopediaCategory[CategoryWonders].SelectHeading = function( selectedSectionID
 			end
 		end
 
-	end	
-	
+	end
+
 	Controls.ListOfArticles:SortChildren( SortFunction );
 	ResizeEtc();
-		
+
 end
 
 
@@ -7431,7 +7432,7 @@ CivilopediaCategory[CategoryPolicies].SelectHeading = function( selectedBranchID
 	g_ListItemManager:ResetInstances();
 
 	sortedList[CategoryPolicies][selectedBranchID].headingOpen = not sortedList[CategoryPolicies][selectedBranchID].headingOpen; -- ain't lua great
-	
+
 	local sortOrder = 0;
 	otherSortedList = {};
 
@@ -7447,7 +7448,7 @@ CivilopediaCategory[CategoryPolicies].SelectHeading = function( selectedBranchID
 	end
 
 	for branch in GameInfo.PolicyBranchTypes() do
-	
+
 		local branchID = branch.ID;
 		-- add a branch header
 		local thisHeadingInstance = g_ListHeadingManager:GetInstance();
@@ -7465,9 +7466,9 @@ CivilopediaCategory[CategoryPolicies].SelectHeading = function( selectedBranchID
 			thisHeadingInstance.ListHeadingButton:SetVoids( branchID, 0 );
 			thisHeadingInstance.ListHeadingButton:RegisterCallback( Mouse.eLClick, CivilopediaCategory[CategoryPolicies].SelectHeading );
 			otherSortedList[tostring( thisHeadingInstance.ListHeadingButton )] = sortOrder;
-		end	
-		
-		-- for each element of the sorted list		
+		end
+
+		-- for each element of the sorted list
 		if sortedList[CategoryPolicies][branchID].headingOpen then
 			for i, v in ipairs(sortedList[CategoryPolicies][branchID]) do
 				local thisListInstance = g_ListItemManager:GetInstance();
@@ -7482,11 +7483,11 @@ CivilopediaCategory[CategoryPolicies].SelectHeading = function( selectedBranchID
 			end
 		end
 
-	end	
-	
+	end
+
 	Controls.ListOfArticles:SortChildren( SortFunction );
 	ResizeEtc();
-		
+
 end
 
 CivilopediaCategory[CategoryPeople].SelectHeading = function( selectedSectionID, dummy )
@@ -7495,7 +7496,7 @@ CivilopediaCategory[CategoryPeople].SelectHeading = function( selectedSectionID,
 	g_ListItemManager:ResetInstances();
 
 	sortedList[CategoryPeople][selectedSectionID].headingOpen = not sortedList[CategoryPeople][selectedSectionID].headingOpen; -- ain't lua great
-	
+
 	local sortOrder = 0;
 	otherSortedList = {};
 
@@ -7510,7 +7511,7 @@ CivilopediaCategory[CategoryPeople].SelectHeading = function( selectedSectionID,
 		otherSortedList[tostring( thisListInstance.ListItemButton )] = sortOrder;
 	end
 
-	for section = 1, 2, 1 do	
+	for section = 1, 2, 1 do
 		-- add a section header
 		local thisHeaderInstance = g_ListHeadingManager:GetInstance();
 		if thisHeaderInstance then
@@ -7527,9 +7528,9 @@ CivilopediaCategory[CategoryPeople].SelectHeading = function( selectedSectionID,
 			thisHeaderInstance.ListHeadingButton:SetVoids( section, 0 );
 			thisHeaderInstance.ListHeadingButton:RegisterCallback( Mouse.eLClick, CivilopediaCategory[CategoryPeople].SelectHeading );
 			otherSortedList[tostring( thisHeaderInstance.ListHeadingButton )] = sortOrder;
-		end	
-		
-		-- for each element of the sorted list		
+		end
+
+		-- for each element of the sorted list
 		if sortedList[CategoryPeople][section].headingOpen then
 			for i, v in ipairs(sortedList[CategoryPeople][section]) do
 				local thisListInstance = g_ListItemManager:GetInstance();
@@ -7544,11 +7545,11 @@ CivilopediaCategory[CategoryPeople].SelectHeading = function( selectedSectionID,
 			end
 		end
 
-	end	
-	
+	end
+
 	Controls.ListOfArticles:SortChildren( SortFunction );
 	ResizeEtc();
-		
+
 end
 
 
@@ -7558,7 +7559,7 @@ CivilopediaCategory[CategoryCivilizations].SelectHeading = function( selectedSec
 	g_ListItemManager:ResetInstances();
 
 	sortedList[CategoryCivilizations][selectedSectionID].headingOpen = not sortedList[CategoryCivilizations][selectedSectionID].headingOpen; -- ain't lua great
-	
+
 	local sortOrder = 0;
 	otherSortedList = {};
 
@@ -7573,7 +7574,7 @@ CivilopediaCategory[CategoryCivilizations].SelectHeading = function( selectedSec
 		otherSortedList[tostring( thisListInstance.ListItemButton )] = sortOrder;
 	end
 
-	for section = 1, 2, 1 do	
+	for section = 1, 2, 1 do
 		-- add a section header
 		local thisHeaderInstance = g_ListHeadingManager:GetInstance();
 		if thisHeaderInstance then
@@ -7590,9 +7591,9 @@ CivilopediaCategory[CategoryCivilizations].SelectHeading = function( selectedSec
 			thisHeaderInstance.ListHeadingButton:SetVoids( section, 0 );
 			thisHeaderInstance.ListHeadingButton:RegisterCallback( Mouse.eLClick, CivilopediaCategory[CategoryCivilizations].SelectHeading );
 			otherSortedList[tostring( thisHeaderInstance.ListHeadingButton )] = sortOrder;
-		end	
-		
-		-- for each element of the sorted list		
+		end
+
+		-- for each element of the sorted list
 		if sortedList[CategoryCivilizations][section].headingOpen then
 			for i, v in ipairs(sortedList[CategoryCivilizations][section]) do
 				local thisListInstance = g_ListItemManager:GetInstance();
@@ -7607,11 +7608,11 @@ CivilopediaCategory[CategoryCivilizations].SelectHeading = function( selectedSec
 			end
 		end
 
-	end	
-	
+	end
+
 	Controls.ListOfArticles:SortChildren( SortFunction );
 	ResizeEtc();
-		
+
 end
 
 
@@ -7621,7 +7622,7 @@ CivilopediaCategory[CategoryCityStates].SelectHeading = function( selectedSectio
 	g_ListItemManager:ResetInstances();
 
 	sortedList[CategoryCityStates][selectedSectionID].headingOpen = not sortedList[CategoryCityStates][selectedSectionID].headingOpen; -- ain't lua great
-	
+
 	local sortOrder = 0;
 	otherSortedList = {};
 
@@ -7638,9 +7639,9 @@ CivilopediaCategory[CategoryCityStates].SelectHeading = function( selectedSectio
 
 	-- for each trait
 	for trait in GameInfo.MinorCivTraits() do
-	
+
 		local traitID = trait.ID;
-	
+
 		local thisHeadingInstance = g_ListHeadingManager:GetInstance();
 		if thisHeadingInstance then
 			sortOrder = sortOrder + 1;
@@ -7656,9 +7657,9 @@ CivilopediaCategory[CategoryCityStates].SelectHeading = function( selectedSectio
 			thisHeadingInstance.ListHeadingButton:SetVoids( traitID, 0 );
 			thisHeadingInstance.ListHeadingButton:RegisterCallback( Mouse.eLClick, CivilopediaCategory[CategoryCityStates].SelectHeading );
 			otherSortedList[tostring( thisHeadingInstance.ListHeadingButton )] = sortOrder;
-		end	
-		
-		-- for each element of the sorted list		
+		end
+
+		-- for each element of the sorted list
 		if sortedList[CategoryCityStates][traitID].headingOpen then
 			for i, v in ipairs(sortedList[CategoryCityStates][traitID]) do
 				local thisListInstance = g_ListItemManager:GetInstance();
@@ -7673,11 +7674,11 @@ CivilopediaCategory[CategoryCityStates].SelectHeading = function( selectedSectio
 			end
 		end
 
-	end	
-	
+	end
+
 	Controls.ListOfArticles:SortChildren( SortFunction );
 	ResizeEtc();
-		
+
 end
 
 CivilopediaCategory[CategoryTerrain].SelectHeading = function( selectedSectionID, dummy )
@@ -7686,7 +7687,7 @@ CivilopediaCategory[CategoryTerrain].SelectHeading = function( selectedSectionID
 	g_ListItemManager:ResetInstances();
 
 	sortedList[CategoryTerrain][selectedSectionID].headingOpen = not sortedList[CategoryTerrain][selectedSectionID].headingOpen; -- ain't lua great
-	
+
 	local sortOrder = 0;
 	otherSortedList = {};
 
@@ -7701,7 +7702,7 @@ CivilopediaCategory[CategoryTerrain].SelectHeading = function( selectedSectionID
 		otherSortedList[tostring( thisListInstance.ListItemButton )] = sortOrder;
 	end
 
-	for section = 1, 2, 1 do	
+	for section = 1, 2, 1 do
 		-- add a section header
 		local thisHeaderInstance = g_ListHeadingManager:GetInstance();
 		if thisHeaderInstance then
@@ -7718,9 +7719,9 @@ CivilopediaCategory[CategoryTerrain].SelectHeading = function( selectedSectionID
 			thisHeaderInstance.ListHeadingButton:SetVoids( section, 0 );
 			thisHeaderInstance.ListHeadingButton:RegisterCallback( Mouse.eLClick, CivilopediaCategory[CategoryTerrain].SelectHeading );
 			otherSortedList[tostring( thisHeaderInstance.ListHeadingButton )] = sortOrder;
-		end	
-		
-		-- for each element of the sorted list		
+		end
+
+		-- for each element of the sorted list
 		if sortedList[CategoryTerrain][section].headingOpen then
 			for i, v in ipairs(sortedList[CategoryTerrain][section]) do
 				local thisListInstance = g_ListItemManager:GetInstance();
@@ -7735,11 +7736,11 @@ CivilopediaCategory[CategoryTerrain].SelectHeading = function( selectedSectionID
 			end
 		end
 
-	end	
-	
+	end
+
 	Controls.ListOfArticles:SortChildren( SortFunction );
 	ResizeEtc();
-		
+
 end
 
 CivilopediaCategory[CategoryResources].SelectHeading = function( selectedSectionID, dummy )
@@ -7748,7 +7749,7 @@ CivilopediaCategory[CategoryResources].SelectHeading = function( selectedSection
 	g_ListItemManager:ResetInstances();
 
 	sortedList[CategoryResources][selectedSectionID].headingOpen = not sortedList[CategoryResources][selectedSectionID].headingOpen; -- ain't lua great
-	
+
 	local sortOrder = 0;
 	otherSortedList = {};
 
@@ -7763,7 +7764,7 @@ CivilopediaCategory[CategoryResources].SelectHeading = function( selectedSection
 		otherSortedList[tostring( thisListInstance.ListItemButton )] = sortOrder;
 	end
 
-	for section = 0, 2, 1 do	
+	for section = 0, 2, 1 do
 		-- add a section header
 		local thisHeaderInstance = g_ListHeadingManager:GetInstance();
 		if thisHeaderInstance then
@@ -7780,9 +7781,9 @@ CivilopediaCategory[CategoryResources].SelectHeading = function( selectedSection
 			thisHeaderInstance.ListHeadingButton:SetVoids( section, 0 );
 			thisHeaderInstance.ListHeadingButton:RegisterCallback( Mouse.eLClick, CivilopediaCategory[CategoryResources].SelectHeading );
 			otherSortedList[tostring( thisHeaderInstance.ListHeadingButton )] = sortOrder;
-		end	
-		
-		-- for each element of the sorted list		
+		end
+
+		-- for each element of the sorted list
 		if sortedList[CategoryResources][section].headingOpen then
 			for i, v in ipairs(sortedList[CategoryResources][section]) do
 				local thisListInstance = g_ListItemManager:GetInstance();
@@ -7797,17 +7798,17 @@ CivilopediaCategory[CategoryResources].SelectHeading = function( selectedSection
 			end
 		end
 
-	end	
-	
+	end
+
 	Controls.ListOfArticles:SortChildren( SortFunction );
 	ResizeEtc();
-		
+
 end
 
 CivilopediaCategory[CategoryImprovements].SelectHeading = function( selectedSection, dummy )
 	print("CivilopediaCategory[CategoryImprovements].SelectHeading");
 	-- todo: implement if there are ever sections in the Improvements page
-	print("I should never get here");		
+	print("I should never get here");
 	ResizeEtc();
 end
 
@@ -7816,7 +7817,7 @@ CivilopediaCategory[CategoryBeliefs].SelectHeading = function( selectedSectionID
 	g_ListItemManager:ResetInstances();
 
 	sortedList[CategoryBeliefs][selectedSectionID].headingOpen = not sortedList[CategoryBeliefs][selectedSectionID].headingOpen; -- ain't lua great
-	
+
 	local sortOrder = 0;
 	otherSortedList = {};
 
@@ -7831,7 +7832,7 @@ CivilopediaCategory[CategoryBeliefs].SelectHeading = function( selectedSectionID
 		otherSortedList[tostring( thisListInstance.ListItemButton )] = sortOrder;
 	end
 
-	for section = 1, 6, 1 do	
+	for section = 1, 6, 1 do
 
 		-- add a section header
 		local thisHeaderInstance = g_ListHeadingManager:GetInstance();
@@ -7849,9 +7850,9 @@ CivilopediaCategory[CategoryBeliefs].SelectHeading = function( selectedSectionID
 			thisHeaderInstance.ListHeadingButton:SetVoids( section, 0 );
 			thisHeaderInstance.ListHeadingButton:RegisterCallback( Mouse.eLClick, CivilopediaCategory[CategoryBeliefs].SelectHeading );
 			otherSortedList[tostring( thisHeaderInstance.ListHeadingButton )] = sortOrder;
-		end	
-		
-		-- for each element of the sorted list		
+		end
+
+		-- for each element of the sorted list
 		if sortedList[CategoryBeliefs][section].headingOpen then
 			for i, v in ipairs(sortedList[CategoryBeliefs][section]) do
 				local thisListInstance = g_ListItemManager:GetInstance();
@@ -7866,11 +7867,11 @@ CivilopediaCategory[CategoryBeliefs].SelectHeading = function( selectedSectionID
 			end
 		end
 
-	end	
-	
+	end
+
 	Controls.ListOfArticles:SortChildren( SortFunction );
 	ResizeEtc();
-		
+
 end
 
 CivilopediaCategory[CategoryWorldCongress].SelectHeading = function( selectedSectionID, dummy )
@@ -7878,7 +7879,7 @@ CivilopediaCategory[CategoryWorldCongress].SelectHeading = function( selectedSec
 	g_ListItemManager:ResetInstances();
 
 	sortedList[CategoryWorldCongress][selectedSectionID].headingOpen = not sortedList[CategoryWorldCongress][selectedSectionID].headingOpen; -- ain't lua great
-	
+
 	local sortOrder = 0;
 	otherSortedList = {};
 
@@ -7892,7 +7893,7 @@ CivilopediaCategory[CategoryWorldCongress].SelectHeading = function( selectedSec
 		thisListInstance.ListItemButton:SetToolTipCallback( TipHandler );
 		otherSortedList[tostring( thisListInstance.ListItemButton )] = sortOrder;
 	end
-	
+
 	for section = 1, 2, 1 do
 
 		-- add a section header
@@ -7911,9 +7912,9 @@ CivilopediaCategory[CategoryWorldCongress].SelectHeading = function( selectedSec
 			thisHeaderInstance.ListHeadingButton:SetVoids( section, 0 );
 			thisHeaderInstance.ListHeadingButton:RegisterCallback( Mouse.eLClick, CivilopediaCategory[CategoryWorldCongress].SelectHeading );
 			otherSortedList[tostring( thisHeaderInstance.ListHeadingButton )] = sortOrder;
-		end	
-			
-		-- for each element of the sorted list		
+		end
+
+		-- for each element of the sorted list
 		if sortedList[CategoryWorldCongress][section].headingOpen then
 			for i, v in ipairs(sortedList[CategoryWorldCongress][section]) do
 				local thisListInstance = g_ListItemManager:GetInstance();
@@ -7928,10 +7929,10 @@ CivilopediaCategory[CategoryWorldCongress].SelectHeading = function( selectedSec
 			end
 		end
 	end
-	
+
 	Controls.ListOfArticles:SortChildren( SortFunction );
 	ResizeEtc();
-		
+
 end
 
 CivilopediaCategory[CategoryCorporations].SelectHeading = function( selectedSectionID, dummy )
@@ -7940,7 +7941,7 @@ CivilopediaCategory[CategoryCorporations].SelectHeading = function( selectedSect
 	g_ListItemManager:ResetInstances();
 
 	sortedList[CategoryCorporations][selectedSectionID].headingOpen = not sortedList[CategoryCorporations][selectedSectionID].headingOpen; -- ain't lua great
-	
+
 	local sortOrder = 0;
 	otherSortedList = {};
 
@@ -7955,7 +7956,7 @@ CivilopediaCategory[CategoryCorporations].SelectHeading = function( selectedSect
 		otherSortedList[tostring( thisListInstance.ListItemButton )] = sortOrder;
 	end
 
-	for section = 0, 2, 1 do	
+	for section = 0, 2, 1 do
 		-- add a section header
 		local thisHeaderInstance = g_ListHeadingManager:GetInstance();
 		if thisHeaderInstance then
@@ -7972,9 +7973,9 @@ CivilopediaCategory[CategoryCorporations].SelectHeading = function( selectedSect
 			thisHeaderInstance.ListHeadingButton:SetVoids( section, 0 );
 			thisHeaderInstance.ListHeadingButton:RegisterCallback( Mouse.eLClick, CivilopediaCategory[CategoryCorporations].SelectHeading );
 			otherSortedList[tostring( thisHeaderInstance.ListHeadingButton )] = sortOrder;
-		end	
-		
-		-- for each element of the sorted list		
+		end
+
+		-- for each element of the sorted list
 		if sortedList[CategoryCorporations][section].headingOpen then
 			for i, v in ipairs(sortedList[CategoryCorporations][section]) do
 				local thisListInstance = g_ListItemManager:GetInstance();
@@ -7989,8 +7990,8 @@ CivilopediaCategory[CategoryCorporations].SelectHeading = function( selectedSect
 			end
 		end
 
-	end	
-	
+	end
+
 	Controls.ListOfArticles:SortChildren( SortFunction );
 	ResizeEtc();
 end
@@ -8017,7 +8018,7 @@ CivilopediaCategory[CategoryHomePage].DisplayList = function( selectedSection, d
 	--	thisListInstance.ListItemButton:SetToolTipCallback( TipHandler );
 	--	otherSortedList[tostring( thisListInstance.ListItemButton )] = sortOrder;
 	--end
-		-- for each element of the sorted list		
+		-- for each element of the sorted list
 	for i, v in ipairs(sortedList[CategoryHomePage][1]) do
 		-- add an entry
 		local thisListInstance = g_ListItemManager:GetInstance();
@@ -8052,37 +8053,37 @@ CivilopediaCategory[CategoryGameConcepts].DisplayList = function( selectedSectio
 		thisListInstance.ListItemButton:SetToolTipCallback( TipHandler );
 		otherSortedList[tostring( thisListInstance.ListItemButton )] = sortOrder;
 	end
-	
+
 	-- for each element of the sorted list
 	local numSections = #sortedList[CategoryGameConcepts];
-	
+
 	local GameConceptsList = sortedList[CategoryGameConcepts];
 	for section = 1,numSections,1 do
-		
+
 		local headingOpen = GameConceptsList[section].headingOpen;
 		if(headingOpen == nil) then
 			headingOpen = true;
 			GameConceptsList[section].headingOpen = true;
 		end
-	
+
 		local thisHeaderInstance = g_ListHeadingManager:GetInstance();
 		if thisHeaderInstance then
-		
+
 			sortOrder = sortOrder + 1;
 			local textString = "TXT_KEY_GAME_CONCEPT_SECTION_"..tostring( section );
 			thisHeaderInstance.ListHeadingButton:SetVoids( section, 0 );
 			thisHeaderInstance.ListHeadingButton:RegisterCallback( Mouse.eLClick, CivilopediaCategory[CategoryGameConcepts].SelectHeading );
 			otherSortedList[tostring( thisHeaderInstance.ListHeadingButton )] = sortOrder;
-			
+
 			if(headingOpen == true) then
 				local localizedLabel = "[ICON_MINUS] "..Locale.ConvertTextKey( textString );
 				thisHeaderInstance.ListHeadingLabel:SetText( localizedLabel );
 			else
 				local localizedLabel = "[ICON_PLUS] "..Locale.ConvertTextKey( textString );
 				thisHeaderInstance.ListHeadingLabel:SetText( localizedLabel );
-			end			
-		end	
-		
+			end
+		end
+
 		if(headingOpen == true) then
 			for i, v in ipairs(sortedList[CategoryGameConcepts][section]) do
 				-- add an entry
@@ -8107,10 +8108,10 @@ CivilopediaCategory[CategoryTech].DisplayList = function()
 	print("CivilopediaCategory[CategoryTech].DisplayList");
 	g_ListHeadingManager:ResetInstances();
 	g_ListItemManager:ResetInstances();
-	
+
 	local sortOrder = 0;
 	otherSortedList = {};
-	
+
 	-- put in a home page before the first era
 	local thisTechInstance = g_ListItemManager:GetInstance();
 	if thisTechInstance then
@@ -8125,7 +8126,7 @@ CivilopediaCategory[CategoryTech].DisplayList = function()
 	-- Infixo GameInfo.Eras is not updated after mods are loaded
 	--for era in GameInfo.Eras() do
 	for era in DB.Query("SELECT ID, Description FROM Eras ORDER BY ID") do
-	
+
 		local eraID = era.ID;
 		-- add an era header
 		local thisEraInstance = g_ListHeadingManager:GetInstance();
@@ -8138,9 +8139,9 @@ CivilopediaCategory[CategoryTech].DisplayList = function()
 			thisEraInstance.ListHeadingButton:SetVoids( eraID, 0 );
 			thisEraInstance.ListHeadingButton:RegisterCallback( Mouse.eLClick, CivilopediaCategory[CategoryTech].SelectHeading );
 			otherSortedList[tostring( thisEraInstance.ListHeadingButton )] = sortOrder;
-		end	
-		
-		-- for each element of the sorted list		
+		end
+
+		-- for each element of the sorted list
 		for i, v in ipairs(sortedList[CategoryTech][eraID]) do
 			-- add a tech entry
 			local thisTechInstance = g_ListItemManager:GetInstance();
@@ -8154,8 +8155,8 @@ CivilopediaCategory[CategoryTech].DisplayList = function()
 			end
 		end
 
-	end	
-	
+	end
+
 	Controls.ListOfArticles:SortChildren( SortFunction );
 	ResizeEtc();
 end
@@ -8167,7 +8168,7 @@ CivilopediaCategory[CategoryUnits].DisplayList = function()
 
 	local sortOrder = 0;
 	otherSortedList = {};
-	
+
 	-- put in a home page before the first era
 	local thisListInstance = g_ListItemManager:GetInstance();
 	if thisListInstance then
@@ -8178,9 +8179,9 @@ CivilopediaCategory[CategoryUnits].DisplayList = function()
 		thisListInstance.ListItemButton:SetToolTipCallback( TipHandler );
 		otherSortedList[tostring( thisListInstance.ListItemButton )] = sortOrder;
 	end
-	
+
 	function PopulateAndAdd(categoryID, headingName)
-		
+
 		-- add an era header
 		local thisEraInstance = g_ListHeadingManager:GetInstance();
 		if thisEraInstance then
@@ -8192,9 +8193,9 @@ CivilopediaCategory[CategoryUnits].DisplayList = function()
 			thisEraInstance.ListHeadingButton:SetVoids( categoryID, 0 );
 			thisEraInstance.ListHeadingButton:RegisterCallback( Mouse.eLClick, CivilopediaCategory[CategoryUnits].SelectHeading );
 			otherSortedList[tostring( thisEraInstance.ListHeadingButton )] = sortOrder;
-		end	
-		
-		-- for each element of the sorted list		
+		end
+
+		-- for each element of the sorted list
 		for i, v in ipairs(sortedList[CategoryUnits][categoryID]) do
 			-- add a unit entry
 			local thisUnitInstance = g_ListItemManager:GetInstance();
@@ -8208,9 +8209,9 @@ CivilopediaCategory[CategoryUnits].DisplayList = function()
 			end
 		end
 	end
-	
+
 	local sectionID = 0;
-	
+
 	if(Game == nil or not Game.IsOption(GameOptionTypes.GAMEOPTION_NO_RELIGION)) then
 		PopulateAndAdd(0, "TXT_KEY_PEDIA_RELIGIOUS");
 		sectionID = sectionID + 1;
@@ -8221,23 +8222,23 @@ CivilopediaCategory[CategoryUnits].DisplayList = function()
 	for era in DB.Query("SELECT ID, Description FROM Eras ORDER BY ID") do
 		local eraID = era.ID;
 		local headingName = era.Description;
-		
+
 		PopulateAndAdd(eraID + sectionID, headingName);
-	end	
-	
+	end
+
 	Controls.ListOfArticles:SortChildren( SortFunction );
 	ResizeEtc();
-		
+
 end
 
 CivilopediaCategory[CategoryPromotions].DisplayList = function()
 	print("start CivilopediaCategory[CategoryPromotions].DisplayList");
 	g_ListHeadingManager:ResetInstances();
 	g_ListItemManager:ResetInstances();
-	
+
 	local sortOrder = 0;
 	otherSortedList = {};
-	
+
 	-- put in a home page before the rest of the stuff
 	local thisListInstance = g_ListItemManager:GetInstance();
 	if thisListInstance then
@@ -8249,7 +8250,7 @@ CivilopediaCategory[CategoryPromotions].DisplayList = function()
 		otherSortedList[tostring( thisListInstance.ListItemButton )] = sortOrder;
 	end
 
-	-- for each element of the sorted list		
+	-- for each element of the sorted list
 
 	-- Infixo more categories
 	--for section = 1,8,1 do
@@ -8266,8 +8267,8 @@ CivilopediaCategory[CategoryPromotions].DisplayList = function()
 			thisHeaderInstance.ListHeadingButton:SetVoids( section, 0 );
 			thisHeaderInstance.ListHeadingButton:RegisterCallback( Mouse.eLClick, CivilopediaCategory[CategoryPromotions].SelectHeading );
 			otherSortedList[tostring( thisHeaderInstance.ListHeadingButton )] = sortOrder;
-		end	
-			
+		end
+
 		for i, v in ipairs(sortedList[CategoryPromotions][section]) do
 			-- add an entry
 			local thisListInstance = g_ListItemManager:GetInstance();
@@ -8295,7 +8296,7 @@ CivilopediaCategory[CategoryBuildings].DisplayList = function()
 
 	local sortOrder = 0;
 	otherSortedList = {};
-	
+
 	-- put in a home page before the first era
 	local thisListInstance = g_ListItemManager:GetInstance();
 	if thisListInstance then
@@ -8306,7 +8307,7 @@ CivilopediaCategory[CategoryBuildings].DisplayList = function()
 		thisListInstance.ListItemButton:SetToolTipCallback( TipHandler );
 		otherSortedList[tostring( thisListInstance.ListItemButton )] = sortOrder;
 	end
-	
+
 	function PopulateAndAdd(categoryID, headingName)
 		local thisEraInstance = g_ListHeadingManager:GetInstance();
 		if thisEraInstance then
@@ -8317,9 +8318,9 @@ CivilopediaCategory[CategoryBuildings].DisplayList = function()
 			thisEraInstance.ListHeadingButton:SetVoids( categoryID, 0 );
 			thisEraInstance.ListHeadingButton:RegisterCallback( Mouse.eLClick, CivilopediaCategory[CategoryBuildings].SelectHeading );
 			otherSortedList[tostring( thisEraInstance.ListHeadingButton )] = sortOrder;
-		end	
-		
-		-- for each element of the sorted list		
+		end
+
+		-- for each element of the sorted list
 		for i, v in ipairs(sortedList[CategoryBuildings][categoryID]) do
 			-- add an entry
 			local thisListInstance = g_ListItemManager:GetInstance();
@@ -8333,14 +8334,14 @@ CivilopediaCategory[CategoryBuildings].DisplayList = function()
 			end
 		end
 	end
-	
+
 	local sectionID = 0;
-	
+
 	if(Game == nil or not Game.IsOption(GameOptionTypes.GAMEOPTION_NO_RELIGION)) then
 		PopulateAndAdd(0, "TXT_KEY_PEDIA_RELIGIOUS");
 		sectionID = sectionID + 1;
 	end
-	
+
 	PopulateAndAdd(sectionID, "TXT_KEY_TOPIC_CORPORATION");
 	sectionID = sectionID + 1;
 
@@ -8350,8 +8351,8 @@ CivilopediaCategory[CategoryBuildings].DisplayList = function()
 		local eraID = era.ID;
 		local headingName = era.Description;
 		PopulateAndAdd(eraID + sectionID, headingName);
-	end	
-	
+	end
+
 	Controls.ListOfArticles:SortChildren( SortFunction );
 	ResizeEtc();
 end
@@ -8363,7 +8364,7 @@ CivilopediaCategory[CategoryWonders].DisplayList = function()
 
 	local sortOrder = 0;
 	otherSortedList = {};
-	
+
 	-- put in a home page before the first section
 	local thisListInstance = g_ListItemManager:GetInstance();
 	if thisListInstance then
@@ -8375,7 +8376,7 @@ CivilopediaCategory[CategoryWonders].DisplayList = function()
 		otherSortedList[tostring( thisListInstance.ListItemButton )] = sortOrder;
 	end
 
-	for section = 1, 4, 1 do	
+	for section = 1, 4, 1 do
 		local thisHeaderInstance = g_ListHeadingManager:GetInstance();
 		if thisHeaderInstance then
 			sortedList[CategoryWonders][section].headingOpen = true; -- ain't lua great
@@ -8386,9 +8387,9 @@ CivilopediaCategory[CategoryWonders].DisplayList = function()
 			thisHeaderInstance.ListHeadingButton:SetVoids( section, 0 );
 			thisHeaderInstance.ListHeadingButton:RegisterCallback( Mouse.eLClick, CivilopediaCategory[CategoryWonders].SelectHeading );
 			otherSortedList[tostring( thisHeaderInstance.ListHeadingButton )] = sortOrder;
-		end	
-		
-		-- for each element of the sorted list		
+		end
+
+		-- for each element of the sorted list
 		for i, v in ipairs(sortedList[CategoryWonders][section]) do
 			-- add a unit entry
 			local thisListInstance = g_ListItemManager:GetInstance();
@@ -8402,12 +8403,12 @@ CivilopediaCategory[CategoryWonders].DisplayList = function()
 			end
 		end
 
-	end	
-	
+	end
+
 	Controls.ListOfArticles:SortChildren( SortFunction );
 	ResizeEtc();
 	Controls.ScrollPanel:CalculateInternalSize();
-		
+
 end
 
 CivilopediaCategory[CategoryPolicies].DisplayList = function()
@@ -8417,7 +8418,7 @@ CivilopediaCategory[CategoryPolicies].DisplayList = function()
 
 	local sortOrder = 0;
 	otherSortedList = {};
-	
+
 	-- put in a home page before the first branch
 	local thisListInstance = g_ListItemManager:GetInstance();
 	if thisListInstance then
@@ -8430,7 +8431,7 @@ CivilopediaCategory[CategoryPolicies].DisplayList = function()
 	end
 
 	for branch in GameInfo.PolicyBranchTypes() do
-	
+
 		local branchID = branch.ID;
 		-- add a branch header
 		local thisHeadingInstance = g_ListHeadingManager:GetInstance();
@@ -8443,9 +8444,9 @@ CivilopediaCategory[CategoryPolicies].DisplayList = function()
 			thisHeadingInstance.ListHeadingButton:SetVoids( branchID, 0 );
 			thisHeadingInstance.ListHeadingButton:RegisterCallback( Mouse.eLClick, CivilopediaCategory[CategoryPolicies].SelectHeading );
 			otherSortedList[tostring( thisHeadingInstance.ListHeadingButton )] = sortOrder;
-		end	
-		
-		-- for each element of the sorted list		
+		end
+
+		-- for each element of the sorted list
 		for i, v in ipairs(sortedList[CategoryPolicies][branchID]) do
 			-- add an entry
 			local thisListInstance = g_ListItemManager:GetInstance();
@@ -8459,11 +8460,11 @@ CivilopediaCategory[CategoryPolicies].DisplayList = function()
 			end
 		end
 
-	end	
-	
+	end
+
 	Controls.ListOfArticles:SortChildren( SortFunction );
 	ResizeEtc();
-		
+
 end
 
 CivilopediaCategory[CategoryPeople].DisplayList = function()
@@ -8473,7 +8474,7 @@ CivilopediaCategory[CategoryPeople].DisplayList = function()
 
 	local sortOrder = 0;
 	otherSortedList = {};
-	
+
 	-- put in a home page before the first section
 	local thisListInstance = g_ListItemManager:GetInstance();
 	if thisListInstance then
@@ -8485,7 +8486,7 @@ CivilopediaCategory[CategoryPeople].DisplayList = function()
 		otherSortedList[tostring( thisListInstance.ListItemButton )] = sortOrder;
 	end
 
-	for section = 1, 2, 1 do	
+	for section = 1, 2, 1 do
 		local thisHeaderInstance = g_ListHeadingManager:GetInstance();
 		if thisHeaderInstance then
 			sortedList[CategoryPeople][section].headingOpen = true; -- ain't lua great
@@ -8496,9 +8497,9 @@ CivilopediaCategory[CategoryPeople].DisplayList = function()
 			thisHeaderInstance.ListHeadingButton:SetVoids( section, 0 );
 			thisHeaderInstance.ListHeadingButton:RegisterCallback( Mouse.eLClick, CivilopediaCategory[CategoryPeople].SelectHeading );
 			otherSortedList[tostring( thisHeaderInstance.ListHeadingButton )] = sortOrder;
-		end	
-		
-		-- for each element of the sorted list		
+		end
+
+		-- for each element of the sorted list
 		for i, v in ipairs(sortedList[CategoryPeople][section]) do
 			-- add a unit entry
 			local thisListInstance = g_ListItemManager:GetInstance();
@@ -8512,11 +8513,11 @@ CivilopediaCategory[CategoryPeople].DisplayList = function()
 			end
 		end
 
-	end	
-	
+	end
+
 	Controls.ListOfArticles:SortChildren( SortFunction );
 	ResizeEtc();
-		
+
 end
 
 CivilopediaCategory[CategoryCivilizations].DisplayList = function()
@@ -8526,7 +8527,7 @@ CivilopediaCategory[CategoryCivilizations].DisplayList = function()
 
 	local sortOrder = 0;
 	otherSortedList = {};
-	
+
 	-- put in a home page before the first section
 	local thisListInstance = g_ListItemManager:GetInstance();
 	if thisListInstance then
@@ -8538,7 +8539,7 @@ CivilopediaCategory[CategoryCivilizations].DisplayList = function()
 		otherSortedList[tostring( thisListInstance.ListItemButton )] = sortOrder;
 	end
 
-	for section = 1, 2, 1 do	
+	for section = 1, 2, 1 do
 		local thisHeaderInstance = g_ListHeadingManager:GetInstance();
 		if thisHeaderInstance then
 			sortedList[CategoryCivilizations][section].headingOpen = true; -- ain't lua great
@@ -8549,9 +8550,9 @@ CivilopediaCategory[CategoryCivilizations].DisplayList = function()
 			thisHeaderInstance.ListHeadingButton:SetVoids( section, 0 );
 			thisHeaderInstance.ListHeadingButton:RegisterCallback( Mouse.eLClick, CivilopediaCategory[CategoryCivilizations].SelectHeading );
 			otherSortedList[tostring( thisHeaderInstance.ListHeadingButton )] = sortOrder;
-		end	
-		
-		-- for each element of the sorted list		
+		end
+
+		-- for each element of the sorted list
 		for i, v in ipairs(sortedList[CategoryCivilizations][section]) do
 			-- add a unit entry
 			local thisListInstance = g_ListItemManager:GetInstance();
@@ -8565,11 +8566,11 @@ CivilopediaCategory[CategoryCivilizations].DisplayList = function()
 			end
 		end
 
-	end	
-	
+	end
+
 	Controls.ListOfArticles:SortChildren( SortFunction );
 	ResizeEtc();
-		
+
 end
 
 CivilopediaCategory[CategoryCityStates].DisplayList = function()
@@ -8579,7 +8580,7 @@ CivilopediaCategory[CategoryCityStates].DisplayList = function()
 
 	local sortOrder = 0;
 	otherSortedList = {};
-	
+
 	-- put in a home page before the first trait
 	local thisListInstance = g_ListItemManager:GetInstance();
 	if thisListInstance then
@@ -8592,7 +8593,7 @@ CivilopediaCategory[CategoryCityStates].DisplayList = function()
 	end
 
 	for trait in GameInfo.MinorCivTraits() do
-	
+
 		local traitID = trait.ID;
 		-- add a header
 		local thisHeadingInstance = g_ListHeadingManager:GetInstance();
@@ -8605,9 +8606,9 @@ CivilopediaCategory[CategoryCityStates].DisplayList = function()
 			thisHeadingInstance.ListHeadingButton:SetVoids( traitID, 0 );
 			thisHeadingInstance.ListHeadingButton:RegisterCallback( Mouse.eLClick, CivilopediaCategory[CategoryCityStates].SelectHeading );
 			otherSortedList[tostring( thisHeadingInstance.ListHeadingButton )] = sortOrder;
-		end	
-		
-		-- for each element of the sorted list		
+		end
+
+		-- for each element of the sorted list
 		for i, v in ipairs(sortedList[CategoryCityStates][traitID]) do
 			-- add an entry
 			local thisListInstance = g_ListItemManager:GetInstance();
@@ -8621,11 +8622,11 @@ CivilopediaCategory[CategoryCityStates].DisplayList = function()
 			end
 		end
 
-	end	
-	
+	end
+
 	Controls.ListOfArticles:SortChildren( SortFunction );
 	ResizeEtc();
-		
+
 end
 
 CivilopediaCategory[CategoryTerrain].DisplayList = function()
@@ -8635,7 +8636,7 @@ CivilopediaCategory[CategoryTerrain].DisplayList = function()
 
 	local sortOrder = 0;
 	otherSortedList = {};
-	
+
 	-- put in a home page before the first section
 	local thisListInstance = g_ListItemManager:GetInstance();
 	if thisListInstance then
@@ -8647,7 +8648,7 @@ CivilopediaCategory[CategoryTerrain].DisplayList = function()
 		otherSortedList[tostring( thisListInstance.ListItemButton )] = sortOrder;
 	end
 
-	for section = 1, 2, 1 do	
+	for section = 1, 2, 1 do
 		local thisHeaderInstance = g_ListHeadingManager:GetInstance();
 		if thisHeaderInstance then
 			sortedList[CategoryTerrain][section].headingOpen = true; -- ain't lua great
@@ -8658,9 +8659,9 @@ CivilopediaCategory[CategoryTerrain].DisplayList = function()
 			thisHeaderInstance.ListHeadingButton:SetVoids( section, 0 );
 			thisHeaderInstance.ListHeadingButton:RegisterCallback( Mouse.eLClick, CivilopediaCategory[CategoryTerrain].SelectHeading );
 			otherSortedList[tostring( thisHeaderInstance.ListHeadingButton )] = sortOrder;
-		end	
-		
-		-- for each element of the sorted list		
+		end
+
+		-- for each element of the sorted list
 		for i, v in ipairs(sortedList[CategoryTerrain][section]) do
 			-- add a unit entry
 			local thisListInstance = g_ListItemManager:GetInstance();
@@ -8674,11 +8675,11 @@ CivilopediaCategory[CategoryTerrain].DisplayList = function()
 			end
 		end
 
-	end	
-	
+	end
+
 	Controls.ListOfArticles:SortChildren( SortFunction );
 	ResizeEtc();
-		
+
 end
 
 CivilopediaCategory[CategoryResources].DisplayList = function()
@@ -8688,7 +8689,7 @@ CivilopediaCategory[CategoryResources].DisplayList = function()
 
 	local sortOrder = 0;
 	otherSortedList = {};
-	
+
 	-- put in a home page before the first section
 	local thisListInstance = g_ListItemManager:GetInstance();
 	if thisListInstance then
@@ -8700,7 +8701,7 @@ CivilopediaCategory[CategoryResources].DisplayList = function()
 		otherSortedList[tostring( thisListInstance.ListItemButton )] = sortOrder;
 	end
 
-	for section = 0, 2, 1 do	
+	for section = 0, 2, 1 do
 		local thisHeaderInstance = g_ListHeadingManager:GetInstance();
 		if thisHeaderInstance then
 			sortedList[CategoryResources][section].headingOpen = true; -- ain't lua great
@@ -8711,9 +8712,9 @@ CivilopediaCategory[CategoryResources].DisplayList = function()
 			thisHeaderInstance.ListHeadingButton:SetVoids( section, 0 );
 			thisHeaderInstance.ListHeadingButton:RegisterCallback( Mouse.eLClick, CivilopediaCategory[CategoryResources].SelectHeading );
 			otherSortedList[tostring( thisHeaderInstance.ListHeadingButton )] = sortOrder;
-		end	
-		
-		-- for each element of the sorted list		
+		end
+
+		-- for each element of the sorted list
 		for i, v in ipairs(sortedList[CategoryResources][section]) do
 			-- add a unit entry
 			local thisListInstance = g_ListItemManager:GetInstance();
@@ -8727,21 +8728,21 @@ CivilopediaCategory[CategoryResources].DisplayList = function()
 			end
 		end
 
-	end	
-	
+	end
+
 	Controls.ListOfArticles:SortChildren( SortFunction );
 	ResizeEtc();
-		
+
 end
 
 CivilopediaCategory[CategoryImprovements].DisplayList = function()
 	print("start CivilopediaCategory[CategoryImprovements].DisplayList");
 	g_ListHeadingManager:ResetInstances();
 	g_ListItemManager:ResetInstances();
-	
+
 	local sortOrder = 0;
 	otherSortedList = {};
-	
+
 	-- put in a home page before the rest of the stuff
 	local thisListInstance = g_ListItemManager:GetInstance();
 	if thisListInstance then
@@ -8753,7 +8754,7 @@ CivilopediaCategory[CategoryImprovements].DisplayList = function()
 		otherSortedList[tostring( thisListInstance.ListItemButton )] = sortOrder;
 	end
 
-	-- for each element of the sorted list		
+	-- for each element of the sorted list
 	for i, v in ipairs(sortedList[CategoryImprovements][1]) do
 		-- add an entry
 		local thisListInstance = g_ListItemManager:GetInstance();
@@ -8778,7 +8779,7 @@ CivilopediaCategory[CategoryBeliefs].DisplayList = function()
 
 	local sortOrder = 0;
 	otherSortedList = {};
-	
+
 	-- put in a home page before the first section
 	local thisListInstance = g_ListItemManager:GetInstance();
 	if thisListInstance then
@@ -8790,7 +8791,7 @@ CivilopediaCategory[CategoryBeliefs].DisplayList = function()
 		otherSortedList[tostring( thisListInstance.ListItemButton )] = sortOrder;
 	end
 
-	for section = 1, 6, 1 do	
+	for section = 1, 6, 1 do
 		local thisHeaderInstance = g_ListHeadingManager:GetInstance();
 		if thisHeaderInstance then
 			sortedList[CategoryBeliefs][section].headingOpen = true; -- ain't lua great
@@ -8801,9 +8802,9 @@ CivilopediaCategory[CategoryBeliefs].DisplayList = function()
 			thisHeaderInstance.ListHeadingButton:SetVoids( section, 0 );
 			thisHeaderInstance.ListHeadingButton:RegisterCallback( Mouse.eLClick, CivilopediaCategory[CategoryBeliefs].SelectHeading );
 			otherSortedList[tostring( thisHeaderInstance.ListHeadingButton )] = sortOrder;
-		end	
-		
-		-- for each element of the sorted list		
+		end
+
+		-- for each element of the sorted list
 		for i, v in ipairs(sortedList[CategoryBeliefs][section]) do
 			-- add a unit entry
 			local thisListInstance = g_ListItemManager:GetInstance();
@@ -8817,8 +8818,8 @@ CivilopediaCategory[CategoryBeliefs].DisplayList = function()
 			end
 		end
 
-	end	
-	
+	end
+
 	Controls.ListOfArticles:SortChildren( SortFunction );
 	ResizeEtc();
 
@@ -8830,7 +8831,7 @@ CivilopediaCategory[CategoryWorldCongress].DisplayList = function()
 
 	local sortOrder = 0;
 	otherSortedList = {};
-	
+
 	-- put in a home page before the first section
 	local thisListInstance = g_ListItemManager:GetInstance();
 	if thisListInstance then
@@ -8854,9 +8855,9 @@ CivilopediaCategory[CategoryWorldCongress].DisplayList = function()
 			thisHeaderInstance.ListHeadingButton:SetVoids( section, 0 );
 			thisHeaderInstance.ListHeadingButton:RegisterCallback( Mouse.eLClick, CivilopediaCategory[CategoryWorldCongress].SelectHeading );
 			otherSortedList[tostring( thisHeaderInstance.ListHeadingButton )] = sortOrder;
-		end	
-		
-		-- for each element of the sorted list		
+		end
+
+		-- for each element of the sorted list
 		for i, v in ipairs(sortedList[CategoryWorldCongress][section]) do
 			-- add a unit entry
 			local thisListInstance = g_ListItemManager:GetInstance();
@@ -8870,7 +8871,7 @@ CivilopediaCategory[CategoryWorldCongress].DisplayList = function()
 			end
 		end
 	end
-	
+
 	Controls.ListOfArticles:SortChildren( SortFunction );
 	ResizeEtc();
 
@@ -8883,7 +8884,7 @@ CivilopediaCategory[CategoryCorporations].DisplayList = function()
 
 	local sortOrder = 0;
 	otherSortedList = {};
-	
+
 	-- put in a home page before the first section
 	local thisListInstance = g_ListItemManager:GetInstance();
 	if thisListInstance then
@@ -8894,8 +8895,8 @@ CivilopediaCategory[CategoryCorporations].DisplayList = function()
 		thisListInstance.ListItemButton:SetToolTipCallback( TipHandler );
 		otherSortedList[tostring( thisListInstance.ListItemButton )] = sortOrder;
 	end
-	
-	-- for each element of the sorted list		
+
+	-- for each element of the sorted list
 	for i, v in ipairs(sortedList[CategoryCorporations][1]) do
 		-- add a unit entry
 		local thisListInstance = g_ListItemManager:GetInstance();
@@ -8908,10 +8909,10 @@ CivilopediaCategory[CategoryCorporations].DisplayList = function()
 			otherSortedList[tostring( thisListInstance.ListItemButton )] = sortOrder;
 		end
 	end
-	
+
 	Controls.ListOfArticles:SortChildren( SortFunction );
 	ResizeEtc();
-	
+
 end
 
 
@@ -8939,7 +8940,7 @@ function ClearArticle()
 	Controls.RangedCombatFrame:SetHide( true );
 	Controls.RangedCombatRangeFrame:SetHide( true );
 	Controls.MovementFrame:SetHide( true );
-	Controls.AirDefenseFrame:SetHide( true );	
+	Controls.AirDefenseFrame:SetHide( true );
 	Controls.FreePromotionsFrame:SetHide( true );
 	Controls.PrereqTechFrame:SetHide( true );
 	Controls.GreatWorksFrame:SetHide( true );
@@ -8950,7 +8951,7 @@ function ClearArticle()
 	Controls.UnlockedBuildingsFrame:SetHide( true );
 	Controls.RequiredBuildingsFrame:SetHide( true );
 	-- CBP
-	Controls.LeadsToBuildingsFrame:SetHide( true );	
+	Controls.LeadsToBuildingsFrame:SetHide( true );
 	Controls.MonopolyResourcesFrame:SetHide( true );
 	Controls.CorporationFrame:SetHide( true );
 	Controls.CorpHeadquartersFrame:SetHide( true );
@@ -8969,17 +8970,17 @@ function ClearArticle()
 	Controls.GameInfoFrame:SetHide( true );
 	Controls.QuoteFrame:SetHide( true );
 	Controls.SilentQuoteFrame:SetHide( true );
-	Controls.AbilitiesFrame:SetHide( true );			
+	Controls.AbilitiesFrame:SetHide( true );
 	Controls.HistoryFrame:SetHide( true );
 	Controls.StrategyFrame:SetHide( true );
-	Controls.RelatedImagesFrame:SetHide( true );		
-	Controls.SummaryFrame:SetHide( true );		
-	Controls.ExtendedFrame:SetHide( true );		
-	Controls.DNotesFrame:SetHide( true );		
-	Controls.RequiredPoliciesFrame:SetHide( true );		
-	Controls.PrereqEraFrame:SetHide( true );		
-	Controls.PolicyBranchFrame:SetHide( true );	
-	Controls.TenetLevelFrame:SetHide(true);	
+	Controls.RelatedImagesFrame:SetHide( true );
+	Controls.SummaryFrame:SetHide( true );
+	Controls.ExtendedFrame:SetHide( true );
+	Controls.DNotesFrame:SetHide( true );
+	Controls.RequiredPoliciesFrame:SetHide( true );
+	Controls.PrereqEraFrame:SetHide( true );
+	Controls.PolicyBranchFrame:SetHide( true );
+	Controls.TenetLevelFrame:SetHide(true);
 	Controls.LeadersFrame:SetHide( true );
 	Controls.UniqueUnitsFrame:SetHide( true );
 	Controls.UniqueBuildingsFrame:SetHide( true );
@@ -8997,9 +8998,9 @@ function ClearArticle()
 	Controls.CorporationTRBonusFrame:SetHide( true );
 	Controls.TradeRouteYieldFrame:SetHide( true );
 	Controls.AdjacentYieldFrame:SetHide( true );
-	Controls.AdjacentTerrainYieldFrame:SetHide( true );	
+	Controls.AdjacentTerrainYieldFrame:SetHide( true );
 	Controls.AdjacentImprovYieldFrame:SetHide( true );
-	Controls.TwoAdjacentImprovYieldFrame:SetHide( true );	
+	Controls.TwoAdjacentImprovYieldFrame:SetHide( true );
 	Controls.ImprovementYieldFrame:SetHide( true );
 	--END
 	Controls.MovementCostFrame:SetHide( true );
@@ -9015,10 +9016,10 @@ function ClearArticle()
 	Controls.WideTextBlockFrame:SetHide( true );
 	Controls.FFTextStack:SetHide( true );
 	Controls.BBTextStack:SetHide ( true );
-	
+
 	Controls.PartialMatchPullDown:SetHide( true );
-	Controls.SearchButton:SetHide( false );	
-	
+	Controls.SearchButton:SetHide( false );
+
 	Controls.Portrait:UnloadTexture();
 	Controls.Portrait:SetTexture("256x256Frame.dds");
 end
@@ -9068,13 +9069,13 @@ Controls.ForwardButton:RegisterCallback( Mouse.eLClick, OnForwardButtonClicked )
 function SearchForPediaEntry( searchString )
 
 	UIManager:SetUICursor( 1 );
-	
+
     if( searchString ~= nil and searchString ~= "" ) then
     	local article = searchableTextKeyList[searchString];
     	if article == nil then
     		article = searchableList[Locale.ToLower(searchString)];
     	end
-    	
+
     	if article then
     		SetSelectedCategory( article.entryCategory );
     		CivilopediaCategory[article.entryCategory].SelectArticle( article.entryID, addToList );
@@ -9082,7 +9083,7 @@ function SearchForPediaEntry( searchString )
     		SetSelectedCategory( CategoryGameConcepts );
     	end
     end
-	
+
 	if( searchString == "OPEN_VIA_HOTKEY" ) then
     	if( ContextPtr:IsHidden() == false ) then
     	    OnClose();
@@ -9127,22 +9128,22 @@ function ValidateText(text)
 			numNonWhiteSpace = numNonWhiteSpace + 1;
 		end
 	end
-	
+
 	if isAllWhiteSpace then
 		return false;
 	end
-	
+
 	if numNonWhiteSpace < 3 then
 		return false;
 	end
-	
+
 	-- don't allow % character
 	for i = 1, #text, 1 do
 		if string.byte(text, i) == 37 then
 			return false;
 		end
 	end
-	
+
 	local invalidCharArray = { '\"', '<', '>', '|', '\b', '\0', '\t', '\n', '/', '\\', '*', '?', '%[', ']' };
 
 	for i, ch in ipairs(invalidCharArray) do
@@ -9150,14 +9151,14 @@ function ValidateText(text)
 			return false;
 		end
 	end
-	
+
 	-- don't allow control characters
 	for i = 1, #text, 1 do
 		if string.byte(text, i) < 32 then
 			return false;
 		end
 	end
-	
+
 	return true;
 end
 
@@ -9176,12 +9177,12 @@ function OnSearchButtonClicked()
 			lowerCaseSearchString = Locale.ToLower(searchString);
 			article = searchableList[lowerCaseSearchString];
 		end
-	    
+
 		if article then
 			SetSelectedCategory( article.entryCategory );
 			CivilopediaCategory[article.entryCategory].SelectArticle( article.entryID, addToList );
 		else
-		
+
 			-- try to see if there is a partial match
 			local partialMatch = {};
 			local numberMatches = 0;
@@ -9204,8 +9205,8 @@ function OnSearchButtonClicked()
 					local controlTable = {};
 					Controls.PartialMatchPullDown:BuildEntry( "InstanceOne", controlTable );
 					controlTable.Button:SetText( v );
-					
-					controlTable.Button:RegisterCallback(Mouse.eLClick, 
+
+					controlTable.Button:RegisterCallback(Mouse.eLClick,
 					function()
 						SearchForPediaEntry( v );
 					end);
@@ -9238,7 +9239,7 @@ function OnSearchNotFoundOK()
 	Controls.SearchFoundNothing:SetHide(true);
 end
 Controls.OK:RegisterCallback(Mouse.eLClick, OnSearchNotFoundOK );
- 
+
 function InputHandler( uiMsg, wParam, lParam )
     if(uiMsg == KeyEvents.KeyDown) then
 		if(not Controls.SearchFoundNothing:IsHidden()) then
@@ -9263,7 +9264,7 @@ function ShowHideHandler( isHide )
         Events.SystemUpdateUI.CallImmediate( SystemUpdateUIType.BulkShowUI );
 	else
         Events.SystemUpdateUI.CallImmediate( SystemUpdateUIType.BulkHideUI );
-        
+
 		if currentTopic then
 			local article = listOfTopicsViewed[currentTopic];
 			if article then
@@ -9305,7 +9306,7 @@ Events.MultiplayerGameServerInvite.Add( OnMultiplayerGameInvite );
 local tipControlTable = {};
 TTManager:GetTypeControlTable( "TypeRoundImage", tipControlTable );
 function TipHandler( control )
-	local id = control:GetVoid1();	
+	local id = control:GetVoid1();
 	local article = categorizedList[(selectedCategory * absurdlyLargeNumTopicsInCategory) + id];
 	if article and article.tooltipTexture then
 		tipControlTable.ToolTipImage:SetTexture( article.tooltipTexture );
@@ -9313,7 +9314,7 @@ function TipHandler( control )
 		tipControlTable.ToolTipFrame:SetHide( false );
 	else
 		tipControlTable.ToolTipFrame:SetHide( true );
-	end		
+	end
 end
 
 

--- a/(2) Vox Populi/Vox Populi.civ5proj
+++ b/(2) Vox Populi/Vox Populi.civ5proj
@@ -927,6 +927,11 @@
         <Type>UpdateDatabase</Type>
         <FileName>Balance Changes/Text/en_US/VPUI_tips_en_us.xml</FileName>
       </Action>
+      <Action>
+        <Set>OnModActivated</Set>
+        <Type>UpdateDatabase</Type>
+        <FileName>Balance Changes/Text/en_US/UIShortcutsCivolopedia_en_US.xml</FileName>
+      </Action>
     </ModActions>
     <ModReferences />
     <ReloadStrategicViewSystem>true</ReloadStrategicViewSystem>
@@ -2868,6 +2873,10 @@
       <ImportIntoVFS>False</ImportIntoVFS>
     </Content>
     <Content Include="Balance Changes\Text\en_US\EspionageEventText.xml">
+      <SubType>Lua</SubType>
+      <ImportIntoVFS>False</ImportIntoVFS>
+    </Content>
+    <Content Include="Balance Changes\Text\en_US\UIShortcutsCivolopedia_en_US.xml">
       <SubType>Lua</SubType>
       <ImportIntoVFS>False</ImportIntoVFS>
     </Content>

--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -1,4 +1,4 @@
-﻿/*	-------------------------------------------------------------------------------------------------------
+/*	-------------------------------------------------------------------------------------------------------
 	© 1991-2012 Take-Two Interactive Software and its subsidiaries.  Developed by Firaxis Games.
 	Sid Meier's Civilization V, Civ, Civilization, 2K Games, Firaxis Games, Take-Two Interactive Software
 	and their respective logos are all trademarks of Take-Two interactive Software, Inc.
@@ -11951,7 +11951,19 @@ void CvCity::SetBuildingInvestment(BuildingClassTypes eBuildingClass, bool bNewV
 
 	m_abBuildingInvestment[eBuildingClass] = bNewValue;
 }
-
+//	--------------------------------------------------------------------------------
+bool CvCity::IsProcessInternationalProject(ProcessTypes eProcess) const
+{
+	for (int iI = 0; iI < GC.getNumLeagueProjectInfos(); iI++)
+	{
+		LeagueProjectTypes eLeagueProject = (LeagueProjectTypes)iI;
+		CvLeagueProjectEntry* pInfo = GC.getLeagueProjectInfo(eLeagueProject);
+		if (pInfo && pInfo->GetProcess() == eProcess) {
+			return true;
+		}
+	}
+	return false;
+}
 //	--------------------------------------------------------------------------------
 bool CvCity::IsUnitInvestment(UnitClassTypes eUnitClass) const
 {
@@ -29742,6 +29754,19 @@ void CvCity::pushOrder(OrderTypes eOrder, int iData1, int iData2, bool bSave, bo
 	if (bAppend)
 	{
 		m_orderQueue.insertAtEnd(&order);
+
+		if (order.eOrderType != ORDER_MAINTAIN || IsProcessInternationalProject((ProcessTypes)order.iData1))
+		{
+			// Bubble down non-process orders to in front of all processes at end of queue
+			uint32 currOrderIdx = uint32(m_orderQueue.getLength()) - 1;
+			while (currOrderIdx > 0
+			  && m_orderQueue.getAt(currOrderIdx - 1)->eOrderType == ORDER_MAINTAIN
+			  && !IsProcessInternationalProject((ProcessTypes)m_orderQueue.getAt(currOrderIdx - 1)->iData1))
+			{
+				m_orderQueue.swapUp(currOrderIdx - 1);
+				currOrderIdx--;
+			}
+		}
 	}
 	else
 	{

--- a/CvGameCoreDLL_Expansion2/CvCity.h
+++ b/CvGameCoreDLL_Expansion2/CvCity.h
@@ -416,6 +416,8 @@ public:
 	void SetBuildingInvestment(BuildingClassTypes eBuildingClass, bool bValue);
 	bool IsBuildingInvestment(BuildingClassTypes eBuildingClass) const;
 
+	bool IsProcessInternationalProject(ProcessTypes eProcess) const;
+
 	void SetUnitInvestment(UnitClassTypes eUnitClass, bool bValue);
 	bool IsUnitInvestment(UnitClassTypes eUnitClass) const;
 

--- a/Vox Populi Installer Files/VPUI/FrontEnd/ContentSwitch.lua
+++ b/Vox Populi Installer Files/VPUI/FrontEnd/ContentSwitch.lua
@@ -1,4 +1,7 @@
 -- Table of Vox Populi tips
+-- Update this when adding new tips
+local tips_count = 33;
+
 -- Localize stuff for performance reason
 local L = Locale.ConvertTextKey;
 local math_random = math.random;
@@ -29,7 +32,7 @@ end
 function VPTipText()
 	local iTipText = 0
 	if		GetVPTip() == "TIP" then
-		iTipText = math_random(1, 32)
+		iTipText = math_random(1, tips_count)
 --[[
 	elseif	GetVPTip() == "QUOTE" then
 		iTipText = math_random(1, 4)
@@ -58,7 +61,7 @@ function OnShowHide( isHide, isInit )
 	Controls.Tips:SetText(VPTipText()) -- Vox Populi tip content
 	Controls.ContentSwitchGrid:SetSizeY( 290 ) -- Reset the size every time this UI appears
 	local contentsize = Controls.Tips:GetSize().y
-	if contentsize > 32 then
+	if contentsize > tips_count then
 		Controls.ContentSwitchGrid:SetSizeY( 290 + contentsize )
 	end
 end


### PR DESCRIPTION
C++ Changes:
Update `CvCity::pushOrder()` append behavior to place new orders before indefinite processes

Lua City View Changes:
Add the following three shortcuts
* Insert Bottom (Back of Queue) All: SHIFT+ALT+LCLICK an item to add it to the bottom of every eligible cities construction queues.
* Insert Top All (Front of Queue):SHIFT+CTRL+LCLICK an item to add it to the top of every eligible owned cities construction queues.
* Invest All: SHIFT+LCLICK a buildings invest button to invest in every copy of this building in any cities active construction queue.

Civilopedia Changes:
Added the following pages under a shared game concepts header
![CivilizationV_DX11_h05pGBFBXN](https://user-images.githubusercontent.com/8049171/211166484-1e7dc953-a411-4204-9499-fcf87483526d.png)
![CivilizationV_DX11_1v2QYhnDQI](https://user-images.githubusercontent.com/8049171/211166488-049b00ac-4626-4f80-ac28-45cc7554b15c.png)

Load Screen Changes:
Added a load screen tip advertising the existence of the aforementioned civilopedia pages