### PR TITLE
Text fix

### DIFF
--- a/(2) Vox Populi/Modular Elements/Corporations/Text/en_US/CorpText.xml
+++ b/(2) Vox Populi/Modular Elements/Corporations/Text/en_US/CorpText.xml
@@ -848,7 +848,7 @@
 			<Text>[ICON_RES_WINE] Wine, [ICON_RES_TRUFFLES] Truffles, [ICON_RES_CITRUS] Citrus provide +1 [ICON_FOOD] Food in all Cities with a TwoKay Foods Franchise.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CORPORATION_OFFICE_BONUS_TWOKAY_FOODS">
-			<Text>+3 [ICON_FOOD] Food, -1 [ICON_HAPPINESS_3] Unhappiness from all Needs and -5% to [ICON_CITY_STATE] Empire Size Modifier for every Global Franchise. +10% [ICON_FOOD] Food in the City.</Text>
+			<Text>+3 [ICON_FOOD] Food for every Global Franchise. +10% [ICON_FOOD] Food in the City. -1 [ICON_HAPPINESS_3] Unhappiness from all Needs and -5% to [ICON_CITY_STATE] Empire Size Modifier in all Cities.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CORPORATION_TRADE_ROUTE_BONUS_TWOKAY_FOODS">
 			<Text>[ICON_INTERNATIONAL_TRADE] Trade Routes to foreign Cities with a TwoKay Foods Franchise grant +10% [ICON_FOOD] Food to the origin City.</Text>


### PR DESCRIPTION
The current text for TwoKay Foods' office bonus suggests that its needs reduction and empire size modifier scales based on number of franchises, when it is actually a global bonus of the office. The submitted text clarifies that.