### PR TITLE
Fix happiness icon too bright

### DIFF
--- a/(3a) EUI Compatibility Files/ImprovedTopPanel/TopPanel.lua
+++ b/(3a) EUI Compatibility Files/ImprovedTopPanel/TopPanel.lua
@@ -41,6 +41,7 @@ if IsDX11 then
 	Controls.CultureTurns:SetAlpha( 1.0 )
 	Controls.FaithTurns:SetAlpha( 1.0 )
 	Controls.GoldPerTurn:SetAlpha( 1.0 )
+	Controls.HappinessString:SetAlpha( 1.0 )
 	Controls.HappyTurns:SetAlpha( 1.0 )
 	Controls.UnitSupplyString:SetAlpha( 1.0 )
 	Controls.NavalSupplyString:SetAlpha( 1.0 )


### PR DESCRIPTION
happiness too bright for dx11, contrast change was missing for this one

before
![Screenshot (38)](https://user-images.githubusercontent.com/49090452/211540252-2cf3bc82-13da-4959-bf4f-8024e60f76b5.png)

after
![Screenshot (36)](https://user-images.githubusercontent.com/49090452/211540262-38acea6e-bde3-45f9-a8c4-b683d0f4a082.png)
