### PR TITLE
Rome rework

### DIFF
--- a/(1) Community Patch/Core Files/Core Tables/CoreTableEntries.sql
+++ b/(1) Community Patch/Core Files/Core Tables/CoreTableEntries.sql
@@ -216,6 +216,9 @@ ALTER TABLE Policies ADD COLUMN 'XCSAlliesLowersPolicyNeedWonders' INTEGER DEFAU
 ALTER TABLE Policies ADD COLUMN 'StealGWSlowerModifier' INTEGER DEFAULT 0;
 -- Policy - increase speed of your Great Work theft rate.
 ALTER TABLE Policies ADD COLUMN 'StealGWFasterModifier' INTEGER DEFAULT 0;
+-- Policy - conquered cities keep all their buildings (except for those with NeverCapture==true).
+ALTER TABLE Policies ADD COLUMN 'KeepConqueredBuildings' BOOLEAN DEFAULT 0;
+
 
 -- Policy Branch - number of unlocked policies (finishers excluded) before branch is unlocked.
 ALTER TABLE PolicyBranchTypes ADD COLUMN 'NumPolicyRequirement' INTEGER DEFAULT 100;
@@ -266,6 +269,9 @@ ALTER TABLE Traits ADD COLUMN 'WonderProductionModGA' INTEGER DEFAULT 0;
 
 -- TRAIT: Changes the food (times 100) consumed by each non-specialist citizen. --
 ALTER TABLE Traits ADD COLUMN 'NonSpecialistFoodChange' INTEGER DEFAULT 0;
+
+-- TRAIT: Annexed City States continue to give yields. --
+ALTER TABLE Traits ADD COLUMN 'AnnexedCityStatesGiveYields' BOOLEAN DEFAULT 0;
 
 -- Abnormal scaler. Works for:
 ---- Trait_SpecialistYieldChanges (specialist yield change x2/x3/x4 in medieval/industrial/atomic eras)

--- a/(2) Vox Populi/Balance Changes/AI/LeaderPersonalities.sql
+++ b/(2) Vox Populi/Balance Changes/AI/LeaderPersonalities.sql
@@ -170,8 +170,8 @@ UPDATE Leader_MajorCivApproachBiases SET Bias = 8 	WHERE LeaderType = 'LEADER_AU
 UPDATE Leader_MajorCivApproachBiases SET Bias = 2 	WHERE LeaderType = 'LEADER_AUGUSTUS' 	AND MajorCivApproachType = 'MAJOR_CIV_APPROACH_FRIENDLY';
 UPDATE Leader_MinorCivApproachBiases SET Bias = 3 	WHERE LeaderType = 'LEADER_AUGUSTUS' 	AND MinorCivApproachType = 'MINOR_CIV_APPROACH_IGNORE';
 UPDATE Leader_MinorCivApproachBiases SET Bias = 2 	WHERE LeaderType = 'LEADER_AUGUSTUS' 	AND MinorCivApproachType = 'MINOR_CIV_APPROACH_PROTECTIVE';
-UPDATE Leader_MinorCivApproachBiases SET Bias = 6 	WHERE LeaderType = 'LEADER_AUGUSTUS' 	AND MinorCivApproachType = 'MINOR_CIV_APPROACH_BULLY';
-UPDATE Leader_MinorCivApproachBiases SET Bias = 10 	WHERE LeaderType = 'LEADER_AUGUSTUS' 	AND MinorCivApproachType = 'MINOR_CIV_APPROACH_CONQUEST';
+UPDATE Leader_MinorCivApproachBiases SET Bias = 10 	WHERE LeaderType = 'LEADER_AUGUSTUS' 	AND MinorCivApproachType = 'MINOR_CIV_APPROACH_BULLY';
+UPDATE Leader_MinorCivApproachBiases SET Bias = 3 	WHERE LeaderType = 'LEADER_AUGUSTUS' 	AND MinorCivApproachType = 'MINOR_CIV_APPROACH_CONQUEST';
 
 -- Bismarck (Germany)
 UPDATE Leaders SET PrimaryVictoryPursuit = 'VICTORY_PURSUIT_DIPLOMACY' WHERE Type = 'LEADER_BISMARCK';

--- a/(2) Vox Populi/Balance Changes/Leaders/Vanilla/VanillaLeaderChanges.sql
+++ b/(2) Vox Populi/Balance Changes/Leaders/Vanilla/VanillaLeaderChanges.sql
@@ -543,18 +543,18 @@ WHERE TraitType = 'TRAIT_CONVERTS_SEA_BARBARIANS';
 INSERT INTO Building_SpecialistYieldChangesLocal (BuildingType, SpecialistType, YieldType, Yield) VALUES 
 ("BUILDING_SIEGE_WORKSHOP", "SPECIALIST_ENGINEER", "YIELD_PRODUCTION", 2);
 
--- Rome -- Unique Monument (Flavian Amphitheater) -- Receive Culture boost when you conquer a City.
+-- Rome -- Production Bonus in Capital, can annex city-states instead of demanding heavy tribute, conquered city-states continue to give yields
 
 UPDATE Traits
 SET CapitalBuildingModifier = '15'
 WHERE Type = 'TRAIT_CAPITAL_BUILDINGS_CHEAPER';
 
 UPDATE Traits
-SET ExtraConqueredCityTerritoryClaimRange = '4'
+SET AnnexedCityStatesGiveYields = '1'
 WHERE Type = 'TRAIT_CAPITAL_BUILDINGS_CHEAPER';
 
 UPDATE Traits
-SET KeepConqueredBuildings = '1'
+SET BullyAnnex = '1'
 WHERE Type = 'TRAIT_CAPITAL_BUILDINGS_CHEAPER';
 
 -- Siam -- adjust Wat

--- a/(2) Vox Populi/Balance Changes/Policies/Exploration/Exploration.sql
+++ b/(2) Vox Populi/Balance Changes/Policies/Exploration/Exploration.sql
@@ -101,7 +101,7 @@ UPDATE Policies
 SET
 	SeaTradeRouteGoldChange = 0,
 	ConquestPerEraBuildingProductionMod = 10,
-	KeepConqueredBuildings = 1;
+	KeepConqueredBuildings = 1
 WHERE Type = 'POLICY_TREASURE_FLEETS';
 
 INSERT INTO Policy_ConquerorYield

--- a/(2) Vox Populi/Balance Changes/Policies/Exploration/Exploration.sql
+++ b/(2) Vox Populi/Balance Changes/Policies/Exploration/Exploration.sql
@@ -100,7 +100,8 @@ WHERE Type = 'POLICY_NAVIGATION_SCHOOL';
 UPDATE Policies
 SET
 	SeaTradeRouteGoldChange = 0,
-	ConquestPerEraBuildingProductionMod = 10
+	ConquestPerEraBuildingProductionMod = 10,
+	KeepConqueredBuildings = 1;
 WHERE Type = 'POLICY_TREASURE_FLEETS';
 
 INSERT INTO Policy_ConquerorYield

--- a/(2) Vox Populi/Balance Changes/Text/en_US/CivText.sql
+++ b/(2) Vox Populi/Balance Changes/Text/en_US/CivText.sql
@@ -956,7 +956,7 @@ WHERE Tag = 'TXT_KEY_MISSION_SELL_EXOTIC_GOODS_HELP';
 -- Rome
 --------------------
 UPDATE Language_en_US
-SET Text = 'When you conquer a City, the City retains all Buildings (including Unique Buildings of other Civilizations) and you immediately acquire additional territory around the City. +15% [ICON_PRODUCTION] Production towards Buildings present in [ICON_CAPITAL] Capital.'
+SET Text = 'City-States can be forcefully annexed if Heavy Tribute can be demanded from them.​ Conquered City States continue to provide rewards. +15% [ICON_PRODUCTION] Production towards Buildings present in [ICON_CAPITAL] Capital.'
 WHERE Tag = 'TXT_KEY_TRAIT_CAPITAL_BUILDINGS_CHEAPER';
 
 UPDATE Language_en_US

--- a/(2) Vox Populi/Balance Changes/Text/en_US/CivText.sql
+++ b/(2) Vox Populi/Balance Changes/Text/en_US/CivText.sql
@@ -798,7 +798,7 @@ INSERT INTO Language_en_US (Tag, Text)
 VALUES ('TXT_KEY_POPUP_MINOR_BULLY_UNIT_AMOUNT_ANNEX', 'Forcefully Annex City-State');
 
 INSERT INTO Language_en_US (Tag, Text)
-VALUES ('TXT_KEY_POP_CSTATE_BULLY_UNIT_TT_ANNEX', 'If this City-State is more [COLOR_POSITIVE_TEXT]afraid[ENDCOLOR] of you than they are [COLOR_WARNING_TEXT]resilient[ENDCOLOR], you can annex the City-State. Doing so will net you [ICON_CULTURE] Culture, [ICON_RESEARCH] Science, [ICON_PRODUCTION] Production, [ICON_PEACE] Faith, or [ICON_FOOD] Food, depending on the City-State being targeted. {1_FearLevel}{2_FactorDetails}');
+VALUES ('TXT_KEY_POP_CSTATE_BULLY_UNIT_TT_ANNEX', 'If this City-State is more [COLOR_POSITIVE_TEXT]afraid[ENDCOLOR] of you than they are [COLOR_WARNING_TEXT]resilient[ENDCOLOR], you can annex the City-State. {1_FearLevel}{2_FactorDetails}');
 
 INSERT INTO Language_en_US (Tag, Text)
 VALUES ('TXT_KEY_BALANCE_ANNEXED_CS_SUMMARY', 'You intimidated {1_CS}!');

--- a/(2) Vox Populi/Balance Changes/Text/en_US/NewText.xml
+++ b/(2) Vox Populi/Balance Changes/Text/en_US/NewText.xml
@@ -164,5 +164,10 @@
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_RESET_PLOT_COST">
 			<Text>Manifest Destiny!</Text>
 		</Row>
+		
+		<!-- Forced City-State Annex (Rome UA) -->
+		<Row Tag="TXT_KEY_CONFIRM_BULLYANNEX">
+			<Text>Are you sure you want to forcefully annex {1_MinorCivName:textkey}?</Text>
+		</Row>
 	</Language_en_US>
 </GameData>

--- a/(2) Vox Populi/Balance Changes/Text/en_US/PolicyText.sql
+++ b/(2) Vox Populi/Balance Changes/Text/en_US/PolicyText.sql
@@ -569,7 +569,7 @@ SET Text = 'Civilizing Mission'
 WHERE Tag = 'TXT_KEY_POLICY_TREASURE_FLEETS';
 
 UPDATE Language_en_US
-SET Text = '[COLOR_POSITIVE_TEXT]Civilizing Mission[ENDCOLOR][NEWLINE]Receive a large sum of [ICON_GOLD] Gold when you conquer a city. [ICON_PUPPET] Puppeted cities and cities with a Courthouse gain +10% [ICON_PRODUCTION] Production towards buildings, with an additional +10% [ICON_PRODUCTION] Production per Era difference between your current Era and the building''s Era.'
+SET Text = '[COLOR_POSITIVE_TEXT]Civilizing Mission[ENDCOLOR][NEWLINE]Receive a large sum of [ICON_GOLD] Gold when you conquer a city. Conquered cities retain all buildings. [ICON_PUPPET] Puppeted cities and cities with a Courthouse gain +10% [ICON_PRODUCTION] Production towards buildings, with an additional +10% [ICON_PRODUCTION] Production per Era difference between your current Era and the building''s Era.'
 WHERE Tag = 'TXT_KEY_POLICY_TREASURE_FLEETS_HELP';
 
 UPDATE Language_en_US

--- a/(2) Vox Populi/Balance Changes/Text/en_US/UIText.xml
+++ b/(2) Vox Populi/Balance Changes/Text/en_US/UIText.xml
@@ -344,6 +344,27 @@
 		<Row Tag="TXT_KEY_CHOOSE_INTERNATIONAL_TRADE_ROUTE_ITEM_TT_YOUR_SCIENCE_GAIN_CS">
 			<Text>Total: {1_Num} [ICON_RESEARCH] Science (due to [ICON_INFLUENCE] Influence over this City-State)</Text>
 		</Row>
+		
+		<!-- Annexed City States -->
+		<Row Tag="TXT_KEY_TP_CULTURE_FROM_ANNEXED_MINORS">
+			<Text>[ICON_BULLET][COLOR_POSITIVE_TEXT]+{1_Num}[ENDCOLOR] from Annexed City-States.</Text>
+		</Row>
+		<Row Tag="TXT_KEY_TP_FAITH_FROM_ANNEXED_MINORS">
+			<Text>[ICON_BULLET][COLOR_POSITIVE_TEXT]+{1_Num}[ENDCOLOR] from Annexed City-States.</Text>
+		</Row>
+		<Row Tag="TXT_KEY_TP_SCIENCE_FROM_ANNEXED_MINORS">
+			<Text>{1_Num} [ICON_RESEARCH] Science from Annexed City-States.</Text>
+		</Row>
+		<Row Tag="TXT_KEY_TP_HAPPINESS_FROM_ANNEXED_MINORS">
+			<Text>[ICON_BULLET][COLOR_POSITIVE_TEXT]+{1_Num}[ENDCOLOR] [ICON_RESEARCH] from Annexed City-States.</Text>
+		</Row>
+		
+		<Row Tag="TXT_KEY_NOTIFICATION_ANNEXED_CITY_STATE_UNIT_SPAWN">
+			<Text>The annexed City-State of {1_CivName:textkey} has given you a new Unit!</Text>
+		</Row>
+		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_ANNEXED_CITY_STATE_UNIT_SPAWN">
+			<Text>New Unit from {1_CivName:textkey}!</Text>
+		</Row>
 
 		<!-- WLTKD LUA -->
 		<Row Tag="TXT_KEY_PRODUCTION_WLTKD_BUILDING">

--- a/(2) Vox Populi/Balance Changes/Text/en_US/UIText.xml
+++ b/(2) Vox Populi/Balance Changes/Text/en_US/UIText.xml
@@ -767,7 +767,7 @@
 			<Text>Demand Relics worth {1_Value} [ICON_PEACE] Faith (-{2_NumInfluence} [ICON_INFLUENCE])</Text>
 		</Row>
 		<Row Tag="TXT_KEY_POP_CSTATE_BULLY_VARIABLE_CBP">
-			<Text>If this City-State is more [COLOR_POSITIVE_TEXT]afraid[ENDCOLOR] of you than they are [COLOR_WARNING_TEXT]resilient[ENDCOLOR], you can take exact heavy tribute from them. Doing so will net you [ICON_CULTURE] Culture, [ICON_RESEARCH] Science, [ICON_PRODUCTION] Production, [ICON_PEACE] Faith, or [ICON_FOOD] Food, depending on the City-State being targeted.[NEWLINE][NEWLINE]The amount you can exact in tribute is based on Game Speed and the Yield output of your Capital. Local Yields, like [ICON_FOOD] Food or [ICON_PRODUCTION] Production, will be delivered to your Capital.[NEWLINE][NEWLINE]{1_FearLevel}{2_FactorDetails}</Text>
+			<Text>If this City-State is more [COLOR_POSITIVE_TEXT]afraid[ENDCOLOR] of you than they are [COLOR_WARNING_TEXT]resilient[ENDCOLOR], you can take heavy tribute from them. Doing so will net you [ICON_CULTURE] Culture, [ICON_RESEARCH] Science, [ICON_PRODUCTION] Production, [ICON_PEACE] Faith, or [ICON_FOOD] Food, depending on the City-State being targeted.[NEWLINE][NEWLINE]The amount you can exact in tribute is based on Game Speed and the Yield output of your Capital. Local Yields, like [ICON_FOOD] Food or [ICON_PRODUCTION] Production, will be delivered to your Capital.[NEWLINE][NEWLINE]{1_FearLevel}{2_FactorDetails}</Text>
 		</Row>
 
 		<!-- City-State Diplo Popup -->

--- a/(2) Vox Populi/Balance Changes/Text/en_US/UIText.xml
+++ b/(2) Vox Populi/Balance Changes/Text/en_US/UIText.xml
@@ -353,10 +353,10 @@
 			<Text>[ICON_BULLET][COLOR_POSITIVE_TEXT]+{1_Num}[ENDCOLOR] from Annexed City-States.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_TP_SCIENCE_FROM_ANNEXED_MINORS">
-			<Text>{1_Num} [ICON_RESEARCH] Science from Annexed City-States.</Text>
+			<Text>[ICON_BULLET][COLOR_POSITIVE_TEXT]+{1_Num}[ENDCOLOR] [ICON_RESEARCH] from Annexed City-States.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_TP_HAPPINESS_FROM_ANNEXED_MINORS">
-			<Text>[ICON_BULLET][COLOR_POSITIVE_TEXT]+{1_Num}[ENDCOLOR] [ICON_RESEARCH] from Annexed City-States.</Text>
+			<Text>+{1_Num} from Annexed City-States.</Text>
 		</Row>
 		
 		<Row Tag="TXT_KEY_NOTIFICATION_ANNEXED_CITY_STATE_UNIT_SPAWN">

--- a/(2) Vox Populi/LUA/CityBannerManager.lua
+++ b/(2) Vox Populi/LUA/CityBannerManager.lua
@@ -108,9 +108,9 @@ function RefreshCityBanner(cityBanner, iActiveTeam, iActivePlayer)
 	local bHasDiplomat = false;
 	local strSpyName = nil;
 	local strSpyRank = nil;
-	local isAutomated = city:IsProductionAutomated() and player:IsHuman() and not city:IsPuppet();
 	
 	if(city ~= nil) then
+		local isAutomated = city:IsProductionAutomated() and player:IsHuman() and not city:IsPuppet();
 		local cityX = city:GetX();
 		local cityY = city:GetY();
 		

--- a/(2) Vox Populi/LUA/CityStateDiploPopup.lua
+++ b/(2) Vox Populi/LUA/CityStateDiploPopup.lua
@@ -28,6 +28,9 @@ local kiGiftedGold = 4;
 local kiPledgedToProtect = 5;
 local kiDeclaredWar = 6;
 local kiRevokedProtection = 7;
+-- CBP
+local kiBullyAnnexed = 8
+-- END
 local m_iLastAction = kiNoAction;
 local m_iPendingAction = kiNoAction; -- For bullying dialog popups
 
@@ -1117,28 +1120,24 @@ function PopulateTakeChoices()
 	local iTheftValue = 0;
 	local pMajor = Players[iActivePlayer];
 	local sBullyUnit = GameInfo.Units[pPlayer:GetBullyUnit()].Description; --antonjs: todo: XML or fn
-	if(pMajor:IsBullyAnnex()) then
-		buttonText = Locale.Lookup("TXT_KEY_POPUP_MINOR_BULLY_UNIT_AMOUNT_ANNEX");
+	if(pPlayer:GetMinorCivTrait() == MinorCivTraitTypes.MINOR_CIV_TRAIT_MARITIME) then
+		iTheftValue = pPlayer:GetYieldTheftAmount(iActivePlayer, YieldTypes.YIELD_FOOD);
+		buttonText = Locale.Lookup("TXT_KEY_POPUP_MINOR_BULLY_FOOD_AMOUNT", iTheftValue, iBullyUnitInfluenceLost);
+	elseif(pPlayer:GetMinorCivTrait() == MinorCivTraitTypes.MINOR_CIV_TRAIT_CULTURED) then
+		iTheftValue = pPlayer:GetYieldTheftAmount(iActivePlayer, YieldTypes.YIELD_CULTURE);
+		buttonText = Locale.Lookup("TXT_KEY_POPUP_MINOR_BULLY_CULTURE_AMOUNT", iTheftValue, iBullyUnitInfluenceLost);
+	elseif(pPlayer:GetMinorCivTrait() == MinorCivTraitTypes.MINOR_CIV_TRAIT_MILITARISTIC) then
+		iTheftValue = pPlayer:GetYieldTheftAmount(iActivePlayer, YieldTypes.YIELD_SCIENCE);
+		buttonText = Locale.Lookup("TXT_KEY_POPUP_MINOR_BULLY_SCIENCE_AMOUNT", iTheftValue, iBullyUnitInfluenceLost);
+	elseif(pPlayer:GetMinorCivTrait() == MinorCivTraitTypes.MINOR_CIV_TRAIT_MERCANTILE) then
+		iTheftValue = pPlayer:GetYieldTheftAmount(iActivePlayer, YieldTypes.YIELD_PRODUCTION);
+		buttonText = Locale.Lookup("TXT_KEY_POPUP_MINOR_BULLY_PRODUCTION_AMOUNT", iTheftValue, iBullyUnitInfluenceLost);
+	elseif(pPlayer:GetMinorCivTrait() == MinorCivTraitTypes.MINOR_CIV_TRAIT_RELIGIOUS) then
+		iTheftValue = pPlayer:GetYieldTheftAmount(iActivePlayer, YieldTypes.YIELD_FAITH);
+		buttonText = Locale.Lookup("TXT_KEY_POPUP_MINOR_BULLY_FAITH_AMOUNT", iTheftValue, iBullyUnitInfluenceLost);
 	else
-		if(pPlayer:GetMinorCivTrait() == MinorCivTraitTypes.MINOR_CIV_TRAIT_MARITIME) then
-			iTheftValue = pPlayer:GetYieldTheftAmount(iActivePlayer, YieldTypes.YIELD_FOOD);
-			buttonText = Locale.Lookup("TXT_KEY_POPUP_MINOR_BULLY_FOOD_AMOUNT", iTheftValue, iBullyUnitInfluenceLost);
-		elseif(pPlayer:GetMinorCivTrait() == MinorCivTraitTypes.MINOR_CIV_TRAIT_CULTURED) then
-			iTheftValue = pPlayer:GetYieldTheftAmount(iActivePlayer, YieldTypes.YIELD_CULTURE);
-			buttonText = Locale.Lookup("TXT_KEY_POPUP_MINOR_BULLY_CULTURE_AMOUNT", iTheftValue, iBullyUnitInfluenceLost);
-		elseif(pPlayer:GetMinorCivTrait() == MinorCivTraitTypes.MINOR_CIV_TRAIT_MILITARISTIC) then
-			iTheftValue = pPlayer:GetYieldTheftAmount(iActivePlayer, YieldTypes.YIELD_SCIENCE);
-			buttonText = Locale.Lookup("TXT_KEY_POPUP_MINOR_BULLY_SCIENCE_AMOUNT", iTheftValue, iBullyUnitInfluenceLost);
-		elseif(pPlayer:GetMinorCivTrait() == MinorCivTraitTypes.MINOR_CIV_TRAIT_MERCANTILE) then
-			iTheftValue = pPlayer:GetYieldTheftAmount(iActivePlayer, YieldTypes.YIELD_PRODUCTION);
-			buttonText = Locale.Lookup("TXT_KEY_POPUP_MINOR_BULLY_PRODUCTION_AMOUNT", iTheftValue, iBullyUnitInfluenceLost);
-		elseif(pPlayer:GetMinorCivTrait() == MinorCivTraitTypes.MINOR_CIV_TRAIT_RELIGIOUS) then
-			iTheftValue = pPlayer:GetYieldTheftAmount(iActivePlayer, YieldTypes.YIELD_FAITH);
-			buttonText = Locale.Lookup("TXT_KEY_POPUP_MINOR_BULLY_FAITH_AMOUNT", iTheftValue, iBullyUnitInfluenceLost);
-		else
-			buttonText = Locale.Lookup("TXT_KEY_POPUP_MINOR_BULLY_UNIT_AMOUNT", sBullyUnit, iBullyUnitInfluenceLost);
-		end	
-	end
+		buttonText = Locale.Lookup("TXT_KEY_POPUP_MINOR_BULLY_UNIT_AMOUNT", sBullyUnit, iBullyUnitInfluenceLost);
+	end	
 -- END
 	ttText = pPlayer:GetMajorBullyUnitDetails(iActivePlayer);
 	if (not pPlayer:CanMajorBullyUnit(iActivePlayer)) then
