### PR TITLE
Fix spies not being able to move to owned cities

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvEspionageClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvEspionageClasses.cpp
@@ -2799,8 +2799,9 @@ bool CvPlayerEspionage::CanMoveSpyTo(CvCity* pCity, uint uiSpyIndex, bool bAsDip
 			return false;
 		}
 	}
-	else if(MOD_BALANCE_CORE_SPIES_ADVANCED)
+	else if(MOD_BALANCE_CORE_SPIES_ADVANCED && pCity->getOwner() != ePlayerID)
 	{
+		// check if any offensive spy mission possible (only for foreign cities)
 		bool bEventsPossible = false;
 		for (int iLoop = 0; iLoop < GC.getNumCityEventInfos(); iLoop++)
 		{


### PR DESCRIPTION
This fixes a bug that a spy isn't able to move to an owned city as counterspy if no _offensive_ spy actions can be done there (because all missions are being conducted by other, foreign, spies). The check if offensive missions are available should obviously be done only for foreign cities. Moving to an owned city as counterspy is always possible