### PR TITLE
(4-28) Weaken Rome UA and Bugfixes

### DIFF
--- a/(2) Vox Populi/Balance Changes/AI/LeaderPersonalities.sql
+++ b/(2) Vox Populi/Balance Changes/AI/LeaderPersonalities.sql
@@ -170,8 +170,8 @@ UPDATE Leader_MajorCivApproachBiases SET Bias = 8 	WHERE LeaderType = 'LEADER_AU
 UPDATE Leader_MajorCivApproachBiases SET Bias = 2 	WHERE LeaderType = 'LEADER_AUGUSTUS' 	AND MajorCivApproachType = 'MAJOR_CIV_APPROACH_FRIENDLY';
 UPDATE Leader_MinorCivApproachBiases SET Bias = 3 	WHERE LeaderType = 'LEADER_AUGUSTUS' 	AND MinorCivApproachType = 'MINOR_CIV_APPROACH_IGNORE';
 UPDATE Leader_MinorCivApproachBiases SET Bias = 2 	WHERE LeaderType = 'LEADER_AUGUSTUS' 	AND MinorCivApproachType = 'MINOR_CIV_APPROACH_PROTECTIVE';
-UPDATE Leader_MinorCivApproachBiases SET Bias = 10 	WHERE LeaderType = 'LEADER_AUGUSTUS' 	AND MinorCivApproachType = 'MINOR_CIV_APPROACH_BULLY';
-UPDATE Leader_MinorCivApproachBiases SET Bias = 3 	WHERE LeaderType = 'LEADER_AUGUSTUS' 	AND MinorCivApproachType = 'MINOR_CIV_APPROACH_CONQUEST';
+UPDATE Leader_MinorCivApproachBiases SET Bias = 3 	WHERE LeaderType = 'LEADER_AUGUSTUS' 	AND MinorCivApproachType = 'MINOR_CIV_APPROACH_BULLY';
+UPDATE Leader_MinorCivApproachBiases SET Bias = 10 	WHERE LeaderType = 'LEADER_AUGUSTUS' 	AND MinorCivApproachType = 'MINOR_CIV_APPROACH_CONQUEST';
 
 -- Bismarck (Germany)
 UPDATE Leaders SET PrimaryVictoryPursuit = 'VICTORY_PURSUIT_DIPLOMACY' WHERE Type = 'LEADER_BISMARCK';

--- a/(2) Vox Populi/Balance Changes/Leaders/Vanilla/VanillaLeaderChanges.sql
+++ b/(2) Vox Populi/Balance Changes/Leaders/Vanilla/VanillaLeaderChanges.sql
@@ -554,7 +554,7 @@ SET AnnexedCityStatesGiveYields = '1'
 WHERE Type = 'TRAIT_CAPITAL_BUILDINGS_CHEAPER';
 
 UPDATE Traits
-SET BullyAnnex = '1'
+SET CityStateCombatModifier = '30'
 WHERE Type = 'TRAIT_CAPITAL_BUILDINGS_CHEAPER';
 
 -- Siam -- adjust Wat

--- a/(2) Vox Populi/Balance Changes/Text/en_US/CivText.sql
+++ b/(2) Vox Populi/Balance Changes/Text/en_US/CivText.sql
@@ -968,7 +968,7 @@ WHERE Tag = 'TXT_KEY_MISSION_SELL_EXOTIC_GOODS_HELP';
 -- Rome
 --------------------
 UPDATE Language_en_US
-SET Text = 'City-States can be forcefully annexed if Heavy Tribute can be demanded from them.​ Conquered City-States provide rewards as if they were Friends (if Militaristic, they also spawn units as if they were Allies). +15% [ICON_PRODUCTION] Production towards Buildings present in [ICON_CAPITAL] Capital.'
+SET Text = '+30% Combat Strength against City-States.​ Conquered City-States provide rewards as if they were Allies. +15% [ICON_PRODUCTION] Production towards Buildings present in [ICON_CAPITAL] Capital.'
 WHERE Tag = 'TXT_KEY_TRAIT_CAPITAL_BUILDINGS_CHEAPER';
 
 UPDATE Language_en_US

--- a/(2) Vox Populi/Balance Changes/Text/en_US/UIText.xml
+++ b/(2) Vox Populi/Balance Changes/Text/en_US/UIText.xml
@@ -347,23 +347,23 @@
 		
 		<!-- Annexed City States -->
 		<Row Tag="TXT_KEY_TP_GOLD_FROM_ANNEXED_MINORS">
