### PR TITLE
getActivePlayer() in getSmallFakeRandNum() causes desyncs

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvGame.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGame.cpp
@@ -10947,7 +10947,7 @@ static unsigned long giLastState = 0;
 int CvGame::getSmallFakeRandNum(int iNum, const CvPlot& input) const
 {
 	//do not use turnslice here, it changes after reload!
-	unsigned long iState = input.getX()*17 + input.getY()*23 + getGameTurn()*37 + getActivePlayer()*73;
+	unsigned long iState = input.getX()*17 + input.getY()*23 + getGameTurn()*37 + getStartYear()*73;
 
 	/*
 	//safety check
@@ -10978,7 +10978,7 @@ int CvGame::getSmallFakeRandNum(int iNum, const CvPlot& input) const
 int CvGame::getSmallFakeRandNum(int iNum, int iExtraSeed) const
 {
 	//do not use turnslice here, it changes after reload!
-	unsigned long iState = getGameTurn()*11 + getActivePlayer()*19 + abs(iExtraSeed);
+	unsigned long iState = getGameTurn()*11 + getStartYear()*19 + abs(iExtraSeed);
 
 	/*
 	//safety check
@@ -10998,7 +10998,16 @@ int CvGame::getSmallFakeRandNum(int iNum, int iExtraSeed) const
 	if (pLog)
 	{
 		char szOut[1024] = { 0 };
-		sprintf_s(szOut, "turn %d, turnslice %d, max %d, res %d, seed %d\n", getGameTurn(), getTurnSlice(), iNum, iResult, iExtraSeed);
+		sprintf_s(
+			szOut, 
+			"turn %d, turnslice %d, activePlayer %d, max %d, res %d, seed %d\n", 
+			getGameTurn(), 
+			getTurnSlice(), 
+			getActivePlayer(),
+			iNum, 
+			iResult, 
+			iExtraSeed
+		);
 		pLog->Msg(szOut);
 	}
 	*/

--- a/CvGameCoreDLL_Expansion2/CvGame.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGame.cpp
@@ -10947,7 +10947,8 @@ static unsigned long giLastState = 0;
 int CvGame::getSmallFakeRandNum(int iNum, const CvPlot& input) const
 {
 	//do not use turnslice here, it changes after reload!
-	unsigned long iState = input.getX()*17 + input.getY()*23 + getGameTurn()*37 + getStartYear()*73;
+	//do not use the active player either, it can be different on both ends of a MP game
+	unsigned long iState = input.getX()*17 + input.getY()*23 + getGameTurn()*37;
 
 	/*
 	//safety check
@@ -10978,7 +10979,8 @@ int CvGame::getSmallFakeRandNum(int iNum, const CvPlot& input) const
 int CvGame::getSmallFakeRandNum(int iNum, int iExtraSeed) const
 {
 	//do not use turnslice here, it changes after reload!
-	unsigned long iState = getGameTurn()*11 + getStartYear()*19 + abs(iExtraSeed);
+	//do not use the active player either, it can be different on both ends of a MP game
+	unsigned long iState = getGameTurn()*11 + abs(iExtraSeed);
 
 	/*
 	//safety check


### PR DESCRIPTION
Hello! I did some MP debugging and looks like `getActivePlayer()` in `getSmallFakeRandNum()` causes a lot of desyncs across players because it differs on host and non-host player. With enabled logging it looks like (left - host; right - another one player): 
![image](https://user-images.githubusercontent.com/3791221/231969296-dd2dd21f-824c-47a9-95a5-536144b33fb8.png)

I'm not sure if `getStartYear()` is suitable here, point me if we should use something else.