### PR TITLE
Minor Fixes

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvEspionageClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvEspionageClasses.cpp
@@ -2898,6 +2898,7 @@ bool CvPlayerEspionage::MoveSpyTo(CvCity* pCity, uint uiSpyIndex, bool bAsDiplom
 		pCityEspionage->m_aiSpyAssignment[m_pPlayer->GetID()] = uiSpyIndex;
 		m_aSpyList[uiSpyIndex].SetSpyState(m_pPlayer->GetID(), uiSpyIndex, SPY_STATE_TRAVELLING);
 		m_aSpyList[uiSpyIndex].m_bIsDiplomat = bAsDiplomat;
+		m_aSpyList[uiSpyIndex].ResetSpySiphon();
 		int iRate = CalcPerTurn(SPY_STATE_TRAVELLING, pCity, uiSpyIndex);
 		int iGoal = CalcRequired(SPY_STATE_TRAVELLING, pCity, uiSpyIndex);
 		pCityEspionage->SetActivity(m_pPlayer->GetID(), 0, iRate, iGoal);

--- a/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
@@ -1951,12 +1951,17 @@ bool CvMinorCivQuest::IsExpired()
 				return true;
 			}
 			//Failed coup?
-			else if(GET_PLAYER(ePlayer).GetMinorCivAI()->IsCoupAttempted(m_eAssignedPlayer))
+			else if (GET_PLAYER(ePlayer).GetMinorCivAI()->IsCoupAttempted(m_eAssignedPlayer))
 			{
-				if(GET_PLAYER(ePlayer).GetMinorCivAI()->GetAlly() != m_eAssignedPlayer)
+				if (GET_PLAYER(ePlayer).GetMinorCivAI()->GetAlly() != m_eAssignedPlayer)
 				{
 					return true;
 				}
+			}
+			// City-state has no ally?
+			else if (GET_PLAYER(ePlayer).GetMinorCivAI()->GetAlly() == NO_PLAYER)
+			{
+				return true;
 			}
 			//already Allied?
 			else if(GET_PLAYER(ePlayer).GetMinorCivAI()->IsAllies(m_eAssignedPlayer))


### PR DESCRIPTION
- Reset spy siphon values when a spy is moved (caused wrong values to be shown in the mission selection screen)
- CS Coup Quest is cancelled if the target has no ally (for example caused by Decol)