-			<Text>{1_Num} from [ICON_CITY_STATE] Annexed City-States.</Text>
+			<Text>{1_Num} from [ICON_CITY_STATE] conquered City-States.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_TP_CULTURE_FROM_ANNEXED_MINORS">
-			<Text>[ICON_BULLET][COLOR_POSITIVE_TEXT]+{1_Num}[ENDCOLOR] from Annexed City-States.</Text>
+			<Text>[ICON_BULLET][COLOR_POSITIVE_TEXT]+{1_Num}[ENDCOLOR] from conquered City-States.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_TP_FAITH_FROM_ANNEXED_MINORS">
-			<Text>[ICON_BULLET][COLOR_POSITIVE_TEXT]+{1_Num}[ENDCOLOR] from Annexed City-States.</Text>
+			<Text>[ICON_BULLET][COLOR_POSITIVE_TEXT]+{1_Num}[ENDCOLOR] from conquered City-States.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_TP_SCIENCE_FROM_ANNEXED_MINORS">
-			<Text>[ICON_BULLET][COLOR_POSITIVE_TEXT]+{1_Num}[ENDCOLOR] [ICON_RESEARCH] from Annexed City-States.</Text>
+			<Text>[ICON_BULLET][COLOR_POSITIVE_TEXT]+{1_Num}[ENDCOLOR] [ICON_RESEARCH] from conquered City-States.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_TP_HAPPINESS_FROM_ANNEXED_MINORS">
-			<Text>{1_Num} from Annexed City-States.</Text>
+			<Text>{1_Num} from conquered City-States.</Text>
 		</Row>
 		
 		<Row Tag="TXT_KEY_NOTIFICATION_ANNEXED_CITY_STATE_UNIT_SPAWN">
-			<Text>The annexed City-State of {1_CivName:textkey} has given you a new Unit!</Text>
+			<Text>The conquered City-State of {1_CivName:textkey} has given you a new Unit!</Text>
 		</Row>
 		<Row Tag="TXT_KEY_NOTIFICATION_SUMMARY_ANNEXED_CITY_STATE_UNIT_SPAWN">
 			<Text>New Unit from {1_CivName:textkey}!</Text>

--- a/(2) Vox Populi/Balance Changes/Text/en_US/UIText.xml
+++ b/(2) Vox Populi/Balance Changes/Text/en_US/UIText.xml
@@ -346,6 +346,9 @@
 		</Row>
 		
 		<!-- Annexed City States -->
+		<Row Tag="TXT_KEY_TP_GOLD_FROM_ANNEXED_MINORS">
+			<Text>{1_Num} from [ICON_CITY_STATE] Annexed City-States.</Text>
+		</Row>
 		<Row Tag="TXT_KEY_TP_CULTURE_FROM_ANNEXED_MINORS">
 			<Text>[ICON_BULLET][COLOR_POSITIVE_TEXT]+{1_Num}[ENDCOLOR] from Annexed City-States.</Text>
 		</Row>
@@ -356,7 +359,7 @@
 			<Text>[ICON_BULLET][COLOR_POSITIVE_TEXT]+{1_Num}[ENDCOLOR] [ICON_RESEARCH] from Annexed City-States.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_TP_HAPPINESS_FROM_ANNEXED_MINORS">
-			<Text>+{1_Num} from Annexed City-States.</Text>
+			<Text>{1_Num} from Annexed City-States.</Text>
 		</Row>
 		
 		<Row Tag="TXT_KEY_NOTIFICATION_ANNEXED_CITY_STATE_UNIT_SPAWN">

--- a/(2) Vox Populi/LUA/TopPanel.lua
+++ b/(2) Vox Populi/LUA/TopPanel.lua
@@ -642,6 +642,7 @@ function GoldTipHandler( control )
 	-- CBP
 	local iInternalRouteGold = pPlayer:GetInternalTradeRouteGoldBonus();
 	local iMinorGold = pPlayer:GetGoldPerTurnFromMinorCivs();
+	local iAnnexedMinorsGold = pPlayer:GetGoldPerTurnFromAnnexedMinors();
 	-- END
 -- C4DF
 	-- Gold from Vassals
@@ -649,7 +650,7 @@ function GoldTipHandler( control )
 	local iGoldFromVassalTax = math.floor(pPlayer:GetMyShareOfVassalTaxes() / 100);
 -- END
 -- C4DF CHANGE
-	local fTotalIncome = fGoldPerTurnFromCities + iGoldPerTurnFromOtherPlayers + fCityConnectionGold + iGoldPerTurnFromReligion + fTradeRouteGold + fTraitGold + iMinorGold + iInternalRouteGold;
+	local fTotalIncome = fGoldPerTurnFromCities + iGoldPerTurnFromOtherPlayers + fCityConnectionGold + iGoldPerTurnFromReligion + fTradeRouteGold + fTraitGold + iMinorGold + iInternalRouteGold + iAnnexedMinorsGold;
 	if (iGoldFromVassals > 0) then
 		fTotalIncome = fTotalIncome + iGoldFromVassals;
 	end
