### PR TITLE
Don't try to move if MOVEFLAG_APPROX_TARGET_RING2 already satisfied

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
@@ -2276,8 +2276,13 @@ void CvHomelandAI::ReviewUnassignedUnits()
 
 					if (pBestPlot != NULL)
 					{
-						if (MoveToTargetButDontEndTurn(pUnit, pBestPlot, iFlags))
-						{
+
+						if (
+							// check if we are satisfying MOVEFLAG_APPROX_TARGET_RING2 already
+							(iBestDistance < 3 && iBestDistance >= 0) || 
+							// move if not
+							MoveToTargetButDontEndTurn(pUnit, pBestPlot, iFlags)
+						) {
 							pUnit->SetTurnProcessed(true);
 
 							CvString strTemp;

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -11926,7 +11926,7 @@ void CvPlayer::EndTurnsForReadyUnits(bool bLinkedUnitsOnly)
 			{
 				CvString strCiv = GET_PLAYER(pLoopUnit->getOwner()).getCivilizationAdjective();
 				CvString strLogString;
-				strLogString.Format("Warning: Forcing turn end for %s %s at %d,d", strCiv.c_str(), pLoopUnit->getName().c_str(), pLoopUnit->getX(), pLoopUnit->getY());
+				strLogString.Format("Warning: Forcing turn end for %s %s at %d,%d", strCiv.c_str(), pLoopUnit->getName().c_str(), pLoopUnit->getX(), pLoopUnit->getY());
 				GetHomelandAI()->LogHomelandMessage(strLogString);
 			}
 		}


### PR DESCRIPTION
Hello! I have several MP saves where CS triremes are stucking because when they are trying to move to neighboring plot, the pathfinder says them smth like "you are already here (because of TARGET_RING2 flag)", `MoveToTargetButDontEndTurn` returns `false` (because unit's plot wasn't changed) and they are trying again and again until timeout. Looks like it's 'ok' for SP because timeout is `10` for local games, but for MP it's `1000` and sometimes we have to wait 2-3 mins each turn again and again. 
I'm not sure whether such fix is ok overall but at least it resolves such situations.