### PR TITLE
Update tooltip for city production modifier keys

### DIFF
--- a/(1) Community Patch/Core Files/Text/CoreText_en_US.sql
+++ b/(1) Community Patch/Core Files/Text/CoreText_en_US.sql
@@ -54,7 +54,7 @@ WHERE Tag = 'TXT_KEY_POPUP_CITY_CAPTURE_INFO_RAZE';
 
 -- Production Queue
 UPDATE Language_en_US
-SET Text = 'LEFT CLICK adds an additional item to the end of the production queue.[NEWLINE]CTRL + LEFT CLICK adds an additional item in front of the production queue.[NEWLINE]ALT + LEFT CLICK adds the chosen item to the end of the production queue on repeat.[NEWLINE]SHIFT + LEFT CLICK replaces everything in the production queue with the chosen item.'
+SET Text = 'LEFT CLICK adds an additional item to the end of the production queue.[NEWLINE]CTRL + LEFT CLICK adds an additional item in front of the production queue.[NEWLINE]ALT + LEFT CLICK adds the chosen item to the end of the production queue on repeat.[NEWLINE]SHIFT + LEFT CLICK replaces everything in the production queue with the chosen item.[NEWLINE]SHIFT + ALT + LCLICK adds the item to the end of every cities production queue.[NEWLINE]SHIFT + CTRL + LCLICK adds the item to the front of every cities production queue.[NEWLINE]SHIFT + LCLICK the invest button invests in this building in every queue.'
 WHERE Tag = 'TXT_KEY_CITYVIEW_QUEUE_PROD_TT';
 
 -- Avoid Growth


### PR DESCRIPTION
New tooltip looks like this:

![image](https://user-images.githubusercontent.com/8049171/222854607-263e571f-8221-4e2e-8b95-f583acf53f0a.png)
