### PR TITLE
Fix9618

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
@@ -23986,7 +23986,10 @@ void CvDiplomacyAI::SelectBestApproachTowardsMinorCiv(PlayerTypes ePlayer, std::
 	////////////////////////////////////
 	// PROXIMITY
 	////////////////////////////////////
-
+	if (GetPlayer()->GetProximityToPlayer(ePlayer) == NO_PLAYER_PROXIMITY)
+	{
+		GetPlayer()->DoUpdateProximityToPlayers();
+	}
 	switch (GetPlayer()->GetProximityToPlayer(ePlayer))
 	{
 	case PLAYER_PROXIMITY_NEIGHBORS:

--- a/CvGameCoreDLL_Expansion2/CvEspionageClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvEspionageClasses.cpp
@@ -7476,6 +7476,10 @@ std::vector<ScoreCityEntry> CvEspionageAI::BuildMinorCityList()
 			kEntry.m_pCity = pLoopCity;
 
 			int iValue = pEspionage->GetTheoreticalChanceOfCoup(pLoopCity);
+			if (m_pPlayer->GetProximityToPlayer(eTargetPlayer) == NO_PLAYER_PROXIMITY)
+			{
+				m_pPlayer->DoUpdateProximityToPlayers();
+			}
 			switch (m_pPlayer->GetProximityToPlayer(eTargetPlayer))
 			{
 			case NO_PLAYER_PROXIMITY:


### PR DESCRIPTION
Fix for #9618.

The CTD was caused by Indonesia's AI trying to get the (cached) distance between Indonesia and the City-State of Amia. The problem was that Amia had been founded in the very same turn (unique ability of Phoenicia). This modmod-related corner case wasn't covered and no distance had been calculated yet.

I've added that the distances are now updated if no cached distance exists yet. Question to the developers: Maybe this should be added before every `switch (GetPlayer()->GetProximityToPlayer(ePlayer))`, just in case? It should affect performance only minimally and make the AI better in case of any similar corner cases or errors that have gone unnoticed so far.