### PR TITLE
Road AI improvements

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
@@ -507,16 +507,42 @@ void CvBuilderTaskingAI::AddRoutePlot(CvPlot* pPlot, RouteTypes eRoute, int iVal
 	if (!pPlot)
 		return;
 
-	// if we already know about this plot, continue on
-	if( GetRouteValue(pPlot)>=iValue )
+	if (iValue <= 0 || eRoute == NO_ROUTE)
 		return;
+
+	RouteTypes eOldRoute = NO_ROUTE;
+	int iOldValue = 0;
+
+	RoutePlotContainer::const_iterator it;
+
+	it = m_routeNeededPlots.find(pPlot->GetPlotIndex());
+	if (it != m_routeNeededPlots.end())
+	{
+		eOldRoute = it->second.first;
+		iOldValue = it->second.second;
+	}
+
+	it = m_routeWantedPlots.find(pPlot->GetPlotIndex());
+	if (it != m_routeWantedPlots.end())
+	{
+		eOldRoute = it->second.first;
+		iOldValue = it->second.second;
+	}
+
+	// if we already want a better route, ignore this
+	if (eOldRoute > eRoute)
+		return;
+
+	// if we wanted a lower tech route, ignore the old value
+	if (eOldRoute < eRoute)
+		iOldValue = 0;
 
 	//if it is the right route, add to needed plots
 	if (pPlot->getRouteType() == eRoute || GetSameRouteBenefitFromTrait(pPlot, eRoute))
-		m_routeNeededPlots[pPlot->GetPlotIndex()] = make_pair(eRoute, iValue);
+		m_routeNeededPlots[pPlot->GetPlotIndex()] = make_pair(eRoute, iValue + iOldValue);
 	else
 		//if no matching route, add to wanted plots
-		m_routeWantedPlots[pPlot->GetPlotIndex()] = make_pair(eRoute, iValue);
+		m_routeWantedPlots[pPlot->GetPlotIndex()] = make_pair(eRoute, iValue + iOldValue);
 }
 
 int CvBuilderTaskingAI::GetRouteValue(CvPlot* pPlot)
