### PR TITLE
make Victory text Localizable

### DIFF
--- a/(2) Vox Populi/Balance Changes/Text/en_US/UIText.xml
+++ b/(2) Vox Populi/Balance Changes/Text/en_US/UIText.xml
@@ -1721,6 +1721,15 @@
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_QUEST_ENDED_REVOKED_WAR">
 			<Text>{1_MinorCivName:textkey} revokes quests</Text>
+		</Row>		
+		<Row Tag="TXT_KEY_VP_VASSALS">
+			<Text>Vassals</Text>
+		</Row>
+		<Row Tag="TXT_KEY_VP_CITYSTATES">
+			<Text>City-State Alliances</Text>
+		</Row>
+		<Row Tag="TXT_KEY_VP_MILITARY">
+			<Text>Military Power</Text>
 		</Row>
 	<!-- UI - Religion Spread -->
 			<Row Tag="TXT_KEY_RO_WR_TOTAL_CITIES">

--- a/(2) Vox Populi/Core Files/CoreLua/VictoryProgress.xml
+++ b/(2) Vox Populi/Core Files/CoreLua/VictoryProgress.xml
@@ -169,10 +169,10 @@
           <Label Offset="0,0" Anchor="L,T" String="TXT_KEY_VP_LAND"/>
           <Label Offset="0,0" Anchor="L,T" String="TXT_KEY_VP_WONDERS"/>
           <Label ID="TechLabel" Offset="0,0" Anchor="L,T" String="TXT_KEY_VP_TECH"/>
-          <Label ID="FutureTechLabel" Offset="0,0" Anchor="L,T" String="TXT_KEY_VP_FUTURE_TECH"/>
-          <Label ID="VassalLabel" Offset="0,0" Anchor="L,T" String="Vassals"/>
-          <Label ID="CSAllyLabel" Offset="0,0" Anchor="L,T" String="City-State Alliances"/>
-          <Label ID="MilitaryPowerLabel" Offset="0,0" Anchor="L,T" String="Military Power"/>
+          <Label ID="FutureTechLabel" Offset="0,0" Anchor="L,T" String="TXT_KEY_VP_FUTURE_TECH"/>          
+          <Label ID="VassalLabel" Offset="0,0" Anchor="L,T" String="TXT_KEY_VP_VASSALS"/>
+          <Label ID="CSAllyLabel" Offset="0,0" Anchor="L,T" String="TXT_KEY_VP_CITYSTATES"/>
+          <Label ID="MilitaryPowerLabel" Offset="0,0" Anchor="L,T" String="TXT_KEY_VP_MILITARY"/>
           <Label ID="PolicyLabel" Offset="0,0" Anchor="L,T" String="TXT_KEY_VP_POLICIES"/>
           <Label Offset="0,0" Anchor="L,T" String="TXT_KEY_VP_GREAT_WORKS"/>
           <Label ID="ReligionLabel" Offset="0,0" Anchor="L,T" String="TXT_KEY_VP_RELIGION"/>


### PR DESCRIPTION
add key for 'Vassals' : TXT_KEY_VP_VASSALS
add key for 'City-State Alliances' : TXT_KEY_VP_CITYSTATES
add key for 'Military Power' : TXT_KEY_VP_MILITARY

For English users, nothing changes.

Part of #9178. I couldn't build the VP so I could only test the xml part. 

![image](https://user-images.githubusercontent.com/53367179/215311937-83c4b6a3-8b3f-4f44-b0e1-1d049ffc8515.png)
