### PR TITLE
Espionage Bugfixes and UI Rework

### DIFF
--- a/(1) Community Patch/Core Files/CoreLua/CityEventPopup.lua
+++ b/(1) Community Patch/Core Files/CoreLua/CityEventPopup.lua
@@ -53,8 +53,8 @@ function OnPopup( popupInfo )
 			local szTitleString;
 			local szHelpString;
 
-			szTitleString = Locale.Lookup("TXT_KEY_CITY_EVENT_TITLE", localizedCityName, pEventChoiceInfo.Description);
-			szHelpString = Locale.Lookup("TXT_KEY_CITY_EVENT_HELP", localizedCityName, city:GetScaledEventChoiceValue(iEventChoiceType, false, spyID, spyOwnerID));
+			szTitleString = Locale.Lookup("TXT_KEY_SPY_MISSION_COMPLETED");
+			szHelpString = Locale.Lookup("TXT_KEY_CITY_EVENT_HELP", localizedCityName, city:GetSpyMissionOutcome(iEventChoiceType, spyID, spyOwnerID));
 			-- Test for any Override Strings
 			tChoiceOverrideStrings = {}
 			LuaEvents.EventChoice_OverrideTextStrings(city:GetOwner(), city:GetID(), pEventChoiceInfo, tChoiceOverrideStrings)
@@ -83,8 +83,8 @@ function OnPopup( popupInfo )
 			local szTitleString;
 			local szHelpString;
 
-			szTitleString = Locale.Lookup("TXT_KEY_CITY_EVENT_FLED_TITLE", localizedCityName, pEventChoiceInfo.Description);
-			szHelpString = Locale.Lookup("TXT_KEY_CITY_EVENT_FLED_HELP", localizedCityName, capitalCity:GetScaledEventChoiceValue(iEventChoiceType, false, spyID, spyOwnerID));
+			szTitleString = Locale.Lookup("TXT_KEY_SPY_MISSION_COMPLETED");
+			szHelpString = Locale.Lookup("TXT_KEY_CITY_EVENT_FLED_HELP", localizedCityName, capitalCity:GetSpyMissionOutcome(iEventChoiceType, spyID, spyOwnerID));
 			-- Test for any Override Strings
 			tChoiceOverrideStrings = {}
 			LuaEvents.EventChoice_OverrideTextStrings(capitalCity:GetOwner(), capitalCity:GetID(), pEventChoiceInfo, tChoiceOverrideStrings)

--- a/(1) Community Patch/Core Files/Text/CoreText_en_US.sql
+++ b/(1) Community Patch/Core Files/Text/CoreText_en_US.sql
@@ -457,45 +457,6 @@ UPDATE Language_en_US
 SET Text = 'Can be purchased with [ICON_PEACE] Faith in any city with a majority Religion that has been enhanced. They can remove other religions from your cities (expending the Inquisitor) or be placed inside or adjacent to a city to protect it from Missionaries and Prophets trying to spread other religions into that city.'
 WHERE Tag = 'TXT_KEY_UNIT_INQUISITOR_STRATEGY';
 
-
--- Espionage
-
-UPDATE Language_en_US
-SET Text = 'Conducting Espionage'
-WHERE Tag = 'TXT_KEY_SPY_STATE_ESTABLISHED_SURVEILLANCE';
-
-UPDATE Language_en_US
-SET Text = 'Disrupting Plans'
-WHERE Tag = 'TXT_KEY_SPY_STATE_ESTABLISHED_SURVEILLANCE_PROGRESS_BAR';
-
-UPDATE Language_en_US
-SET Text = 'Security Level'
-WHERE Tag = 'TXT_KEY_EO_POTENTIAL';
-
-UPDATE Language_en_US
-SET Text = 'Security Level reflects the difficulty of Espionage in a City. The higher the value, the more time it will take to complete Spy Actions. The base value [COLOR_POSITIVE_TEXT](a scale, from 1 to 10)[ENDCOLOR] is based on the overall economic value of the City (relative to all other cities). Security is also affected by Espionage modifiers and buildings in the city, such as the Constabulary and the Police Station. Security also increases when a City has a powerful Counterspy.[NEWLINE][NEWLINE]Click to sort cities by their Security level.'
-WHERE Tag = 'TXT_KEY_EO_POTENTIAL_SORT_TT';
-
-UPDATE Language_en_US
-SET Text = 'If your cities have low Security, you should consider protecting them. There are two ways to do this. You may move your own spies to your cities to act as counterspies that have a chance to catch and kill enemy spies before they steal something. You may also slow down how quickly enemy spies can steal things by constructing buildings like the Constabulary, Police Station, and the Great Firewall.'
-WHERE Tag = 'TXT_KEY_EO_OWN_CITY_POTENTIAL_TT';
-
-UPDATE Language_en_US
-SET Text = '{1_SpyRank} {2_SpyName} is stealing from {3_CityName}.[NEWLINE]The current Security Level of {3_CityName} is {4_Num}.[NEWLINE][NEWLINE]Security reflects the vulnerability of a city to Espionage. The higher the value, the more protected the city. The base value [COLOR_POSITIVE_TEXT](a scale, from 1 to 10)[ENDCOLOR] is based on the overall prosperity and happiness of the city (relative to all other cities). Security may be decreased by Policies and Espionage buildings in the city, such as the Constabulary and the Police Station.'
-WHERE Tag = 'TXT_KEY_EO_CITY_POTENTIAL_TT';
-
-UPDATE Language_en_US
-SET Text = '{1_SpyRank} {2_SpyName} cannot steal technologies from {3_CityName}.[NEWLINE][NEWLINE]The Security Level of {4_CityName} is {5_Num}.[NEWLINE][NEWLINE]Security reflects the vulnerability of a city to Espionage. The higher the value, the more protected the city. The base value [COLOR_POSITIVE_TEXT](a scale, from 1 to 10)[ENDCOLOR] is based on the overall prosperity and happiness of the city. Security may be decreased by Policies and Espionage buildings in the city, such as the Constabulary and the Police Station..'
-WHERE Tag = 'TXT_KEY_EO_CITY_POTENTIAL_CANNOT_STEAL_TT';
-
-UPDATE Language_en_US
-SET Text = 'The Security Level of {1_CityName} is believed to be {2_Num}. Send a [ICON_SPY] Spy to this City to learn more about it.[NEWLINE][NEWLINE]Security reflects the vulnerability of a city to Espionage. The higher the value, the more protected the city. The base value [COLOR_POSITIVE_TEXT](a scale, from 1 to 10)[ENDCOLOR] is based on the overall prosperity and happiness of the city. Security may be decreased by Policies and Espionage buildings in the city, such as the Constabulary and the Police Station.'
-WHERE Tag = 'TXT_KEY_EO_CITY_ONCE_KNOWN_POTENTIAL_TT';
-
-UPDATE Language_en_US
-SET Text = 'Options for {1_SpyRank} {2_SpyName}:[NEWLINE][NEWLINE][ICON_BULLET] Move to a City-State and attempt to [COLOR_POSITIVE_TEXT]Rig an Election[ENDCOLOR] or [COLOR_POSITIVE_TEXT]Stage a Coup[ENDCOLOR].[NEWLINE][ICON_BULLET] Move to a non-Capital City owned by a Major Civilization and attempt to [COLOR_POSITIVE_TEXT]Steal Technology[ENDCOLOR] and [COLOR_POSITIVE_TEXT]Uncover Intrigue[ENDCOLOR].[NEWLINE][ICON_BULLET] Move to a Capital City owned by a Major Civilization and attempt to [COLOR_POSITIVE_TEXT]Steal Technology[ENDCOLOR], [COLOR_POSITIVE_TEXT]Uncover Intrigue[ENDCOLOR], or [COLOR_POSITIVE_TEXT]Schmooze[ENDCOLOR] as a Diplomat.'
-WHERE Tag = 'TXT_KEY_EO_SPY_MOVE_TT';
-
 -- Fixed diacritics for spy names.
 UPDATE Language_en_US
 SET Text = 'Antônio'
@@ -512,9 +473,6 @@ WHERE Tag = 'TXT_KEY_SPY_NAME_BRAZIL_4';
 UPDATE Language_en_US
 SET Text = 'Tomé'
 WHERE Tag = 'TXT_KEY_SPY_NAME_BRAZIL_8';
-
-
--- Trade
 
 -- Trade Deals
 UPDATE Language_en_US

--- a/(1) Community Patch/Core Files/Text/CoreText_en_US.xml
+++ b/(1) Community Patch/Core Files/Text/CoreText_en_US.xml
@@ -5647,7 +5647,7 @@
 
 		<!-- City Rank Increasing -->
 		<Row Tag="TXT_KEY_NOTIFICATION_CITY_RANK_INCREASING">
-			<Text>{1_CityName} is [COLOR_NEGATIVE_TEXT]increasingly vulnerable[ENDCOLOR] to foreign [ICON_SPY] Spies.[NEWLINE]The City currently has a Security Level of [COLOR_NEGATIVE_TEXT]{2_Num}[ENDCOLOR] (out of 10), with lower ranks making it easier for foreign Spies to operate in the city.[NEWLINE]Move a Spy to this city, build Espionage buildings here, and resolve [ICON_HAPPINESS_3] Unhappiness issues to [COLOR_POSITIVE_TEXT]improve[ENDCOLOR] the City's Security Level.</Text>
+			<Text>{1_CityName} is [COLOR_NEGATIVE_TEXT]increasingly vulnerable[ENDCOLOR] to foreign [ICON_SPY] Spies.[NEWLINE]The City currently has a Security Level of [COLOR_NEGATIVE_TEXT]{2_Num}[ENDCOLOR] (out of 50), with lower ranks making it easier for foreign Spies to operate in the city.[NEWLINE]Move a Spy to this city, build Espionage buildings here, and resolve [ICON_HAPPINESS_3] Unhappiness issues to [COLOR_POSITIVE_TEXT]improve[ENDCOLOR] the City's Security Level.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_CITY_RANK_INCREASING_SUMMARY">
 			<Text>Security Level update for {1_CityName}.</Text>
@@ -7487,15 +7487,22 @@
 			<Text>[NEWLINE] [ICON_BULLET] Requires a Counterspy in the city.</Text>
 		</Row>
 
-		<Row Tag="TXT_KEY_EVENT_SPY_DURATION_SCALED">
-			<Text>[NEWLINE]Chance to be [ICON_VIEW_CITY] Identified: [COLOR_NEGATIVE_TEXT]{2_ID}%[ENDCOLOR][NEWLINE]Chance to be [ICON_PIRATE] Killed (Counterspy): [COLOR_NEGATIVE_TEXT]{3_Death}%[ENDCOLOR][NEWLINE][NEWLINE]</Text>
+		<Row Tag="TXT_KEY_EVENT_SPY_KILL_CHANCE">
+			<Text>[NEWLINE]Chance to be [ICON_VIEW_CITY] Identified: [COLOR_NEGATIVE_TEXT]{1_ID}%[ENDCOLOR][NEWLINE]Chance to be [ICON_PIRATE] Killed (Counterspy): [COLOR_NEGATIVE_TEXT]{2_Death}%[ENDCOLOR]</Text>
+		</Row>
+		
+		<Row Tag="TXT_KEY_EO_SPY_RIGGING_ELECTIONS_SHORT_TT">
+			<Text>{1_RankName} {2_SpyName} is attempting to rig the election in {3_CityName} to increase our influence there.</Text>
 		</Row>
 
 		<Row Tag="TXT_KEY_EO_OWN_CITY_POTENTIAL_SHORT_TT">
 			<Text>The Security Level of {1_CityName} is [COLOR_POSITIVE_TEXT]{2_Num}[ENDCOLOR].</Text>
 		</Row>