@@ -1151,6 +1150,23 @@ function PopulateTakeChoices()
 	Controls.UnitTributeButton:SetToolTipString(ttText);
 	SetButtonSize(Controls.UnitTributeLabel, Controls.UnitTributeButton, Controls.UnitTributeAnim, Controls.UnitTributeButtonHL);
 	
+-- CBP: Forced Annex
+	if(pMajor:IsBullyAnnex()) then
+		buttonText = Locale.Lookup("TXT_KEY_POPUP_MINOR_BULLY_UNIT_AMOUNT_ANNEX");
+		Controls.BullyAnnexButton:SetHide(false);
+		if not pPlayer:CanMajorBullyUnit(activePlayerID) then
+			buttonText = "[COLOR_WARNING_TEXT]" .. buttonText .. "[ENDCOLOR]"
+			Controls.BullyAnnexAnim:SetHide(true)
+		else
+			Controls.BullyAnnexAnim:SetHide(false)
+		end
+		Controls.BullyAnnexLabel:SetText(buttonText)
+		Controls.BullyAnnexButton:SetToolTipString(ttText)
+		SetButtonSize(Controls.BullyAnnexLabel, Controls.BullyAnnexButton, Controls.BullyAnnexAnim, Controls.BullyAnnexButtonHL)
+	else
+		Controls.BullyAnnexButton:SetHide(true);
+	end
+-- END
 	UpdateButtonStack();
 end
 
@@ -1200,6 +1216,17 @@ function OnBullyButtonClicked ()
 end
 
 ----------------------------------------------------------------
+-- Forced Annex confirmation
+----------------------------------------------------------------
+function OnBullyAnnexButtonClicked ()
+	local cityStateName = Locale.Lookup(pMinor:GetCivilizationShortDescriptionKey());
+	local bullyConfirmString = Locale.ConvertTextKey("TXT_KEY_CONFIRM_BULLYANNEX", cityStateName);
+	Controls.BullyConfirmLabel:SetText( bullyConfirmString );
+	Controls.BullyConfirm:SetHide(false);
+	Controls.BGBlock:SetHide(true);
+end
+
+----------------------------------------------------------------
 -- Take Gold
 ----------------------------------------------------------------
 function OnGoldTributeButtonClicked()
@@ -1228,6 +1255,21 @@ function OnUnitTributeButtonClicked()
 	end
 end
 Controls.UnitTributeButton:RegisterCallback( Mouse.eLClick, OnUnitTributeButtonClicked );
+
+----------------------------------------------------------------
+-- CBP: Forced Annex (Rome UA)
+----------------------------------------------------------------
+function OnBullyAnnexButtonClicked()
+	local pPlayer = Players[g_iMinorCivID];
+	local iActivePlayer = Game.GetActivePlayer();
+	
+	if (pPlayer:CanMajorBullyUnit(iActivePlayer)) then
+		m_iPendingAction = kiBullyAnnexed;
+		OnForcedAnnexButtonClicked();
+		OnCloseTake();
+	end
+end
+Controls.BullyAnnexButton:RegisterCallback( Mouse.eLClick, OnBullyAnnexButtonClicked );
 
 ----------------------------------------------------------------
 -- Close Take Submenu

--- a/(2) Vox Populi/LUA/CityStateDiploPopup.lua
+++ b/(2) Vox Populi/LUA/CityStateDiploPopup.lua
@@ -1152,6 +1152,7 @@ function PopulateTakeChoices()
 	
 -- CBP: Forced Annex
 	if(pMajor:IsBullyAnnex()) then
+		ttText = pPlayer:GetMajorBullyAnnexDetails(iActivePlayer);
 		buttonText = Locale.Lookup("TXT_KEY_POPUP_MINOR_BULLY_UNIT_AMOUNT_ANNEX");
 		Controls.BullyAnnexButton:SetHide(false);
 		if not pPlayer:CanMajorBullyUnit(activePlayerID) then

--- a/(2) Vox Populi/LUA/CityStateDiploPopup.lua
+++ b/(2) Vox Populi/LUA/CityStateDiploPopup.lua
@@ -1217,7 +1217,7 @@ function OnBullyButtonClicked ()
 end
 
 ----------------------------------------------------------------
--- Forced Annex confirmation
+-- CBP: Forced Annex confirmation
 ----------------------------------------------------------------
 function OnForcedAnnexButtonClicked ()
     local pMinor = Players[g_iMinorCivID];
@@ -1310,6 +1310,7 @@ function OnYesBully( )
 		m_iPendingAction = kiNoAction;
 		m_iLastAction = kiBullyAnnexed;
 		Game.DoMinorBullyAnnex(iActivePlayer, g_iMinorCivID);
+-- END
 	else
 		print("Scripting error - Selected Yes for bully confirmation dialog, but invalid PendingAction type");
 	end

--- a/(2) Vox Populi/LUA/CityStateDiploPopup.lua
+++ b/(2) Vox Populi/LUA/CityStateDiploPopup.lua
@@ -1218,7 +1218,8 @@ end
 ----------------------------------------------------------------
 -- Forced Annex confirmation
 ----------------------------------------------------------------
-function OnBullyAnnexButtonClicked ()
+function OnForcedAnnexButtonClicked ()
+    local pMinor = Players[g_iMinorCivID];
 	local cityStateName = Locale.Lookup(pMinor:GetCivilizationShortDescriptionKey());
 	local bullyConfirmString = Locale.ConvertTextKey("TXT_KEY_CONFIRM_BULLYANNEX", cityStateName);
 	Controls.BullyConfirmLabel:SetText( bullyConfirmString );
@@ -1302,8 +1303,14 @@ function OnYesBully( )
 		m_iLastAction = kiBulliedUnit;
 -- END
 		Game.DoMinorBullyUnit(iActivePlayer, g_iMinorCivID);
+-- CBP
+	elseif (m_iPendingAction == kiBullyAnnexed) then
+		OnCloseButtonClicked();
+		m_iPendingAction = kiNoAction;
+		m_iLastAction = kiBullyAnnexed;
+		Game.DoMinorBullyAnnex(iActivePlayer, g_iMinorCivID);
 	else
-		print("Scripting error - Selected Yes for bully confrirmation dialog, but invalid PendingAction type");
+		print("Scripting error - Selected Yes for bully confirmation dialog, but invalid PendingAction type");
 	end
 
 	Controls.BullyConfirm:SetHide(true);

--- a/(2) Vox Populi/LUA/CityStateDiploPopup.xml
+++ b/(2) Vox Populi/LUA/CityStateDiploPopup.xml
@@ -314,6 +314,16 @@
               </AlphaAnim>
             </ShowOnMouseOver>
           </Button>
+		  <!-- FORCED ANNEX BUTTON-->
+          <Button Size="500,32" Anchor="C,C" Offset="0,0" ID="BullyAnnexButton" ToolTip="">
+            <Label Anchor="C,C" Offset="0,0" ID="BullyAnnexLabel" />
+            <Image Anchor="C,B" Offset="0,0" Texture="bar500x2.dds" Size="500.1"/>
+            <ShowOnMouseOver>
+              <AlphaAnim ID="BullyAnnexAnim" Anchor="C,C" Offset="0,0" Size="500,35" Pause="0" Cycle="Bounce" Speed="1" AlphaStart="2" AlphaEnd="1">
+                <Grid ID="BullyAnnexButtonHL" Size="500,35" Offset="0,0" Padding="0,0" Style="Grid9FrameTurnsHL"/>
+              </AlphaAnim>
+            </ShowOnMouseOver>
+          </Button>
           <!-- EXIT TAKE BUTTON (Back to Main Menu)-->
           <Button Size="500,32" Hidden="0" Anchor="C,C" Offset="0,0" ID="ExitTakeButton">
             <Label Anchor="C,C" Offset="0,0" String="TXT_KEY_BACK_BUTTON"/>

--- a/(2) Vox Populi/LUA/TopPanel.lua
+++ b/(2) Vox Populi/LUA/TopPanel.lua
@@ -1183,6 +1183,7 @@ function CultureTipHandler( control )
 			strText = strText .. "[NEWLINE]";
 			strText = strText .. Locale.ConvertTextKey("TXT_KEY_TP_CULTURE_FROM_ANNEXED_MINORS", iCultureFromAnnexedMinors);
 		end
+-- END
 
 		-- Culture from Religion
 		local iCultureFromReligion = pPlayer:GetCulturePerTurnFromReligion();

--- a/(2) Vox Populi/LUA/TopPanel.lua
+++ b/(2) Vox Populi/LUA/TopPanel.lua
@@ -543,7 +543,22 @@ function ScienceTipHandler( control )
 	
 			strText = strText .. Locale.ConvertTextKey("TXT_KEY_MINOR_SCIENCE_FROM_LEAGUE_ALLIES", iScienceFromAllies);
 		end
-
+		
+-- CBP
+		-- Science from Annexed Minors
+		local iScienceFromAnnexedMinors = pPlayer:GetSciencePerTurnFromAnnexedMinors();
+		if (iScienceFromAnnexedMinors ~= 0) then
+		
+			-- Add separator for non-initial entries
+			if (bFirstEntry) then
+				bFirstEntry = false;
+			else
+				strText = strText .. "[NEWLINE]";
+			end
+	
+			strText = strText .. Locale.ConvertTextKey("TXT_KEY_TP_SCIENCE_FROM_ANNEXED_MINORS", iScienceFromAnnexedMinors);
+		end
+-- END
 		-- Science from Funding from League (CSD MOD)
 		local iScienceFromLeague = pPlayer:GetScienceRateFromLeagueAid();
 		if (iScienceFromLeague ~= 0) then
@@ -828,6 +843,11 @@ function HappinessTipHandler( control )
 			local CityStateHappiness = pPlayer:GetHappinessFromMinorCivs();
 			if (CityStateHappiness ~= 0) then
 				strText = strText .. "[NEWLINE][ICON_BULLET]" .. Locale.ConvertTextKey("TXT_KEY_TP_HAPPINESS_CITY_STATE_FRIENDSHIP", CityStateHappiness);
+			end
+			
+			local AnnexedMinorsHappiness = pPlayer:GetHappinessFromAnnexedMinors();
+			if (AnnexedMinorsHappiness ~= 0) then
+				strText = strText .. "[NEWLINE][ICON_BULLET]" .. Locale.ConvertTextKey("TXT_KEY_TP_HAPPINESS_FROM_ANNEXED_MINORS", AnnexedMinorsHappiness);
 			end
 
 			local VassalHappiness = pPlayer:GetHappinessFromVassals();
@@ -1148,6 +1168,21 @@ function CultureTipHandler( control )
 			strText = strText .. "[NEWLINE]";
 			strText = strText .. Locale.ConvertTextKey("TXT_KEY_TP_CULTURE_FROM_MINORS", iCultureFromMinors);
 		end
+		
+-- CBP
+		-- Culture from Annexed Minors
+		local iCultureFromAnnexedMinors = pPlayer:GetCulturePerTurnFromAnnexedMinors();
+		if (iCultureFromAnnexedMinors ~= 0) then
+		
+			-- Add separator for non-initial entries
+			if (bFirstEntry) then
+				strText = strText .. "[NEWLINE]";
+				bFirstEntry = false;
+			end
+
+			strText = strText .. "[NEWLINE]";
+			strText = strText .. Locale.ConvertTextKey("TXT_KEY_TP_CULTURE_FROM_ANNEXED_MINORS", iCultureFromAnnexedMinors);
+		end
 
 		-- Culture from Religion
 		local iCultureFromReligion = pPlayer:GetCulturePerTurnFromReligion();
@@ -1286,6 +1321,14 @@ function FaithTipHandler( control )
 			strText = strText .. "[NEWLINE]";
 			strText = strText .. Locale.ConvertTextKey("TXT_KEY_TP_FAITH_FROM_MINORS", iFaithFromMinorCivs);
 		end
+-- CBP
+		-- Faith from Annexed Minors
+		local iFaithFromAnnexedMinors = pPlayer:GetFaithPerTurnFromAnnexedMinors();
+		if (iFaithFromAnnexedMinors ~= 0) then
+			strText = strText .. "[NEWLINE]";
+			strText = strText .. Locale.ConvertTextKey("TXT_KEY_TP_FAITH_FROM_ANNEXED_MINORS", iFaithFromAnnexedMinors);
+		end
+-- END
 
 		-- Faith from Religion
 		local iFaithFromReligion = pPlayer:GetFaithPerTurnFromReligion();

--- a/(3a) EUI Compatibility Files/ImprovedTopPanel/TopPanel.lua
+++ b/(3a) EUI Compatibility Files/ImprovedTopPanel/TopPanel.lua
@@ -1039,6 +1039,8 @@ g_toolTipHandler.SciencePerTurn = function()-- control )
 				tips:insertLocalizedIfNonZero( "TXT_KEY_SCIENCE_FUNDING_FROM_LEAGUE", g_activePlayer:GetScienceRateFromLeagueAid() )
 			end
 -- CBP 
+			-- Science from Annexed Minors
+			tips:insertLocalizedIfNonZero( "TXT_KEY_TP_SCIENCE_FROM_ANNEXED_MINORS", g_activePlayer:GetSciencePerTurnFromAnnexedMinors())
 			-- Putmalk
 			local g_bAllowResearchAgreements = Game.IsOption("GAMEOPTION_RESEARCH_AGREEMENTS")
 			-- Science from Religion
@@ -1407,6 +1409,7 @@ if civ5_mode then
 			local MilitaryUnitHappiness = g_activePlayer:GetHappinessFromMilitaryUnits();
 			local CityConnectionHappiness = g_activePlayer:GetHappinessFromTradeRoutes();
 			local CityStateHappiness = g_activePlayer:GetHappinessFromMinorCivs();
+			local HappinessFromAnnexedMinors = g_activePlayer:GetHappinessFromAnnexedMinors();
 			local VassalHappiness = g_activePlayer:GetHappinessFromVassals();
 			local HandicapHappiness = g_activePlayer:GetHandicapHappiness();
 
@@ -1419,6 +1422,7 @@ if civ5_mode then
 			tips:insertLocalizedBulletIfNonZero( "TXT_KEY_TP_HAPPINESS_MILITARY_UNITS", MilitaryUnitHappiness )
 			tips:insertLocalizedBulletIfNonZero( "TXT_KEY_TP_HAPPINESS_CONNECTED_CITIES", CityConnectionHappiness )
 			tips:insertLocalizedBulletIfNonZero( "TXT_KEY_TP_HAPPINESS_CITY_STATE_FRIENDSHIP", CityStateHappiness )
+			tips:insertLocalizedBulletIfNonZero( "TXT_KEY_TP_HAPPINESS__FROM_ANNEXED_MINORS", HappinessFromAnnexedMinors )
 			tips:insertLocalizedBulletIfNonZero( "TXT_KEY_TP_HAPPINESS_VASSALS", VassalHappiness )
     		tips:insertLocalizedBulletIfNonZero( "TXT_KEY_TP_HAPPINESS_DIFFICULTY_LEVEL", HandicapHappiness )
 			tips:insertLocalizedBulletIfNonZero( "TXT_KEY_TP_HAPPINESS_CITY_LOCAL", LocalCityHappiness )
@@ -1833,6 +1837,12 @@ g_toolTipHandler.CultureString = function()-- control )
 			local culturePerTurnFromMinorCivs = g_activePlayer:GetCulturePerTurnFromMinorCivs()
 			tips:insertLocalizedIfNonZero( "TXT_KEY_TP_CULTURE_FROM_MINORS", culturePerTurnFromMinorCivs )
 
+-- CBP
+			-- Culture from Annexed Minors
+			local culturePerTurnFromAnnexedMinors = g_activePlayer:GetCulturePerTurnFromAnnexedMinors()
+			tips:insertLocalizedIfNonZero( "TXT_KEY_TP_CULTURE_FROM_ANNEXED_MINORS", culturePerTurnFromAnnexedMinors )
+-- END
+
 			-- Culture from Religion
 			local culturePerTurnFromReligion = gk_mode and g_activePlayer:GetCulturePerTurnFromReligion() or 0
 			tips:insertLocalizedIfNonZero( "TXT_KEY_TP_CULTURE_FROM_RELIGION", culturePerTurnFromReligion )
@@ -1915,7 +1925,11 @@ if civ5_mode and gk_mode then
 
 			-- Faith from Minor Civs
 			tips:insertLocalizedIfNonZero( "TXT_KEY_TP_FAITH_FROM_MINORS", g_activePlayer:GetFaithPerTurnFromMinorCivs() )
-
+			
+-- CBP
+			-- Faith from Minor Civs
+			tips:insertLocalizedIfNonZero( "TXT_KEY_TP_FAITH_FROM_ANNEXED_MINORS", g_activePlayer:GetFaithPerTurnFromAnnexedMinors() )
+-- END
 			-- Faith from Religion
 			tips:insertLocalizedIfNonZero( "TXT_KEY_TP_FAITH_FROM_RELIGION", g_activePlayer:GetFaithPerTurnFromReligion() )
 

--- a/(3a) EUI Compatibility Files/LUA/CityStateDiploPopup.lua
+++ b/(3a) EUI Compatibility Files/LUA/CityStateDiploPopup.lua
@@ -1220,6 +1220,7 @@ function PopulateTakeChoices()
 
 -- CBP: Forced Annex
 	if(pMajor:IsBullyAnnex()) then
+		ttText = minorPlayer:GetMajorBullyAnnexDetails(activePlayerID)
 		buttonText = Locale.Lookup("TXT_KEY_POPUP_MINOR_BULLY_UNIT_AMOUNT_ANNEX");
 		Controls.BullyAnnexButton:SetHide(false);
 		if not minorPlayer:CanMajorBullyUnit(activePlayerID) then

--- a/(3a) EUI Compatibility Files/LUA/CityStateDiploPopup.lua
+++ b/(3a) EUI Compatibility Files/LUA/CityStateDiploPopup.lua
@@ -1364,6 +1364,9 @@ function OnYesBully( )
 		if not gk_mode then
 			Network.SendPledgeMinorProtection( g_minorCivID, false ) -- does not seem to work in 1.0.3.144
 		end
+	elseif (m_iPendingAction == kiBullyAnnexed) then
+		OnCloseButtonClicked();
+		Game.DoMinorBullyAnnex(activePlayerID, g_minorCivID);
 	else
 		print("Scripting error - Selected Yes for bully confirmation dialog, with invalid PendingAction type")
 	end

--- a/(3a) EUI Compatibility Files/LUA/CityStateDiploPopup.lua
+++ b/(3a) EUI Compatibility Files/LUA/CityStateDiploPopup.lua
@@ -1272,7 +1272,7 @@ function BullyAction( action )
 		else
 			bullyConfirmString = cityStateName .. ": " .. L("TXT_KEY_CONFIRM_WAR")
 		end
-	else if action == kiBullyAnnexed then
+	elseif action == kiBullyAnnexed then
 		bullyConfirmString = L("TXT_KEY_CONFIRM_BULLYANNEX", cityStateName) 
 	else
 		if #listofProtectingCivs == 1 then
@@ -1365,7 +1365,7 @@ function OnYesBully( )
 		if not gk_mode then
 			Network.SendPledgeMinorProtection( g_minorCivID, false ) -- does not seem to work in 1.0.3.144
 		end
-	elseif (m_iPendingAction == kiBullyAnnexed) then
+	elseif m_pendingAction == kiBullyAnnexed then
 		OnCloseButtonClicked();
 		Game.DoMinorBullyAnnex(activePlayerID, g_minorCivID);
 	else

--- a/(3a) EUI Compatibility Files/LUA/CityStateDiploPopup.lua
+++ b/(3a) EUI Compatibility Files/LUA/CityStateDiploPopup.lua
@@ -1365,9 +1365,11 @@ function OnYesBully( )
 		if not gk_mode then
 			Network.SendPledgeMinorProtection( g_minorCivID, false ) -- does not seem to work in 1.0.3.144
 		end
+-- CBP
 	elseif m_pendingAction == kiBullyAnnexed then
 		OnCloseButtonClicked();
 		Game.DoMinorBullyAnnex(activePlayerID, g_minorCivID);
+-- END
 	else
 		print("Scripting error - Selected Yes for bully confirmation dialog, with invalid PendingAction type")
 	end

--- a/(3a) EUI Compatibility Files/LUA/CityStateDiploPopup.xml
+++ b/(3a) EUI Compatibility Files/LUA/CityStateDiploPopup.xml
@@ -316,6 +316,16 @@
               </AlphaAnim>
             </ShowOnMouseOver>
           </Button>
+		  <!-- FORCED ANNEX BUTTON-->
+          <Button Size="500,32" Anchor="C,C" Offset="0,0" ID="BullyAnnexButton" ToolTip="">
+            <Label Anchor="C,C" ID="BullyAnnexLabel" />
+            <Image Anchor="C,B" Texture="bar500x2.dds" Size="500.1"/>
+            <ShowOnMouseOver>
+              <AlphaAnim ID="BullyAnnexAnim" Anchor="C,C" Size="500,35" Pause="0" Cycle="Bounce" Speed="1" AlphaStart="2" AlphaEnd="1">
+                <Grid ID="BullyAnnexButtonHL" Size="500,35" Style="Grid9FrameTurnsHL"/>
+              </AlphaAnim>
+            </ShowOnMouseOver>
+          </Button>
           <!-- EXIT TAKE BUTTON (Back to Main Menu)-->
           <Button Size="500,32" Anchor="C,C" ID="ExitTakeButton">
             <Label Anchor="C,C" String="TXT_KEY_BACK_BUTTON"/>

--- a/CvGameCoreDLL_Expansion2/CvBuildingClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuildingClasses.cpp
@@ -5355,7 +5355,7 @@ void CvCityBuildings::SetBuildingYieldChange(BuildingClassTypes eBuildingClass, 
 
 				BuildingTypes eBuilding = NO_BUILDING;
 
-				if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || GET_PLAYER(m_pCity->getOwner()).GetPlayerTraits()->IsKeepConqueredBuildings())
+				if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 				{
 					eBuilding = GetBuildingTypeFromClass(eBuildingClass);
 				}
@@ -5386,7 +5386,7 @@ void CvCityBuildings::SetBuildingYieldChange(BuildingClassTypes eBuildingClass, 
 
 		BuildingTypes eBuilding = NO_BUILDING;
 
-		if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || GET_PLAYER(m_pCity->getOwner()).GetPlayerTraits()->IsKeepConqueredBuildings())
+		if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 		{
 			eBuilding = GetBuildingTypeFromClass(eBuildingClass);
 		}
@@ -5574,7 +5574,7 @@ bool CvCityBuildings::GetNextAvailableGreatWorkSlot(BuildingClassTypes *eBuildin
 			BuildingClassTypes eLoopBuildingClass = (BuildingClassTypes) iI;
 			BuildingTypes eBuilding = NO_BUILDING;
 
-			if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || GET_PLAYER(m_pCity->getOwner()).GetPlayerTraits()->IsKeepConqueredBuildings())
+			if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 			{
 				eBuilding = GetBuildingTypeFromClass(eLoopBuildingClass);
 			}
