### PR TITLE
Bugfix (2-57)

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -28183,7 +28183,7 @@ int CvCity::getStrengthValue(bool bForRangeStrike, bool bIgnoreBuildings, const 
 
 			// We also remove the garrisoned unit's strength
 			CvUnit* pGarrisonedUnit = GetGarrisonedUnit();
-			if (pGarrisonedUnit)
+			if (pGarrisonedUnit && pGarrisonedUnit->getDomainType() == DOMAIN_LAND)
 			{
 				int iStrengthFromGarrisonRaw = max(pGarrisonedUnit->GetBaseCombatStrength(), pGarrisonedUnit->GetBaseRangedCombatStrength());
 				int iStrengthFromGarrison = (iStrengthFromGarrisonRaw * 100) / /*500 in CP, 200 in VP*/ GD_INT_GET(CITY_STRENGTH_UNIT_DIVISOR);

--- a/CvGameCoreDLL_Expansion2/CvTacticalAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTacticalAI.cpp
@@ -4810,7 +4810,7 @@ CvUnit* CvTacticalAI::FindUnitForThisMove(AITacticalMove eMove, CvPlot* pTarget,
 
 				//naval garrisons cannot attack inside cities and don't increase city strength...
 				if (!pLoopUnit->isNativeDomain(pTarget))
-					iExtraScore -= 50;
+					continue;
 
 				// Don't put units with a defense boosted from promotions in cities, these boosts are ignored
 				iExtraScore -= pLoopUnit->getDefenseModifier();


### PR DESCRIPTION
I played a game with the new garrison proposal ([PR](https://github.com/LoneGazebo/Community-Patch-DLL/pull/9623)) implemented and I noticed a bug in the calculation of the ranged strike strength of cities. Naval units need to be excluded there as well. Also, the AI still used naval units as garrisons, this is now prevented.