### PR TITLE
Bugfix specialists and Rome CTD

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -7861,7 +7861,7 @@ CityTaskResult CvCity::doTask(TaskTypes eTask, int iData1, int iData2, bool bOpt
 		break;
 
 	case TASK_NO_AUTO_ASSIGN_SPECIALISTS:
-		GetCityCitizens()->SetNoAutoAssignSpecialists(bOption);
+		GetCityCitizens()->SetNoAutoAssignSpecialists(bOption, true);
 		break;
 
 	case TASK_ADD_SPECIALIST:

--- a/CvGameCoreDLL_Expansion2/CvCityCitizens.h
+++ b/CvGameCoreDLL_Expansion2/CvCityCitizens.h
@@ -155,7 +155,7 @@ public:
 	void DoAddSpecialistToBuilding(BuildingTypes eBuilding, bool bForced, CvCity::eUpdateMode updateMode);
 	void DoRemoveSpecialistFromBuilding(BuildingTypes eBuilding, bool bForced, CvCity::eUpdateMode updateMode);
 	void DoRemoveAllSpecialistsFromBuilding(BuildingTypes eBuilding, CvCity::eUpdateMode updateMode);
-	bool DoRemoveWorstSpecialist(SpecialistTypes eDontChangeSpecialist, const BuildingTypes eDontRemoveFromBuilding, CvCity::eUpdateMode updateMode);
+	bool DoRemoveWorstSpecialist(SpecialistTypes eDontChangeSpecialist, bool bForced, const BuildingTypes eDontRemoveFromBuilding, CvCity::eUpdateMode updateMode);
 
 	int GetNumDefaultSpecialists() const;
 	void ChangeNumDefaultSpecialists(int iChange, CvCity::eUpdateMode updateMode);

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -48083,7 +48083,7 @@ void CvPlayer::removeAnnexedMilitaryCityStates(PlayerTypes eMinor)
 {
 	for (std::vector< std::pair<PlayerTypes, int> >::const_iterator it = m_AnnexedMilitaryCityStatesUnitSpawnTurns.begin(); it != m_AnnexedMilitaryCityStatesUnitSpawnTurns.end(); ++it)
 	{
-		if ((*it).first != eMinor)
+		if ((*it).first == eMinor)
 		{
 			m_AnnexedMilitaryCityStatesUnitSpawnTurns.erase(it);
 			return;


### PR DESCRIPTION
- Fix #9462: as written in a comment in the issue discussion, `bReset` should be true when `SetNoAutoAssignSpecialists` is called
- Fix #9721: a very stupid mistake: removeAnnexedMilitaryCityStates(eMinor) should remove the city-state eMinor from the list of annexed CSs, not all other ones
- Fix #9723: `DoRemoveWorstSpecialist` always called `DoRemoveSpecialistFromBuilding` with the parameter `bForced=true`. It could happen that no forced specialist was in the building at all, and then the number of forced specialists was set to a negative value, which could then cause the number of unassigned specialists also to become negative. I assume this also fixes #9712 and #9517, these bugs are also caused by negative values of forced specialists / unassigned citizens, but I can't be sure as the error happened in turns before the ones of the save games. I added UNREACHABLEs in the code when numbers of specialists are set to negative values, so if those bugs persist, they will now cause crashes right away