@@ -5614,7 +5614,7 @@ bool CvCityBuildings::GetNextAvailableGreatWorkSlot(GreatWorkSlotType eGreatWork
 			BuildingClassTypes eLoopBuildingClass = (BuildingClassTypes) iI;
 			BuildingTypes eBuilding = NO_BUILDING;
 
-			if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || GET_PLAYER(m_pCity->getOwner()).GetPlayerTraits()->IsKeepConqueredBuildings())
+			if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 			{
 				eBuilding = GetBuildingTypeFromClass(eLoopBuildingClass);
 			}
@@ -5817,7 +5817,7 @@ int CvCityBuildings::GetNumGreatWorks() const
 			{
 				BuildingTypes eBuilding = NO_BUILDING;
 
-				if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || GET_PLAYER(m_pCity->getOwner()).GetPlayerTraits()->IsKeepConqueredBuildings())
+				if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 				{
 					eBuilding = GetBuildingTypeFromClass(eBldgClass);
 				}
@@ -5870,7 +5870,7 @@ int CvCityBuildings::GetNumGreatWorks(GreatWorkSlotType eGreatWorkSlot) const
 			{
 				BuildingTypes eBuilding = NO_BUILDING;
 
-				if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || GET_PLAYER(m_pCity->getOwner()).GetPlayerTraits()->IsKeepConqueredBuildings())
+				if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 				{
 
 					eBuilding = GetBuildingTypeFromClass(eBldgClass);

--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -671,7 +671,6 @@ void CvCity::init(int iID, PlayerTypes eOwner, int iX, int iY, bool bBumpUnits, 
 
 	// Free Buildings
 	const CvCivilizationInfo& thisCiv = getCivilizationInfo();
-	bool bRome = GET_PLAYER(getOwner()).GetPlayerTraits()->IsKeepConqueredBuildings();
 	for (int iBuildingClassLoop = 0; iBuildingClassLoop < GC.getNumBuildingClassInfos(); iBuildingClassLoop++)
 	{
 		const BuildingClassTypes eBuildingClass = static_cast<BuildingClassTypes>(iBuildingClassLoop);
@@ -693,17 +692,6 @@ void CvCity::init(int iID, PlayerTypes eOwner, int iX, int iY, bool bBumpUnits, 
 				CvBuildingEntry* pkBuildingInfo = GC.getBuildingInfo(eBuilding);
 				if (pkBuildingInfo)
 				{
-					if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome)
-					{
-						if (HasBuildingClass(eBuildingClass))
-						{
-							// for Rome, replace the building type with the same, unless we have our own unique building
-							if ((bRome && pkBuildingClassInfo->getDefaultBuildingIndex() != (int)eBuilding))
-							{
-								eBuilding = GetCityBuildings()->GetBuildingTypeFromClass(eBuildingClass);
-							}
-						}
-					}
 					if (isValidBuildingLocation(eBuilding))
 					{
 						if (GetCityBuildings()->GetNumRealBuilding(eBuilding) > 0)
@@ -2565,7 +2553,7 @@ void CvCity::doTurn()
 								}
 
 								BuildingTypes eResourceBuilding = NO_BUILDING;
-								if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || GET_PLAYER(getOwner()).GetPlayerTraits()->IsKeepConqueredBuildings())
+								if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 								{
 									eResourceBuilding = GetCityBuildings()->GetBuildingTypeFromClass(eBuildingClass);
 								}
@@ -5141,7 +5129,7 @@ void CvCity::DoCancelEventChoice(CityEventChoiceTypes eChosenEventChoice)
 						if (pCivilizationInfo != NULL)
 						{
 							BuildingTypes eBuildingType = NO_BUILDING;
-							if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || GET_PLAYER(getOwner()).GetPlayerTraits()->IsKeepConqueredBuildings())
+							if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 							{
 								eBuildingType = GetCityBuildings()->GetBuildingTypeFromClass(eBuildingClass);
 							}
@@ -5218,8 +5206,7 @@ void CvCity::DoCancelEventChoice(CityEventChoiceTypes eChosenEventChoice)
 					if (pkEventChoiceInfo->getBuildingClassYield(eBuildingClass, eYield) != 0)
 					{
 						BuildingTypes eBuilding = NO_BUILDING;
-						bool bRome = GET_PLAYER(getOwner()).GetPlayerTraits()->IsKeepConqueredBuildings();
-						if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome)
+						if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 						{
 							eBuilding = GetCityBuildings()->GetBuildingTypeFromClass(eBuildingClass);
 						}
@@ -5234,7 +5221,7 @@ void CvCity::DoCancelEventChoice(CityEventChoiceTypes eChosenEventChoice)
 							if (pkBuilding)
 							{
 								ChangeEventBuildingClassYield(eBuildingClass, eYield, pkEventChoiceInfo->getBuildingClassYield(eBuildingClass, eYield) * -1);
-								if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome || GetCityBuildings()->GetNumBuilding(eBuilding) > 0)
+								if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || GetCityBuildings()->GetNumBuilding(eBuilding) > 0)
 								{
 									ChangeBaseYieldRateFromBuildings(eYield, pkEventChoiceInfo->getBuildingClassYield(eBuildingClass, eYield) * -1);
 									bChanged = true;
@@ -5245,8 +5232,7 @@ void CvCity::DoCancelEventChoice(CityEventChoiceTypes eChosenEventChoice)
 					if (pkEventChoiceInfo->getBuildingClassYieldModifier(eBuildingClass, eYield) != 0)
 					{
 						BuildingTypes eBuilding = NO_BUILDING;
-						bool bRome = GET_PLAYER(getOwner()).GetPlayerTraits()->IsKeepConqueredBuildings();
-						if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome)
+						if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 						{
 							eBuilding = GetCityBuildings()->GetBuildingTypeFromClass(eBuildingClass);
 						}
@@ -5262,7 +5248,7 @@ void CvCity::DoCancelEventChoice(CityEventChoiceTypes eChosenEventChoice)
 							{
 								ChangeEventBuildingClassYieldModifier(eBuildingClass, eYield, pkEventChoiceInfo->getBuildingClassYieldModifier(eBuildingClass, eYield) * -1);
 								bChanged = true;
-								if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome || GetCityBuildings()->GetNumBuilding(eBuilding) > 0)
+								if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || GetCityBuildings()->GetNumBuilding(eBuilding) > 0)
 								{
 									changeYieldRateModifier(eYield, pkEventChoiceInfo->getBuildingClassYieldModifier(eBuildingClass, eYield) * -1);
 								}
@@ -6368,7 +6354,7 @@ CvString CvCity::GetDisabledTooltip(CityEventChoiceTypes eChosenEventChoice, int
 				if (pCivilizationInfo != NULL)
 				{
 					BuildingTypes eBuildingType = NO_BUILDING;
-					if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || GET_PLAYER(getOwner()).GetPlayerTraits()->IsKeepConqueredBuildings())
+					if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 					{
 						eBuildingType = GetCityBuildings()->GetBuildingTypeFromClass(eBuilding);
 					}
@@ -6947,7 +6933,7 @@ void CvCity::DoEventChoice(CityEventChoiceTypes eEventChoice, CityEventTypes eCi
 						if (pCivilizationInfo != NULL)
 						{
 							BuildingTypes eBuildingType = NO_BUILDING;
-							if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || GET_PLAYER(getOwner()).GetPlayerTraits()->IsKeepConqueredBuildings())
+							if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 							{
 								eBuildingType = GetCityBuildings()->GetBuildingTypeFromClass(eBuildingClass);
 							}
@@ -7001,7 +6987,7 @@ void CvCity::DoEventChoice(CityEventChoiceTypes eEventChoice, CityEventTypes eCi
 					if (pCivilizationInfo != NULL)
 					{
 						BuildingTypes eBuildingType = NO_BUILDING;
-						if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || GET_PLAYER(getOwner()).GetPlayerTraits()->IsKeepConqueredBuildings())
+						if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 						{
 							eBuildingType = GetCityBuildings()->GetBuildingTypeFromClass(eBuildingClass);
 						}
@@ -7067,8 +7053,7 @@ void CvCity::DoEventChoice(CityEventChoiceTypes eEventChoice, CityEventTypes eCi
 						if (pkEventChoiceInfo->getBuildingClassYield(eBuildingClass, eYield) != 0)
 						{
 							BuildingTypes eBuilding = NO_BUILDING;
-							bool bRome = GET_PLAYER(getOwner()).GetPlayerTraits()->IsKeepConqueredBuildings();
-							if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome)
+							if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 							{
 								eBuilding = GetCityBuildings()->GetBuildingTypeFromClass(eBuildingClass);
 							}
@@ -7077,7 +7062,7 @@ void CvCity::DoEventChoice(CityEventChoiceTypes eEventChoice, CityEventTypes eCi
 								eBuilding = (BuildingTypes)getCivilizationInfo().getCivilizationBuildings(eBuildingClass);
 							}
 
-							if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome || eBuilding != NO_BUILDING)
+							if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || eBuilding != NO_BUILDING)
 							{
 								ChangeEventBuildingClassYield(eBuildingClass, eYield, pkEventChoiceInfo->getBuildingClassYield(eBuildingClass, eYield));
 								if (eBuilding != NO_BUILDING && GetCityBuildings()->GetNumBuilding(eBuilding) > 0)
@@ -7089,8 +7074,7 @@ void CvCity::DoEventChoice(CityEventChoiceTypes eEventChoice, CityEventTypes eCi
 						if (pkEventChoiceInfo->getBuildingClassYieldModifier(eBuildingClass, eYield) != 0)
 						{
 							BuildingTypes eBuilding = NO_BUILDING;
-							bool bRome = GET_PLAYER(getOwner()).GetPlayerTraits()->IsKeepConqueredBuildings();
-							if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome)
+							if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 							{
 								eBuilding = GetCityBuildings()->GetBuildingTypeFromClass(eBuildingClass);
 							}
@@ -7099,7 +7083,7 @@ void CvCity::DoEventChoice(CityEventChoiceTypes eEventChoice, CityEventTypes eCi
 								eBuilding = (BuildingTypes)getCivilizationInfo().getCivilizationBuildings(eBuildingClass);
 							}
 
-							if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome || eBuilding != NO_BUILDING)
+							if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || eBuilding != NO_BUILDING)
 							{
 								ChangeEventBuildingClassYieldModifier(eBuildingClass, eYield, pkEventChoiceInfo->getBuildingClassYieldModifier(eBuildingClass, eYield));
 								if (eBuilding != NO_BUILDING && GetCityBuildings()->GetNumBuilding(eBuilding) > 0)
@@ -8834,9 +8818,9 @@ bool CvCity::hasBuildingPrerequisites(BuildingTypes eBuilding) const
 		{
 			//Exception for new Rome UA, because civ type doesn't help you here.
 			//Also use this if the option to check for all buildings in a class is enabled.
-			if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || GET_PLAYER(getOwner()).GetPlayerTraits()->IsKeepConqueredBuildings())
+			if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 			{
-				if (!HasBuildingClass((BuildingClassTypes)iI, GET_PLAYER(getOwner()).GetPlayerTraits()->IsKeepConqueredBuildings()))
+				if (!HasBuildingClass((BuildingClassTypes)iI))
 				{
 					return false;
 				}
@@ -8856,14 +8840,13 @@ bool CvCity::hasBuildingPrerequisites(BuildingTypes eBuilding) const
 			{
 				bool bHasBuildingClass = false;
 
-				//Exception for new Rome UA, because civ type doesn't help you here.
-				//Also use this if the option to check for all buildings in a class is enabled.
-				if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || GET_PLAYER(getOwner()).GetPlayerTraits()->IsKeepConqueredBuildings())
+				//Exception if the option to check for all buildings in a class is enabled.
+				if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 				{
 					int iLoop = 0;
 					for (CvCity* pLoopCity = GET_PLAYER(getOwner()).firstCity(&iLoop); pLoopCity != NULL; pLoopCity = GET_PLAYER(getOwner()).nextCity(&iLoop))
 					{
-						if (pLoopCity->HasBuildingClass((BuildingClassTypes)iI, GET_PLAYER(getOwner()).GetPlayerTraits()->IsKeepConqueredBuildings()))
+						if (pLoopCity->HasBuildingClass((BuildingClassTypes)iI))
 						{
 							bHasBuildingClass = true;
 							break;
@@ -8894,14 +8877,13 @@ bool CvCity::hasBuildingPrerequisites(BuildingTypes eBuilding) const
 			// Does this city have prereq buildings?
 			if (pkBuildingInfo->IsBuildingClassNeededNowhere(iI))
 			{
-				//Exception for new Rome UA, because civ type doesn't help you here.
-				//Also use this if the option to check for all buildings in a class is enabled.
-				if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || GET_PLAYER(getOwner()).GetPlayerTraits()->IsKeepConqueredBuildings())
+				//Exception if the option to check for all buildings in a class is enabled.
+				if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 				{
 					int iLoop = 0;
 					for (CvCity* pLoopCity = GET_PLAYER(getOwner()).firstCity(&iLoop); pLoopCity != NULL; pLoopCity = GET_PLAYER(getOwner()).nextCity(&iLoop))
 					{
-						if (pLoopCity->HasBuildingClass((BuildingClassTypes)iI, GET_PLAYER(getOwner()).GetPlayerTraits()->IsKeepConqueredBuildings()))
+						if (pLoopCity->HasBuildingClass((BuildingClassTypes)iI))
 						{
 							return false;
 						}
@@ -9030,7 +9012,7 @@ bool CvCity::canTrain(UnitTypes eUnit, bool bContinue, bool bTestVisible, bool b
 			{
 				BuildingTypes ePrereqBuilding = NO_BUILDING;
 
-				if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || GET_PLAYER(getOwner()).GetPlayerTraits()->IsKeepConqueredBuildings())
+				if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 				{
 					if (HasBuildingClass(eBuildingClass))
 					{
@@ -15128,7 +15110,7 @@ void CvCity::processBuilding(BuildingTypes eBuilding, int iChange, bool bFirst, 
 			{
 				BuildingTypes eFreeBuildingThisCity = (BuildingTypes)(thisCiv.getCivilizationBuildings(eFreeBuildingClassThisCity));
 
-				if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || owningPlayer.GetPlayerTraits()->IsKeepConqueredBuildings())
+				if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 				{
 					if (HasBuildingClass(eFreeBuildingClassThisCity))
 					{
@@ -21189,9 +21171,8 @@ bool CvCity::CanAirlift() const
 		}
 
 		BuildingTypes eBuilding = NO_BUILDING;
-		// If Rome, or if the option to check for all buildings in a class is enabled, we loop through all buildings in the city
-		bool bRome = kPlayer.GetPlayerTraits()->IsKeepConqueredBuildings();
-		if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome)
+		// If the option to check for all buildings in a class is enabled, we loop through all buildings in the city
+		if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 		{
 			eBuilding = GetCityBuildings()->GetBuildingTypeFromClass((BuildingClassTypes)iBuildingClassLoop);
 		}
@@ -21200,7 +21181,7 @@ bool CvCity::CanAirlift() const
 			eBuilding = (BuildingTypes)kPlayer.getCivilizationInfo().getCivilizationBuildings(eBuildingClass);
 		}
 
-		if (eBuilding != NO_BUILDING && (MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome || GetCityBuildings()->GetNumBuilding(eBuilding) > 0)) // slewis - added the NO_BUILDING check for the ConquestDLX scenario which has civ specific wonders
+		if (eBuilding != NO_BUILDING && (MOD_BUILDINGS_THOROUGH_PREREQUISITES || GetCityBuildings()->GetNumBuilding(eBuilding) > 0)) // slewis - added the NO_BUILDING check for the ConquestDLX scenario which has civ specific wonders
 		{
 			CvBuildingEntry* pkBuildingInfo = GC.getBuildingInfo(eBuilding);
 			if (!pkBuildingInfo)
@@ -22045,9 +22026,7 @@ void CvCity::UpdateHappinessFromBuildingClasses()
 
 	// Building Class Mods
 	iSpecialBuildingHappiness = 0;
-
-	bool bRome = kPlayer.GetPlayerTraits()->IsKeepConqueredBuildings();
-	if (!MOD_BUILDINGS_THOROUGH_PREREQUISITES && !bRome)
+	if (!MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 	{
 		for (int iI = 0; iI < GC.getNumBuildingClassInfos(); iI++)
 		{
@@ -26517,7 +26496,7 @@ int CvCity::GetGPRateModifierPerXFranchises() const
 	int iCurrentValue = 0;
 
 	BuildingTypes eOffice = NO_BUILDING;
-	if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || GET_PLAYER(getOwner()).GetPlayerTraits()->IsKeepConqueredBuildings())
+	if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 	{
 		if (HasBuildingClass(pkCorporationInfo->GetOfficeBuildingClass()))
 		{
@@ -26590,7 +26569,7 @@ bool CvCity::IsHasOffice() const
 	const CvCivilizationInfo& thisCivInfo = getCivilizationInfo();
 	BuildingTypes eBuilding = NO_BUILDING;
 
-	if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || GET_PLAYER(getOwner()).GetPlayerTraits()->IsKeepConqueredBuildings())
+	if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 	{
 		eBuilding = GetCityBuildings()->GetBuildingTypeFromClass(eOffice);
 	}
@@ -26636,7 +26615,7 @@ bool CvCity::IsHasFranchise(CorporationTypes eCorporation) const
 	const CvCivilizationInfo& thisCivInfo = getCivilizationInfo();
 	BuildingTypes eBuilding = NO_BUILDING;
 
-	if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || GET_PLAYER(getOwner()).GetPlayerTraits()->IsKeepConqueredBuildings())
+	if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 	{
 		eBuilding = GetCityBuildings()->GetBuildingTypeFromClass(eFranchise);
 	}
@@ -26669,7 +26648,7 @@ int CvCity::GetBuildingYieldChangeFromCorporationFranchises(BuildingClassTypes e
 		return 0;
 
 	BuildingTypes eBuilding = NO_BUILDING;
-	if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || kPlayer.GetPlayerTraits()->IsKeepConqueredBuildings())
+	if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 	{
 		if (HasBuildingClass(eBuildingClass))
 		{
@@ -26721,7 +26700,7 @@ void CvCity::UpdateYieldFromCorporationFranchises(YieldTypes eIndex)
 		}
 		BuildingTypes eLoopBuilding = NO_BUILDING;
 
-		if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || GET_PLAYER(getOwner()).GetPlayerTraits()->IsKeepConqueredBuildings())
+		if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 		{
 			eLoopBuilding = GetCityBuildings()->GetBuildingTypeFromClass((BuildingClassTypes)iI);
 		}
@@ -34584,9 +34563,9 @@ bool CvCity::HasBuilding(BuildingTypes iBuildingType) const
 	return (GetCityBuildings()->GetNumBuilding(iBuildingType) > 0);
 }
 
-bool CvCity::HasBuildingClass(BuildingClassTypes iBuildingClassType, bool bKeepConqueredBuildings) const
+bool CvCity::HasBuildingClass(BuildingClassTypes iBuildingClassType) const
 {
-	if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || bKeepConqueredBuildings)
+	if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 	{
 		return GetCityBuildings()->HasBuildingClass(iBuildingClassType);
 	}

--- a/CvGameCoreDLL_Expansion2/CvCity.h
+++ b/CvGameCoreDLL_Expansion2/CvCity.h
@@ -1593,7 +1593,7 @@ public:
 
 	bool HasBelief(BeliefTypes iBeliefType) const;
 	bool HasBuilding(BuildingTypes iBuildingType) const;
-	bool HasBuildingClass(BuildingClassTypes iBuildingClassType, bool bKeepConqueredBuildings = false) const;
+	bool HasBuildingClass(BuildingClassTypes iBuildingClassType) const;
 	bool HasAnyWonder() const;
 	bool HasWonder(BuildingTypes iBuildingType) const;
 	bool IsBuildingWorldWonder() const;

--- a/CvGameCoreDLL_Expansion2/CvCultureClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCultureClasses.cpp
@@ -369,7 +369,7 @@ PlayerTypes CvGameCulture::GetGreatWorkController(int iIndex) const
 				const CvCivilizationInfo& playerCivilizationInfo = GET_PLAYER(ePlayer).getCivilizationInfo();
 				BuildingTypes eBuilding = NO_BUILDING;
 
-				if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || GET_PLAYER(ePlayer).GetPlayerTraits()->IsKeepConqueredBuildings())
+				if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 				{
 					eBuilding = pCity->GetCityBuildings()->GetBuildingTypeFromClass((BuildingClassTypes)iBuildingClassLoop);
 				}
@@ -439,7 +439,7 @@ CvCity* CvGameCulture::GetGreatWorkCity(int iIndex) const
 				const CvCivilizationInfo& playerCivilizationInfo = GET_PLAYER(ePlayer).getCivilizationInfo();
 				BuildingTypes eBuilding = NO_BUILDING;
 
-				if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || GET_PLAYER(ePlayer).GetPlayerTraits()->IsKeepConqueredBuildings())
+				if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 				{
 					eBuilding = pCity->GetCityBuildings()->GetBuildingTypeFromClass((BuildingClassTypes)iBuildingClassLoop);
 				}
@@ -496,7 +496,7 @@ int CvGameCulture::GetGreatWorkCurrentThemingBonus (int iIndex) const
 				const CvCivilizationInfo& playerCivilizationInfo = GET_PLAYER(ePlayer).getCivilizationInfo();
 				BuildingTypes eBuilding = NO_BUILDING;
 
-				if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || GET_PLAYER(ePlayer).GetPlayerTraits()->IsKeepConqueredBuildings())
+				if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 				{
 					eBuilding = pCity->GetCityBuildings()->GetBuildingTypeFromClass(eBuildingClass);
 				}
@@ -677,7 +677,7 @@ bool CvGameCulture::SwapGreatWorks (PlayerTypes ePlayer1, int iWork1, PlayerType
 				const CvCivilizationInfo& playerCivilizationInfo = GET_PLAYER(eTempPlayer).getCivilizationInfo();
 				BuildingTypes eBuilding = NO_BUILDING;
 
-				if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || GET_PLAYER(eTempPlayer).GetPlayerTraits()->IsKeepConqueredBuildings())
+				if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 				{
 					eBuilding = pCity->GetCityBuildings()->GetBuildingTypeFromClass((BuildingClassTypes)iBuildingClassLoop);
 				}
@@ -1054,9 +1054,8 @@ bool CvPlayerCulture::ControlsGreatWork (int iIndex)
 		{
 			const CvCivilizationInfo& playerCivilizationInfo = m_pPlayer->getCivilizationInfo();
 			BuildingTypes eBuilding = NO_BUILDING;
-			// If Rome, or if the option to check for all buildings in a class is enabled, we loop through all buildings in the city
-			bool bRome = m_pPlayer->GetPlayerTraits()->IsKeepConqueredBuildings();
-			if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome)
+			// If the option to check for all buildings in a class is enabled, we loop through all buildings in the city
+			if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 			{
 				eBuilding = pLoopCity->GetCityBuildings()->GetBuildingTypeFromClass((BuildingClassTypes)iBuildingClassLoop);
 			}
@@ -1069,7 +1068,7 @@ bool CvPlayerCulture::ControlsGreatWork (int iIndex)
 				CvBuildingEntry *pkBuilding = GC.getBuildingInfo(eBuilding);
 				if (pkBuilding)
 				{
-					if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome || pLoopCity->GetCityBuildings()->GetNumBuilding(eBuilding) > 0)
+					if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || pLoopCity->GetCityBuildings()->GetNumBuilding(eBuilding) > 0)
 					{
 						int iNumSlots = pkBuilding->GetGreatWorkCount();
 						for (int iI = 0; iI < iNumSlots; iI++)
@@ -1101,7 +1100,7 @@ bool CvPlayerCulture::GetGreatWorkLocation(int iSearchIndex, int &iReturnCityID,
 			const CvCivilizationInfo& playerCivilizationInfo = m_pPlayer->getCivilizationInfo();
 			BuildingTypes eBuilding = NO_BUILDING;
 
-			if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || m_pPlayer->GetPlayerTraits()->IsKeepConqueredBuildings())
+			if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 			{
 				eBuilding = pLoopCity->GetCityBuildings()->GetBuildingTypeFromClass((BuildingClassTypes)iBuildingClassLoop);
 			}
@@ -1164,7 +1163,7 @@ void CvPlayerCulture::DoSwapGreatWorksHuman(bool bSwap)
 		{
 			const CvCivilizationInfo& playerCivilizationInfo = m_pPlayer->getCivilizationInfo();
 			BuildingTypes eBuilding = NO_BUILDING;
-			if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || m_pPlayer->GetPlayerTraits()->IsKeepConqueredBuildings())
+			if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 			{
 				eBuilding = pLoopCity->GetCityBuildings()->GetBuildingTypeFromClass((BuildingClassTypes)iBuildingClassLoop);
 			}
@@ -1285,7 +1284,7 @@ void CvPlayerCulture::DoSwapGreatWorks()
 			const CvCivilizationInfo& playerCivilizationInfo = m_pPlayer->getCivilizationInfo();
 			BuildingTypes eBuilding = NO_BUILDING;
 
-			if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || m_pPlayer->GetPlayerTraits()->IsKeepConqueredBuildings())
+			if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 			{
 				eBuilding = pLoopCity->GetCityBuildings()->GetBuildingTypeFromClass((BuildingClassTypes)iBuildingClassLoop);
 			}
@@ -4064,7 +4063,7 @@ void CvPlayerCulture::DoTurn()
 				const CvCivilizationInfo& playerCivilizationInfo = m_pPlayer->getCivilizationInfo();
 				BuildingTypes eBuilding = NO_BUILDING;
 
-				if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || m_pPlayer->GetPlayerTraits()->IsKeepConqueredBuildings())
+				if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 				{
 					eBuilding = pLoopCity->GetCityBuildings()->GetBuildingTypeFromClass((BuildingClassTypes)iBuildingClassLoop);
 				}
@@ -4129,7 +4128,7 @@ void CvPlayerCulture::DoTurn()
 					const CvCivilizationInfo& playerCivilizationInfo = m_pPlayer->getCivilizationInfo();
 					BuildingTypes eBuilding = NO_BUILDING;
 
-					if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || m_pPlayer->GetPlayerTraits()->IsKeepConqueredBuildings())
+					if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 					{
 						eBuilding = pLoopCity->GetCityBuildings()->GetBuildingTypeFromClass((BuildingClassTypes)iBuildingClassLoop);
 					}
@@ -6464,9 +6463,8 @@ void CvCityCulture::ClearGreatWorks()
 	{
 		const CvCivilizationInfo& playerCivilizationInfo = kCityPlayer.getCivilizationInfo();
 		BuildingTypes eBuilding = NO_BUILDING;
-		// If Rome, or if the option to check for all buildings in a class is enabled, we loop through all buildings in the city
-		bool bRome = kCityPlayer.GetPlayerTraits()->IsKeepConqueredBuildings();
-		if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome)
+		// If the option to check for all buildings in a class is enabled, we loop through all buildings in the city
+		if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 		{
 			eBuilding = m_pCity ->GetCityBuildings()->GetBuildingTypeFromClass((BuildingClassTypes)iBuildingClassLoop);
 		}
@@ -6479,7 +6477,7 @@ void CvCityCulture::ClearGreatWorks()
 			CvBuildingEntry *pkBuilding = GC.getBuildingInfo(eBuilding);
 			if (pkBuilding)
 			{
-				if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome || m_pCity->GetCityBuildings()->GetNumBuilding(eBuilding) > 0)
+				if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || m_pCity->GetCityBuildings()->GetNumBuilding(eBuilding) > 0)
 				{
 					int iNumSlots = pkBuilding->GetGreatWorkCount();
 					for (int iI = 0; iI < iNumSlots; iI++)
@@ -6502,7 +6500,7 @@ GreatWorkSlotType CvCityCulture::GetSlotTypeFirstAvailableCultureBuilding() cons
 
 	for(int iBuildingClassLoop = 0; iBuildingClassLoop < GC.getNumBuildingClassInfos(); iBuildingClassLoop++)
 	{
-		if ((MOD_BUILDINGS_THOROUGH_PREREQUISITES || kCityPlayer.GetPlayerTraits()->IsKeepConqueredBuildings()) && m_pCity->HasBuildingClass((BuildingClassTypes)iBuildingClassLoop))
+		if (MOD_BUILDINGS_THOROUGH_PREREQUISITES && m_pCity->HasBuildingClass((BuildingClassTypes)iBuildingClassLoop))
 		{
 			continue;
 		}
@@ -6595,8 +6593,7 @@ void CvCityCulture::CalculateBaseTourismBeforeModifiers()
 			iBase += m_pCity->GetCityBuildings()->GetNumBuildingsFromFaith() * iFaithBuildingTourism;
 		}
 
-		// If Rome, or if the option to check for all buildings in a class is enabled, we loop through all buildings in the city
-		bool bRome = GET_PLAYER(m_pCity->getOwner()).GetPlayerTraits()->IsKeepConqueredBuildings();
+		// If the option to check for all buildings in a class is enabled, we loop through all buildings in the city
 		vector<BuildingTypes> allBuildings = m_pCity->GetCityBuildings()->GetAllBuildingsHere();
 		for(size_t iI = 0; iI < allBuildings.size(); iI++)
 		{
@@ -6604,7 +6601,7 @@ void CvCityCulture::CalculateBaseTourismBeforeModifiers()
 			CvBuildingEntry *pkBuilding = GC.getBuildingInfo(allBuildings[iI]);
 			if (pkBuilding)
 			{
-				if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome || iCount > 0) // GetBuildingTypeFromClass() already checks GetNumBuilding() > 0
+				if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || iCount > 0) // GetBuildingTypeFromClass() already checks GetNumBuilding() > 0
 				{
 					iBase += pReligion->m_Beliefs.GetBuildingClassTourism(pkBuilding->GetBuildingClassType(), m_pCity->getOwner(), m_pCity) * iCount;
 				}
@@ -7714,7 +7711,7 @@ bool CvCityCulture::IsThemingBonusPossible(BuildingClassTypes eBuildingClass) co
 	CvPlayer &kPlayer = GET_PLAYER(m_pCity->getOwner());
 	BuildingTypes eBuilding = NO_BUILDING;
 
-	if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || kPlayer.GetPlayerTraits()->IsKeepConqueredBuildings())
+	if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 	{
 		if (m_pCity->HasBuildingClass(eBuildingClass))
 		{
@@ -7753,7 +7750,7 @@ int CvCityCulture::GetThemingBonus(BuildingClassTypes eBuildingClass) const
 		{
 			BuildingTypes eBuilding = NO_BUILDING;
 
-			if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || kPlayer.GetPlayerTraits()->IsKeepConqueredBuildings())
+			if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 			{
 				if (m_pCity->HasBuildingClass(eBuildingClass))
 				{
@@ -7807,7 +7804,7 @@ CvString CvCityCulture::GetThemingTooltip(BuildingClassTypes eBuildingClass) con
 	{
 		BuildingTypes eBuilding = NO_BUILDING;
 
-		if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || kPlayer.GetPlayerTraits()->IsKeepConqueredBuildings())
+		if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 		{
 			if (m_pCity->HasBuildingClass(eBuildingClass))
 			{
@@ -8003,7 +8000,7 @@ int CvCityCulture::GetThemingBonusIndex(BuildingClassTypes eBuildingClass) const
 	{
 		BuildingTypes eBuilding = NO_BUILDING;
 
-		if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || GET_PLAYER(m_pCity->getOwner()).GetPlayerTraits()->IsKeepConqueredBuildings())
+		if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 		{
 			eBuilding = m_pCity->GetCityBuildings()->GetBuildingTypeFromClass(eBuildingClass);
 		}
@@ -8031,7 +8028,7 @@ void CvCityCulture::UpdateThemingBonusIndex(BuildingClassTypes eBuildingClass)
 	{
 		BuildingTypes eBuilding = NO_BUILDING;
 
-		if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || GET_PLAYER(m_pCity->getOwner()).GetPlayerTraits()->IsKeepConqueredBuildings())
+		if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 		{
 			eBuilding = m_pCity->GetCityBuildings()->GetBuildingTypeFromClass(eBuildingClass);
 		}

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
@@ -23611,11 +23611,11 @@ void CvDiplomacyAI::SelectBestApproachTowardsMinorCiv(PlayerTypes ePlayer, std::
 
 	bool bIsGoodWarTarget = false;
 	bool bCheckIfGoodWarTarget = true;
-	
+
 	////////////////////////////////////
 	// EASY TARGET
 	////////////////////////////////////
-	
+
 	if (bEasyTarget)
 	{
 		vApproachScores[CIV_APPROACH_WAR] += vApproachBias[CIV_APPROACH_WAR] * 2;
@@ -31695,6 +31695,16 @@ void CvDiplomacyAI::DoContactMinorCivs()
 	bool bWantsToBuyout = GetPlayer()->GetPlayerTraits()->IsDiplomaticMarriage() || GetPlayer()->IsAbleToAnnexCityStates();
 
 	// **************************
+	// Would we like to forcefully annex a minor this turn?  (Rome UA)
+	// **************************
+
+	bool bWantsToBullyAnnex = false;
+	if (MOD_BALANCE_CORE_AFRAID_ANNEX)
+	{
+		bWantsToBullyAnnex = GetPlayer()->GetPlayerTraits()->IsBullyAnnex();
+	}
+
+	// **************************
 	// Would we like to give a gold gift this turn?
 	// **************************
 
@@ -31792,6 +31802,7 @@ void CvDiplomacyAI::DoContactMinorCivs()
 	}
 
 	CvWeightedVector<PlayerTypes> veMinorsToBuyout; // Austria UA
+	CvWeightedVector<PlayerTypes> veMinorsToBullyAnnex; //Rome UA
 	CvWeightedVector<MinorGoldGiftInfo> veMinorsToGiveGold;
 	CvWeightedVector<PlayerTypes> veMinorsToBullyGold;
 	CvWeightedVector<PlayerTypes> veMinorsToBullyUnit;
@@ -31806,15 +31817,6 @@ void CvDiplomacyAI::DoContactMinorCivs()
 
 	if(MOD_BALANCE_CORE_AFRAID_ANNEX)
 	{
-		if (GetPlayer()->GetPlayerTraits()->IsBullyAnnex())
-		{
-			if(!GetPlayer()->IsEmpireUnhappy())
-			{
-				bWantsToBullyUnit = true;
-				bWantsToBullyGold = false;
-				bWantsToMakeGoldGift = false;
-			}
-		}
 		if (GetPlayer()->GetPlayerTraits()->GetBullyMilitaryStrengthModifier() != 0 || GetPlayer()->GetPlayerTraits()->GetBullyValueModifier() != 0)
 		{
 			if (!GetPlayer()->IsEmpireUnhappy())
@@ -31852,6 +31854,7 @@ void CvDiplomacyAI::DoContactMinorCivs()
 		bool bWantsToBullyUnitFromThisMinor = false;
 		bool bWantsToBullyGoldFromThisMinor = false;
 		bool bWantsToBuyoutThisMinor = false;
+		bool bWantsToBullyAnnexThisMinor = false;
 
 		if(IsPlayerValid(eMinor))
 		{
@@ -31880,6 +31883,143 @@ void CvDiplomacyAI::DoContactMinorCivs()
 					else if (pMinorCivAI->IsActiveQuestForPlayer(eID, MINOR_CIV_QUEST_ROUTE))
 					{
 						bWantsToConnect = true;
+					}
+				}
+			}
+
+			// Calculate desirability to forcefully annex this minor
+			if (bWantsToBullyAnnex)
+			{
+				int iValue = 100; //antonjs: todo: xml
+				// Only bother if we actually can annex
+				CvCity* pMinorCapital = pMinor->getCapitalCity();
+				if (pMinor->GetMinorCivAI()->CanMajorBullyUnit(eID) && pMinorCapital != NULL)
+				{
+					// Determine presence of player cities on this continent
+					CvArea* pMinorArea = pMinorCapital->plot()->area();
+					bool bPresenceInArea = false;
+					int iMajorCapitalsInArea = 0;
+					if (pMinorArea)
+					{
+						// Do we have a city here?
+						if (pMinorArea->getCitiesPerPlayer(eID) > 0)
+							bPresenceInArea = true;
+
+						// Does another major civ have their capital here? (must be visible)
+						for (int iMajorRivalLoop = 0; iMajorRivalLoop < MAX_MAJOR_CIVS; iMajorRivalLoop++)
+						{
+							PlayerTypes eMajorRivalLoop = (PlayerTypes)iMajorRivalLoop;
+							if (eMajorRivalLoop == eID)
+								continue;
+
+							if (GET_PLAYER(eMajorRivalLoop).isAlive())
+							{
+								CvCity* pCapital = GET_PLAYER(eMajorRivalLoop).getCapitalCity();
+								if (pCapital && pCapital->plot())
+								{
+									CvPlot* pPlot = pCapital->plot();
+									if (pPlot->isVisible(GetTeam()))
+										iMajorCapitalsInArea++;
+								}
+							}
+						}
+					}
+					else
+					{
+						CvAssertMsg(false, "Could not lookup minor civ's area! Please send Anton your save file and version.");
+					}
+
+					// How many units does the city-state have?
+					int iMinorMilitaryUnits = 0;
+					int iMinorUnits = 0;
+					int iLoop = 0;
+					for (CvUnit* pLoopUnit = pMinor->firstUnit(&iLoop); pLoopUnit != NULL; pLoopUnit = pMinor->nextUnit(&iLoop))
+					{
+						if (pLoopUnit->IsCanAttack() && pLoopUnit->AI_getUnitAIType() != UNITAI_EXPLORE && pLoopUnit->AI_getUnitAIType() != UNITAI_EXPLORE_SEA)
+						{
+							iMinorMilitaryUnits++;
+						}
+						iMinorUnits++;
+					}
+
+					// Foreign continent
+					if (!bPresenceInArea)
+					{
+						// Military foothold to attack other majors
+						if (IsGoingForWorldConquest() && iMajorCapitalsInArea > 0)
+						{
+							iValue += 100; //antonjs: todo: xml
+						}
+						// Expansion
+						else if (bExpandToOtherContinents)
+						{
+							iValue += 60; //antonjs: todo: xml
+						}
+						else
+						{
+							iValue += -50; //antonjs: todo: xml
+						}
+					}
+					// Continent we have presence on
+					else
+					{
+						// Proximity plays a large factor, since we don't want a remote, isolated city
+						if (GetPlayer()->GetProximityToPlayer(eMinor) == PLAYER_PROXIMITY_NEIGHBORS)
+						{
+							iValue += 100; //antonjs: todo: xml
+							// Military units could come to our rescue quickly
+							if (GetStateAllWars() == STATE_ALL_WARS_LOSING)
+							{
+								if (iMinorMilitaryUnits > 0)  //antonjs: todo: xml
+								{
+									iValue += (iMinorMilitaryUnits) * 10; //antonjs: todo: xml
+								}
+								else
+								{
+									iValue -= 50; //antonjs: todo: xml
+								}
+							}
+						}
+						else if (GetPlayer()->GetProximityToPlayer(eMinor) == PLAYER_PROXIMITY_CLOSE)
+						{
+							iValue += 10; //antonjs: todo: xml
+						}
+						else if (GetPlayer()->GetProximityToPlayer(eMinor) == PLAYER_PROXIMITY_FAR)
+						{
+							iValue += -50; //antonjs: todo: xml
+						}
+						else if (GetPlayer()->GetProximityToPlayer(eMinor) == PLAYER_PROXIMITY_DISTANT)
+						{
+							iValue += -100; //antonjs: todo: xml
+						}
+					}
+
+					// Military units - How many, and can we support them?
+					if (GetPlayer()->GetNumUnitsSupplied() >= GetPlayer()->getNumUnits() + iMinorUnits)
+					{
+						iValue += (iMinorMilitaryUnits) * 5;
+					}
+
+					// Happiness
+					if (bNeedHappiness)
+						iValue += -50; //antonjs: todo: xml
+					if (bNeedHappinessCritical)
+						iValue += -150; //antonjs: todo: xml
+
+					// Bonuses from Annexed City-States
+					MinorCivTraitTypes eTrait = pMinorCivAI->GetTrait();
+					if (GetPlayer()->GetPlayerTraits()->IsAnnexedCityStatesGiveYields()) {
+						//if (eTrait == MINOR_CIV_TRAIT_CULTURED && IsGoingForCultureVictory())
+						//{
+							//iValue += 70; //antonjs: todo: xml
+						//}
+						// todo...
+					}
+					// Time to decide - Do we want it enough?
+					if (iValue > 100)  //antonjs: todo: xml
+					{
+						veMinorsToBullyAnnex.push_back(eMinor, iValue);
+						bWantsToBullyAnnexThisMinor = true;
 					}
 				}
 			}
@@ -32033,7 +32173,7 @@ void CvDiplomacyAI::DoContactMinorCivs()
 			}
 
 			// Calculate desirability to give this minor gold
-			if (bWantsToMakeGoldGift && !bWantsToBuyoutThisMinor)
+			if (bWantsToMakeGoldGift && !bWantsToBuyoutThisMinor && !bWantsToBullyAnnexThisMinor)
 			{
 				if (GET_PLAYER(eMinor).GetMinorCivAI()->IsNoAlly())
 				{
@@ -32219,7 +32359,7 @@ void CvDiplomacyAI::DoContactMinorCivs()
 			}
 
 			// Calculate desirability to bully a unit from this minor
-			if (bWantsToBullyUnit && !bWantsToBuyoutThisMinor && !bWantsToGiveGoldToThisMinor)  //antonjs: todo: xml
+			if (bWantsToBullyUnit && !bWantsToBuyoutThisMinor && !bWantsToBullyAnnexThisMinor && !bWantsToGiveGoldToThisMinor)  //antonjs: todo: xml
 			{
 				int iValue = 100; //antonjs: todo: XML, bully threshold
 				if (MOD_BALANCE_CORE_MINOR_VARIABLE_BULLYING)
@@ -32301,22 +32441,6 @@ void CvDiplomacyAI::DoContactMinorCivs()
 						}
 
 						//Do we get a bonus from this?
-						if(MOD_BALANCE_CORE_AFRAID_ANNEX)
-						{
-							if (GetPlayer()->GetPlayerTraits()->IsBullyAnnex())
-							{
-								if(!GetPlayer()->IsEmpireUnhappy())
-								{
-									iValue += 100;
-								}
-								else
-								{
-									iValue -= 50;
-								}
-							}
-						}
-
-						//Do we get a bonus from this?
 						if (MOD_BALANCE_CORE_AFRAID_ANNEX)
 						{
 							if (GetPlayer()->GetPlayerTraits()->GetBullyMilitaryStrengthModifier() != 0 || GetPlayer()->GetPlayerTraits()->GetBullyValueModifier() != 0)
@@ -32357,7 +32481,7 @@ void CvDiplomacyAI::DoContactMinorCivs()
 			}
 
 			// Calculate desirability to bully gold from this minor
-			if(bWantsToBullyGold && !bWantsToBuyoutThisMinor && !bWantsToGiveGoldToThisMinor && !bWantsToBullyUnitFromThisMinor)
+			if(bWantsToBullyGold && !bWantsToBuyoutThisMinor && !bWantsToBullyAnnexThisMinor && !bWantsToGiveGoldToThisMinor && !bWantsToBullyUnitFromThisMinor)
 			{
 				int iValue = 100; //antonjs: todo: XML, bully threshold
 				if (MOD_BALANCE_CORE_MINOR_VARIABLE_BULLYING)
@@ -32494,6 +32618,27 @@ void CvDiplomacyAI::DoContactMinorCivs()
 					LogMinorCivBuyout(eLoopMinor, iBuyoutCost, /*bSaving*/ true);
 					GetPlayer()->GetEconomicAI()->StartSaveForPurchase(PURCHASE_TYPE_MINOR_CIV_GIFT, iBuyoutCost, /*350*/ GD_INT_GET(AI_GOLD_PRIORITY_BUYOUT_CITY_STATE));
 				}
+			}
+		}
+	}
+
+	// Do we want to annex a minor?
+	if (veMinorsToBullyAnnex.size() > 0)
+	{
+		veMinorsToBullyAnnex.SortItems();
+		PlayerTypes eLoopMinor = NO_PLAYER;
+		for (int i = 0; i < veMinorsToBullyAnnex.size(); i++)
+		{
+			eLoopMinor = veMinorsToBullyAnnex.GetElement(i);
+			CvAssertMsg(eLoopMinor != NO_PLAYER, "Trying to bully-annex NO_PLAYER!");
+			if (GET_PLAYER(eLoopMinor).GetMinorCivAI()->CanMajorBullyUnit(eID))
+			{
+				GC.getGame().DoMinorBullyAnnex(eID, eLoopMinor);
+				break; // Don't annex more than one city-state in a single turn
+			}
+			else
+			{
+				CvAssertMsg(false, "Chose a minor to bully-annex that cannot actually be bullied!");
 			}
 		}
 	}

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
@@ -31813,7 +31813,13 @@ void CvDiplomacyAI::DoContactMinorCivs()
 
 	PlayerTypes eID = GetID();
 
-	int iGrowthFlavor = GetPlayer()->GetGrandStrategyAI()->GetPersonalityAndGrandStrategy((FlavorTypes) GC.getInfoTypeForString("FLAVOR_GROWTH"));
+	int iGrowthFlavor = GetPlayer()->GetGrandStrategyAI()->GetPersonalityAndGrandStrategy((FlavorTypes)GC.getInfoTypeForString("FLAVOR_GROWTH"));
+	int iScienceFlavor = GetPlayer()->GetGrandStrategyAI()->GetPersonalityAndGrandStrategy((FlavorTypes)GC.getInfoTypeForString("FLAVOR_SCIENCE"));
+	int iCultureFlavor = GetPlayer()->GetGrandStrategyAI()->GetPersonalityAndGrandStrategy((FlavorTypes)GC.getInfoTypeForString("FLAVOR_CULTURE"));
+	int iFaithFlavor = GetPlayer()->GetGrandStrategyAI()->GetPersonalityAndGrandStrategy((FlavorTypes)GC.getInfoTypeForString("FLAVOR_RELIGION"));
+	int iOffenseFlavor = GetPlayer()->GetGrandStrategyAI()->GetPersonalityAndGrandStrategy((FlavorTypes)GC.getInfoTypeForString("FLAVOR_OFFENSE"));
+	int iHappinessFlavor = GetPlayer()->GetGrandStrategyAI()->GetPersonalityAndGrandStrategy((FlavorTypes)GC.getInfoTypeForString("FLAVOR_HAPPINESS"));
+	int iProductionFlavor = GetPlayer()->GetGrandStrategyAI()->GetPersonalityAndGrandStrategy((FlavorTypes)GC.getInfoTypeForString("FLAVOR_PRODUCTION")) / 2;
 
 	if(MOD_BALANCE_CORE_AFRAID_ANNEX)
 	{
@@ -32007,13 +32013,38 @@ void CvDiplomacyAI::DoContactMinorCivs()
 						iValue += -150; //antonjs: todo: xml
 
 					// Bonuses from Annexed City-States
-					MinorCivTraitTypes eTrait = pMinorCivAI->GetTrait();
 					if (GetPlayer()->GetPlayerTraits()->IsAnnexedCityStatesGiveYields()) {
-						//if (eTrait == MINOR_CIV_TRAIT_CULTURED && IsGoingForCultureVictory())
-						//{
-							//iValue += 70; //antonjs: todo: xml
-						//}
-						// todo...
+						MinorCivTraitTypes eTrait = pMinorCivAI->GetTrait();
+						if (eTrait == MINOR_CIV_TRAIT_MILITARISTIC)
+						{
+							iValue += (iScienceFlavor + iOffenseFlavor);
+						}
+						else if (eTrait == MINOR_CIV_TRAIT_MERCANTILE)
+						{
+							iValue += iHappinessFlavor * 2;
+						}
+						else if (eTrait == MINOR_CIV_TRAIT_CULTURED)
+						{
+							iValue += iCultureFlavor * 2;
+						}
+						else if (eTrait == MINOR_CIV_TRAIT_RELIGIOUS)
+						{
+							iValue += iFaithFlavor * 2;
+						}
+						else if (eTrait == MINOR_CIV_TRAIT_MARITIME)
+						{
+							iValue += iGrowthFlavor * 2;
+						}
+					}
+
+					// Annexing the Ally of another player?
+					PlayerTypes eAlly = pMinorCivAI->GetAlly();
+					if (eAlly != NO_PLAYER)
+					{
+						if (GetPlayer()->GetDiplomacyAI()->GetCivOpinion(eAlly) != NO_CIV_OPINION)
+						{
+							iValue -= (GetPlayer()->GetDiplomacyAI()->GetCivOpinion(eAlly) - CIV_OPINION_NEUTRAL) * 10;
+						}
 					}
 					// Time to decide - Do we want it enough?
 					if (iValue > 100)  //antonjs: todo: xml
@@ -32374,32 +32405,26 @@ void CvDiplomacyAI::DoContactMinorCivs()
 					if (pMinor->GetMinorCivAI()->CanMajorBullyUnit(eID, MOD_BALANCE_CORE_MINOR_VARIABLE_BULLYING ? iValue - 25 : 0))
 					{
 						if (MOD_BALANCE_CORE_MINOR_VARIABLE_BULLYING)
-						{
-							int iGrowthFlavor = GetPlayer()->GetGrandStrategyAI()->GetPersonalityAndGrandStrategy((FlavorTypes)GC.getInfoTypeForString("FLAVOR_GROWTH")) / 2;
-							int iScienceFlavor = GetPlayer()->GetGrandStrategyAI()->GetPersonalityAndGrandStrategy((FlavorTypes)GC.getInfoTypeForString("FLAVOR_SCIENCE")) / 2;
-							int iCultureFlavor = GetPlayer()->GetGrandStrategyAI()->GetPersonalityAndGrandStrategy((FlavorTypes)GC.getInfoTypeForString("FLAVOR_CULTURE")) / 2;
-							int iFaithFlavor = GetPlayer()->GetGrandStrategyAI()->GetPersonalityAndGrandStrategy((FlavorTypes)GC.getInfoTypeForString("FLAVOR_RELIGION")) / 2;
-							int iProductionFlavor = GetPlayer()->GetGrandStrategyAI()->GetPersonalityAndGrandStrategy((FlavorTypes)GC.getInfoTypeForString("FLAVOR_PRODUCTION")) / 2;
-
+						{		
 							if (GET_PLAYER(eMinor).GetMinorCivAI()->GetTrait() == MINOR_CIV_TRAIT_MILITARISTIC)
 							{
-								iValue += (GET_PLAYER(eMinor).GetMinorCivAI()->GetYieldTheftAmount(GetID(), YIELD_SCIENCE) * iScienceFlavor) / 5;
+								iValue += (GET_PLAYER(eMinor).GetMinorCivAI()->GetYieldTheftAmount(GetID(), YIELD_SCIENCE) * iScienceFlavor) / 10;
 							}
 							else if (GET_PLAYER(eMinor).GetMinorCivAI()->GetTrait() == MINOR_CIV_TRAIT_MERCANTILE)
 							{
-								iValue += (GET_PLAYER(eMinor).GetMinorCivAI()->GetYieldTheftAmount(GetID(), YIELD_PRODUCTION) * iProductionFlavor) / 5;
+								iValue += (GET_PLAYER(eMinor).GetMinorCivAI()->GetYieldTheftAmount(GetID(), YIELD_PRODUCTION) * iProductionFlavor) / 10;
 							}
 							else if (GET_PLAYER(eMinor).GetMinorCivAI()->GetTrait() == MINOR_CIV_TRAIT_CULTURED)
 							{
-								iValue += (GET_PLAYER(eMinor).GetMinorCivAI()->GetYieldTheftAmount(GetID(), YIELD_CULTURE) * iCultureFlavor) / 5;
+								iValue += (GET_PLAYER(eMinor).GetMinorCivAI()->GetYieldTheftAmount(GetID(), YIELD_CULTURE) * iCultureFlavor) / 10;
 							}
 							else if (GET_PLAYER(eMinor).GetMinorCivAI()->GetTrait() == MINOR_CIV_TRAIT_RELIGIOUS)
 							{
-								iValue += (GET_PLAYER(eMinor).GetMinorCivAI()->GetYieldTheftAmount(GetID(), YIELD_FAITH) * iFaithFlavor) / 5;
+								iValue += (GET_PLAYER(eMinor).GetMinorCivAI()->GetYieldTheftAmount(GetID(), YIELD_FAITH) * iFaithFlavor) / 10;
 							}
 							else if (GET_PLAYER(eMinor).GetMinorCivAI()->GetTrait() == MINOR_CIV_TRAIT_MARITIME)
 							{
-								iValue += (GET_PLAYER(eMinor).GetMinorCivAI()->GetYieldTheftAmount(GetID(), YIELD_FOOD) * iGrowthFlavor) / 5;
+								iValue += (GET_PLAYER(eMinor).GetMinorCivAI()->GetYieldTheftAmount(GetID(), YIELD_FOOD) * iGrowthFlavor) / 10;
 							}
 							iValue += GC.getGame().getSmallFakeRandNum(GetBoldness(), eID+m_pPlayer->GetPseudoRandomSeed()+GC.getGame().GetCultureMedian());
 						}

--- a/CvGameCoreDLL_Expansion2/CvEspionageClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvEspionageClasses.cpp
@@ -4507,8 +4507,8 @@ std::vector<int> CvPlayerEspionage::BuildGWList(CvCity* pCity)
 	{
 		const CvCivilizationInfo& playerCivilizationInfo = GET_PLAYER(ePlayer).getCivilizationInfo();
 		BuildingTypes eBuilding = NO_BUILDING;
-		// If Rome, or if the option to check for all buildings in a class is enabled, we loop through all buildings in the city
-		if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || GET_PLAYER(ePlayer).GetPlayerTraits()->IsKeepConqueredBuildings())
+		// If the option to check for all buildings in a class is enabled, we loop through all buildings in the city
+		if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 		{
 			eBuilding = pCity->GetCityBuildings()->GetBuildingTypeFromClass((BuildingClassTypes)iBuildingClassLoop);
 		}

--- a/CvGameCoreDLL_Expansion2/CvGame.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGame.cpp
@@ -12724,7 +12724,7 @@ void CvGame::DoMinorBuyout(PlayerTypes eMajor, PlayerTypes eMinor)
 }
 #if defined(MOD_BALANCE_CORE_AFRAID_ANNEX)
 //	--------------------------------------------------------------------------------
-/// Do the action of a major buying out a minor and acquiring it
+/// Do the action of a major annexing a minor using tribute (Rome UA)
 void CvGame::DoMinorBullyAnnex(PlayerTypes eMajor, PlayerTypes eMinor)
 {
 	if (eMajor < 0 || eMajor >= MAX_MAJOR_CIVS) return;

--- a/CvGameCoreDLL_Expansion2/CvGame.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGame.cpp
@@ -12722,6 +12722,17 @@ void CvGame::DoMinorBuyout(PlayerTypes eMajor, PlayerTypes eMinor)
 
 	gDLL->sendMinorBuyout(eMajor, eMinor);
 }
+#if defined(MOD_BALANCE_CORE_AFRAID_ANNEX)
+//	--------------------------------------------------------------------------------
+/// Do the action of a major buying out a minor and acquiring it
+void CvGame::DoMinorBullyAnnex(PlayerTypes eMajor, PlayerTypes eMinor)
+{
+	if (eMajor < 0 || eMajor >= MAX_MAJOR_CIVS) return;
+	if (eMinor < MAX_MAJOR_CIVS || eMinor >= MAX_CIV_PLAYERS) return;
+
+	GET_PLAYER(eMinor).GetMinorCivAI()->DoMajorBullyAnnex(eMajor);
+}
+#endif
 //	--------------------------------------------------------------------------------
 /// Do the action of a major buying out a minor and marrying it
 void CvGame::DoMinorMarriage(PlayerTypes eMajor, PlayerTypes eMinor)

--- a/CvGameCoreDLL_Expansion2/CvGame.h
+++ b/CvGameCoreDLL_Expansion2/CvGame.h
@@ -632,6 +632,9 @@ public:
 	void DoMinorBullyGold(PlayerTypes eBully, PlayerTypes eMinor);
 	void DoMinorBullyUnit(PlayerTypes eBully, PlayerTypes eMinor);
 	void DoMinorBuyout(PlayerTypes eMajor, PlayerTypes eMinor);
+#if defined(MOD_BALANCE_CORE_AFRAID_ANNEX)
+	void DoMinorBullyAnnex(PlayerTypes eMajor, PlayerTypes eMinor);
+#endif
 	void DoMinorMarriage(PlayerTypes eMajor, PlayerTypes eMinor);
 
 	void DoDefensivePactNotification(PlayerTypes eFirstPlayer, PlayerTypes eSecondPlayer);

--- a/CvGameCoreDLL_Expansion2/CvMinorCivAI.h
+++ b/CvGameCoreDLL_Expansion2/CvMinorCivAI.h
@@ -694,9 +694,9 @@ public:
 	bool IsUnitSpawningAllowed(PlayerTypes ePlayer);
 	bool IsUnitSpawningDisabled(PlayerTypes ePlayer) const;
 	void SetUnitSpawningDisabled(PlayerTypes ePlayer, bool bValue);
-	CvUnit* DoSpawnUnit(PlayerTypes eMajor, bool bLocal = false, bool bExplore = false);
+	CvUnit* DoSpawnUnit(PlayerTypes eMajor, bool bLocal = false, bool bExplore = false, bool bCityStateAnnexed = false);
 	void DoUnitSpawnTurn();
-	int GetSpawnBaseTurns(PlayerTypes ePlayer);
+	int GetSpawnBaseTurns(PlayerTypes ePlayer, bool bCityStateAnnexed = false);
 	int GetCurrentSpawnEstimate(PlayerTypes ePlayer);
 
 	// Austria UA Stuff
@@ -731,6 +731,9 @@ public:
 	bool CanMajorBullyUnit(PlayerTypes ePlayer);
 	bool CanMajorBullyUnit(PlayerTypes ePlayer, int iSpecifiedBullyMetric);
 	CvString GetMajorBullyUnitDetails(PlayerTypes ePlayer);
+#if defined(MOD_BALANCE_CORE_AFRAID_ANNEX)
+	CvString GetMajorBullyAnnexDetails(PlayerTypes ePlayer);
+#endif
 
 	void DoMajorBullyGold(PlayerTypes eBully, int iGold);
 	void DoMajorBullyUnit(PlayerTypes eBully, UnitTypes eUnitType);

--- a/CvGameCoreDLL_Expansion2/CvMinorCivAI.h
+++ b/CvGameCoreDLL_Expansion2/CvMinorCivAI.h
@@ -713,7 +713,7 @@ public:
 	int GetBuyoutCost(PlayerTypes eMajor);
 
 	void DoBuyout(PlayerTypes eMajor);
-	int TransferUnitsAndCitiesToMajor(PlayerTypes eMajor); // also used by Merchant of Venice
+	int TransferUnitsAndCitiesToMajor(PlayerTypes eMajor, bool bForced = false); // also used by Merchant of Venice and Rome
 
 	// ************************************
 	// ***** Bullying *****
@@ -735,6 +735,9 @@ public:
 	void DoMajorBullyGold(PlayerTypes eBully, int iGold);
 	void DoMajorBullyUnit(PlayerTypes eBully, UnitTypes eUnitType);
 
+#if defined(MOD_BALANCE_CORE_AFRAID_ANNEX)
+	void DoMajorBullyAnnex(PlayerTypes eBully);
+#endif
 #if defined(MOD_BALANCE_CORE)
 	int GetYieldTheftAmount(PlayerTypes eBully, YieldTypes eYield, bool bIgnoreScaling = false);
 #endif

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -11127,25 +11127,6 @@ void CvPlayer::doTurn()
 		//Reset for reevaluation of citystrategy AI
 		countCitiesNeedingTerrainImprovements(true);
 #endif
-#if defined(MOD_BALANCE_CORE_AFRAID_ANNEX)
-		if(MOD_BALANCE_CORE_AFRAID_ANNEX)
-		{
-			if(GetPlayerTraits()->IsBullyAnnex() && !IsEmpireVeryUnhappy() && !isHuman())
-			{
-				for(int iPlayerLoop = MAX_MAJOR_CIVS; iPlayerLoop < MAX_CIV_PLAYERS; iPlayerLoop++)
-				{
-					PlayerTypes eLoopPlayer = (PlayerTypes) iPlayerLoop;
-					if(GET_PLAYER(eLoopPlayer).isMinorCiv() && GET_PLAYER(eLoopPlayer).isAlive())
-					{
-						if(GET_PLAYER(eLoopPlayer).GetMinorCivAI()->CanMajorBullyUnit(GetID()))
-						{
-							GC.getGame().DoMinorBullyUnit(GetID(), eLoopPlayer);
-						}
-					}
-				}
-			}
-		}
-#endif
 		if(GetPlayerTraits()->IsEndOfMayaLongCount())
 		{
 			ChangeNumMayaBoosts(1);

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -11087,10 +11087,6 @@ void CvPlayer::doTurn()
 
 	if(MOD_BALANCE_CORE && !isMinorCiv() && !isBarbarian())
 	{
-		if (GetPlayerTraits()->IsAnnexedCityStatesGiveYields())
-		{
-
-		}
 		RefreshCSAlliesFriends();
 		UpdateHappinessFromMinorCivs();
 #endif

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -398,107 +398,108 @@ CvPlayer::CvPlayer() :
 	, m_paiNumResourceTotal()
 	, m_paiResourceGiftedToMinors()
 	, m_paiResourceExport()
-	, m_paiResourceImportFromMajor()
-	, m_paiResourceFromMinors()
-	, m_paiResourcesSiphoned()
-	, m_aiNumResourceFromGP()
-	, m_paiImprovementCount()
-	, m_paiImprovementBuiltCount()
+, m_paiResourceImportFromMajor()
+, m_paiResourceFromMinors()
+, m_paiResourcesSiphoned()
+, m_aiNumResourceFromGP()
+, m_paiImprovementCount()
+, m_paiImprovementBuiltCount()
 #if defined(MOD_BALANCE_CORE)
-	, m_paiTotalImprovementsBuilt()
+, m_paiTotalImprovementsBuilt()
 #endif
-	, m_paiFreeBuildingCount()
-	, m_paiFreePromotionCount()
-	, m_paiUnitCombatProductionModifiers()
-	, m_paiUnitCombatFreeExperiences()
-	, m_paiUnitClassCount()
-	, m_paiUnitClassMaking()
-	, m_paiBuildingClassCount()
-	, m_paiBuildingClassMaking()
-	, m_paiProjectMaking()
-	, m_paiHurryCount()
-	, m_paiHurryModifier()
-	, m_pabLoyalMember()
-	, m_pabGetsScienceFromPlayer()
-	, m_ppaaiSpecialistExtraYield()
-	, m_ppiYieldFromYieldGlobal()
-	, m_ppaaiImprovementYieldChange()
-	, m_bEverPoppedGoody()
-	, m_bEverTrainedBuilder()
-	, m_iCityConnectionHappiness()
-	, m_iHolyCityID()
-	, m_iTurnsSinceSettledLastCity()
-	, m_iNumNaturalWondersDiscoveredInArea()
-	, m_iStrategicResourceMod()
-	, m_iSpecialistCultureChange()
-	, m_iGreatPeopleSpawnCounter()
-	, m_iFreeTechCount()
-	, m_iMedianTechPercentage(50)
-	, m_iNumFreePolicies()
-	, m_iNumFreePoliciesEver()
-	, m_iNumFreeTenets()
-	, m_iLastSliceMoved()
-	, m_eEndTurnBlockingType(NO_ENDTURN_BLOCKING_TYPE)
-	, m_iEndTurnBlockingNotificationIndex(0)
-	, m_activeWaitingForEndTurnMessage(false)
-	, m_endTurnBusyUnitUpdatesLeft(0)
-	, m_lastGameTurnInitialAIProcessed(-1)
-	, m_iNumFreeGreatPeople()
-	, m_iNumMayaBoosts()
-	, m_iNumFaithGreatPeople()
-	, m_iNumArchaeologyChoices()
-	, m_eFaithPurchaseType(NO_AUTOMATIC_FAITH_PURCHASE)
-	, m_iFaithPurchaseIndex()
-	, m_bProcessedAutoMoves(false)
+, m_paiFreeBuildingCount()
+, m_paiFreePromotionCount()
+, m_paiUnitCombatProductionModifiers()
+, m_paiUnitCombatFreeExperiences()
+, m_paiUnitClassCount()
+, m_paiUnitClassMaking()
+, m_paiBuildingClassCount()
+, m_paiBuildingClassMaking()
+, m_paiProjectMaking()
+, m_paiHurryCount()
+, m_paiHurryModifier()
+, m_pabLoyalMember()
+, m_pabGetsScienceFromPlayer()
+, m_ppaaiSpecialistExtraYield()
+, m_ppiYieldFromYieldGlobal()
+, m_ppaaiImprovementYieldChange()
+, m_bEverPoppedGoody()
+, m_bEverTrainedBuilder()
+, m_iCityConnectionHappiness()
+, m_iHolyCityID()
+, m_iTurnsSinceSettledLastCity()
+, m_iNumNaturalWondersDiscoveredInArea()
+, m_iStrategicResourceMod()
+, m_iSpecialistCultureChange()
+, m_iGreatPeopleSpawnCounter()
+, m_iFreeTechCount()
+, m_iMedianTechPercentage(50)
+, m_iNumFreePolicies()
+, m_iNumFreePoliciesEver()
+, m_iNumFreeTenets()
+, m_iLastSliceMoved()
+, m_eEndTurnBlockingType(NO_ENDTURN_BLOCKING_TYPE)
+, m_iEndTurnBlockingNotificationIndex(0)
+, m_activeWaitingForEndTurnMessage(false)
+, m_endTurnBusyUnitUpdatesLeft(0)
+, m_lastGameTurnInitialAIProcessed(-1)
+, m_iNumFreeGreatPeople()
+, m_iNumMayaBoosts()
+, m_iNumFaithGreatPeople()
+, m_iNumArchaeologyChoices()
+, m_eFaithPurchaseType(NO_AUTOMATIC_FAITH_PURCHASE)
+, m_iFaithPurchaseIndex()
+, m_bProcessedAutoMoves(false)
 #pragma warning(push)
 #pragma warning(disable:4355 )
-	, m_kPlayerAchievements(*this)
+, m_kPlayerAchievements(*this)
 #pragma warning(pop)
-	, m_neededUnitAITypes()
-	, m_aiCityYieldModFromMonopoly()
-	, m_iUnhappiness()
-	, m_iHappinessTotal()
-	, m_iEmpireSizeModifierReductionGlobal()
-	, m_iDistressFlatReductionGlobal()
-	, m_iPovertyFlatReductionGlobal()
-	, m_iIlliteracyFlatReductionGlobal()
-	, m_iBoredomFlatReductionGlobal()
-	, m_iReligiousUnrestFlatReductionGlobal()
-	, m_iBasicNeedsMedianModifierGlobal()
-	, m_iGoldMedianModifierGlobal()
-	, m_iCultureMedianModifierGlobal()
-	, m_iScienceMedianModifierGlobal()
-	, m_iReligiousUnrestModifierGlobal()
-	, m_iBasicNeedsMedianModifierCapital()
-	, m_iGoldMedianModifierCapital()
-	, m_iCultureMedianModifierCapital()
-	, m_iScienceMedianModifierCapital()
-	, m_iReligiousUnrestModifierCapital()
-	, m_iLandmarksTourismPercentGlobal()
-	, m_iGreatWorksTourismModifierGlobal()
-	, m_bAllowsProductionTradeRoutesGlobal()
-	, m_bAllowsFoodTradeRoutesGlobal()
+, m_neededUnitAITypes()
+, m_aiCityYieldModFromMonopoly()
+, m_iUnhappiness()
+, m_iHappinessTotal()
+, m_iEmpireSizeModifierReductionGlobal()
+, m_iDistressFlatReductionGlobal()
+, m_iPovertyFlatReductionGlobal()
+, m_iIlliteracyFlatReductionGlobal()
+, m_iBoredomFlatReductionGlobal()
+, m_iReligiousUnrestFlatReductionGlobal()
+, m_iBasicNeedsMedianModifierGlobal()
+, m_iGoldMedianModifierGlobal()
+, m_iCultureMedianModifierGlobal()
+, m_iScienceMedianModifierGlobal()
+, m_iReligiousUnrestModifierGlobal()
+, m_iBasicNeedsMedianModifierCapital()
+, m_iGoldMedianModifierCapital()
+, m_iCultureMedianModifierCapital()
+, m_iScienceMedianModifierCapital()
+, m_iReligiousUnrestModifierCapital()
+, m_iLandmarksTourismPercentGlobal()
+, m_iGreatWorksTourismModifierGlobal()
+, m_bAllowsProductionTradeRoutesGlobal()
+, m_bAllowsFoodTradeRoutesGlobal()
 #if defined(MOD_BALANCE_CORE)
-	, m_iCenterOfMassX()
-	, m_iCenterOfMassY()
-	, m_iReferenceFoundValue()
-	, m_iReformationFollowerReduction()
-	, m_bIsReformation()
-	, m_iSupplyFreeUnits()
-	, m_viInstantYieldsTotal()
-	, m_miLocalInstantYieldsTotal()
-	, m_aiYieldHistory()
+, m_iCenterOfMassX()
+, m_iCenterOfMassY()
+, m_iReferenceFoundValue()
+, m_iReformationFollowerReduction()
+, m_bIsReformation()
+, m_iSupplyFreeUnits()
+, m_viInstantYieldsTotal()
+, m_miLocalInstantYieldsTotal()
+, m_aiYieldHistory()
 #endif
 #if defined(MOD_BALANCE_CORE_POLICIES)
-	, m_iHappinessPerXPopulationGlobal()
-	, m_iIdeologyPoint()
-	, m_iNoXPLossUnitPurchase()
-	, m_iXCSAlliesLowersPolicyNeedWonders()
-	, m_iHappinessFromMinorCivs()
-	, m_iPositiveWarScoreTourismMod()
-	, m_iIsNoCSDecayAtWar()
-	, m_iCanBullyFriendlyCS()
-	, m_iBullyGlobalCSReduction()
+, m_iHappinessPerXPopulationGlobal()
+, m_iIdeologyPoint()
+, m_iNoXPLossUnitPurchase()
+, m_iXCSAlliesLowersPolicyNeedWonders()
+, m_iHappinessFromMinorCivs()
+, m_iPositiveWarScoreTourismMod()
+, m_iIsNoCSDecayAtWar()
+, m_iCanBullyFriendlyCS()
+, m_iKeepConqueredBuildings()
+, m_iBullyGlobalCSReduction()
 #endif
 	, m_iIsVassalsNoRebel()
 	, m_iVassalYieldBonusModifier()
@@ -1282,6 +1283,7 @@ void CvPlayer::uninit()
 	m_iPositiveWarScoreTourismMod = 0;
 	m_iIsNoCSDecayAtWar = 0;
 	m_iCanBullyFriendlyCS = 0;
+	m_iKeepConqueredBuildings = 0;
 	m_iBullyGlobalCSReduction = 0;
 #endif
 	m_iIsVassalsNoRebel = 0;
@@ -4095,14 +4097,12 @@ CvCity* CvPlayer::acquireCity(CvCity* pCity, bool bConquest, bool bGift)
 
 		BuildingTypes ePalace = (BuildingTypes)getCivilizationInfo().getCivilizationBuildings(GD_INT_GET(CAPITAL_BUILDINGCLASS));
 		CvCity* pCurrentCapital = getCapitalCity();
-		bool bRome = GetPlayerTraits()->IsKeepConqueredBuildings();
-
 		if (ePalace != NO_BUILDING)
 		{
 			// Remove the Palace from the current capital, if any
 			if (pCurrentCapital)
 			{
-				if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome)
+				if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 				{
 					pCurrentCapital->GetCityBuildings()->RemoveAllRealBuildingsOfClass((BuildingClassTypes)GD_INT_GET(CAPITAL_BUILDINGCLASS));
 				}
@@ -4146,7 +4146,7 @@ CvCity* CvPlayer::acquireCity(CvCity* pCity, bool bConquest, bool bGift)
 				// Delete from current capital
 				if (pCurrentCapital)
 				{
-					if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome)
+					if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 					{
 						pCurrentCapital->GetCityBuildings()->RemoveAllRealBuildingsOfClass(eBuildingClass);
 					}
@@ -4280,8 +4280,8 @@ CvCity* CvPlayer::acquireCity(CvCity* pCity, bool bConquest, bool bGift)
 		}
 	}
 
-	// Gifted/liberated/revolting cities and Rome always keep valid buildings
-	bool bKeepAllValidBuildings = GetPlayerTraits()->IsKeepConqueredBuildings() || !bConquest || bGift;
+	// Keep all valid buildings if city is gifted/liberated/revolting of if policy/trait IsKeepConqueredBuildings
+	bool bKeepAllValidBuildings = GetPlayerTraits()->IsKeepConqueredBuildings() || IsKeepConqueredBuildings() || !bConquest || bGift;
 	int iCaptureGreatWorks = 0;
 
 	// Now transfer buildings from the old city
@@ -4824,38 +4824,18 @@ bool CvPlayer::IsValidBuildingForPlayer(CvCity* pCity, BuildingTypes eBuilding, 
 	const CvBuildingClassInfo& pkClassInfo = pkLoopBuildingInfo->GetBuildingClassInfo();
 
 	bool bIsNationalWonder = ::isNationalWonderClass(pkClassInfo);
-	bool bCivUnique = pkClassInfo.getDefaultBuildingIndex() != eBuilding;
 	bool bProductionMaxed = isProductionMaxedBuildingClass(pkLoopBuildingInfo->GetBuildingClassType(), true);
 
-	if (GetPlayerTraits()->IsKeepConqueredBuildings())
-	{
-		if (!bCivUnique)
-		{
-			if (bIsNationalWonder || bProductionMaxed)
-				return false;
-		}
-		else
-		{
-			if (bIsNationalWonder && getNumBuildings(eBuilding) > 0)
-				return false;
-			else if (bProductionMaxed)
-				return false;
-		}
-	}
-	else
-	{
-		if (pkLoopBuildingInfo->IsNeverCapture() || bProductionMaxed || bIsNationalWonder)
-			return false;
 
-		if (!bConquest)
-			return true;
+	if (pkLoopBuildingInfo->IsNeverCapture() || bProductionMaxed || bIsNationalWonder)
+		return false;
 
-		int iConquestChance = GC.getGame().getSmallFakeRandNum(34, *pCity->plot()) + GC.getGame().getSmallFakeRandNum(34, pkLoopBuildingInfo->GetID()) + GC.getGame().getSmallFakeRandNum(32, GetPseudoRandomSeed() + GC.getGame().GetGoldMedian());
+	if (!bConquest || GetPlayerTraits()->IsKeepConqueredBuildings() || IsKeepConqueredBuildings())
+		return true;
 
-		return iConquestChance <= pkLoopBuildingInfo->GetConquestProbability();
-	}
+	int iConquestChance = GC.getGame().getSmallFakeRandNum(34, *pCity->plot()) + GC.getGame().getSmallFakeRandNum(34, pkLoopBuildingInfo->GetID()) + GC.getGame().getSmallFakeRandNum(32, GetPseudoRandomSeed() + GC.getGame().GetGoldMedian());
 
-	return true;
+	return iConquestChance <= pkLoopBuildingInfo->GetConquestProbability();
 }
 
 //	--------------------------------------------------------------------------------
@@ -6983,12 +6963,11 @@ void CvPlayer::DoCancelEventChoice(EventChoiceTypes eChosenEventChoice)
 						if (pCivilizationInfo != NULL)
 						{
 							BuildingTypes eBuildingType = NO_BUILDING;
-							bool bRome = GetPlayerTraits()->IsKeepConqueredBuildings();
-							if (!MOD_BUILDINGS_THOROUGH_PREREQUISITES && !bRome)
+							if (!MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 							{
 								eBuildingType = (BuildingTypes)pCivilizationInfo->getCivilizationBuildings(eBuildingClass);
 							}
-							if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome || eBuildingType != NO_BUILDING)
+							if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || eBuildingType != NO_BUILDING)
 							{
 								int iLoop = 0;
 								for (CvCity* pLoopCity = firstCity(&iLoop); pLoopCity != NULL; pLoopCity = nextCity(&iLoop))
@@ -7001,7 +6980,7 @@ void CvPlayer::DoCancelEventChoice(EventChoiceTypes eChosenEventChoice)
 									{
 										continue;
 									}
-									if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome || GET_PLAYER(pLoopCity->getOwner()).GetPlayerTraits()->IsKeepConqueredBuildings())
+									if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 									{
 										eBuildingType = pLoopCity->GetCityBuildings()->GetBuildingTypeFromClass(eBuildingClass);
 										if (eBuildingType == NO_BUILDING)
@@ -7149,13 +7128,12 @@ void CvPlayer::DoCancelEventChoice(EventChoiceTypes eChosenEventChoice)
 					if(pkEventChoiceInfo->getBuildingClassYield(eBuildingClass, eYield) != 0)
 					{
 						BuildingTypes eBuilding = NO_BUILDING;
-						bool bRome = GetPlayerTraits()->IsKeepConqueredBuildings();
-						if (!MOD_BUILDINGS_THOROUGH_PREREQUISITES && !bRome)
+						if (!MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 						{
 							eBuilding = (BuildingTypes)getCivilizationInfo().getCivilizationBuildings(eBuildingClass);
 						}
 
-						if(MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome || eBuilding != NO_BUILDING)
+						if(MOD_BUILDINGS_THOROUGH_PREREQUISITES || eBuilding != NO_BUILDING)
 						{
 							int iLoop = 0;
 							for(CvCity* pLoopCity = firstCity(&iLoop); pLoopCity != NULL; pLoopCity = nextCity(&iLoop))
@@ -7168,7 +7146,7 @@ void CvPlayer::DoCancelEventChoice(EventChoiceTypes eChosenEventChoice)
 								{
 									continue;
 								}
-								if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome)
+								if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 								{
 									eBuilding = pLoopCity->GetCityBuildings()->GetBuildingTypeFromClass(eBuildingClass);
 									if (eBuilding == NO_BUILDING)
@@ -7179,7 +7157,7 @@ void CvPlayer::DoCancelEventChoice(EventChoiceTypes eChosenEventChoice)
 
 								pLoopCity->ChangeEventBuildingClassYield(eBuildingClass, eYield, pkEventChoiceInfo->getBuildingClassYield(eBuildingClass, eYield) * -1);
 								bChanged = true;
-								if(MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome || pLoopCity->GetCityBuildings()->GetNumBuilding(eBuilding) > 0)
+								if(MOD_BUILDINGS_THOROUGH_PREREQUISITES || pLoopCity->GetCityBuildings()->GetNumBuilding(eBuilding) > 0)
 								{
 									pLoopCity->ChangeBaseYieldRateFromBuildings(eYield, pkEventChoiceInfo->getBuildingClassYield(eBuildingClass, eYield) * -1);
 								}
@@ -7189,13 +7167,12 @@ void CvPlayer::DoCancelEventChoice(EventChoiceTypes eChosenEventChoice)
 					if(pkEventChoiceInfo->getBuildingClassYieldModifier(eBuildingClass, eYield) != 0)
 					{
 						BuildingTypes eBuilding = NO_BUILDING;
-						bool bRome = GetPlayerTraits()->IsKeepConqueredBuildings();
-						if (!MOD_BUILDINGS_THOROUGH_PREREQUISITES && !bRome)
+						if (!MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 						{
 							eBuilding = (BuildingTypes)getCivilizationInfo().getCivilizationBuildings(eBuildingClass);
 						}
 
-						if(MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome || eBuilding != NO_BUILDING)
+						if(MOD_BUILDINGS_THOROUGH_PREREQUISITES || eBuilding != NO_BUILDING)
 						{
 							int iLoop = 0;
 							for(CvCity* pLoopCity = firstCity(&iLoop); pLoopCity != NULL; pLoopCity = nextCity(&iLoop))
@@ -7208,7 +7185,7 @@ void CvPlayer::DoCancelEventChoice(EventChoiceTypes eChosenEventChoice)
 								{
 									continue;
 								}
-								if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome)
+								if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 								{
 									eBuilding = pLoopCity->GetCityBuildings()->GetBuildingTypeFromClass(eBuildingClass);
 									if (eBuilding == NO_BUILDING)
@@ -7219,7 +7196,7 @@ void CvPlayer::DoCancelEventChoice(EventChoiceTypes eChosenEventChoice)
 
 								pLoopCity->ChangeEventBuildingClassYieldModifier(eBuildingClass, eYield, pkEventChoiceInfo->getBuildingClassYieldModifier(eBuildingClass, eYield) * -1);
 								bChanged = true;
-								if(MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome || pLoopCity->GetCityBuildings()->GetNumBuilding(eBuilding) > 0)
+								if(MOD_BUILDINGS_THOROUGH_PREREQUISITES || pLoopCity->GetCityBuildings()->GetNumBuilding(eBuilding) > 0)
 								{
 									pLoopCity->changeYieldRateModifier(eYield, pkEventChoiceInfo->getBuildingClassYieldModifier(eBuildingClass, eYield) * -1);
 								}
@@ -8342,14 +8319,12 @@ void CvPlayer::DoEventSyncChoices(EventChoiceTypes eEventChoice, CvCity* pCity)
 							if (pCivilizationInfo != NULL)
 							{
 								BuildingTypes eBuildingType = NO_BUILDING;
-								bool bRome = GetPlayerTraits()->IsKeepConqueredBuildings();
-
-								if (!MOD_BUILDINGS_THOROUGH_PREREQUISITES && !bRome)
+								if (!MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 								{
 									eBuildingType = (BuildingTypes)pCivilizationInfo->getCivilizationBuildings(eBuildingClass);
 								}
 
-								if(MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome || eBuildingType != NO_BUILDING)
+								if(MOD_BUILDINGS_THOROUGH_PREREQUISITES || eBuildingType != NO_BUILDING)
 								{
 									int iLoop = 0;
 									for(CvCity* pLoopCity = firstCity(&iLoop); pLoopCity != NULL; pLoopCity = nextCity(&iLoop))
@@ -8367,7 +8342,7 @@ void CvPlayer::DoEventSyncChoices(EventChoiceTypes eEventChoice, CvCity* pCity)
 											continue;
 										}
 
-										if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome)
+										if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 										{
 											eBuildingType = pLoopCity->GetCityBuildings()->GetBuildingTypeFromClass(eBuildingClass);
 											if (eBuildingType == NO_BUILDING)
@@ -8435,13 +8410,12 @@ void CvPlayer::DoEventSyncChoices(EventChoiceTypes eEventChoice, CvCity* pCity)
 						if(pkEventChoiceInfo->getBuildingClassYield(eBuildingClass, eYield) != 0)
 						{
 							BuildingTypes eBuilding = NO_BUILDING;
-							bool bRome = GetPlayerTraits()->IsKeepConqueredBuildings();
-							if (!MOD_BUILDINGS_THOROUGH_PREREQUISITES && !bRome)
+							if (!MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 							{
 								eBuilding = (BuildingTypes)getCivilizationInfo().getCivilizationBuildings(eBuildingClass);
 							}
 
-							if(MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome || eBuilding != NO_BUILDING)
+							if(MOD_BUILDINGS_THOROUGH_PREREQUISITES || eBuilding != NO_BUILDING)
 							{
 								int iLoop = 0;
 								for(CvCity* pLoopCity = firstCity(&iLoop); pLoopCity != NULL; pLoopCity = nextCity(&iLoop))
@@ -8457,7 +8431,7 @@ void CvPlayer::DoEventSyncChoices(EventChoiceTypes eEventChoice, CvCity* pCity)
 									{
 										continue;
 									}
-									if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome)
+									if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 									{
 										eBuilding = pLoopCity->GetCityBuildings()->GetBuildingTypeFromClass(eBuildingClass);
 									}
@@ -8472,13 +8446,12 @@ void CvPlayer::DoEventSyncChoices(EventChoiceTypes eEventChoice, CvCity* pCity)
 						if(pkEventChoiceInfo->getBuildingClassYieldModifier(eBuildingClass, eYield) != 0)
 						{
 							BuildingTypes eBuilding = NO_BUILDING;
-							bool bRome = GetPlayerTraits()->IsKeepConqueredBuildings();
-							if (!MOD_BUILDINGS_THOROUGH_PREREQUISITES && !bRome)
+							if (!MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 							{
 								eBuilding = (BuildingTypes)getCivilizationInfo().getCivilizationBuildings(eBuildingClass);
 							}
 
-							if(MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome || eBuilding != NO_BUILDING)
+							if(MOD_BUILDINGS_THOROUGH_PREREQUISITES || eBuilding != NO_BUILDING)
 							{
 								int iLoop = 0;
 								for(CvCity* pLoopCity = firstCity(&iLoop); pLoopCity != NULL; pLoopCity = nextCity(&iLoop))
@@ -8494,7 +8467,7 @@ void CvPlayer::DoEventSyncChoices(EventChoiceTypes eEventChoice, CvCity* pCity)
 									{
 										continue;
 									}
-									if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome)
+									if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 									{
 										eBuilding = pLoopCity->GetCityBuildings()->GetBuildingTypeFromClass(eBuildingClass);
 									}
@@ -8840,13 +8813,12 @@ void CvPlayer::DoEventChoice(EventChoiceTypes eEventChoice, EventTypes eEvent, b
 						if (pCivilizationInfo != NULL)
 						{
 							BuildingTypes eBuildingType = NO_BUILDING;
-							bool bRome = GetPlayerTraits()->IsKeepConqueredBuildings();
-							if (!MOD_BUILDINGS_THOROUGH_PREREQUISITES && !bRome)
+							if (!MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 							{
 								eBuildingType = (BuildingTypes)pCivilizationInfo->getCivilizationBuildings(eBuildingClass);
 							}
 							
-							if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome || eBuildingType != NO_BUILDING)
+							if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || eBuildingType != NO_BUILDING)
 							{
 								int iLoop = 0;
 								for (CvCity* pLoopCity = firstCity(&iLoop); pLoopCity != NULL; pLoopCity = nextCity(&iLoop))
@@ -8861,7 +8833,7 @@ void CvPlayer::DoEventChoice(EventChoiceTypes eEventChoice, EventTypes eEvent, b
 										continue;
 									}
 
-									if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome)
+									if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 									{
 										eBuildingType = (BuildingTypes)pCivilizationInfo->getCivilizationBuildings(eBuildingClass);
 										if (eBuildingType == NO_BUILDING)
@@ -8968,13 +8940,12 @@ void CvPlayer::DoEventChoice(EventChoiceTypes eEventChoice, EventTypes eEvent, b
 						if (pkEventChoiceInfo->getBuildingClassYield(eBuildingClass, eYield) != 0)
 						{
 							BuildingTypes eBuilding = NO_BUILDING;
-							bool bRome = GetPlayerTraits()->IsKeepConqueredBuildings();
-							if (!MOD_BUILDINGS_THOROUGH_PREREQUISITES && !bRome)
+							if (!MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 							{
 								eBuilding = (BuildingTypes)getCivilizationInfo().getCivilizationBuildings(eBuildingClass);
 							}
 
-							if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome || eBuilding != NO_BUILDING)
+							if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || eBuilding != NO_BUILDING)
 							{
 								int iLoop = 0;
 								for (CvCity* pLoopCity = firstCity(&iLoop); pLoopCity != NULL; pLoopCity = nextCity(&iLoop))
@@ -8987,7 +8958,7 @@ void CvPlayer::DoEventChoice(EventChoiceTypes eEventChoice, EventTypes eEvent, b
 									{
 										continue;
 									}
-									if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome)
+									if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 									{
 										eBuilding = pLoopCity->GetCityBuildings()->GetBuildingTypeFromClass(eBuildingClass);
 									}
@@ -9003,13 +8974,12 @@ void CvPlayer::DoEventChoice(EventChoiceTypes eEventChoice, EventTypes eEvent, b
 						if (pkEventChoiceInfo->getBuildingClassYieldModifier(eBuildingClass, eYield) != 0)
 						{
 							BuildingTypes eBuilding = (BuildingTypes)getCivilizationInfo().getCivilizationBuildings(eBuildingClass);
-							bool bRome = GetPlayerTraits()->IsKeepConqueredBuildings();
-							if (!MOD_BUILDINGS_THOROUGH_PREREQUISITES && !bRome)
+							if (!MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 							{
 								eBuilding = (BuildingTypes)getCivilizationInfo().getCivilizationBuildings(eBuildingClass);
 							}
 
-							if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome || eBuilding != NO_BUILDING)
+							if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || eBuilding != NO_BUILDING)
 							{
 								int iLoop = 0;
 								for (CvCity* pLoopCity = firstCity(&iLoop); pLoopCity != NULL; pLoopCity = nextCity(&iLoop))
@@ -9022,7 +8992,7 @@ void CvPlayer::DoEventChoice(EventChoiceTypes eEventChoice, EventTypes eEvent, b
 									{
 										continue;
 									}
-									if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome)
+									if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 									{
 										eBuilding = pLoopCity->GetCityBuildings()->GetBuildingTypeFromClass(eBuildingClass);
 									}
@@ -12465,7 +12435,6 @@ void CvPlayer::findNewCapital()
 
 	BuildingClassTypes eCapitalBuildingClass = (BuildingClassTypes)GD_INT_GET(CAPITAL_BUILDINGCLASS);
 	BuildingTypes eCapitalBuilding = ((BuildingTypes)(getCivilizationInfo().getCivilizationBuildings(eCapitalBuildingClass)));
-	bool bRome = GetPlayerTraits()->IsKeepConqueredBuildings();
 
 	CvCity* pOldCapital = getCapitalCity();
 	int iBestValue = 0;
@@ -12475,7 +12444,7 @@ void CvPlayer::findNewCapital()
 	{
 		if(pLoopCity != pOldCapital)
 		{
-			if(0 == pLoopCity->GetCityBuildings()->GetNumRealBuilding(eCapitalBuilding) || ((MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome) && !HasBuildingClass(eCapitalBuildingClass)))
+			if(0 == pLoopCity->GetCityBuildings()->GetNumRealBuilding(eCapitalBuilding) || (MOD_BUILDINGS_THOROUGH_PREREQUISITES && !HasBuildingClass(eCapitalBuildingClass)))
 			{
 				// First pass, exclude cities in resistance, puppets, and those burning to the ground
 				if (!(pLoopCity->IsResistance() || pLoopCity->IsPuppet() || pLoopCity->IsRazing()))
@@ -12505,7 +12474,7 @@ void CvPlayer::findNewCapital()
 		{
 			if (pLoopCity != pOldCapital)
 			{
-				if (0 == pLoopCity->GetCityBuildings()->GetNumRealBuilding(eCapitalBuilding) || ((MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome) && !HasBuildingClass(eCapitalBuildingClass)))
+				if (0 == pLoopCity->GetCityBuildings()->GetNumRealBuilding(eCapitalBuilding) || (MOD_BUILDINGS_THOROUGH_PREREQUISITES && !HasBuildingClass(eCapitalBuildingClass)))
 				{
 					int iValue = 0;
 
@@ -12540,7 +12509,7 @@ void CvPlayer::findNewCapital()
 	{
 		if (pOldCapital != NULL)
 		{
-			if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome)
+			if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 			{
 				if (pOldCapital->HasBuildingClass(eCapitalBuildingClass))
 				{
@@ -16726,12 +16695,11 @@ void CvPlayer::removeBuildingClass(BuildingClassTypes eBuildingClass)
 	BuildingTypes eBuilding = ((BuildingTypes)(getCivilizationInfo().getCivilizationBuildings(eBuildingClass)));
 	int iLoop = 0;
 
-	bool bRome = GetPlayerTraits()->IsKeepConqueredBuildings();
-	if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || eBuilding != NO_BUILDING || bRome)
+	if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || eBuilding != NO_BUILDING)
 	{
 		for(CvCity* pLoopCity = firstCity(&iLoop); pLoopCity != NULL; pLoopCity = nextCity(&iLoop))
 		{
-			if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome)
+			if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 			{
 				eBuilding = pLoopCity->GetCityBuildings()->GetBuildingTypeFromClass(eBuildingClass);
 			}
@@ -17149,7 +17117,7 @@ void CvPlayer::processBuilding(BuildingTypes eBuilding, int iChange, bool bFirst
 			}
 
 			BuildingTypes eTestBuilding = NO_BUILDING;
-			if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || GetPlayerTraits()->IsKeepConqueredBuildings())
+			if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 			{
 				eTestBuilding = pLoopCityBuildings->GetBuildingTypeFromClass(eBuildingClass);
 			}
@@ -19394,7 +19362,7 @@ void CvPlayer::DoFreeGreatWorkOnConquest(PlayerTypes ePlayer, CvCity* pCity)
 						{
 							const CvCivilizationInfo& playerCivilizationInfo = GET_PLAYER(ePlayer).getCivilizationInfo();
 							BuildingTypes eBuilding = NO_BUILDING;
-							if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || GET_PLAYER(ePlayer).GetPlayerTraits()->IsKeepConqueredBuildings())
+							if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 							{
 								eBuilding = pPlayerCity->GetCityBuildings()->GetBuildingTypeFromClass((BuildingClassTypes)iBuildingClassLoop);
 							}
@@ -19482,7 +19450,7 @@ void CvPlayer::DoFreeGreatWorkOnConquest(PlayerTypes ePlayer, CvCity* pCity)
 								}
 								const CvCivilizationInfo& playerCivilizationInfo = GET_PLAYER(ePlayer).getCivilizationInfo();
 								BuildingTypes eBuilding = NO_BUILDING;
-								if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || GET_PLAYER(ePlayer).GetPlayerTraits()->IsKeepConqueredBuildings())
+								if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 								{
 									eBuilding = pPlayerCity->GetCityBuildings()->GetBuildingTypeFromClass((BuildingClassTypes)iBuildingClassLoop);
 								}
@@ -23907,6 +23875,14 @@ void CvPlayer::ChangeCanBullyFriendlyCS(int iValue)
 bool CvPlayer::IsCanBullyFriendlyCS() const
 {
 	return m_iCanBullyFriendlyCS > 0;
+}
+void CvPlayer::ChangeKeepConqueredBuildings(int iValue)
+{
+	m_iKeepConqueredBuildings += iValue;
+}
+bool CvPlayer::IsKeepConqueredBuildings() const
+{
+	return m_iKeepConqueredBuildings > 0;
 }
 void CvPlayer::ChangeBullyGlobalCSReduction(int iValue)
 {
@@ -43855,15 +43831,13 @@ int CvPlayer::getAdvancedStartBuildingCost(BuildingTypes eBuilding, bool bAdd, C
 								{
 									int iNumBuildings = 0;
 									BuildingTypes ePrereqBuilding = ((BuildingTypes)(getCivilizationInfo().getCivilizationBuildings(iBuildingClassPrereqLoop)));
-									bool bRome = GetPlayerTraits()->IsKeepConqueredBuildings();
-
-									if(ePrereqBuilding != NO_BUILDING || MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome)
+									if(ePrereqBuilding != NO_BUILDING || MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 									{
 										CvCity* pLoopCity = NULL;
 										int iLoop = 0;
 										for(pLoopCity = firstCity(&iLoop); pLoopCity != NULL; pLoopCity = nextCity(&iLoop))
 										{
-											if(pLoopCity->GetCityBuildings()->GetNumBuilding(ePrereqBuilding) > 0 || ((MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome) && pLoopCity->HasBuildingClass(eBuildingClass)))
+											if(pLoopCity->GetCityBuildings()->GetNumBuilding(ePrereqBuilding) > 0 || (MOD_BUILDINGS_THOROUGH_PREREQUISITES && pLoopCity->HasBuildingClass(eBuildingClass)))
 											{
 												iNumBuildings++;
 											}
@@ -43878,14 +43852,13 @@ int CvPlayer::getAdvancedStartBuildingCost(BuildingTypes eBuilding, bool bAdd, C
 								if(MOD_BALANCE_CORE && pkBuildingLoopInfo->IsBuildingClassNeededNowhere(iBuildingClassPrereqLoop))
 								{
 									BuildingTypes ePrereqBuilding = ((BuildingTypes)(getCivilizationInfo().getCivilizationBuildings(iBuildingClassPrereqLoop)));
-									bool bRome = GetPlayerTraits()->IsKeepConqueredBuildings();
 
-									if(ePrereqBuilding != NO_BUILDING || MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome)
+									if(ePrereqBuilding != NO_BUILDING || MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 									{
 										int iLoop = 0;
 										for(CvCity* pLoopCity = firstCity(&iLoop); pLoopCity != NULL; pLoopCity = nextCity(&iLoop))
 										{
-											if(pLoopCity->GetCityBuildings()->GetNumBuilding(ePrereqBuilding) > 0 || ((MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome) && pLoopCity->HasBuildingClass(eBuildingClass)))
+											if(pLoopCity->GetCityBuildings()->GetNumBuilding(ePrereqBuilding) > 0 || (MOD_BUILDINGS_THOROUGH_PREREQUISITES && pLoopCity->HasBuildingClass(eBuildingClass)))
 											{
 												return -1;
 											}
@@ -44398,6 +44371,7 @@ void CvPlayer::processPolicies(PolicyTypes ePolicy, int iChange)
 
 	ChangeIsNoCSDecayAtWar(pPolicy->IsNoCSDecayAtWar() * iChange);
 	ChangeCanBullyFriendlyCS(pPolicy->CanBullyFriendlyCS() * iChange);
+	ChangeKeepConqueredBuildings(pPolicy->IsKeepConqueredBuildings() * iChange);
 	ChangeBullyGlobalCSReduction(pPolicy->GetBullyGlobalCSReduction() * iChange);
 	changeInfluenceForLiberation(pPolicy->GetInfluenceForLiberation() * iChange);
 	changeExperienceForLiberation(pPolicy->GetExperienceForLiberation() * iChange);
@@ -45154,7 +45128,7 @@ void CvPlayer::processPolicies(PolicyTypes ePolicy, int iChange)
 			}
 
 			eBuilding = NO_BUILDING;
-			if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || GetPlayerTraits()->IsKeepConqueredBuildings())
+			if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 			{
 				eBuilding = pLoopCity->GetCityBuildings()->GetBuildingTypeFromClass(eBuildingClass);
 			}
@@ -45282,7 +45256,7 @@ void CvPlayer::processPolicies(PolicyTypes ePolicy, int iChange)
 			if (iNumFreeBuildings > 0 || (pPolicy->GetAllCityFreeBuilding() == eBuildingClass))
 			{
 				BuildingTypes eBuilding = ((BuildingTypes)(getCivilizationInfo().getCivilizationBuildings(pkBuildingClassInfo->GetID())));
-				if (NO_BUILDING != eBuilding || (MOD_BUILDINGS_THOROUGH_PREREQUISITES || GetPlayerTraits()->IsKeepConqueredBuildings()))
+				if (NO_BUILDING != eBuilding || (MOD_BUILDINGS_THOROUGH_PREREQUISITES))
 				{
 					CvBuildingEntry* pkBuildingInfo = GC.getBuildingInfo(eBuilding);
 					if (pkBuildingInfo)
@@ -45292,7 +45266,7 @@ void CvPlayer::processPolicies(PolicyTypes ePolicy, int iChange)
 						int iLoopTwo = 0;
 						for (pLoopCity = firstCity(&iLoopTwo); pLoopCity != NULL; pLoopCity = nextCity(&iLoopTwo))
 						{
-							if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || GetPlayerTraits()->IsKeepConqueredBuildings())
+							if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 							{
 								if (pLoopCity->HasBuildingClass(eBuildingClass))
 								{
@@ -46224,7 +46198,7 @@ void CvPlayer::processCorporations(CorporationTypes eCorporation, int iChange)
 			}
 
 			BuildingTypes eTestBuilding = NO_BUILDING;
-			if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || GetPlayerTraits()->IsKeepConqueredBuildings())
+			if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 			{
 				eTestBuilding = pLoopCity->GetCityBuildings()->GetBuildingTypeFromClass(eBuildingClass);
 			}
@@ -46624,6 +46598,7 @@ void CvPlayer::Serialize(Player& player, Visitor& visitor)
 	visitor(player.m_iPositiveWarScoreTourismMod);
 	visitor(player.m_iIsNoCSDecayAtWar);
 	visitor(player.m_iCanBullyFriendlyCS);
+	visitor(player.m_iKeepConqueredBuildings);
 	visitor(player.m_iBullyGlobalCSReduction);
 	visitor(player.m_iIsVassalsNoRebel);
 	visitor(player.m_iVassalYieldBonusModifier);

--- a/CvGameCoreDLL_Expansion2/CvPlayer.h
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.h
@@ -801,6 +801,20 @@ public:
 	void ChangeConversionModifier(int iChange);
 #endif
 
+	// Extra Yields from Annexed Minors
+	int GetFoodInCapitalPerTurnFromAnnexedMinors() const;
+	void UpdateFoodInCapitalPerTurnFromAnnexedMinors();
+	int GetFoodInOtherCitiesPerTurnFromAnnexedMinors() const;
+	void UpdateFoodInOtherCitiesPerTurnFromAnnexedMinors();
+	int GetCulturePerTurnFromAnnexedMinors() const;
+	void UpdateCulturePerTurnFromAnnexedMinors();
+	int GetSciencePerTurnFromAnnexedMinors() const;
+	void UpdateSciencePerTurnFromAnnexedMinors();
+	int GetFaithPerTurnFromAnnexedMinors() const;
+	void UpdateFaithPerTurnFromAnnexedMinors();
+	int GetHappinessFromAnnexedMinors() const;
+	void UpdateHappinessFromAnnexedMinors();
+
 	int GetExtraLeagueVotes() const;
 	int GetImprovementLeagueVotes() const;
 	void ChangeImprovementLeagueVotes(int iChange);
@@ -1852,6 +1866,9 @@ public:
 	int getGoldenAgeYieldMod(YieldTypes eIndex)	const;
 	void changeGoldenAgeYieldMod(YieldTypes eIndex, int iChange);
 
+	int GetNumAnnexedCityStates(MinorCivTraitTypes eIndex)	const;
+	void ChangeNumAnnexedCityStates(MinorCivTraitTypes eIndex, int iChange);
+
 	int getYieldFromNonSpecialistCitizens(YieldTypes eIndex)	const;
 	void changeYieldFromNonSpecialistCitizens(YieldTypes eIndex, int iChange);
 
@@ -2435,6 +2452,10 @@ public:
 
 	int getUnitExtraCost(UnitClassTypes eUnitClass) const;
 	void setUnitExtraCost(UnitClassTypes eUnitClass, int iCost);
+
+	void addAnnexedMilitaryCityStates(PlayerTypes eMinor);
+	void removeAnnexedMilitaryCityStates(PlayerTypes eMinor);
+	void updateTimerAnnexedMilitaryCityStates();
 
 	void launch(VictoryTypes victoryType);
 
@@ -3027,6 +3048,12 @@ protected:
 #if defined(MOD_RELIGION_CONVERSION_MODIFIERS)
 	int m_iConversionModifier;
 #endif
+	int m_iFoodInCapitalFromAnnexedMinors;
+	int	m_iFoodInOtherCitiesFromAnnexedMinors;
+	int	m_iCulturePerTurnFromAnnexedMinors;
+	int	m_iSciencePerTurnFromAnnexedMinors;
+	int	m_iFaithPerTurnFromAnnexedMinors;
+	int	m_iHappinessFromAnnexedMinors;
 	int m_iExtraLeagueVotes;
 	int m_iImprovementLeagueVotes;
 	int m_iFaithToVotes;
@@ -3453,6 +3480,8 @@ protected:
 	std::vector<int> m_aiRelicYieldBonus;
 	std::vector<int> m_aiReligionYieldRateModifier;
 	std::vector<int> m_aiGoldenAgeYieldMod;
+	std::vector<int> m_aiNumAnnexedCityStates;
+	std::vector< std::pair<PlayerTypes, int> > m_AnnexedMilitaryCityStatesUnitSpawnTurns;
 	std::vector<int> m_aiYieldFromNonSpecialistCitizens;
 	std::vector<int> m_aiYieldModifierFromGreatWorks;
 	std::vector<int> m_aiYieldModifierFromActiveSpies;
@@ -3847,6 +3876,12 @@ SYNC_ARCHIVE_VAR(int, m_iHappinessPerXGreatWorks)
 SYNC_ARCHIVE_VAR(int, m_iEspionageModifier)
 SYNC_ARCHIVE_VAR(int, m_iSpyStartingRank)
 SYNC_ARCHIVE_VAR(int, m_iConversionModifier)
+SYNC_ARCHIVE_VAR(int, m_iFoodInCapitalFromAnnexedMinors)
+SYNC_ARCHIVE_VAR(int, m_iFoodInOtherCitiesFromAnnexedMinors)
+SYNC_ARCHIVE_VAR(int, m_iCulturePerTurnFromAnnexedMinors)
+SYNC_ARCHIVE_VAR(int, m_iSciencePerTurnFromAnnexedMinors)
+SYNC_ARCHIVE_VAR(int, m_iFaithPerTurnFromAnnexedMinors)
+SYNC_ARCHIVE_VAR(int, m_iHappinessFromAnnexedMinors)
 SYNC_ARCHIVE_VAR(int, m_iExtraLeagueVotes)
 SYNC_ARCHIVE_VAR(int, m_iImprovementLeagueVotes)
 SYNC_ARCHIVE_VAR(int, m_iFaithToVotes)
@@ -4226,6 +4261,7 @@ SYNC_ARCHIVE_VAR(std::vector<int>, m_aiFilmYieldBonus)
 SYNC_ARCHIVE_VAR(std::vector<int>, m_aiRelicYieldBonus)
 SYNC_ARCHIVE_VAR(std::vector<int>, m_aiReligionYieldRateModifier)
 SYNC_ARCHIVE_VAR(std::vector<int>, m_aiGoldenAgeYieldMod)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiNumAnnexedCityStates)
 SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldFromNonSpecialistCitizens)
 SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldModifierFromGreatWorks)
 SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldModifierFromActiveSpies)

--- a/CvGameCoreDLL_Expansion2/CvPlayer.h
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.h
@@ -1976,6 +1976,9 @@ public:
 	void ChangeCanBullyFriendlyCS(int iValue);
 	bool IsCanBullyFriendlyCS() const;
 
+	void ChangeKeepConqueredBuildings(int iValue);
+	bool IsKeepConqueredBuildings() const;
+
 	void ChangeBullyGlobalCSReduction(int iValue);
 	int GetBullyGlobalCSReduction() const;
 #endif
@@ -3004,6 +3007,7 @@ protected:
 	int m_iPositiveWarScoreTourismMod;
 	int m_iIsNoCSDecayAtWar;
 	int m_iCanBullyFriendlyCS;
+	int m_iKeepConqueredBuildings;
 	int m_iBullyGlobalCSReduction;	
 #endif
 	int m_iIsVassalsNoRebel;
@@ -3826,6 +3830,7 @@ SYNC_ARCHIVE_VAR(int, m_iHappinessFromMinorCivs)
 SYNC_ARCHIVE_VAR(int, m_iPositiveWarScoreTourismMod)
 SYNC_ARCHIVE_VAR(int, m_iIsNoCSDecayAtWar)
 SYNC_ARCHIVE_VAR(int, m_iCanBullyFriendlyCS)
+SYNC_ARCHIVE_VAR(int, m_iKeepConqueredBuildings)
 SYNC_ARCHIVE_VAR(int, m_iBullyGlobalCSReduction)
 SYNC_ARCHIVE_VAR(int, m_iIsVassalsNoRebel)
 SYNC_ARCHIVE_VAR(int, m_iVassalYieldBonusModifier)

--- a/CvGameCoreDLL_Expansion2/CvPlayer.h
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.h
@@ -3049,10 +3049,10 @@ protected:
 	int m_iConversionModifier;
 #endif
 	int m_iFoodInCapitalFromAnnexedMinors;
-	int	m_iFoodInOtherCitiesFromAnnexedMinors;
-	int	m_iCulturePerTurnFromAnnexedMinors;
-	int	m_iSciencePerTurnFromAnnexedMinors;
-	int	m_iFaithPerTurnFromAnnexedMinors;
+	int m_iFoodInOtherCitiesFromAnnexedMinors;
+	int m_iCulturePerTurnFromAnnexedMinors;
+	int m_iSciencePerTurnFromAnnexedMinors;
+	int m_iFaithPerTurnFromAnnexedMinors;
 	int	m_iHappinessFromAnnexedMinors;
 	int m_iExtraLeagueVotes;
 	int m_iImprovementLeagueVotes;

--- a/CvGameCoreDLL_Expansion2/CvPolicyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPolicyAI.cpp
@@ -874,18 +874,17 @@ int CvPolicyAI::GetBranchBuildingHappiness(CvPlayer* pPlayer, PolicyBranchTypes 
 					if (pkPolicyInfo->GetBuildingClassHappiness(eBuildingClass) != 0)
 					{
 						BuildingTypes eBuilding = NO_BUILDING;
-						bool bRome = pPlayer->GetPlayerTraits()->IsKeepConqueredBuildings();
 
-						if (!MOD_BUILDINGS_THOROUGH_PREREQUISITES && !bRome)
+						if (!MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 						{
 							eBuilding = (BuildingTypes)pPlayer->getCivilizationInfo().getCivilizationBuildings(eBuildingClass);
 						}
-						if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome || eBuilding != NO_BUILDING)
+						if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || eBuilding != NO_BUILDING)
 						{
 							int iLoop = 0;
 							for (CvCity* pCity = pPlayer->firstCity(&iLoop); pCity != NULL; pCity = pPlayer->nextCity(&iLoop))
 							{
-								if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome)
+								if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 								{
 									eBuilding = pCity->GetCityBuildings()->GetBuildingTypeFromClass(eBuildingClass);
 									if (eBuilding == NO_BUILDING)

--- a/CvGameCoreDLL_Expansion2/CvPolicyClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPolicyClasses.cpp
@@ -3023,7 +3023,7 @@ bool CvPolicyEntry::GetDoubleBorderGrowthWLTKD() const
 	return m_bDoubleBorderGrowthWLTKD;
 }
 /// Are all buildings kept on city conquest?
-bool CvPolicyEntry::GetKeepConqueredBuildings() const
+bool CvPolicyEntry::IsKeepConqueredBuildings() const
 {
 	return m_bKeepConqueredBuildings;
 }
@@ -5794,7 +5794,7 @@ void CvPlayerPolicies::DoSwitchIdeologies(PolicyBranchTypes eNewBranchType)
 				const CvCivilizationInfo& playerCivilizationInfo = kCityPlayer.getCivilizationInfo();
 				BuildingTypes eBuilding = NO_BUILDING;
 
-				if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || m_pPlayer->GetPlayerTraits()->IsKeepConqueredBuildings())
+				if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 				{
 					eBuilding = pLoopCity->GetCityBuildings()->GetBuildingTypeFromClass((BuildingClassTypes)iBuildingClassLoop);
 				}

--- a/CvGameCoreDLL_Expansion2/CvPolicyClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPolicyClasses.cpp
@@ -297,6 +297,7 @@ CvPolicyEntry::CvPolicyEntry(void):
 	m_bNoUnhappyIsolation(false),
 	m_bDoubleBorderGrowthGA(false),
 	m_bDoubleBorderGrowthWLTKD(false),
+	m_bKeepConqueredBuildings(false),
 	m_iIncreasedQuestInfluence(0),
 	m_iGreatScientistBeakerModifier(0),
 	m_iGreatEngineerHurryModifier(0),
@@ -745,6 +746,7 @@ bool CvPolicyEntry::CacheResults(Database::Results& kResults, CvDatabaseUtility&
 	m_bNoUnhappyIsolation = kResults.GetBool("NoUnhappyIsolation");
 	m_bDoubleBorderGrowthGA = kResults.GetBool("DoubleBorderGrowthGA");
 	m_bDoubleBorderGrowthWLTKD = kResults.GetBool("DoubleBorderGrowthWLTKD");
+	m_bKeepConqueredBuildings = kResults.GetBool("KeepConqueredBuildings");
 	m_iIncreasedQuestInfluence = kResults.GetInt("IncreasedQuestRewards");
 	m_iGreatScientistBeakerModifier = kResults.GetInt("GreatScientistBeakerModifier");
 	m_iGreatEngineerHurryModifier = kResults.GetInt("GreatEngineerHurryModifier");
@@ -3019,6 +3021,11 @@ bool CvPolicyEntry::GetDoubleBorderGrowthGA() const
 bool CvPolicyEntry::GetDoubleBorderGrowthWLTKD() const
 {
 	return m_bDoubleBorderGrowthWLTKD;
+}
+/// Are all buildings kept on city conquest?
+bool CvPolicyEntry::GetKeepConqueredBuildings() const
+{
+	return m_bKeepConqueredBuildings;
 }
 /// Increased influence from quests?
 int CvPolicyEntry::GetIncreasedQuestInfluence() const

--- a/CvGameCoreDLL_Expansion2/CvPolicyClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvPolicyClasses.h
@@ -315,6 +315,7 @@ public:
 	bool GetNoUnhappyIsolation() const;
 	bool GetDoubleBorderGrowthGA() const;
 	bool GetDoubleBorderGrowthWLTKD() const;
+	bool GetKeepConqueredBuildings() const;
 	int GetIncreasedQuestInfluence() const;
 	int GetGreatScientistBeakerModifier() const;
 	int GetGreatEngineerHurryModifier() const;
@@ -758,6 +759,7 @@ private:
 	bool m_bNoUnhappyIsolation;
 	bool m_bDoubleBorderGrowthGA;
 	bool m_bDoubleBorderGrowthWLTKD;
+	bool m_bKeepConqueredBuildings;
 	int m_iGreatScientistBeakerModifier;
 	int m_iGreatEngineerHurryModifier;
 	int m_iTechCostXCitiesMod;

--- a/CvGameCoreDLL_Expansion2/CvPolicyClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvPolicyClasses.h
@@ -315,7 +315,7 @@ public:
 	bool GetNoUnhappyIsolation() const;
 	bool GetDoubleBorderGrowthGA() const;
 	bool GetDoubleBorderGrowthWLTKD() const;
-	bool GetKeepConqueredBuildings() const;
+	bool IsKeepConqueredBuildings() const;
 	int GetIncreasedQuestInfluence() const;
 	int GetGreatScientistBeakerModifier() const;
 	int GetGreatEngineerHurryModifier() const;

--- a/CvGameCoreDLL_Expansion2/CvReligionClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvReligionClasses.cpp
@@ -8473,7 +8473,7 @@ int CvReligionAI::ScoreBeliefAtCity(CvBeliefEntry* pEntry, CvCity* pCity) const
 
 			BuildingTypes eBuilding = NO_BUILDING;
 
-			if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || m_pPlayer->GetPlayerTraits()->IsKeepConqueredBuildings())
+			if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 			{
 				eBuilding = pCity->GetCityBuildings()->GetBuildingTypeFromClass((BuildingClassTypes)jJ);
 			}
@@ -10158,9 +10158,8 @@ bool CvReligionAI::AreAllOurCitiesHaveFaithBuilding(ReligionTypes eReligion, boo
 					continue;
 				}
 
-				//Exception for new Rome UA, because civ type doesn't help you here.
-				//Also use this if the option to check for all buildings in a class is enabled.
-				if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || m_pPlayer->GetPlayerTraits()->IsKeepConqueredBuildings())
+				//Exception if the option to check for all buildings in a class is enabled
+				if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 				{
 					if (!pLoopCity->HasBuildingClass(eFaithBuildingClass))
 					{

--- a/CvGameCoreDLL_Expansion2/CvTeam.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTeam.cpp
@@ -8886,9 +8886,25 @@ void CvTeam::SetCurrentEra(EraTypes eNewValue)
 				//specialist food consumption changed, set all cities dirty
 				for(CvCity* pLoopCity = kPlayer.firstCity(&iLoop); pLoopCity != NULL; pLoopCity = kPlayer.nextCity(&iLoop))
 					pLoopCity->GetCityCitizens()->SetDirty(true);
+
 			}
 		}
 #endif
+		// Update Yields from Annexed City-States (Rome UA)
+		for (int iPlayerLoop = 0; iPlayerLoop < MAX_CIV_PLAYERS; iPlayerLoop++)
+		{
+			ePlayer = (PlayerTypes)iPlayerLoop;
+			CvPlayerAI& kPlayer = GET_PLAYER(ePlayer);
+			if (kPlayer.isAlive() && kPlayer.getTeam() == GetID())
+			{
+				kPlayer.UpdateFoodInCapitalPerTurnFromAnnexedMinors();
+				kPlayer.UpdateFoodInOtherCitiesPerTurnFromAnnexedMinors();
+				kPlayer.UpdateCulturePerTurnFromAnnexedMinors();
+				kPlayer.UpdateSciencePerTurnFromAnnexedMinors();
+				kPlayer.UpdateFaithPerTurnFromAnnexedMinors();
+				kPlayer.UpdateHappinessFromAnnexedMinors();
+			}
+		}
 #if defined(MOD_BALANCE_CORE)
 		updateYield();
 		for (int iPlayerLoop = 0; iPlayerLoop < MAX_CIV_PLAYERS; iPlayerLoop++)

--- a/CvGameCoreDLL_Expansion2/CvTeam.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTeam.cpp
@@ -5301,8 +5301,7 @@ void CvTeam::changeProjectCount(ProjectTypes eIndex, int iChange)
 									if(pCapital == NULL)
 										continue;
 
-									bool bRome = GET_PLAYER((PlayerTypes)iJ).GetPlayerTraits()->IsKeepConqueredBuildings();
-									if ((MOD_BUILDINGS_THOROUGH_PREREQUISITES || bRome) && pCapital->HasBuildingClass(eBuildingClass))
+									if ((MOD_BUILDINGS_THOROUGH_PREREQUISITES) && pCapital->HasBuildingClass(eBuildingClass))
 									{
 										eBuilding = pCapital->GetCityBuildings()->GetBuildingTypeFromClass(eBuildingClass);
 									}
@@ -8047,7 +8046,7 @@ void CvTeam::processTech(TechTypes eTech, int iChange)
 								{
 									bool bHasBuildingClass = pLoopCity->HasBuildingClass((BuildingClassTypes)iI);
 									BuildingTypes eReplacedBuilding = eBuilding;
-									if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || kPlayer.GetPlayerTraits()->IsKeepConqueredBuildings())
+									if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 									{
 										if (bHasBuildingClass)
 										{

--- a/CvGameCoreDLL_Expansion2/CvTradeClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTradeClasses.cpp
@@ -5315,7 +5315,7 @@ int CvPlayerTrade::GetTradeRouteTurnMod(CvCity* pOriginCity) const
 		{
 			BuildingTypes eBuilding = NO_BUILDING;
 
-			if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || m_pPlayer->GetPlayerTraits()->IsKeepConqueredBuildings())
+			if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 			{
 				eBuilding = pLoopCity->GetCityBuildings()->GetBuildingTypeFromClass((BuildingClassTypes)iI);
 			}
@@ -6592,7 +6592,7 @@ CvTradeAI::TRSortElement CvTradeAI::ScoreInternationalTR(const TradeConnection& 
 					{
 						BuildingTypes eOfficeBuilding = NO_BUILDING;
 
-						if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || m_pPlayer->GetPlayerTraits()->IsKeepConqueredBuildings())
+						if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 						{
 							if (pFromCity->HasBuildingClass(eOffice))
 							{

--- a/CvGameCoreDLL_Expansion2/CvTraitClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTraitClasses.cpp
@@ -150,6 +150,7 @@ CvTraitEntry::CvTraitEntry() :
 	m_iSharedReligionTourismModifier(0),
 	m_iExtraMissionaryStrength(0),
 	m_bCanGoldInternalTradeRoutes(false),
+	m_bAnnexedCityStatesGiveYields(false),
 	m_iExtraTradeRoutesPerXOwnedCities(0),
 	m_iExtraTradeRoutesPerXOwnedVassals(0),
 	m_iMinorInfluencePerGiftedUnit(0),
@@ -920,6 +921,11 @@ int CvTraitEntry::GetExtraMissionaryStrength() const
 bool CvTraitEntry::IsCanGoldInternalTradeRoutes() const
 {
 	return m_bCanGoldInternalTradeRoutes;
+}
+/// Conquered City-States continue to give bonus yields
+bool CvTraitEntry::IsAnnexedCityStatesGiveYields() const
+{
+	return m_bAnnexedCityStatesGiveYields;
 }
 int CvTraitEntry::GetExtraTradeRoutesPerXOwnedCities() const
 {
@@ -2409,6 +2415,7 @@ bool CvTraitEntry::CacheResults(Database::Results& kResults, CvDatabaseUtility& 
 	m_iSharedReligionTourismModifier		= kResults.GetInt("SharedReligionTourismModifier");
 	m_iExtraMissionaryStrength				= kResults.GetInt("ExtraMissionaryStrength");
 	m_bCanGoldInternalTradeRoutes			= kResults.GetBool("CanGoldInternalTradeRoutes");
+	m_bAnnexedCityStatesGiveYields =	kResults.GetBool("AnnexedCityStatesGiveYields");
 	m_iExtraTradeRoutesPerXOwnedCities		= kResults.GetInt("TradeRoutesPerXOwnedCities");
 	m_iExtraTradeRoutesPerXOwnedVassals		= kResults.GetInt("TradeRoutesPerXOwnedVassals");
 	m_iMinorInfluencePerGiftedUnit			= kResults.GetInt("MinorInfluencePerGiftedUnit");
@@ -3925,6 +3932,7 @@ void CvPlayerTraits::SetIsWarmonger()
 		IsCanPurchaseNavalUnitsFaith() ||
 		IsBullyAnnex() ||
 		IgnoreBullyPenalties() ||
+		IsAnnexedCityStatesGiveYields() ||
 		GetBullyYieldMultiplierAnnex() != 0 ||
 		(GetPuppetPenaltyReduction() != 0 && !IsNoAnnexing()) || // puppet & annexing - Warmonger, puppet & no annexing - Smaller
 		IsFightWellDamaged() ||
@@ -4498,6 +4506,10 @@ void CvPlayerTraits::InitPlayerTraits()
 			if (trait->IsCanGoldInternalTradeRoutes())
 			{
 				m_bCanGoldInternalTradeRoutes = true;
+			}
+			if (trait->IsAnnexedCityStatesGiveYields())
+			{
+				m_bAnnexedCityStatesGiveYields = true;
 			}
 			m_iExtraTradeRoutesPerXOwnedCities += trait->GetExtraTradeRoutesPerXOwnedCities();
 			m_iExtraTradeRoutesPerXOwnedVassals += trait->GetExtraTradeRoutesPerXOwnedVassals();
@@ -5296,6 +5308,7 @@ void CvPlayerTraits::Reset()
 	m_iSharedReligionTourismModifier = 0;
 	m_iExtraMissionaryStrength = 0;
 	m_bCanGoldInternalTradeRoutes = false;
+	m_bAnnexedCityStatesGiveYields = false;
 	m_iExtraTradeRoutesPerXOwnedCities = 0;
 	m_iExtraTradeRoutesPerXOwnedVassals = 0;
 	m_iMinorInfluencePerGiftedUnit = 0;
@@ -7517,6 +7530,7 @@ void CvPlayerTraits::Serialize(PlayerTraits& playerTraits, Visitor& visitor)
 	visitor(playerTraits.m_iSharedReligionTourismModifier);
 	visitor(playerTraits.m_iExtraMissionaryStrength);
 	visitor(playerTraits.m_bCanGoldInternalTradeRoutes);
+	visitor(playerTraits.m_bAnnexedCityStatesGiveYields);
 	visitor(playerTraits.m_iExtraTradeRoutesPerXOwnedCities);
 	visitor(playerTraits.m_iExtraTradeRoutesPerXOwnedVassals);
 	visitor(playerTraits.m_iMinorInfluencePerGiftedUnit);

--- a/CvGameCoreDLL_Expansion2/CvTraitClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTraitClasses.cpp
@@ -2415,7 +2415,7 @@ bool CvTraitEntry::CacheResults(Database::Results& kResults, CvDatabaseUtility& 
 	m_iSharedReligionTourismModifier		= kResults.GetInt("SharedReligionTourismModifier");
 	m_iExtraMissionaryStrength				= kResults.GetInt("ExtraMissionaryStrength");
 	m_bCanGoldInternalTradeRoutes			= kResults.GetBool("CanGoldInternalTradeRoutes");
-	m_bAnnexedCityStatesGiveYields =	kResults.GetBool("AnnexedCityStatesGiveYields");
+	m_bAnnexedCityStatesGiveYields			= kResults.GetBool("AnnexedCityStatesGiveYields");
 	m_iExtraTradeRoutesPerXOwnedCities		= kResults.GetInt("TradeRoutesPerXOwnedCities");
 	m_iExtraTradeRoutesPerXOwnedVassals		= kResults.GetInt("TradeRoutesPerXOwnedVassals");
 	m_iMinorInfluencePerGiftedUnit			= kResults.GetInt("MinorInfluencePerGiftedUnit");

--- a/CvGameCoreDLL_Expansion2/CvTraitClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvTraitClasses.h
@@ -234,6 +234,7 @@ public:
 	int GetSharedReligionTourismModifier() const;
 	int GetExtraMissionaryStrength() const;
 	bool IsCanGoldInternalTradeRoutes() const;
+	bool IsAnnexedCityStatesGiveYields() const;
 	int GetExtraTradeRoutesPerXOwnedCities() const;
 	int GetExtraTradeRoutesPerXOwnedVassals() const;
 	int GetMinorInfluencePerGiftedUnit() const;
@@ -594,6 +595,7 @@ protected:
 	int m_iSharedReligionTourismModifier;
 	int m_iExtraMissionaryStrength;
 	bool m_bCanGoldInternalTradeRoutes;
+	bool m_bAnnexedCityStatesGiveYields;
 	int m_iExtraTradeRoutesPerXOwnedCities;
 	int m_iExtraTradeRoutesPerXOwnedVassals;
 	int m_iMinorInfluencePerGiftedUnit;
@@ -1381,6 +1383,10 @@ public:
 	bool IsCanGoldInternalTradeRoutes() const
 	{
 		return m_bCanGoldInternalTradeRoutes;
+	};
+	bool IsAnnexedCityStatesGiveYields() const
+	{
+		return m_bAnnexedCityStatesGiveYields;
 	};
 	int GetExtraTradeRoutesPerXOwnedCities() const
 	{
@@ -2206,6 +2212,7 @@ private:
 	int m_iSharedReligionTourismModifier;
 	int m_iExtraMissionaryStrength;
 	bool m_bCanGoldInternalTradeRoutes;
+	bool m_bAnnexedCityStatesGiveYields;
 	int m_iExtraTradeRoutesPerXOwnedCities;
 	int m_iExtraTradeRoutesPerXOwnedVassals;
 	int m_iMinorInfluencePerGiftedUnit;

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaCity.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaCity.cpp
@@ -1185,7 +1185,7 @@ int CvLuaCity::lGetPurchaseUnitTooltip(lua_State* L)
 			{
 				BuildingTypes ePrereqBuilding = NO_BUILDING;
 
-				if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || GET_PLAYER(pkCity->getOwner()).GetPlayerTraits()->IsKeepConqueredBuildings())
+				if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 				{
 					if (pkCity->HasBuildingClass(eBuildingClass))
 					{
@@ -2452,7 +2452,7 @@ int CvLuaCity::lGetNumBuildingClass(lua_State* L)
 		const CvCivilizationInfo& playerCivilizationInfo = GET_PLAYER(pkCity->getOwner()).getCivilizationInfo();
 		BuildingTypes eBuilding = NO_BUILDING;
 		int iResult = 0;
-		if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || GET_PLAYER(pkCity->getOwner()).GetPlayerTraits()->IsKeepConqueredBuildings())
+		if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 		{
 			iResult = pkCity->GetCityBuildings()->GetNumBuildingClass(eBuildingClassType);
 		}
@@ -2477,7 +2477,7 @@ int CvLuaCity::lIsHasBuildingClass(lua_State* L)
 	const BuildingClassTypes eBuildingClassType = (BuildingClassTypes)lua_tointeger(L, 2);
 	if(eBuildingClassType != NO_BUILDINGCLASS)
 	{
-		if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || GET_PLAYER(pkCity->getOwner()).GetPlayerTraits()->IsKeepConqueredBuildings())
+		if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 		{
 			const bool bResult = pkCity->HasBuildingClass(eBuildingClassType);
 			lua_pushboolean(L, bResult);

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaGame.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaGame.cpp
@@ -279,6 +279,7 @@ void CvLuaGame::RegisterMembers(lua_State* L)
 	Method(DoMinorGiftTileImprovement);
 	Method(DoMinorBullyGold);
 	Method(DoMinorBullyUnit);
+	Method(DoMinorBullyAnnex);
 	Method(DoMinorBuyout);
 	Method(DoMinorMarriage);
 
@@ -1920,6 +1921,15 @@ int CvLuaGame::lDoMinorBullyUnit(lua_State* L)
 	const int iBully = lua_tointeger(L, 1);
 	const int iMinor = lua_tointeger(L, 2);
 	GC.getGame().DoMinorBullyUnit((PlayerTypes)iBully, (PlayerTypes)iMinor);
+
+	return 1;
+}
+//void DoMinorBullyAnnex(int iBullyCivID, int iMinorCivID);
+int CvLuaGame::lDoMinorBullyAnnex(lua_State* L)
+{
+	const int iBully = lua_tointeger(L, 1);
+	const int iMinor = lua_tointeger(L, 2);
+	GC.getGame().DoMinorBullyAnnex((PlayerTypes)iBully, (PlayerTypes)iMinor);
 
 	return 1;
 }

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaGame.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaGame.cpp
@@ -279,7 +279,9 @@ void CvLuaGame::RegisterMembers(lua_State* L)
 	Method(DoMinorGiftTileImprovement);
 	Method(DoMinorBullyGold);
 	Method(DoMinorBullyUnit);
+#if defined(MOD_BALANCE_CORE_AFRAID_ANNEX)
 	Method(DoMinorBullyAnnex);
+#endif
 	Method(DoMinorBuyout);
 	Method(DoMinorMarriage);
 
@@ -1924,6 +1926,7 @@ int CvLuaGame::lDoMinorBullyUnit(lua_State* L)
 
 	return 1;
 }
+#if defined(MOD_BALANCE_CORE_AFRAID_ANNEX)
 //void DoMinorBullyAnnex(int iBullyCivID, int iMinorCivID);
 int CvLuaGame::lDoMinorBullyAnnex(lua_State* L)
 {
@@ -1933,6 +1936,7 @@ int CvLuaGame::lDoMinorBullyAnnex(lua_State* L)
 
 	return 1;
 }
+#endif
 //------------------------------------------------------------------------------
 //void DoMinorBuyout(int iMajorCivID, int iMinorCivID);
 int CvLuaGame::lDoMinorBuyout(lua_State* L)

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaGame.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaGame.h
@@ -264,6 +264,7 @@ protected:
 	static int lDoMinorGiftTileImprovement(lua_State* L);
 	static int lDoMinorBullyGold(lua_State* L);
 	static int lDoMinorBullyUnit(lua_State* L);
+	static int lDoMinorBullyAnnex(lua_State* L);
 	static int lDoMinorBuyout(lua_State* L);
 	static int lDoMinorMarriage(lua_State* L);
 

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaGame.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaGame.h
@@ -264,7 +264,9 @@ protected:
 	static int lDoMinorGiftTileImprovement(lua_State* L);
 	static int lDoMinorBullyGold(lua_State* L);
 	static int lDoMinorBullyUnit(lua_State* L);
+#if defined(MOD_BALANCE_CORE_AFRAID_ANNEX)
 	static int lDoMinorBullyAnnex(lua_State* L);
+#endif
 	static int lDoMinorBuyout(lua_State* L);
 	static int lDoMinorMarriage(lua_State* L);
 

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
@@ -749,6 +749,9 @@ void CvLuaPlayer::PushMethods(lua_State* L, int t)
 	Method(GetMajorBullyGoldDetails);
 	Method(CanMajorBullyUnit);
 	Method(GetMajorBullyUnitDetails);
+#if defined(MOD_BALANCE_CORE_AFRAID_ANNEX);
+	Method(GetMajorBullyAnnexDetails);
+#endif
 	Method(GetMajorBullyValue);
 	Method(CanMajorBuyout);
 	Method(CanMajorMarry);
@@ -1092,6 +1095,10 @@ void CvLuaPlayer::PushMethods(lua_State* L, int t)
 	Method(IsDiplomaticMarriage);
 	Method(IsGPWLTKD);
 	Method(IsCarnaval);
+	Method(GetCulturePerTurnFromAnnexedMinors);
+	Method(GetFaithPerTurnFromAnnexedMinors);
+	Method(GetSciencePerTurnFromAnnexedMinors);
+	Method(GetHappinessFromAnnexedMinors);
 	Method(GetTraitConquestOfTheWorldCityAttackMod);
 	Method(IsUsingMayaCalendar);
 	Method(GetMayaCalendarString);
@@ -8955,6 +8962,19 @@ int CvLuaPlayer::lGetMajorBullyUnitDetails(lua_State* L)
 	lua_pushstring(L, sResult);
 	return 1;
 }
+#if defined(MOD_BALANCE_CORE_AFRAID_ANNEX)
+//------------------------------------------------------------------------------
+//bool GetMajorBullyAnnexDetails(PlayerTypes eMajor);
+int CvLuaPlayer::lGetMajorBullyAnnexDetails(lua_State* L)
+{
+	CvPlayerAI* pkPlayer = GetInstance(L);
+	PlayerTypes eMajor = (PlayerTypes)lua_tointeger(L, 2);
+
+	const CvString sResult = pkPlayer->GetMinorCivAI()->GetMajorBullyAnnexDetails(eMajor);
+	lua_pushstring(L, sResult);
+	return 1;
+}
+#endif
 
 //------------------------------------------------------------------------------
 //bool GetMajorBullyUnitDetails(PlayerTypes eMajor);
@@ -12212,6 +12232,59 @@ int CvLuaPlayer::lIsCarnaval(lua_State* L)
 	return 1;
 }
 #endif
+//------------------------------------------------------------------------------
+int CvLuaPlayer::lGetCulturePerTurnFromAnnexedMinors(lua_State* L)
+{
+	CvPlayer* pkPlayer = GetInstance(L);
+	if (pkPlayer)
+	{
+		lua_pushinteger(L, pkPlayer->GetCulturePerTurnFromAnnexedMinors());
+		return 1;
+	}
+	//BUG: This can't be right...
+	lua_pushinteger(L, -1);
+	return 0;
+}
+//------------------------------------------------------------------------------
+int CvLuaPlayer::lGetFaithPerTurnFromAnnexedMinors(lua_State* L)
+{
+	CvPlayer* pkPlayer = GetInstance(L);
+	if (pkPlayer)
+	{
+		lua_pushinteger(L, pkPlayer->GetFaithPerTurnFromAnnexedMinors());
+		return 1;
+	}
+	//BUG: This can't be right...
+	lua_pushinteger(L, -1);
+	return 0;
+}
+//------------------------------------------------------------------------------
+int CvLuaPlayer::lGetSciencePerTurnFromAnnexedMinors(lua_State* L)
+{
+	CvPlayer* pkPlayer = GetInstance(L);
+	if (pkPlayer)
+	{
+		lua_pushinteger(L, pkPlayer->GetSciencePerTurnFromAnnexedMinors());
+		return 1;
+	}
+	//BUG: This can't be right...
+	lua_pushinteger(L, -1);
+	return 0;
+}
+//------------------------------------------------------------------------------
+int CvLuaPlayer::lGetHappinessFromAnnexedMinors(lua_State* L)
+{
+	CvPlayer* pkPlayer = GetInstance(L);
+	if (pkPlayer)
+	{
+		lua_pushinteger(L, pkPlayer->GetHappinessFromAnnexedMinors());
+		return 1;
+	}
+	//BUG: This can't be right...
+	lua_pushinteger(L, -1);
+	return 0;
+}
+
 //------------------------------------------------------------------------------
 int CvLuaPlayer::lIsUsingMayaCalendar(lua_State* L)
 {

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
@@ -3600,7 +3600,7 @@ int CvLuaPlayer::lGetBuildingOfClosestGreatWorkSlot(lua_State* L)
 	if (pkCity && pkCivInfo)
 	{
 		int iBuilding = -1;
-		if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || pkPlayer->GetPlayerTraits()->IsKeepConqueredBuildings())
+		if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 		{
 			iBuilding = (int)pkCity->GetCityBuildings()->GetBuildingTypeFromClass(eBuildingClass);
 		}
@@ -6230,7 +6230,7 @@ int CvLuaPlayer::lGetGreatWorks(lua_State* L)
 			const CvCivilizationInfo& playerCivilizationInfo = pkPlayer->getCivilizationInfo();
 			BuildingTypes eBuilding = NO_BUILDING;
 
-			if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || pkPlayer->GetPlayerTraits()->IsKeepConqueredBuildings())
+			if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 			{
 				eBuilding = pCity->GetCityBuildings()->GetBuildingTypeFromClass((BuildingClassTypes)iBuildingClassLoop);
 			}
@@ -12539,7 +12539,7 @@ int CvLuaPlayer::lGetPlayerBuildingClassHappiness(lua_State* L)
 			if (!pkBuildingClassInfo)
 				continue;
 
-			if (MOD_BUILDINGS_THOROUGH_PREREQUISITES || pkPlayer->GetPlayerTraits()->IsKeepConqueredBuildings())
+			if (MOD_BUILDINGS_THOROUGH_PREREQUISITES)
 			{
 				if (pkPlayer->getBuildingClassCount(eParentBuildingClass) > 0)
 				{

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.h
@@ -852,6 +852,9 @@ protected:
 	static int lGetMajorBullyGoldDetails(lua_State* L);
 	static int lCanMajorBullyUnit(lua_State* L);
 	static int lGetMajorBullyUnitDetails(lua_State* L);
+#if defined(MOD_BALANCE_CORE_AFRAID_ANNEX)
+	static int lGetMajorBullyAnnexDetails(lua_State* L);
+#endif
 	static int lGetMajorBullyValue(lua_State* L);
 	static int lCanMajorBuyout(lua_State* L);
 #if defined(MOD_BALANCE_CORE)
@@ -1191,6 +1194,10 @@ protected:
 	static int lIsCarnaval(lua_State* L);
 	static int lGetTraitConquestOfTheWorldCityAttackMod(lua_State* L);
 #endif
+	static int lGetCulturePerTurnFromAnnexedMinors(lua_State* L);
+	static int lGetFaithPerTurnFromAnnexedMinors(lua_State* L);
+	static int lGetSciencePerTurnFromAnnexedMinors(lua_State* L);
+	static int lGetHappinessFromAnnexedMinors(lua_State* L);
 	static int lIsUsingMayaCalendar(lua_State* L);
 	static int lGetMayaCalendarString(lua_State* L);
 	static int lGetMayaCalendarLongString(lua_State* L);


### PR DESCRIPTION
Rome Rework:
- Trait KeepConqueredBuildings changed to not include unique building
- Buildings with NeverCapture==false and CaptureChance==0 _are_ captured if KeepConqueredBuildings==true
- Civilizing Mission keeps conquered buildings (logic as above)
- Rome can force-annex City-States and annexed CSs continue to give yields
- Diplomacy AI for force-annexing of City-States reworked: Was based on the valuation of the heavy tribute, should be based on the valuation of the annexed city (like Austria's/Venice's UA)