+		<Row Tag="TXT_KEY_EO_ENEMY_CITY_POTENTIAL_SHORT_TT">
+			<Text>The Security Level of {1_CityName} is [COLOR_NEGATIVE_TEXT]{2_Num}[ENDCOLOR].</Text>
+		</Row>
 		<Row Tag="TXT_KEY_EO_CITY_ONCE_KNOWN_POTENTIAL_TT_SHORT">
-			<Text>The Security Level of {1_CityName} is believed to be {2_Num}. Send a [ICON_SPY] Spy to learn more.</Text>
+			<Text>The Security Level of {1_CityName} is believed to be [COLOR_NEGATIVE_TEXT]{2_Num}[ENDCOLOR]. Send a [ICON_SPY] Spy to learn more.</Text>
 		</Row>
 
 		<Row Tag="TXT_KEY_POTENTIAL_CALCULATION">
@@ -7514,23 +7521,14 @@
 		</Row>
 
 		<Row Tag="TXT_KEY_EO_INCREASED_CHANCE_TO_CATCH_SPY">
-			<Text>[NEWLINE]  [ICON_BULLET]Policies: {1_Num}% increased chance in catching enemy spies.</Text>
+			<Text>[COLOR_POSITIVE_TEXT][NEWLINE]Chance of catching enemy spies increased by {1_Num}% because of Policies.[ENDCOLOR]</Text>
 		</Row>
 		<Row Tag="TXT_KEY_EO_INCREASED_CHANCE_TO_CATCH_SPY_AGAINST">
-			<Text>[NEWLINE]  [ICON_BULLET]Policies: {1_Num}% increased chance in catching our spies.</Text>
+			<Text>[COLOR_NEGATIVE_TEXT][NEWLINE]Chance of catching our spies increased by {1_Num}% because of Policies.[ENDCOLOR]</Text>
 		</Row>
 
 		<Row Tag="TXT_KEY_DEFENSIVE_SPY_POTENTIAL">
-			<Text>Possible outcomes while defending:</Text>
-		</Row>
-		<Row Tag="TXT_KEY_DEFENSIVE_SPY_POTENTIAL_AA">
-			<Text>Possible outcomes while defending against Spy Events:</Text>
-		</Row>
-		<Row Tag="TXT_KEY_OFFENSIVE_SPY_RISKS">
-			<Text>Possible outcomes from Espionage:</Text>
-		</Row>
-		<Row Tag="TXT_KEY_OFFENSIVE_SPY_RISKS_AA">
-			<Text>Possible outcomes from Spy Events:</Text>
+			<Text>[COLOR_POSITIVE_TEXT]Possible outcomes while defending:[ENDCOLOR]</Text>
 		</Row>
 
 		<Row Tag="TXT_KEY_SPY_INTRIGUE_DISCOVERED">
@@ -7538,98 +7536,83 @@
 		</Row>
 
 
-		
-
 		<Row Tag="TXT_KEY_DEFENSIVE_SPY_BONUSES_KILL">
 			<Text>[ICON_BULLET] Chance to kill [ICON_SPY] Spies: [COLOR_POSITIVE_TEXT]{1_Num}%[ENDCOLOR].</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DEFENSIVE_SPY_BONUSES_CATCH">
 			<Text>[ICON_BULLET] Chance to identify [ICON_SPY] Spies: [COLOR_POSITIVE_TEXT]{1_Num}%[ENDCOLOR].</Text>
 		</Row>
-		<Row Tag="TXT_KEY_DEFENSIVE_SPY_BONUSES_DETECT">
-			<Text>[ICON_BULLET] Chance to detect [ICON_SPY] Spies: [COLOR_POSITIVE_TEXT]{1_Num}%[ENDCOLOR].</Text>
-		</Row>
-
-		<Row Tag="TXT_KEY_OFFENSIVE_SPY_DANGER_KILL">
-			<Text>[ICON_BULLET] Chance to be killed (Counterspy): [COLOR_POSITIVE_TEXT]{1_Num}%[ENDCOLOR].</Text>
-		</Row>
-		<Row Tag="TXT_KEY_OFFENSIVE_SPY_DANGER_CATCH">
-			<Text>[ICON_BULLET] Chance to be caught: [COLOR_POSITIVE_TEXT]{1_Num}%[ENDCOLOR].</Text>
-		</Row>
-		<Row Tag="TXT_KEY_OFFENSIVE_SPY_DANGER_DETECT">
-			<Text>[ICON_BULLET] Chance to be detected: [COLOR_POSITIVE_TEXT]{1_Num}%[ENDCOLOR].</Text>
-		</Row>
-		<Row Tag="TXT_KEY_OFFENSIVE_SPY_DANGER_UNDETECTED">
-			<Text>[ICON_BULLET] Chance to remain undetected: [COLOR_POSITIVE_TEXT]{1_Num}%[ENDCOLOR].</Text>
-		</Row>
-
-		<Row Tag="TXT_KEY_CITY_ESPIONAGE_RATIO">
-			<Text>Your current Spy Power: [COLOR_POSITIVE_TEXT]{3_Num}[ENDCOLOR].[NEWLINE]Security Threshold for City: [COLOR_NEGATIVE_TEXT]{1_Num}[ENDCOLOR].[NEWLINE][NEWLINE]Your Spy earns [COLOR_POSITIVE_TEXT]+{2_Num}[ENDCOLOR] Spy Power each turn.[NEWLINE][NEWLINE]When it exceeds the Security Threshold, the [COLOR_POSITIVE_TEXT]Spy Event[ENDCOLOR] will occur.</Text>
-		</Row>
 
 		<Row Tag="TXT_KEY_ESPIONAGE_CURRENT_MISSION">
 			<Text>[COLOR_POSITIVE_TEXT]Current Mission:[ENDCOLOR] {1_Mission}</Text>
 		</Row>
+		<Row Tag="TXT_KEY_ESPIONAGE_TURNS_COMPLETED">
+			<Text>({1_Turns} completed)</Text>
+		</Row>
 
+		<Row Tag="TXT_KEY_ESPIONAGE_MISSION_BASE_DURATION">
+			<Text>Base Mission Duration: {1_Num} Turns</Text>
+		</Row>
+		<Row Tag="TXT_KEY_SPY_POWER">
+			<Text>[COLOR_POSITIVE_TEXT]Total Spy Power in this City:[ENDCOLOR] [COLOR_POSITIVE_TEXT]{1_Num}[ENDCOLOR]</Text>
+		</Row>
+		<Row Tag="TXT_KEY_SPY_POWER_MODIFIER">
+			<Text>[NEWLINE]  [ICON_BULLET] Spy Power Modifier: [COLOR_POSITIVE_TEXT]-{1_Num}%[ENDCOLOR]</Text>
+		</Row>
+		<Row Tag="TXT_KEY_CITY_SECURITY_MODIFIER">
+			<Text>[NEWLINE]  [ICON_BULLET] City Resistance Modifier: [COLOR_NEGATIVE_TEXT]+{1_Num}%[ENDCOLOR]</Text>
+		</Row>
 		<Row Tag="TXT_KEY_OFFENSIVE_SPY_BONUSES_BASE_POWER">
 			<Text>Base Spy Power: [COLOR_POSITIVE_TEXT]{1_Num}[ENDCOLOR]</Text>
 		</Row>
-		<Row Tag="TXT_KEY_OFFENSIVE_SPY_BONUSES">
-			<Text>Spy Speed Modifier: [COLOR_POSITIVE_TEXT]{1_Num}%[ENDCOLOR]</Text>
+		<Row Tag="TXT_KEY_OFFENSIVE_SPY_BONUSES_GAMESPEED_NEGATIVE_MOD">
+			<Text>[NEWLINE]  [ICON_BULLET] [ICON_STAR] Game Speed: [COLOR_NEGATIVE_TEXT]{1_Num}%[ENDCOLOR]</Text>
+		</Row>
+		<Row Tag="TXT_KEY_OFFENSIVE_SPY_BONUSES_GAMESPEED_POSITIVE_MOD">
+			<Text>[NEWLINE]  [ICON_BULLET] [ICON_STAR] Game Speed: [COLOR_POSITIVE_TEXT]+{1_Num}%[ENDCOLOR]</Text>
 		</Row>
 		<Row Tag="TXT_KEY_OFFENSIVE_SPY_BONUSES_DETAIL_OUR_MOD">
-			<Text>[NEWLINE]  [ICON_BULLET] [ICON_STAR] Policies and Wonders: [COLOR_POSITIVE_TEXT]{1_Num}%[ENDCOLOR]</Text>
+			<Text>[NEWLINE]  [ICON_BULLET] [ICON_STAR] Policies and Wonders: [COLOR_POSITIVE_TEXT]+{1_Num}%[ENDCOLOR]</Text>
 		</Row>
 		<Row Tag="TXT_KEY_OFFENSIVE_SPY_BONUSES_DETAIL_SPY_MOD">
-			<Text>[NEWLINE]  [ICON_BULLET] [ICON_SPY] Spy Rank Modifier: [COLOR_POSITIVE_TEXT]{1_Num}%[ENDCOLOR]</Text>
+			<Text>[NEWLINE]  [ICON_BULLET] [ICON_SPY] Spy Rank Modifier: [COLOR_POSITIVE_TEXT]+{1_Num}%[ENDCOLOR]</Text>
 		</Row>
 		<Row Tag="TXT_KEY_OFFENSIVE_SPY_BONUSES_DETAIL_SPY_MOD_OB">
-			<Text>[NEWLINE]  [ICON_BULLET] [ICON_INTERNATIONAL_TRADE] Open Borders: [COLOR_POSITIVE_TEXT]{1_Num}%[ENDCOLOR]</Text>
+			<Text>[NEWLINE]  [ICON_BULLET] [ICON_INTERNATIONAL_TRADE] Open Borders: [COLOR_POSITIVE_TEXT]+{1_Num}%[ENDCOLOR]</Text>
 		</Row>
 		<Row Tag="TXT_KEY_OFFENSIVE_SPY_BONUSES_DETAIL_SPY_MOD_INFLUENCE">