@@ -700,6 +701,9 @@ function GoldTipHandler( control )
 -- COMMUNITY PATCH CHANGE
 	if (iMinorGold > 0) then
 		strText = strText .. "[NEWLINE]  [ICON_BULLET]" .. Locale.ConvertTextKey("TXT_KEY_TP_GOLD_FROM_MINORS", iMinorGold);
+	end
+	if (iAnnexedMinorsGold > 0) then
+		strText = strText .. "[NEWLINE]  [ICON_BULLET]" .. Locale.ConvertTextKey("TXT_KEY_TP_GOLD_FROM_ANNEXED_MINORS", iAnnexedMinorsGold);
 	end
 --END
 	strText = strText .. "[/COLOR]";
@@ -1215,7 +1219,7 @@ function CultureTipHandler( control )
 		end
 		
 		-- Culture from Golden Age (COMMUNITY PATCH EDIT)
-		local iCultureFromGoldenAge = pPlayer:GetTotalJONSCulturePerTurn() - iCultureForFree - iCultureFromCities - iCultureFromHappiness - iCultureFromMinors - iCultureFromReligion - iCultureFromTraits - iCultureFromBonusTurns; -- last part added (COMMUNITY PATCH)
+		local iCultureFromGoldenAge = pPlayer:GetTotalJONSCulturePerTurn() - iCultureForFree - iCultureFromCities - iCultureFromHappiness - iCultureFromMinors - iCultureFromReligion - iCultureFromTraits - iCultureFromBonusTurns - iCultureFromAnnexedMinors - iCultureFromVassals; -- last part added (COMMUNITY PATCH)
 		if (iCultureFromGoldenAge ~= 0) then
 		
 			-- Add separator for non-initial entries
@@ -1345,7 +1349,7 @@ function FaithTipHandler( control )
 		end
 -- END	
 		
-		if (iFaithFromCities ~= 0 or iFaithFromMinorCivs ~= 0 or iFaithFromReligion ~= 0) then
+		if (iFaithFromCities ~= 0 or iFaithFromMinorCivs ~= 0 or iFaithFromReligion ~= 0 or iFaithFromAnnexedMinors ~= 0 or iFaithFromVassals ~= 0) then
 			strText = strText .. "[NEWLINE]";
 		end
 	

--- a/(3a) EUI Compatibility Files/ImprovedTopPanel/TopPanel.lua
+++ b/(3a) EUI Compatibility Files/ImprovedTopPanel/TopPanel.lua
@@ -1200,10 +1200,11 @@ g_toolTipHandler.GoldPerTurn = function()-- control )
 -- CBP
 		-- Gold gained from happiness
 	local iInternalRouteGold = g_activePlayer:GetInternalTradeRouteGoldBonus();
-	local iGoldFromMinors = g_activePlayer:GetGoldPerTurnFromMinorCivs()
+	local iGoldFromMinors = g_activePlayer:GetGoldPerTurnFromMinorCivs();
+	local iGoldFromAnnexedMinors = g_activePlayer:GetGoldPerTurnFromAnnexedMinors();
 
 	local totalIncome, totalWealth
-	local explicitIncome = goldPerTurnFromCities + goldPerTurnFromOtherPlayers + cityConnectionGold + goldPerTurnFromReligion + tradeRouteGold + playerTraitGold + iGoldFromMinors + iInternalRouteGold -- C4DF
+	local explicitIncome = goldPerTurnFromCities + goldPerTurnFromOtherPlayers + cityConnectionGold + goldPerTurnFromReligion + tradeRouteGold + playerTraitGold + iGoldFromMinors + iInternalRouteGold + iGoldFromAnnexedMinors -- C4DF
 -- C4DF CHANGE
 	if (iGoldFromVassals > 0) then
 		explicitIncome = explicitIncome + iGoldFromVassals;
@@ -1271,6 +1272,7 @@ g_toolTipHandler.GoldPerTurn = function()-- control )
 	tips:insertLocalizedBulletIfNonZero( "TXT_KEY_TP_YIELD_FROM_UNCATEGORIZED", math.floor(totalIncome - explicitIncome) )
 -- CBP
 	tips:insertLocalizedBulletIfNonZero( S("TXT_KEY_TP_GOLD_FROM_MINORS", g_currencyString), iGoldFromMinors)
