### PR TITLE
XP Caps

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -7689,7 +7689,7 @@ void CvCity::ChangeEventHappiness(int iValue)
 int CvCity::maxXPValue() const
 {
 	VALIDATE_OBJECT
-	int iMaxValue = -1;
+	int iMaxValue = MAX_INT; // negative values mean no XP limit, and MAX_INT is the same in effect
 
 	if (isBarbarian())
 	{

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -17738,7 +17738,7 @@ int CvUnit::defenseXPValue() const
 int CvUnit::maxXPValue() const
 {
 	VALIDATE_OBJECT
-	int iMaxValue = -1; // negative values mean no XP limit
+	int iMaxValue = MAX_INT; // negative values mean no XP limit, and MAX_INT is the same in effect
 
 	if (isBarbarian())
 	{
@@ -21517,7 +21517,7 @@ void CvUnit::changeExperienceTimes100(int iChangeTimes100, int iMax, bool bFromC
 				iCombatExperienceMod += getGreatGeneralModifier();
 			}
 
-			if(iMax == -1)
+			if(iMax < 0)
 			{
 				if(getDomainType() == DOMAIN_SEA)
 				{


### PR DESCRIPTION
 - Set the default no limit back to MAX_INT so that the min() functions work properly
 - now that any negative max XP is now considered no limit, multiplying MAX_INT by a value > 1 will return a negative number and therefore no limit
 - fixes #9590