-			<Text>[NEWLINE]  [ICON_BULLET] [ICON_TOURISM] Cultural Influence over them: [COLOR_POSITIVE_TEXT]{1_Num}%[ENDCOLOR]</Text>
-		</Row>
-
-		<Row Tag="TXT_KEY_OFFENSIVE_SPY_BONUSES_BASE_DEFENSE">
-			<Text>Mission Duration Modifiers: [COLOR_NEGATIVE_TEXT]{1_Num}[ENDCOLOR]</Text>
-		</Row>
-		<Row Tag="TXT_KEY_DEFENSIVE_SPY_BONUSES">
-			<Text>[NEWLINE]Mission Duration Modifier: [COLOR_NEGATIVE_TEXT]{1_Num}%[ENDCOLOR]</Text>
-		</Row>
-		<Row Tag="TXT_KEY_OFFENSIVE_SPY_BONUSES_DETAIL_THEIR_MOD">
-			<Text>[NEWLINE]  [ICON_BULLET] [ICON_STAR] Policies and Wonders: [COLOR_NEGATIVE_TEXT]{1_Num}%[ENDCOLOR]</Text>
-		</Row>
-		<Row Tag="TXT_KEY_OFFENSIVE_SPY_BONUSES_DETAIL_CITY_MOD">
-			<Text>[NEWLINE]  [ICON_BULLET] [ICON_CITIZEN] Local Buildings: [COLOR_NEGATIVE_TEXT]{1_Num}%[ENDCOLOR]</Text>
-		</Row>
-		<Row Tag="TXT_KEY_OFFENSIVE_SPY_BONUSES_DETAIL_SPY_MOD_POLICY">
-			<Text>[NEWLINE]  [ICON_BULLET] [ICON_CULTURE] Policy Difference: [COLOR_NEGATIVE_TEXT]{1_Num}%[ENDCOLOR]</Text>
-		</Row>
-		<Row Tag="TXT_KEY_OFFENSIVE_SPY_BONUSES_DETAIL_SPY_MOD_TECH">
-			<Text>[NEWLINE]  [ICON_BULLET] [ICON_RESEARCH] Tech Difference: [COLOR_NEGATIVE_TEXT]{1_Num}%[ENDCOLOR]</Text>
-		</Row>
-		<Row Tag="TXT_KEY_OFFENSIVE_SPY_BONUSES_DETAIL_SPY_MOD_REPEAT">
-			<Text>[NEWLINE]  [ICON_BULLET] [ICON_SPY] Spy Events Against Civ: [COLOR_NEGATIVE_TEXT]{1_Num}%[ENDCOLOR]</Text>
+			<Text>[NEWLINE]  [ICON_BULLET] [ICON_TOURISM] Cultural Influence over them: [COLOR_POSITIVE_TEXT]+{1_Num}%[ENDCOLOR]</Text>
 		</Row>
 		
-		<!-- Spy Focus -->
-		<Row Tag="TXT_KEY_OFFENSIVE_SPY_FOCUS_ECONOMIC">
-			<Text>Current Focus: [COLOR_POSITIVE_TEXT]Economics and Industry[ENDCOLOR]</Text>
+		<Row Tag="TXT_KEY_DEFENSIVE_SPY_RESISTANCE_MOD_POSITIVE">
+			<Text>[NEWLINE]  [ICON_BULLET] [ICON_SPY] Spy Resistance: [COLOR_NEGATIVE_TEXT]+{1_Num}%[ENDCOLOR]</Text>
 		</Row>
-		<Row Tag="TXT_KEY_OFFENSIVE_SPY_FOCUS_MILITARY">
-			<Text>Current Focus: [COLOR_POSITIVE_TEXT]Military Infiltration[ENDCOLOR]</Text>
+		<Row Tag="TXT_KEY_DEFENSIVE_SPY_RESISTANCE_MOD_NEGATIVE">
+			<Text>[NEWLINE]  [ICON_BULLET] [ICON_SPY] Spy Resistance: [COLOR_POSITIVE_TEXT]{1_Num}%[ENDCOLOR]</Text>
 		</Row>
-		<Row Tag="TXT_KEY_OFFENSIVE_SPY_FOCUS_SCIENTIFIC">
-			<Text>Current Focus: [COLOR_POSITIVE_TEXT]Research and Development[ENDCOLOR]</Text>
+		<Row Tag="TXT_KEY_DEFENSIVE_SPY_BONUSES_DETAIL_SPY_MOD_POLICY_POSITIVE">
+			<Text>[NEWLINE]  [ICON_BULLET] [ICON_CULTURE] Fewer Policies than us: [COLOR_NEGATIVE_TEXT]+{1_Num}%[ENDCOLOR]</Text>
 		</Row>
-		<Row Tag="TXT_KEY_OFFENSIVE_SPY_FOCUS_URBAN">
-			<Text>Current Focus: [COLOR_POSITIVE_TEXT]Embedding in the Citizenry[ENDCOLOR]</Text>
+		<Row Tag="TXT_KEY_DEFENSIVE_SPY_BONUSES_DETAIL_SPY_MOD_POLICY_NEGATIVE">
+			<Text>[NEWLINE]  [ICON_BULLET] [ICON_CULTURE] More Policies than us: [COLOR_POSITIVE_TEXT]{1_Num}%[ENDCOLOR]</Text>
 		</Row>
-		<Row Tag="TXT_KEY_OFFENSIVE_SPY_FOCUS_ALL">
-			<Text>Current Focus: [COLOR_POSITIVE_TEXT]All Opportunities[ENDCOLOR]</Text>
+		<Row Tag="TXT_KEY_DEFENSIVE_SPY_BONUSES_DETAIL_SPY_MOD_TECH_POSITIVE">
+			<Text>[NEWLINE]  [ICON_BULLET] [ICON_RESEARCH] Fewer Techs than us: [COLOR_NEGATIVE_TEXT]+{1_Num}%[ENDCOLOR]</Text>
 		</Row>
-		<Row Tag="TXT_KEY_OFFENSIVE_SPY_FOCUS_NONE">
-			<Text>Current Focus: [COLOR_POSITIVE_TEXT]No Focus[ENDCOLOR]</Text>
+		<Row Tag="TXT_KEY_DEFENSIVE_SPY_BONUSES_DETAIL_SPY_MOD_TECH_NEGATIVE">
+			<Text>[NEWLINE]  [ICON_BULLET] [ICON_RESEARCH] More Techs than us: [COLOR_POSITIVE_TEXT]{1_Num}%[ENDCOLOR]</Text>
+		</Row>
+		<Row Tag="TXT_KEY_DEFENSIVE_SPY_BONUSES_DETAIL_SPY_MOD_REPEAT">
+			<Text>[NEWLINE]  [ICON_BULLET] [ICON_SPY] Previous Spy Missions: [COLOR_NEGATIVE_TEXT]+{1_Num}%[ENDCOLOR]</Text>
+		</Row>
+		<Row Tag="TXT_KEY_DEFENSIVE_SPY_BONUSES_DETAIL_SPY_WONDERCONSTRUCT_POSITIVE">
+			<Text>[NEWLINE]  [ICON_BULLET] [ICON_SPY] Constructing a Wonder: [COLOR_NEGATIVE_TEXT]+{1_Num}%[ENDCOLOR]</Text>
+		</Row>
+		<Row Tag="TXT_KEY_DEFENSIVE_SPY_BONUSES_DETAIL_SPY_WONDERCONSTRUCT_NEGATIVE">
+			<Text>[NEWLINE]  [ICON_BULLET] [ICON_SPY] Constructing a Wonder: [COLOR_POSITIVE_TEXT]{1_Num}%[ENDCOLOR]</Text>
+		</Row>
+		<Row Tag="TXT_KEY_CITY_SECURITY">
+			<Text>[COLOR_NEGATIVE_TEXT]Total City Resistance against our Spies: {1_Num}[ENDCOLOR]</Text>
 		</Row>
 
 		<Row Tag="TXT_KEY_OFFENSIVE_SPY_RELIGOUS_PRESSURE">
@@ -7641,14 +7624,6 @@
 		</Row>
 		<Row Tag="TXT_KEY_OFFENSIVE_COUP_CHANCE_ALLIES">
 			<Text>[NEWLINE][ICON_BULLET]   Reason: already Allies!</Text>
-		</Row>
-
-		<Row Tag="TXT_KEY_OFFENSIVE_RIG_CHANCE">
-			<Text>Current chance to Rig Election here: [COLOR_POSITIVE_TEXT]{1_Num}%[ENDCOLOR].</Text>
-		</Row>
-
-		<Row Tag="TXT_KEY_OFFENSIVE_SPY_COUNTERSPY_POSSIBLY_PRESENT">
-			<Text>Foreign [ICON_SPY] Counterspies are rumored to be in the City - be careful!</Text>
 		</Row>
 		
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_DIPLOMATIC_REQUEST">

--- a/(1) Community Patch/Modules/Events/Text/en_US/EventCore_en_US.xml
+++ b/(1) Community Patch/Modules/Events/Text/en_US/EventCore_en_US.xml
@@ -104,20 +104,20 @@
 		</Row>
 		<!-- Espionage Version FAILURE -->
 		<Row Tag="TXT_KEY_NOTIFICATION_EVENT_FAILED_CITY_ESPIONAGE">
-			<Text>{5_CivAdj} spies [COLOR_POSITIVE_TEXT]failed[ENDCOLOR] a Spy Action in {4_City}: '{3_Event}'.[NEWLINE][NEWLINE]{1_EventChoice} ({2_EventChoiceHelp})</Text>
+			<Text>{3_CivAdj} spies [COLOR_POSITIVE_TEXT]failed[ENDCOLOR] a Spy Mission in {2_City}: {1_EventChoice}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_EVENT_FAILED_CITY_T_ESPIONAGE">
 			<Text>{2_CivAdj} Operatives Thwarted in {1_City}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_EVENT_FAILED_CITY_ESPIONAGE_UNKNOWN">
-			<Text>Unknown foreign operatives [COLOR_POSITIVE_TEXT]failed[ENDCOLOR] a Spy Action in {4_City}: '{3_Event}'.[NEWLINE][NEWLINE]{1_EventChoice} ({2_EventChoiceHelp})</Text>
+			<Text>Unknown foreign operatives [COLOR_POSITIVE_TEXT]failed[ENDCOLOR] a Spy Mission in {2_City}: {1_EventChoice}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_EVENT_FAILED_CITY_T_ESPIONAGE_UNKNOWN">
 			<Text>Unknown Foreign Operatives Thwarted in {1_City}!</Text>
 		</Row>
 
 		<Row Tag="TXT_KEY_NOTIFICATION_EVENT_FAILED_CITY_ESPIONAGE_US">
-			<Text>Our attempted Spy Action in {4_City} failed. '{3_Event}': [NEWLINE][NEWLINE]{1_EventChoice} ({2_EventChoiceHelp})</Text>
+			<Text>Our attempted Spy Mission in {2_City} failed. {1_EventChoice}.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_EVENT_FAILED_CITY_T_ESPIONAGE_US">
 			<Text>Our Operatives Thwarted in {1_City}!</Text>
@@ -125,13 +125,13 @@
 		
 		<!-- Espionage Success -->
 		<Row Tag="TXT_KEY_NOTIFICATION_EVENT_SUCCEEDED_ESPIONAGE">
-			<Text>{4_CivAdj} spies [COLOR_NEGATIVE_TEXT]completed[ENDCOLOR] a Spy Action in {3_City}: [NEWLINE]{1_EventChoice} ({2_EventChoiceHelp})</Text>
+			<Text>{2_CivAdj} spies [COLOR_NEGATIVE_TEXT]completed[ENDCOLOR] a Spy Mission in {1_City}: {3_MissionResult}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_EVENT_SUCCEEDED_ESPIONAGE_T_ESPIONAGE">
 			<Text>{2_CivAdj} Operatives Succeeded in {1_City}!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_EVENT_SUCCEEDED_ESPIONAGE_UNKNOWN">