+	tips:insertLocalizedBulletIfNonZero( S("TXT_KEY_TP_GOLD_FROM_ANNEXED_MINORS", g_currencyString), iGoldFromAnnexedMinors)
 --END
 	tips:insert( "[ENDCOLOR]" )
 
@@ -1867,7 +1869,7 @@ g_toolTipHandler.CultureString = function()-- control )
 			-- Culture from Golden Age
 -- CBP
 	
-			local iCultureFromGoldenAge = (culturePerTurn - culturePerTurnForFree - culturePerTurnFromCities - culturePerTurnFromExcessHappiness - culturePerTurnFromMinorCivs - culturePerTurnFromReligion - culturePerTurnFromTraits - culturePerTurnFromBonusTurns - culturePerTurnFromVassals)
+			local iCultureFromGoldenAge = (culturePerTurn - culturePerTurnForFree - culturePerTurnFromCities - culturePerTurnFromExcessHappiness - culturePerTurnFromMinorCivs - culturePerTurnFromReligion - culturePerTurnFromTraits - culturePerTurnFromBonusTurns - culturePerTurnFromVassals - culturePerTurnFromAnnexedMinors)
 			
 			tips:insertLocalizedIfNonZero( "TXT_KEY_TP_CULTURE_FROM_GOLDEN_AGE", iCultureFromGoldenAge)
 -- END

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -511,6 +511,7 @@ CvPlayer::CvPlayer() :
 #endif
 	, m_iFoodInCapitalFromAnnexedMinors()
 	, m_iFoodInOtherCitiesFromAnnexedMinors()
+	, m_iGoldPerTurnFromAnnexedMinors()
 	, m_iCulturePerTurnFromAnnexedMinors()
 	, m_iSciencePerTurnFromAnnexedMinors()
 	, m_iFaithPerTurnFromAnnexedMinors()
@@ -1309,6 +1310,7 @@ void CvPlayer::uninit()
 #endif
 	m_iFoodInCapitalFromAnnexedMinors = 0;
 	m_iFoodInOtherCitiesFromAnnexedMinors = 0;
+	m_iGoldPerTurnFromAnnexedMinors = 0;
 	m_iCulturePerTurnFromAnnexedMinors = 0;
 	m_iSciencePerTurnFromAnnexedMinors = 0;
 	m_iFaithPerTurnFromAnnexedMinors = 0;
@@ -24092,6 +24094,7 @@ void CvPlayer::UpdateFoodInCapitalPerTurnFromAnnexedMinors()
 		{
 			iBonus = /*200 in CP, 600 in VP*/ GD_INT_GET(FRIENDS_CAPITAL_FOOD_BONUS_AMOUNT_POST_RENAISSANCE);
 		}
+		iBonus += GD_INT_GET(ALLIES_CAPITAL_FOOD_BONUS_AMOUNT);
 		iBonus *= iNumCityStates;
 		int iFoodDiff = iBonus - iFoodInCapitalFromAnnexedMinorsOld;
 		if (iFoodDiff != 0)
@@ -24130,6 +24133,7 @@ void CvPlayer::UpdateFoodInOtherCitiesPerTurnFromAnnexedMinors()
 		{
 			iBonus = /*0 in CP, 100 in VP*/ GD_INT_GET(FRIENDS_OTHER_CITIES_FOOD_BONUS_AMOUNT_POST_RENAISSANCE);
 		}
+		iBonus += GD_INT_GET(ALLIES_OTHER_CITIES_FOOD_BONUS_AMOUNT);
 		iBonus *= iNumCityStates;
 		int iFoodDiff = iBonus - iFoodInOtherCitiesFromAnnexedMinorsOld;
 		if (iFoodDiff != 0)
@@ -24137,6 +24141,60 @@ void CvPlayer::UpdateFoodInOtherCitiesPerTurnFromAnnexedMinors()
 			ChangeCityYieldChangeTimes100(YIELD_FOOD, iFoodDiff);
 		}
 		m_iFoodInOtherCitiesFromAnnexedMinors = iBonus;
