### PR TITLE
AI workers ignore improvements in razing cities

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
@@ -336,7 +336,7 @@ void CvBuilderTaskingAI::ConnectCitiesToCapital(CvCity* pPlayerCapital, CvCity* 
 		int iSideBenefits = 500 + iRoadLength * 100;
 
 		// give an additional bump if we're almost done (don't get distracted and leave half-finished roads)
-		if (iPlotsNeeded < 3 && iRoadLength - iPlotsNeeded > 3)
+		if (iPlotsNeeded > 0 && iPlotsNeeded < 3)
 			iSideBenefits += 20000;
 
 		//assume one unhappiness is worth gold per turn per city

--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
@@ -886,6 +886,10 @@ void CvBuilderTaskingAI::AddImprovingResourcesDirectives(CvUnit* pUnit, CvPlot* 
 			return;
 	}
 
+	// if city owning this plot is being razed, ignore this plot
+	if (pCity && pCity->IsRazing())
+		return;
+
 	CvResourceInfo* pkResource = GC.getResourceInfo(eResource);
 
 	// loop through the build types to find one that we can use
@@ -1047,6 +1051,10 @@ void CvBuilderTaskingAI::AddImprovingPlotsDirectives(CvUnit* pUnit, CvPlot* pPlo
 	}
 
 	if(!m_bEvaluateAdjacent && !pPlot->isWithinTeamCityRadius(pUnit->getTeam()))
+		return;
+
+	// if city owning this plot is being razed, ignore this plot
+	if (pCity && pCity->IsRazing())
 		return;
 
 	// check to see if a non-bonus resource is here. if so, bail out!
@@ -1418,6 +1426,10 @@ void CvBuilderTaskingAI::AddChopDirectives(CvUnit* pUnit, CvPlot* pPlot, CvCity*
 	if (pPlot->IsImprovementPillaged())
 		return;
 
+	// if city owning this plot is being razed, ignore this plot
+	if (pCity && pCity->IsRazing())
+		return;
+
 	// check to see if a resource is here. If so, bail out!
 	ResourceTypes eResource = pPlot->getResourceType(m_pPlayer->getTeam());
 	if(eResource != NO_RESOURCE)
@@ -1620,6 +1632,12 @@ void CvBuilderTaskingAI::AddRepairTilesDirectives(CvUnit* pUnit, CvPlot* pPlot, 
 		return;
 	}
 
+	// if city owning this plot is being razed, and it's not a route we want to repair, ignore this plot
+	if (pWorkingCity && pWorkingCity->IsRazing() && !isPillagedRouteWeWantToRepair)
+	{
+		return;
+	}
+
 	//nothing pillaged here? hmm...
 	if (!pPlot->IsImprovementPillaged() && !pPlot->IsRoutePillaged())
 	{
@@ -1652,7 +1670,7 @@ void CvBuilderTaskingAI::AddRepairTilesDirectives(CvUnit* pUnit, CvPlot* pPlot, 
 	}
 }
 // Everything means less than zero, hey
-void CvBuilderTaskingAI::AddScrubFalloutDirectives(CvUnit* pUnit, CvPlot* pPlot, CvCity* /*pCity*/, int iMoveTurnsAway)
+void CvBuilderTaskingAI::AddScrubFalloutDirectives(CvUnit* pUnit, CvPlot* pPlot, CvCity* pCity, int iMoveTurnsAway)
 {
 	if(m_eFalloutFeature == NO_FEATURE || m_eFalloutRemove == NO_BUILD)
 	{
@@ -1663,6 +1681,10 @@ void CvBuilderTaskingAI::AddScrubFalloutDirectives(CvUnit* pUnit, CvPlot* pPlot,
 	{
 		return;
 	}
+
+	// if city owning this plot is being razed, ignore this plot
+	if (pCity && pCity->IsRazing())
+		return;
 
 	if(pPlot->getFeatureType() == m_eFalloutFeature && pUnit->canBuild(pPlot, m_eFalloutRemove))
 	{

--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
@@ -385,6 +385,10 @@ void CvBuilderTaskingAI::ConnectCitiesForShortcuts(CvCity* pCity1, CvCity* pCity
 	if(pCity1->getOwner() != pCity2->getOwner())
 		return;
 
+	// don't connect razing cities
+	if (pCity1->IsRazing() || pCity2->IsRazing())
+		return;
+
 	CvCity* pPlayerCapital = m_pPlayer->getCapitalCity();
 	// only build a shortcut if both cities have a connection to the capital (including sea routes)
 	if (!m_pPlayer->IsCityConnectedToCity(pCity1, pPlayerCapital, eRoute, false) || !m_pPlayer->IsCityConnectedToCity(pCity2, pPlayerCapital, eRoute, false))


### PR DESCRIPTION
AI workers no longer build improvements in tiles belonging to cities being razed.
AI workers no longer make shortcut routes to cities being razed.

Fix route "finishing up" logic.