-			<Text>Unknown foreign operatives [COLOR_NEGATIVE_TEXT]completed[ENDCOLOR] a Spy Action in {3_City}: [NEWLINE]{1_EventChoice} ({2_EventChoiceHelp})</Text>
+			<Text>Unknown foreign operatives [COLOR_NEGATIVE_TEXT]completed[ENDCOLOR] a Spy Mission in {1_City}: {2_MissionResult}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_EVENT_SUCCEEDED_T_ESPIONAGE_UNKNOWN">
 			<Text>Unknown Foreign Operatives Succeeded in {1_City}!</Text>
@@ -140,6 +140,12 @@
 
 		<Row Tag="TXT_KEY_CITY_EVENT_TITLE">
 			<Text>Event in {1_City}: {2_Event}</Text>
+		</Row>
+		<Row Tag="TXT_KEY_SPY_MISSION">
+			<Text>[COLOR_POSITIVE_TEXT]Spy Mission:[ENDCOLOR] {1_Mission}</Text>
+		</Row>
+		<Row Tag="TXT_KEY_SPY_MISSION_COMPLETED">
+			<Text>Spy Mission Completed</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CITY_EVENT_HELP">
 			<Text>News from [COLOR_POSITIVE_TEXT]{1_City}[ENDCOLOR]:[NEWLINE][NEWLINE]{2_Event}</Text>
@@ -225,15 +231,6 @@
 		</Row>
 		<Row Tag="TXT_KEY_EVENT_YIELD_DURATION">
 			<Text>{1_Num} Turns</Text>
-		</Row>
-		<Row Tag="TXT_KEY_ESPIONAGE_MISSION_DURATION">
-			<Text>({1_Num} Turns)</Text>
-		</Row>
-		<Row Tag="TXT_KEY_EVENT_YIELD_SIPHON_PAST">
-			<Text>Total Amount Siphoned: {3_Value} {2_Icon} {1_Yield}</Text>
-		</Row>
-		<Row Tag="TXT_KEY_EVENT_YIELD_SIPHON_PRESENT">
-			<Text>Preparing Siphon: {3_Value} {2_Icon} {1_Yield} Collected ({4_Turns}) Turn(s) remaining)</Text>
 		</Row>
 
 		<Row Tag="TXT_KEY_NEED_OTHER_PLAYER_EVENT_ACTIVE">

--- a/(2) Vox Populi/Balance Changes/CoreDefines.sql
+++ b/(2) Vox Populi/Balance Changes/CoreDefines.sql
@@ -101,6 +101,9 @@ UPDATE GameSpeeds SET InstantYieldPercent = '150' WHERE Type = 'GAMESPEED_EPIC';
 UPDATE GameSpeeds SET InstantYieldPercent = '100' WHERE Type = 'GAMESPEED_STANDARD';
 UPDATE GameSpeeds SET InstantYieldPercent = '75' WHERE Type = 'GAMESPEED_QUICK';
 
+-- Spy Mission Durations (values above 100 make spy missions quicker, values below 100 make them slower)
+UPDATE GameSpeeds SET SpyRatePercent = '150' WHERE Type = 'GAMESPEED_QUICK';
+
 -- City Stuff
 UPDATE Defines SET Value = '2.22' WHERE Name = 'CITY_GROWTH_EXPONENT';
 UPDATE Defines SET Value = '12.0' WHERE Name = 'CITY_GROWTH_MULTIPLIER';

--- a/(2) Vox Populi/Balance Changes/Espionage/PrimaryEspionageEvents.xml
+++ b/(2) Vox Populi/Balance Changes/Espionage/PrimaryEspionageEvents.xml
@@ -595,7 +595,7 @@
 	<CityEventChoice_Notification>
 		<Row>
 			<CityEventChoiceType>ESPIONAGE_EVENT_CHOICE_SIPHON_TOURISM</CityEventChoiceType>
-			<NotificationType>NOTIFICATION_ESPIONAGE_OUTCOME</NotificationType>
+			<NotificationType>NOTIFICATION_SPY_RIG_ELECTION_SUCCESS</NotificationType>
 			<Description>TXT_KEY_ESPIONAGE_EVENT_CHOICE_SUCCESS</Description>
 			<ShortDescription>TXT_KEY_ESPIONAGE_EVENT_CHOICE_SUCCESS_S</ShortDescription>
 			<EspionageEvent>true</EspionageEvent>
@@ -605,7 +605,7 @@
 		</Row>
 		<Row>
 			<CityEventChoiceType>ESPIONAGE_EVENT_CHOICE_SIPHON_SCIENCE</CityEventChoiceType>
-			<NotificationType>NOTIFICATION_ESPIONAGE_OUTCOME</NotificationType>
+			<NotificationType>NOTIFICATION_SPY_RIG_ELECTION_SUCCESS</NotificationType>
 			<Description>TXT_KEY_ESPIONAGE_EVENT_CHOICE_SUCCESS</Description>
 			<ShortDescription>TXT_KEY_ESPIONAGE_EVENT_CHOICE_SUCCESS_S</ShortDescription>
 			<EspionageEvent>true</EspionageEvent>
@@ -615,7 +615,7 @@
 		</Row>
 		<Row>
 			<CityEventChoiceType>ESPIONAGE_EVENT_CHOICE_SIPHON_GOLD</CityEventChoiceType>
-			<NotificationType>NOTIFICATION_ESPIONAGE_OUTCOME</NotificationType>
+			<NotificationType>NOTIFICATION_SPY_RIG_ELECTION_SUCCESS</NotificationType>
 			<Description>TXT_KEY_ESPIONAGE_EVENT_CHOICE_SUCCESS</Description>
 			<ShortDescription>TXT_KEY_ESPIONAGE_EVENT_CHOICE_SUCCESS_S</ShortDescription>
 			<EspionageEvent>true</EspionageEvent>
@@ -625,7 +625,7 @@
 		</Row>
 		<Row>
 			<CityEventChoiceType>ESPIONAGE_EVENT_CHOICE_SIPHON_FAITH</CityEventChoiceType>
-			<NotificationType>NOTIFICATION_ESPIONAGE_OUTCOME</NotificationType>
+			<NotificationType>NOTIFICATION_SPY_RIG_ELECTION_SUCCESS</NotificationType>
 			<Description>TXT_KEY_ESPIONAGE_EVENT_CHOICE_SUCCESS</Description>
 			<ShortDescription>TXT_KEY_ESPIONAGE_EVENT_CHOICE_SUCCESS_S</ShortDescription>
 			<EspionageEvent>true</EspionageEvent>
@@ -635,7 +635,7 @@
 		</Row>
 		<Row>
 			<CityEventChoiceType>ESPIONAGE_EVENT_CHOICE_SCIENTIFIC_GREATPEOPLE</CityEventChoiceType>
-			<NotificationType>NOTIFICATION_ESPIONAGE_OUTCOME</NotificationType>
+			<NotificationType>NOTIFICATION_SPY_RIG_ELECTION_SUCCESS</NotificationType>
 			<Description>TXT_KEY_ESPIONAGE_EVENT_CHOICE_SUCCESS</Description>
 			<ShortDescription>TXT_KEY_ESPIONAGE_EVENT_CHOICE_SUCCESS_S</ShortDescription>
 			<EspionageEvent>true</EspionageEvent>
@@ -645,7 +645,7 @@
 		</Row>
 		<Row>
 			<CityEventChoiceType>ESPIONAGE_EVENT_CHOICE_MILITARY_GARRISON</CityEventChoiceType>
-			<NotificationType>NOTIFICATION_ESPIONAGE_OUTCOME</NotificationType>
+			<NotificationType>NOTIFICATION_SPY_RIG_ELECTION_SUCCESS</NotificationType>
 			<Description>TXT_KEY_ESPIONAGE_EVENT_CHOICE_SUCCESS</Description>
 			<ShortDescription>TXT_KEY_ESPIONAGE_EVENT_CHOICE_SUCCESS_S</ShortDescription>
 			<EspionageEvent>true</EspionageEvent>
@@ -655,7 +655,7 @@
 		</Row>
 		<Row>
 			<CityEventChoiceType>ESPIONAGE_EVENT_CHOICE_URBAN_UNREST</CityEventChoiceType>
-			<NotificationType>NOTIFICATION_ESPIONAGE_OUTCOME</NotificationType>
+			<NotificationType>NOTIFICATION_SPY_RIG_ELECTION_SUCCESS</NotificationType>
 			<Description>TXT_KEY_ESPIONAGE_EVENT_CHOICE_SUCCESS</Description>
 			<ShortDescription>TXT_KEY_ESPIONAGE_EVENT_CHOICE_SUCCESS_S</ShortDescription>
 			<EspionageEvent>true</EspionageEvent>
@@ -665,7 +665,7 @@
 		</Row>
 		<Row>
 			<CityEventChoiceType>ESPIONAGE_EVENT_CHOICE_ECONOMIC_TILES</CityEventChoiceType>
-			<NotificationType>NOTIFICATION_ESPIONAGE_OUTCOME</NotificationType>
+			<NotificationType>NOTIFICATION_SPY_RIG_ELECTION_SUCCESS</NotificationType>
 			<Description>TXT_KEY_ESPIONAGE_EVENT_CHOICE_SUCCESS</Description>
 			<ShortDescription>TXT_KEY_ESPIONAGE_EVENT_CHOICE_SUCCESS_S</ShortDescription>
 			<EspionageEvent>true</EspionageEvent>
@@ -675,7 +675,7 @@
 		</Row>
 		<Row>
 			<CityEventChoiceType>ESPIONAGE_EVENT_CHOICE_STEAL_TECH</CityEventChoiceType>
-			<NotificationType>NOTIFICATION_ESPIONAGE_OUTCOME</NotificationType>
+			<NotificationType>NOTIFICATION_SPY_RIG_ELECTION_SUCCESS</NotificationType>
 			<Description>TXT_KEY_ESPIONAGE_EVENT_CHOICE_SUCCESS</Description>
 			<ShortDescription>TXT_KEY_ESPIONAGE_EVENT_CHOICE_SUCCESS_S</ShortDescription>
 			<EspionageEvent>true</EspionageEvent>
@@ -685,7 +685,7 @@
 		</Row>
 		<Row>
 			<CityEventChoiceType>ESPIONAGE_EVENT_CHOICE_STEAL_GW</CityEventChoiceType>
-			<NotificationType>NOTIFICATION_ESPIONAGE_OUTCOME</NotificationType>
+			<NotificationType>NOTIFICATION_SPY_RIG_ELECTION_SUCCESS</NotificationType>
 			<Description>TXT_KEY_ESPIONAGE_EVENT_CHOICE_SUCCESS</Description>
 			<ShortDescription>TXT_KEY_ESPIONAGE_EVENT_CHOICE_SUCCESS_S</ShortDescription>
 			<EspionageEvent>true</EspionageEvent>
@@ -695,7 +695,7 @@
 		</Row>
 		<Row>
 			<CityEventChoiceType>ESPIONAGE_EVENT_CHOICE_REVEAL_AREA</CityEventChoiceType>
