### PR TITLE
fix IsCoastMakesValid logic in CvPlot::getImprovementTypeNeededToImproveResource()

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -7233,11 +7233,15 @@ ImprovementTypes CvPlot::getImprovementTypeNeededToImproveResource(PlayerTypes e
 		if (bIgnoreSpecialImprovements && (pImprovementInfo->IsCreatedByGreatPerson() || pImprovementInfo->IsAdjacentCity()))
 			continue;
 
-		if(pImprovementInfo->IsWater() != isWater())
+		if (pImprovementInfo->IsWater() != isWater())
 			continue;
 
-		if(pImprovementInfo->IsCoastMakesValid() != (isWater() && !isLake()))
-			continue;
+		bool isCoast = isWater() && !isLake();
+		if (pImprovementInfo->IsCoastMakesValid() && isCoast)
+		{
+			eImprovementNeeded = eImprovement;
+			break;
+		}
 
 		eImprovementNeeded = eImprovement;
 	}


### PR DESCRIPTION
Right now in the loop of improvement builds to check, we have the following conditional regarding coastal tiles:
```
if (pImprovementInfo->IsCoastMakesValid() != (isWater() && !isLake()))
	continue;
```
the problem here is that while `IsCoastMakesValid` on a costal tile makes an improvement build valid, the contrapositive is NOT true, i.e. an improvement with  `IsCoastMakesValid=False` on a coastal tile should not make the build considered invalid, but it currently does. For further clarifiaction, consult the following truth table:

| IsCoastMakesValid | isWater | isLake | isWater & !isLake | Invalid |
|-------------------|---------|--------|-------------------|---------|
| T                 | T       | T      | F                 | T       |
| T                 | T       | F      | T                 | F       |
| T                 | F       | T      | F                 | T       |
| T                 | F       | F      | F                 | T       |
| F                 | T       | T      | F                 | F       |
| F                 | T       | F      | T                 | T       |
| F                 | F       | T      | F                 | F       |
| F                 | F       | F      | F                 | F       |

In particular the problematic row is third from the bottom, where for example fishing boats have `IsCoastMakesValid=False`, but for coastal tiles with fish/coral/whales etc. the `CvPlot::getImprovementTypeNeededToImproveResource()` does not return fishing boats because of this issue!

Fixes a bug where ctrl-clicking a coastal tile sea resource with fishing boats does not improve it on arrival