+	}
+}
+//	--------------------------------------------------------------------------------
+/// Get the gold yields per turn from annexed City-States (Rome UA)
+int CvPlayer::GetGoldPerTurnFromAnnexedMinors() const
+{
+	return m_iGoldPerTurnFromAnnexedMinors;
+}
+//	--------------------------------------------------------------------------------
+/// Update the gold yields per turn from annexed City-States (Rome UA)
+void CvPlayer::UpdateGoldPerTurnFromAnnexedMinors()
+{
+	if (GetPlayerTraits()->IsAnnexedCityStatesGiveYields())
+	{
+		int iNumCityStates = m_aiNumAnnexedCityStates[MINOR_CIV_TRAIT_MERCANTILE];
+		int iBonus = 0;
+
+		EraTypes eCurrentEra = GET_TEAM(getTeam()).GetCurrentEra();
+
+		EraTypes eIndustrial = (EraTypes)GC.getInfoTypeForString("ERA_INDUSTRIAL", true);
+		EraTypes eRenaissance = (EraTypes)GC.getInfoTypeForString("ERA_RENAISSANCE", true);
+		EraTypes eMedieval = (EraTypes)GC.getInfoTypeForString("ERA_MEDIEVAL", true);
+		EraTypes eClassical = (EraTypes)GC.getInfoTypeForString("ERA_CLASSICAL", true);
+
+		// Industrial era or later
+		if (eCurrentEra >= eIndustrial)
+		{
+			iBonus += GD_INT_GET(FRIENDS_GOLD_FLAT_BONUS_AMOUNT_INDUSTRIAL) + GD_INT_GET(ALLIES_GOLD_FLAT_BONUS_AMOUNT_INDUSTRIAL);
+		}
+
+		// Renaissance era
+		else if (eCurrentEra >= eRenaissance)
+		{
+			iBonus += GD_INT_GET(FRIENDS_GOLD_FLAT_BONUS_AMOUNT_RENAISSANCE) + GD_INT_GET(ALLIES_GOLD_FLAT_BONUS_AMOUNT_RENAISSANCE);
+		}
+
+		// Medieval era
+		else if (eCurrentEra >= eMedieval)
+		{
+			iBonus += GD_INT_GET(FRIENDS_GOLD_FLAT_BONUS_AMOUNT_MEDIEVAL) + GD_INT_GET(ALLIES_GOLD_FLAT_BONUS_AMOUNT_MEDIEVAL);
+		}
+
+		// Classical era
+		else if (eCurrentEra >= eClassical)
+		{
+			iBonus += GD_INT_GET(FRIENDS_GOLD_FLAT_BONUS_AMOUNT_CLASSICAL) + GD_INT_GET(ALLIES_GOLD_FLAT_BONUS_AMOUNT_CLASSICAL);
+		}
+
+		// Ancient era
+		else
+		{
+			iBonus += GD_INT_GET(FRIENDS_GOLD_FLAT_BONUS_AMOUNT_ANCIENT) + GD_INT_GET(ALLIES_GOLD_FLAT_BONUS_AMOUNT_ANCIENT);
+		}
+		m_iGoldPerTurnFromAnnexedMinors = iBonus * iNumCityStates;
 	}
 }
 //	--------------------------------------------------------------------------------
@@ -24160,17 +24218,19 @@ void CvPlayer::UpdateCulturePerTurnFromAnnexedMinors()
 		// Industrial era or Later
 		if (eCurrentEra >= eIndustrial)
 		{
-			iBonus = /*13 in CP, 10 in VP*/ GD_INT_GET(FRIENDS_CULTURE_BONUS_AMOUNT_INDUSTRIAL);
+			iBonus += GD_INT_GET(FRIENDS_CULTURE_BONUS_AMOUNT_INDUSTRIAL) + GD_INT_GET(ALLIES_CULTURE_BONUS_AMOUNT_INDUSTRIAL);
 		}
+
 		// Medieval era or later
 		else if (eCurrentEra >= eMedieval)
 		{
-			iBonus = /*6 in CP, 4 in VP*/ GD_INT_GET(FRIENDS_CULTURE_BONUS_AMOUNT_MEDIEVAL);
+			iBonus += GD_INT_GET(FRIENDS_CULTURE_BONUS_AMOUNT_MEDIEVAL) + GD_INT_GET(ALLIES_CULTURE_BONUS_AMOUNT_MEDIEVAL);
 		}
+
 		// Pre-Medieval
 		else
 		{
-			iBonus = /*3 in CP, 1 in VP*/ GD_INT_GET(FRIENDS_CULTURE_BONUS_AMOUNT_ANCIENT);
+			iBonus += GD_INT_GET(FRIENDS_CULTURE_BONUS_AMOUNT_ANCIENT) + GD_INT_GET(ALLIES_CULTURE_BONUS_AMOUNT_ANCIENT);
 		}
 		m_iCulturePerTurnFromAnnexedMinors = iBonus * iNumCityStates;
 	}