-			<NotificationType>NOTIFICATION_ESPIONAGE_OUTCOME</NotificationType>
+			<NotificationType>NOTIFICATION_SPY_RIG_ELECTION_SUCCESS</NotificationType>
 			<Description>TXT_KEY_ESPIONAGE_EVENT_CHOICE_SUCCESS</Description>
 			<ShortDescription>TXT_KEY_ESPIONAGE_EVENT_CHOICE_SUCCESS_S</ShortDescription>
 			<EspionageEvent>true</EspionageEvent>

--- a/(2) Vox Populi/Balance Changes/Text/en_US/CivText.sql
+++ b/(2) Vox Populi/Balance Changes/Text/en_US/CivText.sql
@@ -296,7 +296,7 @@ WHERE Tag = 'TXT_KEY_TRAIT_WONDER_BUILDER';
 -- England
 --------------------
 UPDATE Language_en_US
-SET Text = '+1 [ICON_MOVES] Movement for Naval and Embarked Units, and -25% Naval Unit [ICON_GOLD] Gold maintenance. Foreign [ICON_SPY] Spies operate 25% slower in owned Cities. [ICON_SPY] Spies are faster and operate one Rank higher than normal. Starts with a [ICON_SPY] Spy.'
+SET Text = '+1 [ICON_MOVES] Movement for Naval and Embarked Units, and -25% Naval Unit [ICON_GOLD] Gold maintenance. Spy Resistance increased by 25% in all owned Cities. [ICON_SPY] Spies operate one Rank higher than normal. Starts with a [ICON_SPY] Spy.'
 WHERE Tag = 'TXT_KEY_TRAIT_OCEAN_MOVEMENT';
 
 UPDATE Language_en_US

--- a/(2) Vox Populi/Balance Changes/Text/en_US/EspionageEventText.xml
+++ b/(2) Vox Populi/Balance Changes/Text/en_US/EspionageEventText.xml
@@ -33,85 +33,89 @@
 			<Text>Sabotage local [ICON_TOURISM] Tourism</Text>
 		</Row>
 		<Row Tag="TXT_KEY_ESPIONAGE_EVENT_CHOICE_SIPHON_TOURISM_HELP">
-			<Text>[COLOR_POSITIVE_TEXT]{8_MissionLength}[ENDCOLOR][NEWLINE]{6_Spy}Target City: Spy collects 75% of City's [ICON_TOURISM] Tourism output each turn for duration of mission. When complete, Spy steals all collected [ICON_TOURISM] Tourism.</Text>
+			<Text>Spy collects 75% of the Target City's [ICON_TOURISM] Tourism output each turn for duration of mission. When complete, Spy steals all collected [ICON_TOURISM] Tourism.{8_MissionLength}{6_Spy}{3_YieldCityTip}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_ESPIONAGE_EVENT_CHOICE_SIPHON_SCIENCE">
 			<Text>Infiltrate [ICON_RESEARCH] Science facilities</Text>
 		</Row>
 		<Row Tag="TXT_KEY_ESPIONAGE_EVENT_CHOICE_SIPHON_SCIENCE_HELP">
-			<Text>[COLOR_POSITIVE_TEXT]{8_MissionLength}[ENDCOLOR][NEWLINE]{6_Spy}Target City: Spy collects 50% of City's [ICON_RESEARCH] Science output each turn for duration of mission. When complete, Spy steals all collected [ICON_RESEARCH] Science.</Text>
+			<Text>Spy collects 50% of the Target City's [ICON_RESEARCH] Science output each turn for duration of mission. When complete, Spy steals all collected [ICON_RESEARCH] Science.{8_MissionLength}{6_Spy}{3_YieldCityTip}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_ESPIONAGE_EVENT_CHOICE_SIPHON_GOLD">
 			<Text>Steal [ICON_GOLD] Gold from treasury</Text>
 		</Row>
 		<Row Tag="TXT_KEY_ESPIONAGE_EVENT_CHOICE_SIPHON_GOLD_HELP">
-			<Text>[COLOR_POSITIVE_TEXT]{8_MissionLength}[ENDCOLOR][NEWLINE]{6_Spy}Target City: Spy collects 50% of City's [ICON_GOLD] Gold output each turn for duration of mission. When complete, Spy steals all collected [ICON_GOLD] Gold.</Text>
+			<Text>Spy collects 50% of the Target City's [ICON_GOLD] Gold output each turn for duration of mission. When complete, Spy steals all collected [ICON_GOLD] Gold.{8_MissionLength}{6_Spy}{3_YieldCityTip}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_ESPIONAGE_EVENT_CHOICE_SIPHON_FAITH">
 			<Text>Pilfer [ICON_PEACE] Religious Relics</Text>
 		</Row>
 		<Row Tag="TXT_KEY_ESPIONAGE_EVENT_CHOICE_SIPHON_FAITH_HELP">
-			<Text>[COLOR_POSITIVE_TEXT]{8_MissionLength}[ENDCOLOR][NEWLINE]{6_Spy}Target City: Spy collects 75% of City's [ICON_PEACE] Faith output each turn for duration of mission. When complete, Spy steals all collected [ICON_PEACE] Faith.</Text>
+			<Text>Spy collects 75% of the Target City's [ICON_PEACE] Faith output each turn for duration of mission. When complete, Spy steals all collected [ICON_PEACE] Faith.{8_MissionLength}{6_Spy}{3_YieldCityTip}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_ESPIONAGE_EVENT_CHOICE_ECONOMIC_TILES">
 			<Text>Radicalize the rural [ICON_CITIZEN] citizenry</Text>
 		</Row>
 		<Row Tag="TXT_KEY_ESPIONAGE_EVENT_CHOICE_ECONOMIC_TILES_HELP">
-			<Text>[COLOR_POSITIVE_TEXT]{8_MissionLength}[ENDCOLOR][NEWLINE]{6_Spy}One of each primary improvement (Farm, Mine, Plantation, Trading Post) is pillaged around the City. Two improved [COLOR_POSITIVE_TEXT] Strategic Resource [ENDCOLOR] tiles are pillaged. -25% [ICON_FOOD] Growth for {5_Turns}</Text>
+			<Text>One of each primary improvement (Farm, Mine, Plantation, Trading Post) is pillaged around the Target City. Two improved [COLOR_POSITIVE_TEXT] Strategic Resource [ENDCOLOR] tiles are pillaged. -25% [ICON_FOOD] Growth for {5_Turns}.{8_MissionLength}{6_Spy}{3_YieldCityTip}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_ESPIONAGE_EVENT_CHOICE_STOKE">
 			<Text>Foment Local [ICON_HAPPINESS_3] Unhappiness</Text>
 		</Row>
 		<Row Tag="TXT_KEY_ESPIONAGE_EVENT_CHOICE_STOKE_HELP">
-			<Text>[COLOR_POSITIVE_TEXT]{8_MissionLength}[ENDCOLOR][NEWLINE]{6_Spy}Target City: +34% Unhappiness from Needs.</Text>
+			<Text>+34% Unhappiness from Needs in Target City.{8_MissionLength}{6_Spy}{3_YieldCityTip}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_ESPIONAGE_EVENT_CHOICE_SCIENTIFIC_GREATPEOPLE">
 			<Text>Kidnap [ICON_GREAT_PEOPLE] Specialists in the City</Text>
 		</Row>
 		<Row Tag="TXT_KEY_ESPIONAGE_EVENT_CHOICE_SCIENTIFIC_GREATPEOPLE_HELP">
-			<Text>[COLOR_POSITIVE_TEXT]{8_MissionLength}[ENDCOLOR][NEWLINE]{6_Spy}Target City: -1 [ICON_RESEARCH] Science from Scientists; -1 [ICON_GOLD] Gold from Merchants; -1 [ICON_PRODUCTION] Production from Engineers; -1 [ICON_CULTURE] Culture from Musicians, Artists, and Writers.[NEWLINE]Your Benefit: {7_PlayerEventEffect}</Text>
+			<Text>In the Target City: -1 [ICON_RESEARCH] Science from Scientists; -1 [ICON_GOLD] Gold from Merchants; -1 [ICON_PRODUCTION] Production from Engineers; -1 [ICON_CULTURE] Culture from Musicians, Artists, and Writers. {7_PlayerEventEffect}.{8_MissionLength}{6_Spy}{3_YieldCityTip}</Text>
 		</Row>
+		<Row Tag="TXT_KEY_ESPIONAGE_EVENT_CHOICE_BENEFIT">
+			<Text>[COLOR_POSITIVE_TEXT]Your Benefit:[ENDCOLOR]</Text>
+		</Row>
+		Your Benefit:
 		<Row Tag="TXT_KEY_ESPIONAGE_EVENT_CHOICE_MILITARY_GARRISON">
 			<Text>Target local City [ICON_STRENGTH] Defenses</Text>
 		</Row>
 		<Row Tag="TXT_KEY_ESPIONAGE_EVENT_CHOICE_MILITARY_GARRISON_HELP">
-			<Text>[COLOR_POSITIVE_TEXT]{8_MissionLength}[ENDCOLOR][NEWLINE]{6_Spy}Target City takes [COLOR_NEGATIVE_TEXT]100[ENDCOLOR] Damage and Garrison (if present) takes [COLOR_NEGATIVE_TEXT]25[ENDCOLOR] Damage. City is [COLOR_NEGATIVE_TEXT]Sapped[ENDCOLOR] (cannot heal) for 5 turns.</Text>
+			<Text>Target City takes [COLOR_NEGATIVE_TEXT]100[ENDCOLOR] Damage and Garrison (if present) takes [COLOR_NEGATIVE_TEXT]25[ENDCOLOR] Damage. City is [COLOR_NEGATIVE_TEXT]Sapped[ENDCOLOR] (cannot heal) for 5 turns.{8_MissionLength}{6_Spy}{3_YieldCityTip}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_ESPIONAGE_EVENT_CHOICE_URBAN_UNREST">
 			<Text>[ICON_RESISTANCE] Arm the local populace</Text>
 		</Row>
 		<Row Tag="TXT_KEY_ESPIONAGE_EVENT_CHOICE_URBAN_UNREST_HELP">
-			<Text>[COLOR_POSITIVE_TEXT]{8_MissionLength}[ENDCOLOR][NEWLINE]{6_Spy}City enters [ICON_RESISTANCE] Resistance for 2 Turns. 5 Rebel Units spawn around the City.</Text>
+			<Text>City enters [ICON_RESISTANCE] Resistance for 2 Turns. 5 Rebel Units spawn around the City.{8_MissionLength}{6_Spy}{3_YieldCityTip}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_ESPIONAGE_EVENT_CHOICE_STEAL_TECH">
 			<Text>Sabotage Science and Steal a [ICON_RESEARCH] Technology</Text>
 		</Row>
 		<Row Tag="TXT_KEY_ESPIONAGE_EVENT_CHOICE_STEAL_TECH_HELP">
