### PR TITLE
Various AI route building fixes and updates

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.h
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.h
@@ -94,7 +94,10 @@ public:
 	bool DoesBuildHelpRush(CvUnit* pUnit, CvPlot* pPlot, BuildTypes eBuild);
 	bool WantRouteAtPlot(const CvPlot* pPlot) const; //build it
 	bool NeedRouteAtPlot(const CvPlot* pPlot) const; //keep it
+	RouteTypes GetRouteTypeWantedAtPlot(const CvPlot* pPlot) const;
+	RouteTypes GetRouteTypeNeededAtPlot(const CvPlot* pPlot) const;
 	bool WantCanalAtPlot(const CvPlot* pPlot) const; //build it and keep it
+	bool GetSameRouteBenefitFromTrait(CvPlot* pPlot, RouteTypes eRoute) const;
 
 	int ScorePlotBuild(CvPlot* pPlot, ImprovementTypes eImprovement, BuildTypes eBuild);
 

--- a/CvGameCoreDLL_Expansion2/CvCityConnections.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCityConnections.cpp
@@ -169,7 +169,7 @@ void CvCityConnections::UpdatePlotsToConnect(void)
 			}
 
 			//in industrial era, AI becomes much more generous with routes ...
-			if (bIsIndustrial && bHaveGoldToSpare && pLoopPlot->IsAdjacentOwnedByTeamOtherThan(m_pPlayer->getTeam()))
+			if (bIsIndustrial && bHaveGoldToSpare && pLoopPlot->IsAdjacentOwnedByTeamOtherThan(m_pPlayer->getTeam(), false, true))
 				m_plotIdsToConnect.push_back(pLoopPlot->GetPlotIndex());
 		}
 	}


### PR DESCRIPTION
Wilderness computation moved into pathfinder. This should improve performance, as well as make AI more capable of building routes in several cases.

Several changes to make AI more capable of using the traits that give free routes (Askia and Hiawatha UAs).

AI should now be more capable of building roads for city state quests. Or at least build more sensible routes to them.

AI now takes into account other planned routes before considering already built routes when planning their routing. This should make their routes much more well planned out.
It does not consider existing roads when planning out new railroads.

Added a small optimization for the shortcut logic (they will not consider building routes between two cities if a third city was encountered in the middle, since we will build routes between all three cities anyway).

AI will no longer consider neighboring impassable tiles when planning routes along their borders.

AI should now prefer build strategic routes to potential enemies.