### PR TITLE
Squads CityView closing bugfix

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvGame.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGame.cpp
@@ -1634,15 +1634,6 @@ void CvGame::update()
 			LuaSupport::CallHook(pkScriptSystem, "GameCoreUpdateEnd", args.get(), bResult);
 		}
 	}
-
-	// For an uknown reason the game loop stops calling updateTestEndTurn() sometimes, which
-	// can cause the game to become stuck with an out of date ENDTURN_BLOCKING_TYPE that
-	// really should be cleared after squad movement ends. Without this workaround the blocking
-	// type never gets set to NO_ENDTURN_BLOCKING_TYPE even when it should, softlocking the game
-	if (MOD_SQUADS)
-	{
-		updateTestEndTurn();
-	}
 }
 
 //	---------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
The reason is no longer unknown: 
basically, the game loop stopped calling `updateTestEndTurn()` because I acquired the turnTimerSemaphore without properly releasing it in an early iteration of my UI and the game loop doesn't call this function when that semaphore is acquired. The original bug of not being able to end turn got fixed by this because this forced it to do the end turn logic despite the semaphore being held by the UI, but had the unfortunate consequence of breaking other things that acquire this semaphore specifically so that DOESN'T happen.

In this particular case the bug happened only in cases where cities with an empty production queue because this changed the end turn blocking type from city production to something else, which was picked up by the regular call to `updateTestEndTurn()` and so the game brought the user attention to the next thing blocking the turn end possibility (hence why CityView acquires this semaphore in the first place)