-			<Text>[COLOR_POSITIVE_TEXT]{8_MissionLength}[ENDCOLOR][NEWLINE]{6_Spy}Target Player: Steal one [ICON_RESEARCH] Technology from enemy [ICON_CAPITAL] Capital. Target City: {3_CityYield}[NEWLINE][NEWLINE]If no Techs are available to steal at completion, a [ICON_GOLDEN_AGE] Golden Age Begins.</Text>
+			<Text>Steal one [ICON_RESEARCH] Technology from enemy [ICON_CAPITAL] Capital.[NEWLINE][NEWLINE]If no Techs are available to steal at completion, a [ICON_GOLDEN_AGE] Golden Age Begins.{8_MissionLength}{6_Spy}{3_YieldCityTip}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_ESPIONAGE_EVENT_CHOICE_STEAL_GW">
 			<Text>Create a forgery of a [ICON_GREAT_WORK] Great Work in the City</Text>
 		</Row>
 		<Row Tag="TXT_KEY_ESPIONAGE_EVENT_CHOICE_STEAL_GW_HELP">
-			<Text>[COLOR_POSITIVE_TEXT]{8_MissionLength}[ENDCOLOR][NEWLINE]{6_Spy}Target City: Copy one [ICON_GREAT_WORK] Great Work. Target City: {3_CityYield}[NEWLINE][NEWLINE]If no Great Works are available to steal at completion, a [ICON_GOLDEN_AGE] Golden Age Begins.</Text>
+			<Text>Copy one of the [ICON_GREAT_WORK] Great Works in the Target City.[NEWLINE][NEWLINE]If no Great Works are available to steal at completion, a [ICON_GOLDEN_AGE] Golden Age Begins.{8_MissionLength}{6_Spy}{3_YieldCityTip}</Text>
 		</Row>
 
 		<Row Tag="TXT_KEY_ESPIONAGE_EVENT_CHOICE_REVEAL_AREA">
 			<Text>Broaden [ICON_SPY] Surveillance in City</Text>
 		</Row>
 		<Row Tag="TXT_KEY_ESPIONAGE_EVENT_CHOICE_REVEAL_AREA_HELP">
-			<Text>[COLOR_POSITIVE_TEXT]{8_MissionLength}[ENDCOLOR][NEWLINE]{6_Spy}Target City: Expand number of tiles visible around City for {5_Turns}.</Text>
+			<Text>Expand the number of tiles visible around the Target City for {5_Turns}.{8_MissionLength}{6_Spy}{3_YieldCityTip}</Text>
 		</Row>
 
 		<Row Tag="TXT_KEY_ESPIONAGE_EVENT_PLAYER_YIELD_BASIC">
-			<Text>Repatriated Specialists (Spy Event)</Text>
+			<Text>Repatriated Specialists</Text>
 		</Row>
 		<Row Tag="TXT_KEY_ESPIONAGE_EVENT_PLAYER_YIELD_BASIC_HELP">
 			<Text>+2 [ICON_RESEARCH] Science from Scientists; +2 [ICON_GOLD] Gold from Merchants; +2 [ICON_PRODUCTION] Production from Engineers; +2 [ICON_CULTURE] Culture from Musicians, Artists, and Writers in [ICON_CAPITAL] Capital. Duration: {4_Turns}</Text>
 		</Row>
 
 		<Row Tag="TXT_KEY_ESPIONAGE_EVENT_PLAYER_YIELD_BASIC_PARENT">
-			<Text>Repatriated Specialists (Spy Event)</Text>
+			<Text>Repatriated Specialists</Text>
 		</Row>
 		<Row Tag="TXT_KEY_ESPIONAGE_EVENT_PLAYER_YIELD_BASIC_PARENT_HELP">
 			<Text>+2 [ICON_RESEARCH] Science from Scientists; +2 [ICON_GOLD] Gold from Merchants; +2 [ICON_PRODUCTION] Production from Engineers; +2 [ICON_CULTURE] Culture from Musicians, Artists, and Writers in [ICON_CAPITAL] Capital. Duration: {4_Turns}</Text>
@@ -150,8 +154,24 @@
 		</Row>
 		
 		<!-- Notifications -->
+		<Row Tag="TXT_KEY_ESPIONAGE_MISSION_DURATION">
+			<Text>[COLOR_POSITIVE_TEXT]Estimated Mission Duration:[ENDCOLOR] {1_Num} Turns</Text>
+		</Row>
+		<Row Tag="TXT_KEY_ESPIONAGE_EVENT_YIELD_SIPHON_PAST">
+			<Text>[COLOR_POSITIVE_TEXT]Total Amount Stolen:[ENDCOLOR] {1_Yield}</Text>
+		</Row>
+		<Row Tag="TXT_KEY_ESPIONAGE_EVENT_YIELD_SIPHON_PAST_ENEMY">
+			<Text>[COLOR_NEGATIVE_TEXT]Total Amount Stolen:[ENDCOLOR] {1_Yield}</Text>
+		</Row>
+		<Row Tag="TXT_KEY_ESPIONAGE_EVENT_YIELD_SIPHON_PRESENT">
+			<Text>Preparing Theft: {1_Yield} Collected.</Text>
+		</Row>
+		<Row Tag="TXT_KEY_ESPIONAGE_EVENT_YIELD_SIPHON_ESTIMATED">
+			<Text>[COLOR_POSITIVE_TEXT]Estimated Total Amount to Steal:[ENDCOLOR] {1_Yield}</Text>
+		</Row>
+		
 		<Row Tag="TXT_KEY_ESPIONAGE_EVENT_CHOICE_SUCCESS">
-			<Text>{1_SpyRank} {2_SpyName} in {3_CityName} completed their mission![NEWLINE][NEWLINE]{4_EventChoiceHelpText}</Text>
+			<Text>{1_SpyRank} {2_SpyName} in {3_CityName} completed their mission: {4_MissionResult}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_ESPIONAGE_EVENT_CHOICE_SUCCESS_S">
 			<Text>{1_SpyRank} {2_SpyName} succeeded in {3_CityName}!</Text>
@@ -164,7 +184,7 @@
 			<Text>[COLOR_POSITIVE_TEXT]MISSION OUTCOME:[ENDCOLOR] SUCCESS, BUT IDENTIFIED![NEWLINE][NEWLINE]Message: "Our cover is blown, we're returning to HQ for reassignment."[NEWLINE][NEWLINE]</Text>
 		</Row>
 		<Row Tag="TXT_KEY_EVENT_SPY_KILLED">
-			<Text>[COLOR_NEGATIVE_TEXT]MISSION OUTCOME:[ENDCOLOR] FAILURE[NEWLINE][NEWLINE] Communications have gone dark. Your operative is KIA.[NEWLINE][NEWLINE]</Text>
+			<Text>[COLOR_NEGATIVE_TEXT]MISSION OUTCOME:[ENDCOLOR] FAILURE[NEWLINE][NEWLINE]Communications have gone dark. Your operative is KIA.[NEWLINE][NEWLINE]</Text>
 		</Row>
 
 		<Row Tag="TXT_KEY_NOTIFICATION_EXTRA_SIGHT_EVENT_HAS_ENDED_CITY">

--- a/(2) Vox Populi/Balance Changes/Text/en_US/PolicyText.sql
+++ b/(2) Vox Populi/Balance Changes/Text/en_US/PolicyText.sql
@@ -246,7 +246,7 @@ WHERE Tag = 'TXT_KEY_POLICY_ACADEMY_SCIENCES_HELP';
 
 -- Cultural Revolution
 UPDATE Language_en_US
-SET Text = '[COLOR_POSITIVE_TEXT]Cultural Revolution[ENDCOLOR]: +34% [ICON_TOURISM] Tourism to other Order civilizations, and +5 [ICON_TOURISM] Tourism from all [ICON_GREAT_WORK] Great Works. Spies complete Spy Events at double the normal rate.'
+SET Text = '[COLOR_POSITIVE_TEXT]Cultural Revolution[ENDCOLOR]: +34% [ICON_TOURISM] Tourism to other Order civilizations, and +5 [ICON_TOURISM] Tourism from all [ICON_GREAT_WORK] Great Works. Spies complete Spy Missions at double the normal rate.'
 WHERE Tag = 'TXT_KEY_POLICY_CULTURAL_REVOLUTION_HELP';
 
 -- Dictatorship of the Proletariat

--- a/(2) Vox Populi/Balance Changes/Text/en_US/UIText.sql
+++ b/(2) Vox Populi/Balance Changes/Text/en_US/UIText.sql
@@ -187,25 +187,80 @@ SET Text = 'You are currently using more {1_Resource:textkey} than you have! All
 WHERE Tag = 'TXT_KEY_NOTIFICATION_OVER_RESOURCE_LIMIT';
 	
 -- Text Changes for Spies in Cities
+
+-- Espionage
+
 UPDATE Language_en_US
-SET Text = '{1_SpyRank} {2_SpyName} cannot steal technologies from, or perform Great Work Heists against {3_CityName}, however they can continue to disrupt the player through additional actions like sabotage.[NEWLINE][NEWLINE]The base Spy Resistance of {4_CityName} is {5_Num}.[NEWLINE][NEWLINE]Security reflects the vulnerability of a city to Espionage. The higher the value, the less vulnerable the city. The base value [COLOR_POSITIVE_TEXT](a scale, from 1 to 10)[ENDCOLOR] is based on the overall prosperity of the city. Spy Resistance may be increased by defensive buildings in the city, such as the Constabulary and the Police Station.'
+SET Text = 'Security Level'
+WHERE Tag = 'TXT_KEY_EO_POTENTIAL';
+
+UPDATE Language_en_US
+SET Text = 'Security Level reflects the difficulty of Espionage in a City. The higher the value, the more time it will take to complete Spy Missions. The base value (from 1 to 50) is based on the overall economic value of the City (relative to all other cities). Security is also affected by Espionage modifiers and buildings in the city, such as the Constabulary and the Police Station. Security also increases when a City has a powerful Counterspy.[NEWLINE][NEWLINE]Click to sort cities by their Security level.'
+WHERE Tag = 'TXT_KEY_EO_POTENTIAL_SORT_TT';
+
+UPDATE Language_en_US
+SET Text = 'If your cities have low Security, you should consider protecting them. There are two ways to do this. You may move your own spies to your cities to act as counterspies that have a chance to catch and kill enemy spies before they steal something. You may also slow down how quickly enemy spies can steal things by constructing buildings like the Constabulary, Police Station, and the Great Firewall.'
+WHERE Tag = 'TXT_KEY_EO_OWN_CITY_POTENTIAL_TT';
+
+UPDATE Language_en_US
+SET Text = '{1_SpyRank} {2_SpyName} is stealing from {3_CityName}.[NEWLINE]The current Security Level of {3_CityName} is {4_Num}.[NEWLINE][NEWLINE]Security reflects the vulnerability of a city to Espionage. The higher the value, the more protected the city. The base value (from 1 to 50) is based on the overall prosperity and happiness of the city (relative to all other cities). Security may be decreased by Policies and Espionage buildings in the city, such as the Constabulary and the Police Station.'
+WHERE Tag = 'TXT_KEY_EO_CITY_POTENTIAL_TT';
+
+UPDATE Language_en_US
+SET Text = '{1_SpyRank} {2_SpyName} cannot steal technologies from {3_CityName}.[NEWLINE][NEWLINE]The Security Level of {4_CityName} is {5_Num}.[NEWLINE][NEWLINE]Security reflects the vulnerability of a city to Espionage. The higher the value, the more protected the city. The base value (a scale, from 1 to 50) is based on the overall prosperity and happiness of the city. Security may be decreased by Policies and Espionage buildings in the city, such as the Constabulary and the Police Station..'
 WHERE Tag = 'TXT_KEY_EO_CITY_POTENTIAL_CANNOT_STEAL_TT';
 
 UPDATE Language_en_US