@@ -24199,27 +24259,27 @@ void CvPlayer::UpdateSciencePerTurnFromAnnexedMinors()
 		// Industrial era or later
 		if (eCurrentEra >= eIndustrial)
 		{
-			iBonus += /*10*/ GD_INT_GET(FRIENDS_SCIENCE_FLAT_BONUS_AMOUNT_INDUSTRIAL);
+			iBonus += GD_INT_GET(FRIENDS_SCIENCE_FLAT_BONUS_AMOUNT_INDUSTRIAL) + GD_INT_GET(ALLIES_SCIENCE_FLAT_BONUS_AMOUNT_INDUSTRIAL);
 		}
 		// Renaissance era
 		else if (eCurrentEra >= eRenaissance)
 		{
-			iBonus += /*6*/ GD_INT_GET(FRIENDS_SCIENCE_FLAT_BONUS_AMOUNT_RENAISSANCE);
+			iBonus += GD_INT_GET(FRIENDS_SCIENCE_FLAT_BONUS_AMOUNT_RENAISSANCE) + GD_INT_GET(ALLIES_SCIENCE_FLAT_BONUS_AMOUNT_RENAISSANCE);
 		}
 		// Medieval era
 		else if (eCurrentEra >= eMedieval)
 		{
-			iBonus += /*4*/ GD_INT_GET(FRIENDS_SCIENCE_FLAT_BONUS_AMOUNT_MEDIEVAL);
+			iBonus += GD_INT_GET(FRIENDS_SCIENCE_FLAT_BONUS_AMOUNT_MEDIEVAL) + GD_INT_GET(ALLIES_SCIENCE_FLAT_BONUS_AMOUNT_MEDIEVAL);
 		}
 		// Classical era
 		else if (eCurrentEra >= eClassical)
 		{
-			iBonus += /*2*/ GD_INT_GET(FRIENDS_SCIENCE_FLAT_BONUS_AMOUNT_CLASSICAL);
+			iBonus += GD_INT_GET(FRIENDS_SCIENCE_FLAT_BONUS_AMOUNT_CLASSICAL) + GD_INT_GET(ALLIES_SCIENCE_FLAT_BONUS_AMOUNT_CLASSICAL);
 		}
 		// Ancient era
 		else
 		{
-			iBonus += /*1*/ GD_INT_GET(FRIENDS_SCIENCE_FLAT_BONUS_AMOUNT_ANCIENT);
+			iBonus += GD_INT_GET(FRIENDS_SCIENCE_FLAT_BONUS_AMOUNT_ANCIENT) + GD_INT_GET(ALLIES_SCIENCE_FLAT_BONUS_AMOUNT_ANCIENT);
 		}
 		m_iSciencePerTurnFromAnnexedMinors = iBonus * iNumCityStates;
 	}
@@ -24249,27 +24309,27 @@ void CvPlayer::UpdateFaithPerTurnFromAnnexedMinors()
 		// Industrial era or later
 		if (eCurrentEra >= eIndustrial)
 		{
-			iBonus = /*8 in CP, 12 in VP*/ GD_INT_GET(FRIENDS_FAITH_FLAT_BONUS_AMOUNT_INDUSTRIAL);
+			iBonus = GD_INT_GET(FRIENDS_FAITH_FLAT_BONUS_AMOUNT_INDUSTRIAL) + GD_INT_GET(ALLIES_FAITH_FLAT_BONUS_AMOUNT_INDUSTRIAL);
 		}
 		// Renaissance era
 		else if (eCurrentEra >= eRenaissance)
 		{
-			iBonus = /*4 in CP, 9 in VP*/ GD_INT_GET(FRIENDS_FAITH_FLAT_BONUS_AMOUNT_RENAISSANCE);
+			iBonus = GD_INT_GET(FRIENDS_FAITH_FLAT_BONUS_AMOUNT_RENAISSANCE) + GD_INT_GET(ALLIES_FAITH_FLAT_BONUS_AMOUNT_RENAISSANCE);
 		}
 		// Medieval era
 		else if (eCurrentEra >= eMedieval)
 		{
-			iBonus = /*4 in CP, 7 in VP*/ GD_INT_GET(FRIENDS_FAITH_FLAT_BONUS_AMOUNT_MEDIEVAL);
+			iBonus = GD_INT_GET(FRIENDS_FAITH_FLAT_BONUS_AMOUNT_MEDIEVAL) + GD_INT_GET(ALLIES_FAITH_FLAT_BONUS_AMOUNT_MEDIEVAL);
 		}
 		// Classical era
 		else if (eCurrentEra >= eClassical)
 		{
-			iBonus = /*2*/ GD_INT_GET(FRIENDS_FAITH_FLAT_BONUS_AMOUNT_CLASSICAL);
+			iBonus = GD_INT_GET(FRIENDS_FAITH_FLAT_BONUS_AMOUNT_CLASSICAL) + GD_INT_GET(ALLIES_FAITH_FLAT_BONUS_AMOUNT_CLASSICAL);
 		}
 		// Ancient era
 		else
 		{
-			iBonus = /*2 in CP, 1 in VP*/ GD_INT_GET(FRIENDS_FAITH_FLAT_BONUS_AMOUNT_ANCIENT);
+			iBonus = GD_INT_GET(FRIENDS_FAITH_FLAT_BONUS_AMOUNT_ANCIENT) + GD_INT_GET(ALLIES_FAITH_FLAT_BONUS_AMOUNT_ANCIENT);
 		}
 		m_iFaithPerTurnFromAnnexedMinors = iBonus * iNumCityStates;
 	}