@@ -668,54 +694,11 @@ void CvBuilderTaskingAI::ConnectPointsForStrategy(CvCity* pOriginCity, CvPlot* p
 	if (!path)
 		return;
 
-	int iStrategicValue = 100;
-
-	//citadels and forts
-	CvImprovementEntry* pImprovementInfo = GC.getImprovementInfo(pTargetPlot->getImprovementType());
-	if (pImprovementInfo && pImprovementInfo->GetDefenseModifier() >= 20)
-	{
-		iStrategicValue += 200;
-	}
-
-	CvDiplomacyAI* pDiploAI = m_pPlayer->GetDiplomacyAI();
-	for (size_t i = 0; i < path.vPlots.size(); i++)
-	{
-		CvPlot* pPlot = path.get(i);
-		if (!pPlot)
-			break;
-
-		//cities don't count
-		if (pPlot->isCity())
-			continue;
-
-		else
-		{
-			//if any neighboring plot is owned by someone else, calculate its strategic value
-			CvPlot** aPlotsToCheck = GC.getMap().getNeighborsUnchecked(pPlot);
-			for (int iI = 0; iI < NUM_DIRECTION_TYPES; iI++)
-			{
-				CvPlot* pAdjacentPlot = aPlotsToCheck[iI];
-				if (pAdjacentPlot != NULL && pAdjacentPlot->isOwned() && pAdjacentPlot->getTeam() != m_pPlayer->getTeam() && !pAdjacentPlot->isImpassable(pAdjacentPlot->getTeam()))
-				{
-					// Neighboring plot is owned by someone else, so this is a strategic point
-					PlayerTypes eAdjacentPlayer = pAdjacentPlot->getOwner();
-					if (pDiploAI->IsPotentialMilitaryTargetOrThreat(eAdjacentPlayer, m_pPlayer->isHuman()))
-					{
-						iStrategicValue += 100;
-						break;
-					}
-				}
-			}
-		}
-	}
-
 	//and this to see if we actually build it
 	int iCost = pRouteInfo->GetGoldMaintenance()*(100 + m_pPlayer->GetImprovementGoldMaintenanceMod());
 	iCost *= path.length();
 	if (iNetGoldTimes100 - iCost <= 6)
 		return;
-
-	int iValue = iStrategicValue;
 
 	for (int i = 0; i<path.length(); i++)
 	{
@@ -733,7 +716,7 @@ void CvBuilderTaskingAI::ConnectPointsForStrategy(CvCity* pOriginCity, CvPlot* p
 			continue;
 
 		// remember the plot
-		AddRoutePlot(pPlot, eRoute, iValue);
+		AddRoutePlot(pPlot, eRoute, 54);
 	}
 }
 /// Looks at city connections and marks plots that can be added as routes by EvaluateBuilder
@@ -1744,12 +1727,12 @@ void CvBuilderTaskingAI::AddRepairTilesDirectives(CvUnit* pUnit, CvPlot* pPlot, 
 	{
 		return;
 	}
+	bool isPillagedRouteWeWantToRepair = NeedRouteAtPlot(pPlot) && pPlot->IsRoutePillaged();
 	// If it's owned by us, but it's being razed, ignore it (check actual owning city instead of working city)
-	if (isOwnedByUs && pPlot->getOwningCity()->IsRazing())
+	if (isOwnedByUs && pPlot->getOwningCity()->IsRazing() && !isPillagedRouteWeWantToRepair)
 	{
 		return;
 	}
-	bool isPillagedRouteWeWantToRepair = NeedRouteAtPlot(pPlot) && pPlot->IsRoutePillaged();
 	// If it's not owned by us, and it's not a route we want to repair, ignore it
 	if (!isOwned && !isPillagedRouteWeWantToRepair)
 	{
@@ -1778,6 +1761,13 @@ void CvBuilderTaskingAI::AddRepairTilesDirectives(CvUnit* pUnit, CvPlot* pPlot, 
 
 	if (pWorkingCity && pWorkingCity->GetCityCitizens()->IsWorkingPlot(pPlot))
 		iWeight *= 2;
+
+	if (isPillagedRouteWeWantToRepair)
+	{
+		RoutePlotContainer::const_iterator it = m_routeNeededPlots.find(pPlot->GetPlotIndex());
+		if (it != m_routeNeededPlots.end())
+			iWeight += it->second.second;
+	}
 
 	if (iWeight > 0)
 	{

--- a/CvGameCoreDLL_Expansion2/CvCityConnections.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCityConnections.cpp
@@ -150,13 +150,23 @@ void CvCityConnections::UpdatePlotsToConnect(void)
 			CvPlot* pLoopPlot = GC.getMap().plotByIndex(vPlots[j]);
 			if (pLoopPlot->isWater())
 				continue;
+
+			if (pLoopPlot->isCity())
+				continue;
+
+			if (pLoopPlot->isImpassable(m_pPlayer->getTeam()))
+				continue;
 					
 			//ignore plots which are not exposed
 			if (!pLoopPlot->IsBorderLand(m_pPlayer->GetID()))
 				continue;
 
+			//ignore plots that are owned by a city we are razing
+			if (pLoopPlot->getOwningCity() && pLoopPlot->getOwningCity()->IsRazing())
+				continue;
+
 			//natural defenses
-			if (pLoopPlot->defenseModifier(m_pPlayer->getTeam(), false, false) >= 30 || pLoopPlot->IsChokePoint())
+			if (pLoopPlot->defenseModifier(m_pPlayer->getTeam(), false, false) >= 25 || pLoopPlot->IsChokePoint())
 			{
 				m_plotIdsToConnect.push_back(pLoopPlot->GetPlotIndex());
 			}

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
@@ -27827,7 +27827,7 @@ bool CvDiplomacyAI::IsPotentialMilitaryTargetOrThreat(PlayerTypes ePlayer, bool 
 	if ((IsDoFAccepted(ePlayer) || IsHasDefensivePact(ePlayer)) && !IsUntrustworthy(ePlayer))
 		return false;
 
-	if (!bIgnoreCurrentApproach)
+	if (!bIgnoreCurrentApproach && !GET_PLAYER(ePlayer).isHuman())
 	{
 		CivApproachTypes eApproach = GetCivApproach(ePlayer);
 		if (eApproach != NO_CIV_APPROACH && eApproach <= CIV_APPROACH_AFRAID)

--- a/CvGameCoreDLL_Expansion2/CvPlot.h
+++ b/CvGameCoreDLL_Expansion2/CvPlot.h
@@ -208,6 +208,7 @@ public:
 	bool isAdjacentOwned() const;
 	bool isAdjacentPlayer(PlayerTypes ePlayer, bool bLandOnly = false) const;
 	bool IsAdjacentOwnedByTeamOtherThan(TeamTypes eTeam, bool bAllowNoTeam=false, bool bIgnoreImpassable=false) const;
+	bool IsAdjacentOwnedByUnfriendly(PlayerTypes ePlayer) const;
 	bool IsAdjacentOwnedByEnemy(TeamTypes eTeam) const;
 	bool isAdjacentTeam(TeamTypes eTeam, bool bLandOnly = false) const;
 	bool IsAdjacentCity(TeamTypes eTeam = NO_TEAM) const;


### PR DESCRIPTION
AI now much more likely to build road tiles that are needed for several routes first (make value calculation additive instead of just taking the max value).

AI should now be better at repairing important pillaged routes.

Modify IsBorderLand function to only return true for tiles that are bordering or are close to an unfriendly civ. This seems to be the intended behavior of the function.

Align strategic route plotting between CvCityConnections and CvBuilderTaskingAI.

AI can now repair routes in cities they are razing.

AI no longer wants to build strategic routes in cities they are razing.