-SET Text = '{1_SpyRank} {2_SpyName} is in {3_CityName}. While {4_SpyRank} {5_SpyName} is in your city, they will perform counter-espionage operations to capture and kill any enemy spies that try to complete Spy Events.'
+SET Text = 'The Security Level of {1_CityName} is believed to be {2_Num}. Send a [ICON_SPY] Spy to this City to learn more about it.[NEWLINE][NEWLINE]Security reflects the vulnerability of a city to Espionage. The higher the value, the more protected the city. The base value (from 1 to 50) is based on the overall prosperity and happiness of the city. Security may be decreased by Policies and Espionage buildings in the city, such as the Constabulary and the Police Station.'
+WHERE Tag = 'TXT_KEY_EO_CITY_ONCE_KNOWN_POTENTIAL_TT';
+
+
+UPDATE Language_en_US
+SET Text = '[ICON_CAPITAL] Security Level: [COLOR_POSITIVE_TEXT]{2_Num}[ENDCOLOR][NEWLINE][ICON_SPY] Spy Resistance: [COLOR_POSITIVE_TEXT]{1_Num}%[ENDCOLOR][NEWLINE][NEWLINE]If [ICON_SPY] Spy Resistance is negative, the City''s Security Level will [COLOR_NEGATIVE_TEXT]fall[ENDCOLOR] towards 1 and enemy Spies will operate more quickly. If positive, it will [COLOR_POSITIVE_TEXT]rise[ENDCOLOR] towards 50 and enemy Spies will operate more slowly. [NEWLINE][NEWLINE]If an enemy Spy completes a Mission in the City, the Security Level is reset to 50.'
+WHERE Tag = 'TXT_KEY_POTENTIAL_CALCULATION';
+UPDATE Language_en_US
+SET Text = '[COLOR_POSITIVE_TEXT]Estimated Duration:[ENDCOLOR] {1_Num} Turns'
+WHERE Tag = 'TXT_KEY_ESPIONAGE_MISSION_DURATION';
+
+UPDATE Language_en_US
+SET Text = 'Conducting Spy Mission'
+WHERE Tag = 'TXT_KEY_SPY_STATE_GATHERING_INTEL';
+
+UPDATE Language_en_US
+SET Text = '{1_RankName} {2_SpyName} is attempting to rig the election in {3_CityName} to increase our influence there. Successfully rigging elections also increases the success chance of a coup in the City-State.'
+WHERE Tag = 'TXT_KEY_EO_SPY_RIGGING_ELECTIONS_SHORT_TT';
+
+UPDATE Language_en_US
+SET Text = '{1_RankName} {2_SpyName} is conducting a Spy Mission in {3_CityName}. If the city''s owner has a spy in the city, your spy has a chance of being discovered and killed when they try to complete their mission!'
+WHERE Tag = 'TXT_KEY_EO_SPY_GATHERING_INTEL_TT';
+
+UPDATE Language_en_US
+SET Text = '{1_RankName} {2_SpyName} is schmoozing in {3_CityName} as a diplomat.[NEWLINE][NEWLINE]A spy can be a diplomat if they are placed in the capital of another civilization you are not at war with. (If war is declared, your spy will escape the city.) A diplomat will not attempt to conduct Spy Missions but will still provide intrigue. Once the World Congress convenes and the diplomat has begun schmoozing, you will be able to determine their opinion on proposals and trade for their support if needed. Diplomats also conduct propaganda that provides a boost to [ICON_TOURISM] Tourism output to the target civilization.'
+WHERE Tag = 'TXT_KEY_SPY_STATE_SCHMOOZING_TT';
+
+UPDATE Language_en_US
+SET Text = '{1_RankName} {2_SpyName} is trying to make all the right connections in  {3_CityName} as a diplomat. After they have made their introductions, they will be able to schmooze.[NEWLINE][NEWLINE]A spy can be a diplomat if they are placed in the capital of another civilization. A diplomat will not attempt to conduct Spy Missions but will still provide intrigue. Once the World Congress convenes and the diplomat has begun schmoozing, you will be able to determine their opinion on proposals and trade for their support if needed.'
+WHERE Tag = 'TXT_KEY_SPY_STATE_MAKING_INTRODUCTIONS_TT';
+
+UPDATE Language_en_US
+SET Text = '{1_RankName} {2_SpyName} is conducting counter-intelligence operations in {3_CityName}.[NEWLINE][NEWLINE]If an enemy spy tries to finish a Spy Mission in the city you have the spy in, your spy will ensure that the theft is detected. It has a chance of determining who stole the information as well as killing the enemy spy outright. The higher rank your spy, the more likely you are to kill the enemy spy.'
+WHERE Tag = 'TXT_KEY_EO_SPY_COUNTER_INTEL_TT';
+
+UPDATE Language_en_US
+SET Text = '{1_SpyRank} {2_SpyName} is in {3_CityName}. While {4_SpyRank} {5_SpyName} is in your city, they will perform counter-espionage operations to capture and kill any enemy spies that try to complete Spy Missions.'
 WHERE Tag = 'TXT_KEY_CITY_SPY_YOUR_CITY_TT';
 
 UPDATE Language_en_US
-SET Text = '{1_SpyRank} {2_SpyName} is in {3_CityName}. While {4_SpyRank} {5_SpyName} is in the city, they establish surveillance and work towards completing Spy Events. {6_SpyRank} {7_SpyName} will also inform you of any intrigue that they discover during their operations.'
+SET Text = '{1_SpyRank} {2_SpyName} is in {3_CityName}. While {4_SpyRank} {5_SpyName} is in the city, they establish surveillance and work towards completing Spy Missions. {6_SpyRank} {7_SpyName} will also inform you of any intrigue that they discover during their operations.'
 WHERE Tag = 'TXT_KEY_CITY_SPY_OTHER_CIV_TT';
 
 UPDATE Language_en_US
-SET Text = 'Options for {1_SpyRank} {2_SpyName}:[NEWLINE][NEWLINE][ICON_BULLET] Move to a City-State and attempt to [COLOR_POSITIVE_TEXT]Rig an Election[ENDCOLOR] or [COLOR_POSITIVE_TEXT]Stage a Coup[ENDCOLOR].[NEWLINE][ICON_BULLET] Move to a non-Capital City owned by a Major Civilization and attempt a [COLOR_POSITIVE_TEXT]Spy Event[ENDCOLOR].[NEWLINE][ICON_BULLET] Move to a Capital City owned by a Major Civilization and attempt a [COLOR_POSITIVE_TEXT]Spy Event[ENDCOLOR], [COLOR_POSITIVE_TEXT]Uncover Intrigue[ENDCOLOR], or [COLOR_POSITIVE_TEXT]Schmooze[ENDCOLOR] as a Diplomat.'
+SET Text = 'Options for {1_SpyRank} {2_SpyName}:[NEWLINE][NEWLINE][ICON_BULLET] Move to a City-State and attempt to [COLOR_POSITIVE_TEXT]Rig an Election[ENDCOLOR] or [COLOR_POSITIVE_TEXT]Stage a Coup[ENDCOLOR].[NEWLINE][ICON_BULLET] Move to a non-Capital City owned by a Major Civilization and attempt to conduct a [COLOR_POSITIVE_TEXT]Spy Mission[ENDCOLOR].[NEWLINE][ICON_BULLET] Move to a Capital City owned by a Major Civilization and attempt to conduct a [COLOR_POSITIVE_TEXT]Spy Mission[ENDCOLOR], [COLOR_POSITIVE_TEXT]Uncover Intrigue[ENDCOLOR], or [COLOR_POSITIVE_TEXT]Schmooze[ENDCOLOR] as a Diplomat.'
 WHERE Tag = 'TXT_KEY_EO_SPY_MOVE_TT';
 
 
 UPDATE Language_en_US
-SET Text = '{1_SpyName} has achieved the rank of {2_RankName}.[NEWLINE][NEWLINE]There are three spy ranks: Recruit, Agent, and Special Agent. Each subsequent level makes the spy more effective. A higher ranking spy will operate faster and kill enemy spies that are trying to work against you more frequently, rig elections in City-States more effectively, and have a greater chance of pulling off a coup in a City-State allied with another civilization.[NEWLINE][NEWLINE]Spies level up when they successfully complete Spy Events, kill an enemy spy, schmooze as as a diplomat, or if they uncover intrigue.'
+SET Text = '{1_SpyName} has achieved the rank of {2_RankName}.[NEWLINE][NEWLINE]There are three spy ranks: Recruit, Agent, and Special Agent. Each subsequent level makes the spy more effective. A higher ranking spy will operate faster and kill enemy spies that are trying to work against you more frequently, rig elections in City-States more effectively, and have a greater chance of pulling off a coup in a City-State allied with another civilization.[NEWLINE][NEWLINE]Spies level up when they successfully complete Spy Missions, kill an enemy spy, schmooze as as a diplomat, or if they uncover intrigue.'
 WHERE Tag = 'TXT_KEY_EO_SPY_RANK_TT';
 
 UPDATE Language_en_US

--- a/CvGameCoreDLL_Expansion2/CvCity.h
+++ b/CvGameCoreDLL_Expansion2/CvCity.h
@@ -156,7 +156,7 @@ public:
 	void DoCancelEventChoice(CityEventChoiceTypes eEventChoice);
 	void DoStartEvent(CityEventTypes eEvent);
 	void DoEventChoice(CityEventChoiceTypes eEventChoice, CityEventTypes eCityEvent = NO_EVENT_CITY, bool bSendMsg = true, int iEspionageValue = -1, PlayerTypes eSpyOwner = NO_PLAYER, CvCity* pOriginalCity = NULL);
-	CvString GetScaledHelpText(CityEventChoiceTypes eEventChoice, bool bYieldsOnly, int iSpyIndex = -1, PlayerTypes eSpyOwner = NO_PLAYER);
+	CvString GetScaledHelpText(CityEventChoiceTypes eEventChoice, bool bYieldsOnly, int iSpyIndex = -1, PlayerTypes eSpyOwner = NO_PLAYER, bool bSpyMissionEnd = false);
 	CvString GetDisabledTooltip(CityEventChoiceTypes eEventChoice, int iSpyIndex = -1, PlayerTypes eSpyOwner = NO_PLAYER);
 
 	void SetEventActive(CityEventTypes eEvent, bool bValue);
@@ -1048,8 +1048,13 @@ public:
 
 	int GetContestedPlotScore(PlayerTypes eOtherPlayer) const;
 
-#if defined(MOD_BALANCE_CORE_SPIES)
+#if defined(MOD_BALANCE_CORE_SPIES_ADVANCED)
 	int GetEspionageRanking() const;