@@ -24297,17 +24357,17 @@ void CvPlayer::UpdateHappinessFromAnnexedMinors()
 		// Industrial era or Later
 		if (eCurrentEra >= eIndustrial)
 		{
-			iBonus = /*3*/ GD_INT_GET(FRIENDS_HAPPINESS_FLAT_BONUS_AMOUNT_INDUSTRIAL);
+			iBonus = GD_INT_GET(FRIENDS_HAPPINESS_FLAT_BONUS_AMOUNT_INDUSTRIAL) + GD_INT_GET(ALLIES_HAPPINESS_FLAT_BONUS_AMOUNT_INDUSTRIAL);
 		}
 		// Medieval era or later
 		else if (eCurrentEra >= eMedieval)
 		{
-			iBonus = /*3*/ GD_INT_GET(FRIENDS_HAPPINESS_FLAT_BONUS_AMOUNT_MEDIEVAL);
+			iBonus = GD_INT_GET(FRIENDS_HAPPINESS_FLAT_BONUS_AMOUNT_MEDIEVAL) + GD_INT_GET(ALLIES_HAPPINESS_FLAT_BONUS_AMOUNT_MEDIEVAL);
 		}
 		// Pre-Medieval
 		else
 		{
-			iBonus = /*2*/ GD_INT_GET(FRIENDS_HAPPINESS_FLAT_BONUS_AMOUNT_ANCIENT);
+			iBonus = GD_INT_GET(FRIENDS_HAPPINESS_FLAT_BONUS_AMOUNT_ANCIENT) + GD_INT_GET(ALLIES_HAPPINESS_FLAT_BONUS_AMOUNT_ANCIENT);
 		}
 		m_iHappinessFromAnnexedMinors = iBonus * iNumCityStates;
 
