### PR TITLE
Fix bugs with coup quest

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvEspionageClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvEspionageClasses.cpp
@@ -4101,12 +4101,13 @@ bool CvPlayerEspionage::AttemptCoup(uint uiSpyIndex)
 	{
 		LevelUpSpy(uiSpyIndex, /*50*/ GD_INT_GET(ESPIONAGE_OFFENSIVE_SPY_EXPERIENCE));
 		m_pPlayer->doInstantYield(INSTANT_YIELD_TYPE_SPY_ATTACK, false, NO_GREATPERSON, NO_BUILDING, 1);
-		pMinorCivAI->SetCoupAttempted(m_pPlayer->GetID(), true);
 
 		//Achievements!
 		if (MOD_API_ACHIEVEMENTS && m_pPlayer->GetID() == GC.getGame().getActivePlayer())
 			gDLL->UnlockAchievement(ACHIEVEMENT_XP1_13);
 	}
+
+	pMinorCivAI->SetCoupAttempted(m_pPlayer->GetID(), true);
 
 	// Update City banners and game info
 	GC.GetEngineUserInterface()->setDirty(GameData_DIRTY_BIT, true);

--- a/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
@@ -1965,7 +1965,10 @@ bool CvMinorCivQuest::IsExpired()
 			}
 			//already Allied?
 			else if(GET_PLAYER(ePlayer).GetMinorCivAI()->IsAllies(m_eAssignedPlayer))
-				return true;		
+				return true;	
+			//Sphere of Influence?
+			else if (GET_PLAYER(ePlayer).GetMinorCivAI()->GetPermanentAlly() != NO_PLAYER)
+				return true;
 		}
 	}
 	else if (m_eType == MINOR_CIV_QUEST_UNIT_GET_CITY)
@@ -10303,6 +10306,12 @@ CvCity* CvMinorCivAI::GetBestSpyTarget(PlayerTypes ePlayer, bool bMinor)
 			continue;
 
 		if (bMinor && GET_PLAYER(eTarget).GetMinorCivAI()->IsNoAlly())
+			continue;
+
+		if (bMinor && GET_PLAYER(eTarget).GetMinorCivAI()->GetAlly() == NO_PLAYER)
+			continue;
+
+		if (bMinor && GET_PLAYER(eTarget).GetMinorCivAI()->GetPermanentAlly() != NO_PLAYER)
 			continue;
 
 		if(bMinor && GET_PLAYER(eTarget).GetMinorCivAI()->IsCoupAttempted(ePlayer))


### PR DESCRIPTION
More bugfixes for the CS Coup Quest:
- The quest to stage a coup in a City-State is not given if the City-State is under a Sphere of Influence
- The quest to stage a coup in a City-State is not given if the City-State has no Ally
- The quest to stage a coup in a City-State is canceled after an unsuccessful coup