+	int GetSpyDefenseModifier(PlayerTypes ePlayer, CityEventChoiceTypes eEventChoice) const;
+	CvString GetSpyDefenseModifierText(PlayerTypes ePlayer, CityEventChoiceTypes eEventChoice);
+	int GetSpyOffenseModifier(PlayerTypes ePlayer, uint iSpyIndex) const;
+	CvString GetSpyOffenseModifierText(PlayerTypes ePlayer, uint iSpyIndex) const;
+	CvString GetSpyMissionOutcome(CityEventChoiceTypes eEventChoice, uint iSpyIndex, PlayerTypes ePlayer, bool bOwnSpy = 1, bool bSucceeded = 1, bool bShowPopup = 1);
 	int GetSpyTurnsToCompleteMission(PlayerTypes ePlayer, CityEventChoiceTypes eEventChoice, uint iSpyIndex, int iProgress = 0) const;
 	void ChangeEspionageRanking(int iRank, bool bNotify);
 	void ResetEspionageRanking();

--- a/CvGameCoreDLL_Expansion2/CvCultureClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCultureClasses.cpp
@@ -4761,7 +4761,7 @@ int CvPlayerCulture::GetInfluenceSurveillanceTime(PlayerTypes ePlayer) const
 	{
 		InfluenceLevelTypes eLevel = GetInfluenceLevel(ePlayer);
 
-		if (MOD_BALANCE_CORE_SPIES)
+		if (MOD_BALANCE_CORE_SPIES_ADVANCED)
 		{
 			switch (eLevel)
 			{
@@ -4877,6 +4877,11 @@ int CvPlayerCulture::GetInfluenceMajorCivSpyRankBonus(PlayerTypes ePlayer) const
 CvString CvPlayerCulture::GetInfluenceSpyRankTooltip(CvString szName, CvString szRank, PlayerTypes ePlayer, bool bNoBasicHelp, int iSpyID)
 {
 	CvString szRtnValue = "";
+	if (!MOD_BALANCE_CORE_SPIES_ADVANCED) 
+	{
+		szRtnValue = GetLocalizedText("TXT_KEY_EO_SPY_RANK_TT", szName, szRank);
+		return szRtnValue;
+	}
 
 	CvPlayerEspionage* pkPlayerEspionage = m_pPlayer->GetEspionage();
 	if (pkPlayerEspionage)

--- a/CvGameCoreDLL_Expansion2/CvEspionageClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvEspionageClasses.h
@@ -82,7 +82,10 @@ public:
 	void ResetSpySiphon();
 	CvString GetSiphonHistory();
 	void ResetSiphonHistory();
-	void UpdateSiphonHistory(CvCity* pCity, PlayerTypes eSpyOwner, uint iSpyIndex, CityEventChoiceTypes eEventChoice = NO_EVENT_CHOICE_CITY, CvSpyResult eResult = NUM_SPY_RESULTS);
+	void UpdateSiphonHistory(CvCity* pCity, PlayerTypes eSpyOwner, uint iSpyIndex);
+	CvString GetLastMissionOutcome();
+	void ResetLastMissionOutcome();
+	void UpdateLastMissionOutcome(CvCity* pCity, PlayerTypes eSpyOwner, uint iSpyIndex, CvSpyResult eResult = NUM_SPY_RESULTS);
 
 	// Public data
 	int m_iName;
@@ -101,6 +104,7 @@ public:
 	int m_iYieldSiphon;
 	YieldTypes m_eSiphonYield;
 	CvString m_sSiphonHistory;
+	CvString m_sLastMissionOutcome;
 };
 
 FDataStream& operator>>(FDataStream&, CvEspionageSpy&);
@@ -179,7 +183,6 @@ public:
 
 	void CreateSpy(void);
 	void ProcessSpy(uint uiSpyIndex);
-#if defined(MOD_BALANCE_CORE_SPIES)
 	void ProcessSpyFocus();
 	void ProcessSpySiphon(CvCity* pCity, int uiSpyIndex);
 	void TriggerSpyFocusSetup(CvCity* pCity, int uiSpyIndex);
@@ -203,7 +206,6 @@ public:
 
 	int GetDefenseChance(CvEspionageType eEspionage, CvCity* pCity, CityEventChoiceTypes eEventChoice = NO_EVENT_CHOICE_CITY, bool bPreview = false);
 	CvSpyResult GetSpyRollResult(CvCity* pCity, CityEventChoiceTypes eEventChoice = NO_EVENT_CHOICE_CITY);
-#endif
 	void UncoverIntrigue(uint uiSpyIndex);
 	void GetRandomIntrigue(CvCity* pCity, uint uiSpyIndex);
 	void GetNextSpyName(CvEspionageSpy* pSpy);
@@ -227,6 +229,7 @@ public:
 	int CalcRequired(int iSpyState, CvCity* pCity, int iSpyIndex, bool bGlobalCheck = false);
 
 	int GetSpyPower(CvCity* pCity, int iSpyIndex, int iSpyState);
+	int GetSpyResistanceModifier(CvCity* pCity, bool bConsiderPotentialSpy = false);
 	int GetSpyResistance(CvCity* pCity, bool bConsiderPotentialSpy = false);
 
 	const char* GetSpyRankName(int iRank) const;

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -704,7 +704,7 @@ CvPlayer::CvPlayer() :
 	, m_iTradeReligionModifier()
 	, m_iCityStateCombatModifier()
 #endif
-#if defined(MOD_BALANCE_CORE_SPIES)
+#if defined(MOD_BALANCE_CORE_SPIES_ADVANCED)
 	, m_iMaxAirUnits()
 #endif
 #if defined(MOD_BALANCE_CORE_BUILDING_INVESTMENTS)
@@ -1574,7 +1574,7 @@ void CvPlayer::uninit()
 	m_iUnitsInLiberatedCities = 0;
 	m_iCityCaptureHealGlobal = 0;
 #endif
-#if defined(MOD_BALANCE_CORE_SPIES)
+#if defined(MOD_BALANCE_CORE_SPIES_ADVANCED)
 	m_iMaxAirUnits = 0;
 #endif
 #if defined(MOD_BALANCE_CORE_BUILDING_INVESTMENTS)
@@ -36715,7 +36715,7 @@ void CvPlayer::changeBuildingClassCultureChange(BuildingClassTypes eIndex, int i
 	CvAssert(getBuildingClassCultureChange(eIndex) >= 0);
 }
 #endif
-#if defined(MOD_BALANCE_CORE_SPIES)
+#if defined(MOD_BALANCE_CORE_SPIES_ADVANCED)
 void CvPlayer::changeMaxAirUnits(int iChange)
 {
 	if (iChange != 0)

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaCity.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaCity.cpp
@@ -695,6 +695,7 @@ void CvLuaCity::PushMethods(lua_State* L, int t)
 #if defined(MOD_BALANCE_CORE_EVENTS)
 	Method(GetDisabledTooltip);
 	Method(GetScaledEventChoiceValue);
+	Method(GetSpyMissionOutcome);
 	Method(IsCityEventChoiceActive);
 	Method(DoCityEventChoice);
 	Method(DoCityStartEvent);
@@ -6227,6 +6228,21 @@ int CvLuaCity::lGetScaledEventChoiceValue(lua_State* L)
 	if(eEventChoice != NO_EVENT_CHOICE_CITY)
 	{
 		CoreYieldTip = pkCity->GetScaledHelpText(eEventChoice, bYieldsOnly, iSpyID, eSpyOwner);
+	}
+
+	lua_pushstring(L, CoreYieldTip.c_str());
+	return 1;
+}
+int CvLuaCity::lGetSpyMissionOutcome(lua_State* L)
+{
+	CvString CoreYieldTip = "";
+	CvCity* pkCity = GetInstance(L);
+	const CityEventChoiceTypes eEventChoice = (CityEventChoiceTypes)lua_tointeger(L, 2);
+	const int iSpyID = luaL_optint(L, 3, -1);
+	const PlayerTypes eSpyOwner = (PlayerTypes)luaL_optint(L, 4, NO_PLAYER);
+	if (eEventChoice != NO_EVENT_CHOICE_CITY)
+	{
+		CoreYieldTip = pkCity->GetSpyMissionOutcome(eEventChoice, iSpyID, eSpyOwner);
 	}
 
 	lua_pushstring(L, CoreYieldTip.c_str());

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaCity.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaCity.h
@@ -695,6 +695,7 @@ protected:
 #if defined(MOD_BALANCE_CORE_EVENTS)
 	static int lGetDisabledTooltip(lua_State* L);
 	static int lGetScaledEventChoiceValue(lua_State* L);
+	static int lGetSpyMissionOutcome(lua_State* L);
 	static int lIsCityEventChoiceActive(lua_State* L);
 	static int lDoCityEventChoice(lua_State* L);
 	static int lDoCityStartEvent(lua_State* L);


### PR DESCRIPTION
okay, this is one very large PR... (I will try to split things up into different PRs next time). I was working on the espionage bugfixes and then I saw more and more things that needed to be done there...

I don't know if you want to include this in the upcoming version already, it's fine if it will be only in the one after that.

------------
Bugfixes:
- Fix cities being initialized with the lowest possible espionage resistance instead of the highest one (caused by #9669)
- Fix replacement spies starting with the XP of the dead spy they replace
- Fix spy mission durations being longer on quick game speed than on other game speeds
- Fix mission durations not being updated when the mission duration modifiers change
- Fix a bunch of unintended VP changes in community patch. They were caused by mixing up MOD_BALANCE_CORE_SPIES (number of spies depends on map size) and MOD_BALANCE_CORE_SPIES_ADVANCED (all the VP changes to the espionage system)

I had to remove that XP is given to diplomats when they discover that a wonder is built. The reason for that is a bug that gave the XP again on every single turn in which the wonder was still under construction, and I didn't find a better way to solve this.

A small change: Security Level was internally a value between 100 and 1000, which was displayed in the UI as a value between 1 and 10 (Security Level / 100). The mission duration modifier was based on (Security Level / 20) (so between 5% and 50%). I changed the displayed value now to also be (Security Level / 20) to make the displayed value equal to the percentage modifier. In this context, I changed the possible internal range of values from 100-1000 to 20-1000, so possible modifiers are now from 1% to 50%.

------------
UI changes:
- Fix #9501
- Siphon Mission now show an estimate of the amount of yields that will be stolen
- Modifiers for mission duration and security level are now explained in the spy screen
- Spy Mission Result Screens now show the correct values (those of the completed spy mission and not those of the next one) (Fix #9520, #9437)
- Removed unnecessary/incorrect information in notifications (like spy kill chance for completed missions)

![Screenshot (309)](https://user-images.githubusercontent.com/95587882/222285703-f09f04cf-3dc3-4fce-9b34-04a79eb28192.png)
![Screenshot (311)](https://user-images.githubusercontent.com/95587882/222285830-3c1facae-ecaa-4a32-bc4f-5b8f6248e6b0.png)
![Screenshot (312)](https://user-images.githubusercontent.com/95587882/222285854-08759817-187c-4718-ac8d-5dc4b98dd100.png)
![Screenshot (313)](https://user-images.githubusercontent.com/95587882/222285862-ae7a8121-82d6-47a8-9da6-2131c133ab4c.png)
![Screenshot (316)](https://user-images.githubusercontent.com/95587882/222286720-ad95cb57-a15d-4bd7-9528-58bd570c1bcd.png)