@@ -36077,6 +36137,7 @@ void CvPlayer::ChangeNumAnnexedCityStates(MinorCivTraitTypes eIndex, int iChange
 		UpdateFoodInCapitalPerTurnFromAnnexedMinors();
 		UpdateFoodInOtherCitiesPerTurnFromAnnexedMinors();
 		UpdateFoodInOtherCitiesPerTurnFromAnnexedMinors();
+		UpdateGoldPerTurnFromAnnexedMinors();
 		UpdateCulturePerTurnFromAnnexedMinors();
 		UpdateSciencePerTurnFromAnnexedMinors();
 		UpdateFaithPerTurnFromAnnexedMinors();
@@ -46988,6 +47049,7 @@ void CvPlayer::Serialize(Player& player, Visitor& visitor)
 	visitor(player.m_iConversionModifier);
 	visitor(player.m_iFoodInCapitalFromAnnexedMinors);
 	visitor(player.m_iFoodInOtherCitiesFromAnnexedMinors);
+	visitor(player.m_iGoldPerTurnFromAnnexedMinors);
 	visitor(player.m_iCulturePerTurnFromAnnexedMinors);
 	visitor(player.m_iSciencePerTurnFromAnnexedMinors);
 	visitor(player.m_iFaithPerTurnFromAnnexedMinors);

--- a/CvGameCoreDLL_Expansion2/CvPlayer.h
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.h
@@ -806,6 +806,8 @@ public:
 	void UpdateFoodInCapitalPerTurnFromAnnexedMinors();
 	int GetFoodInOtherCitiesPerTurnFromAnnexedMinors() const;
 	void UpdateFoodInOtherCitiesPerTurnFromAnnexedMinors();
+	int GetGoldPerTurnFromAnnexedMinors() const;
+	void UpdateGoldPerTurnFromAnnexedMinors();
 	int GetCulturePerTurnFromAnnexedMinors() const;
 	void UpdateCulturePerTurnFromAnnexedMinors();
 	int GetSciencePerTurnFromAnnexedMinors() const;
@@ -3062,6 +3064,7 @@ protected:
 #endif
 	int m_iFoodInCapitalFromAnnexedMinors;
 	int m_iFoodInOtherCitiesFromAnnexedMinors;
+	int m_iGoldPerTurnFromAnnexedMinors;
 	int m_iCulturePerTurnFromAnnexedMinors;
 	int m_iSciencePerTurnFromAnnexedMinors;
 	int m_iFaithPerTurnFromAnnexedMinors;
@@ -3892,6 +3895,7 @@ SYNC_ARCHIVE_VAR(int, m_iSpyStartingRank)
 SYNC_ARCHIVE_VAR(int, m_iConversionModifier)
 SYNC_ARCHIVE_VAR(int, m_iFoodInCapitalFromAnnexedMinors)
 SYNC_ARCHIVE_VAR(int, m_iFoodInOtherCitiesFromAnnexedMinors)
+SYNC_ARCHIVE_VAR(int, m_iGoldPerTurnFromAnnexedMinors)
 SYNC_ARCHIVE_VAR(int, m_iCulturePerTurnFromAnnexedMinors)
 SYNC_ARCHIVE_VAR(int, m_iSciencePerTurnFromAnnexedMinors)
 SYNC_ARCHIVE_VAR(int, m_iFaithPerTurnFromAnnexedMinors)

--- a/CvGameCoreDLL_Expansion2/CvTeam.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTeam.cpp
@@ -8899,6 +8899,7 @@ void CvTeam::SetCurrentEra(EraTypes eNewValue)
 			{
 				kPlayer.UpdateFoodInCapitalPerTurnFromAnnexedMinors();
 				kPlayer.UpdateFoodInOtherCitiesPerTurnFromAnnexedMinors();
+				kPlayer.UpdateGoldPerTurnFromAnnexedMinors();
 				kPlayer.UpdateCulturePerTurnFromAnnexedMinors();
 				kPlayer.UpdateSciencePerTurnFromAnnexedMinors();
 				kPlayer.UpdateFaithPerTurnFromAnnexedMinors();

--- a/CvGameCoreDLL_Expansion2/CvTreasury.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTreasury.cpp
@@ -443,6 +443,9 @@ int CvTreasury::CalculateGrossGoldTimes100()
 	}
 #endif
 
+	// Annexed City-States (Rome UA)
+	iNetGold += m_pPlayer->GetGoldPerTurnFromAnnexedMinors() * 100;
+
 	return iNetGold;
 }
 /// Gross income across entire game

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
@@ -1092,6 +1092,7 @@ void CvLuaPlayer::PushMethods(lua_State* L, int t)
 	Method(IsDiplomaticMarriage);
 	Method(IsGPWLTKD);
 	Method(IsCarnaval);
+	Method(GetGoldPerTurnFromAnnexedMinors);
 	Method(GetCulturePerTurnFromAnnexedMinors);
 	Method(GetFaithPerTurnFromAnnexedMinors);
 	Method(GetSciencePerTurnFromAnnexedMinors);
@@ -12273,6 +12274,19 @@ int CvLuaPlayer::lIsCarnaval(lua_State* L)
 	return 1;
 }
 #endif
+//------------------------------------------------------------------------------
+int CvLuaPlayer::lGetGoldPerTurnFromAnnexedMinors(lua_State* L)
+{
+	CvPlayer* pkPlayer = GetInstance(L);
+	if (pkPlayer)
+	{
+		lua_pushinteger(L, pkPlayer->GetGoldPerTurnFromAnnexedMinors());
+		return 1;
+	}
+	//BUG: This can't be right...
+	lua_pushinteger(L, -1);
+	return 0;
+}
 //------------------------------------------------------------------------------
 int CvLuaPlayer::lGetCulturePerTurnFromAnnexedMinors(lua_State* L)
 {

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.h
@@ -1195,6 +1195,7 @@ protected:
 	static int lIsCarnaval(lua_State* L);
 	static int lGetTraitConquestOfTheWorldCityAttackMod(lua_State* L);
 #endif
+	static int lGetGoldPerTurnFromAnnexedMinors(lua_State* L);
 	static int lGetCulturePerTurnFromAnnexedMinors(lua_State* L);
 	static int lGetFaithPerTurnFromAnnexedMinors(lua_State* L);
 	static int lGetSciencePerTurnFromAnnexedMinors(lua_State* L);


### PR DESCRIPTION
Rome:
- Removed ability to forcefully annex City-States 
- Added +30% Combat Strengtha against City-States
- Conquered City-States provide Rewards as if they were Allies

Bug fixes:
- Rome UA: Fixed conquered Mercantile City-States not providing Gold
- Fixed incorrect values for Culture from Golden Age in Top Panel (#9502)