### PR TITLE
improve squad movement robustness

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvUnit.h
+++ b/CvGameCoreDLL_Expansion2/CvUnit.h
@@ -636,6 +636,7 @@ public:
 	void AssignToSquad(int iNewSquadNumber);
 	void RemoveFromSquad();
 	void DoSquadMovement(CvPlot* pDestPlot);
+	bool IsUnitInActiveMoveMission();
 	bool IsSquadMoving();
 	void TryEndSquadMovement();
 	void SetSquadDestination(CvPlot* pDestPlot = NULL);


### PR DESCRIPTION
Wait for a path to become available instead of cancelling the move mission if moving into the fog of war reveals obstacles that block further path progress with current movement left