### PR TITLE
Bomber Evasion Promotions

### DIFF
--- a/(2) Vox Populi/Balance Changes/Text/en_US/PromotionText.sql
+++ b/(2) Vox Populi/Balance Changes/Text/en_US/PromotionText.sql
@@ -632,7 +632,7 @@
 	WHERE Tag = 'TXT_KEY_PROMOTION_EVASION';
 
 	UPDATE Language_en_US
-	SET Text = 'Reduces damage taken from Interception by 50%.'
+	SET Text = '-50% Damage received while performing an [COLOR_POSITIVE_TEXT]Air Strike[ENDCOLOR].'
 	WHERE Tag = 'TXT_KEY_PROMOTION_EVASION_HELP';
 
 	-- Evasion

--- a/(2) Vox Populi/Balance Changes/Text/en_US/UnitText.xml
+++ b/(2) Vox Populi/Balance Changes/Text/en_US/UnitText.xml
@@ -881,7 +881,7 @@
 			<Text>Stealth</Text>
 		</Row>
 		<Row Tag="TXT_KEY_PROMOTION_EVASION_III_HELP">
-			<Text>[COLOR_POSITIVE_TEXT]+25%[ENDCOLOR] chance to evade Interception.[NEWLINE]-25% Damage received from [COLOR_POSITIVE_TEXT]Interceptions[ENDCOLOR].[NEWLINE]+50 Hit Points.</Text>
+			<Text>[COLOR_POSITIVE_TEXT]+25%[ENDCOLOR] chance to evade Interception.[NEWLINE]-25% Damage received during an [COLOR_POSITIVE_TEXT]Air Strike[ENDCOLOR].[NEWLINE]+50 Hit Points.</Text>
 		</Row>
 
 		<Row Tag="TXT_KEY_PROMOTION_HELI_REPAIR">

--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -33803,12 +33803,14 @@ int CvCity::GetAirStrikeDefenseDamage(const CvUnit* pAttacker, bool bIncludeRand
 	int iBaseValue = 15;
 
 	if (MOD_BALANCE_CORE_MILITARY_PROMOTION_ADVANCED)
+	{
 		iBaseValue = GetCityAirStrikeDefense();
 
-	if (pAttacker != NULL && pAttacker->GetInterceptionDefenseDamageModifier() != 0)
-	{
-		iBaseValue = iBaseValue * (100 - pAttacker->GetInterceptionDefenseDamageModifier());
-		iBaseValue /= 100;
+		if (pAttacker != NULL && pAttacker->GetInterceptionDefenseDamageModifier() != 0)
+		{
+			iBaseValue = iBaseValue * (100 + pAttacker->GetInterceptionDefenseDamageModifier());
+			iBaseValue /= 100;
+		}
 	}
 
 	if (bIncludeRand)


### PR DESCRIPTION
 - InterceptionDefenseDamageModifier is a negative value when positive, so CvCity::GetAirStrikeDefenseDamage() has the wrong sign
 - damage reduction during interception was changed in the 12-20 patch (faf7c1) to be for air strikes in general; updated promotion text to clarify
 - this only takes place in VP, not CP
 - fixes #9627 

One thing to check; do bombers perform "Air Strikes" or was it renamed to something different than Fighters?