### PR TITLE
Add support for AI workers repairing and removing roads outside of their borders

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
@@ -616,11 +616,6 @@ void CvBuilderTaskingAI::ConnectPointsForStrategy(CvCity* pOriginCity, CvPlot* p
 
 		// remember the plot
 		AddRoutePlot(pPlot, eRoute, 54);
-
-		// for citadels also put routes on the neighboring plots ...
-		if (TacticalAIHelpers::IsPlayerCitadel(pPlot, m_pPlayer->GetID()))
-			for (int i = RING0_PLOTS; i < RING1_PLOTS; i++)
-				AddRoutePlot(iterateRingPlots(pPlot, i), eRoute, 42);
 	}
 }
 /// Looks at city connections and marks plots that can be added as routes by EvaluateBuilder

--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
@@ -616,6 +616,11 @@ void CvBuilderTaskingAI::ConnectPointsForStrategy(CvCity* pOriginCity, CvPlot* p
 
 		// remember the plot
 		AddRoutePlot(pPlot, eRoute, 54);
+
+		// for citadels also put routes on the neighboring plots ...
+		if (TacticalAIHelpers::IsPlayerCitadel(pPlot, m_pPlayer->GetID()))
+			for (int i = RING0_PLOTS; i < RING1_PLOTS; i++)
+				AddRoutePlot(iterateRingPlots(pPlot, i), eRoute, 42);
 	}
 }
 /// Looks at city connections and marks plots that can be added as routes by EvaluateBuilder


### PR DESCRIPTION
AI workers will now consider pillaged road tiles outside their borders for repairs.
AI workers will now consider removing unused road tiles outside of their borders if they were responsible for creating them.