### PR TITLE
(4-21b) Changes to Spy Mission Selection

### DIFF
--- a/(1) Community Patch/Core Files/Core Tables/GameEventsTable.xml
+++ b/(1) Community Patch/Core Files/Core Tables/GameEventsTable.xml
@@ -807,7 +807,9 @@
 		<Column name="IsEspionageEffect" type="boolean" default="false"/>
 		<!-- Set to true for any mission that's part of the 'setup' phase for a Spy -->
 		<Column name="MissionSetup" type="boolean" default="false"/>
-		<!-- Effect applies to spy owner capital instead! Note: if you use  -->
+		<!-- If true, Spy will go into the State "Surveillance established" and mission selection will be possible again next turn -->
+		<Column name="IsSurveillance" type="boolean" default="false"/>
+		<!-- Effect applies to spy owner capital instead!-->
 		<Column name="IsSpyBenefit" type="boolean" default="false"/>
 		<!-- Modifier to chance to be identified on a spy mission-->
 		<Column name="IDModifier" type="integer" default="0"/>
@@ -839,6 +841,9 @@
 		<Column name="NoLevelUp" type="boolean" default="false"/>
 		<!-- Mission ignores other local spies. -->
 		<Column name="IgnoreLocalForeignSpies" type="boolean" default="false"/>
+		<!-- Checks if empire of the targeted civ is unhappy -->
+		<Column name="IsEnemyUnhappy" type="boolean" default="false"/>
+		<Column name="IsEnemySuperUnhappy" type="boolean" default="false"/>
 
 		<!-- Spy copies num techs; if it fails at end, it converts amount to GA turns -->
 		<Column name="StealNumTechs" type="integer" default="0"/>

--- a/(1) Community Patch/Modules/Events/Text/en_US/EventCore_en_US.xml
+++ b/(1) Community Patch/Modules/Events/Text/en_US/EventCore_en_US.xml
@@ -331,6 +331,14 @@
 			<Text>[NEWLINE] [ICON_BULLET] Empire must be Unhappy</Text>
 		</Row>
 		
+		<Row Tag="TXT_KEY_NEED_ENEMY_SUPER_UNHAPPY">
+			<Text>[NEWLINE] [ICON_BULLET] Targeted Civilization must be Very Unhappy</Text>
+		</Row>
+		
+		<Row Tag="TXT_KEY_NEED_ENEMY_UNHAPPY">
+			<Text>[NEWLINE] [ICON_BULLET] Targeted Civilization must be Unhappy</Text>
+		</Row>
+		
 		<Row Tag="TXT_KEY_NEED_TRADE_SLOT">
 			<Text>[NEWLINE] [ICON_BULLET] Requires an available slot for a Trade Unit</Text>
 		</Row>

--- a/(2) Vox Populi/Balance Changes/Espionage/PrimaryEspionageEvents.xml
+++ b/(2) Vox Populi/Balance Changes/Espionage/PrimaryEspionageEvents.xml
@@ -44,6 +44,18 @@
 			<SpyVisionRange>3</SpyVisionRange>
 			<SpyLevelRequired>0</SpyLevelRequired>
 		</Row>
+		<!-- DEFER MISSION SELECTION FOR ONE TURN -->
+		<Row>
+			<Type>ESPIONAGE_EVENT_CHOICE_ESTABLISH_SURVEILLANCE</Type>
+			<Description>TXT_KEY_ESPIONAGE_EVENT_CHOICE_ESTABLISH_SURVEILLANCE</Description>
+			<Help>TXT_KEY_ESPIONAGE_EVENT_CHOICE_ESTABLISH_SURVEILLANCE_HELP</Help>
+			<IsEspionageEffect>true</IsEspionageEffect>
+			<MissionSetup>true</MissionSetup>
+			<EventDuration>-1</EventDuration>
+			<EspionageMissionDuration>1</EspionageMissionDuration>
+			<IsSurveillance>1</IsSurveillance>
+			<IgnoreLocalForeignSpies>1</IgnoreLocalForeignSpies>
+		</Row>
 		<!-- CULTURE/TOURISM -->
 		<Row>
 			<Type>ESPIONAGE_EVENT_CHOICE_SIPHON_TOURISM</Type>
@@ -144,7 +156,7 @@
 			<MissionSetup>true</MissionSetup>
 			<IDModifier>60</IDModifier>
 			<EventDuration>-1</EventDuration>
-			<IsUnhappy>true</IsUnhappy>
+			<IsEnemyUnhappy>true</IsEnemyUnhappy>
 			<ExperienceGainedModifier>25</ExperienceGainedModifier>
 			<EspionageMissionDuration>25</EspionageMissionDuration>
 			<ResistanceTurns>2</ResistanceTurns>
@@ -397,6 +409,10 @@
 	</CityEventChoice_SpecialistYieldChange>
 	<CityEvent_ParentEvents>
 		<Row>
+			<CityEventChoiceType>ESPIONAGE_EVENT_CHOICE_ESTABLISH_SURVEILLANCE</CityEventChoiceType>
+			<CityEventType>ESPIONAGE_EVENT_CHOICE_SELECT_FOCUS</CityEventType>
+		</Row>
+		<Row>
 			<CityEventChoiceType>ESPIONAGE_EVENT_CHOICE_REVEAL_AREA</CityEventChoiceType>
 			<CityEventType>ESPIONAGE_EVENT_CHOICE_SELECT_FOCUS</CityEventType>
 		</Row>
@@ -405,11 +421,11 @@
 			<CityEventType>ESPIONAGE_EVENT_CHOICE_SELECT_FOCUS</CityEventType>
 		</Row>
 		<Row>
-			<CityEventChoiceType>ESPIONAGE_EVENT_CHOICE_SIPHON_TOURISM</CityEventChoiceType>
+			<CityEventChoiceType>ESPIONAGE_EVENT_CHOICE_SIPHON_FAITH</CityEventChoiceType>
 			<CityEventType>ESPIONAGE_EVENT_CHOICE_SELECT_FOCUS</CityEventType>
 		</Row>
 		<Row>
-			<CityEventChoiceType>ESPIONAGE_EVENT_CHOICE_SIPHON_FAITH</CityEventChoiceType>
+			<CityEventChoiceType>ESPIONAGE_EVENT_CHOICE_SIPHON_TOURISM</CityEventChoiceType>
 			<CityEventType>ESPIONAGE_EVENT_CHOICE_SELECT_FOCUS</CityEventType>
 		</Row>
 		<Row>
@@ -503,6 +519,11 @@
 			<CityEventChoiceType>ESPIONAGE_EVENT_CHOICE_STEAL_TECH</CityEventChoiceType>
 			<FlavorType>FLAVOR_SCIENCE</FlavorType>
 			<Flavor>50</Flavor>
+		</Row>
+		<Row>
+			<CityEventChoiceType>ESPIONAGE_EVENT_CHOICE_ESTABLISH_SURVEILLANCE</CityEventChoiceType>
+			<FlavorType>FLAVOR_ESPIONAGE</FlavorType>
+			<Flavor>1</Flavor>
 		</Row>
 		<Row>
 			<CityEventChoiceType>ESPIONAGE_EVENT_CHOICE_REVEAL_AREA</CityEventChoiceType>

--- a/(2) Vox Populi/Balance Changes/Text/en_US/EspionageEventText.xml
+++ b/(2) Vox Populi/Balance Changes/Text/en_US/EspionageEventText.xml
@@ -29,6 +29,12 @@
 		<Row Tag="TXT_KEY_ESPIONAGE_EVENT_CHOICE_SELECT_FOCUS_HELP">
 			<Text>Your newly established spy network requires a mission. What would you like them to focus on?</Text>
 		</Row>
+		<Row Tag="TXT_KEY_ESPIONAGE_EVENT_CHOICE_ESTABLISH_SURVEILLANCE">
+			<Text>Defer Mission Selection</Text>
+		</Row>
+		<Row Tag="TXT_KEY_ESPIONAGE_EVENT_CHOICE_ESTABLISH_SURVEILLANCE_HELP">
+			<Text>Mission Selection is deferred, and the Mission Selection Screen appears again next turn. </Text>
+		</Row>
 		<Row Tag="TXT_KEY_ESPIONAGE_EVENT_CHOICE_SIPHON_TOURISM">
 			<Text>Sabotage local [ICON_TOURISM] Tourism</Text>
 		</Row>
@@ -104,7 +110,7 @@
 			<Text>Broaden [ICON_SPY] Surveillance in City</Text>
 		</Row>
 		<Row Tag="TXT_KEY_ESPIONAGE_EVENT_CHOICE_REVEAL_AREA_HELP">
-			<Text>Expand the number of tiles visible around the Target City for {5_Turns}.{8_MissionLength}{6_Spy}{3_YieldCityTip}</Text>
+			<Text>Expand the number of tiles visible around the Target City for {5_Turns} after the mission is completed.{8_MissionLength}{6_Spy}{3_YieldCityTip}</Text>
 		</Row>
 
 		<Row Tag="TXT_KEY_ESPIONAGE_EVENT_PLAYER_YIELD_BASIC">

--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -4688,6 +4688,10 @@ bool CvCity::IsCityEventChoiceValidEspionage(CityEventChoiceTypes eEventChoice, 
 	if (eEvent == NO_EVENT_CITY)
 		return false;
 
+	// The mission to establish surveillance can always be chosen
+	if (pkEventInfo->isSurveillance())
+		return true;
+
 	if (pkEventInfo->GetSpyLevelRequired() > pSpy->GetSpyRank(eSpyOwner))
 		return false;
 
@@ -4821,6 +4825,12 @@ bool CvCity::IsCityEventChoiceValidEspionage(CityEventChoiceTypes eEventChoice, 
 		return false;
 
 	if (pkEventInfo->isSuperUnhappy() && !GET_PLAYER(eSpyOwner).IsEmpireSuperUnhappy())
+		return false;
+
+	if (pkEventInfo->isEnemyUnhappy() && !GET_PLAYER(getOwner()).IsEmpireUnhappy())
+		return false;
+
+	if (pkEventInfo->isEnemySuperUnhappy() && !GET_PLAYER(getOwner()).IsEmpireSuperUnhappy())
 		return false;
 
 	if (pkEventInfo->hasMetAnotherCiv())
@@ -6710,7 +6720,10 @@ void CvCity::DoEventChoice(CityEventChoiceTypes eEventChoice, CityEventTypes eCi
 						bDefer = true;
 
 					eResult = GET_PLAYER(eSpyOwner).GetEspionage()->ProcessSpyFocusResult(eSpyOwner, this, iEspionageValue, eEventChoice, bDefer);
-					pSpy->UpdateLastMissionOutcome(this, eSpyOwner, iEspionageValue, eResult);
+					if (!pkEventChoiceInfo->isSurveillance())
+					{
+						pSpy->UpdateLastMissionOutcome(this, eSpyOwner, iEspionageValue, eResult);
+					}
 
 					//if setup, we don't actually fire the choice right now...we wait!
 					if (bDefer && !pkEventChoiceInfo->isExpiresOnCounterSpyExit())

--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -5838,6 +5838,19 @@ CvString CvCity::GetDisabledTooltip(CityEventChoiceTypes eChosenEventChoice, int
 		CvCity* pCity = GET_PLAYER(eSpyOwner).GetEspionage()->GetCityWithSpy(iSpyIndex);
 		if (pCity)
 		{
+			if (pkEventInfo->isEnemyUnhappy() && !GET_PLAYER(pCity->getOwner()).IsEmpireUnhappy())
+			{
+				localizedDurationText = Localization::Lookup("TXT_KEY_NEED_UNHAPPY");
+				DisabledTT += localizedDurationText.toUTF8();
+			}
+
+			if (pkEventInfo->isEnemySuperUnhappy() && !GET_PLAYER(pCity->getOwner()).IsEmpireSuperUnhappy())
+			{
+				localizedDurationText = Localization::Lookup("TXT_KEY_NEED_SUPER_UNHAPPY");
+				DisabledTT += localizedDurationText.toUTF8();
+			}
+
+
 			bool bSiphon = true;
 			for (int iI = 0; iI < NUM_YIELD_TYPES; iI++)
 			{

--- a/CvGameCoreDLL_Expansion2/CvEspionageClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvEspionageClasses.cpp
@@ -1585,15 +1585,6 @@ CvSpyResult CvPlayerEspionage::ProcessSpyFocusResult(PlayerTypes ePlayer, CvCity
 		pSpy->SetSpyState(m_pPlayer->GetID(), uiSpyIndex, SPY_STATE_SURVEILLANCE);
 		pCityEspionage->SetActivity(ePlayer, 1, 1, 1);
 		TriggerSpyFocusSetup(pCity, uiSpyIndex);
-		/*pSpy->SetSpyFocus(eEventChoice);
-		pSpy->SetSpySiphon(eEventChoice);
-		pSpy->SetSpyState(m_pPlayer->GetID(), uiSpyIndex, SPY_STATE_GATHERING_INTEL);
-		pCityEspionage->ResetProgress(ePlayer);
-		int iPotentialRate = CalcPerTurn(SPY_STATE_GATHERING_INTEL, pCity, uiSpyIndex);
-		int iGoal = CalcRequired(SPY_STATE_GATHERING_INTEL, pCity, uiSpyIndex);
-		pCityEspionage->SetActivity(ePlayer, 0, iPotentialRate, iGoal);
-		pCityEspionage->SetLastProgress(ePlayer, iPotentialRate);
-		pCityEspionage->SetLastPotential(ePlayer, iPotentialRate);*/
 	}
 
 	//AI should reeval to see if they want to stay.

--- a/CvGameCoreDLL_Expansion2/CvEspionageClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvEspionageClasses.cpp
@@ -1308,18 +1308,19 @@ CvSpyResult CvPlayerEspionage::ProcessSpyFocusResult(PlayerTypes ePlayer, CvCity
 	{
 		if (eCityOwner != m_pPlayer->GetID())
 		{
-
-			pSpy->SetSpyFocus(eEventChoice);
-			pSpy->SetSpySiphon(eEventChoice);
-			pSpy->SetSpyState(m_pPlayer->GetID(), uiSpyIndex, SPY_STATE_GATHERING_INTEL);
-			pCityEspionage->ResetProgress(ePlayer);
-			int iPotentialRate = CalcPerTurn(SPY_STATE_GATHERING_INTEL, pCity, uiSpyIndex);
-			int iGoal = CalcRequired(SPY_STATE_GATHERING_INTEL, pCity, uiSpyIndex);
-			pCityEspionage->SetActivity(ePlayer, 0, iPotentialRate, iGoal);
-			pCityEspionage->SetLastProgress(ePlayer, iPotentialRate);
-			pCityEspionage->SetLastPotential(ePlayer, iPotentialRate);
-			pSpy->m_bEvaluateReassignment = false;
-
+			if (!pkEventChoiceInfo->isSurveillance())
+			{
+				pSpy->SetSpyFocus(eEventChoice);
+				pSpy->SetSpySiphon(eEventChoice);
+				pSpy->SetSpyState(m_pPlayer->GetID(), uiSpyIndex, SPY_STATE_GATHERING_INTEL);
+				pCityEspionage->ResetProgress(ePlayer);
+				int iPotentialRate = CalcPerTurn(SPY_STATE_GATHERING_INTEL, pCity, uiSpyIndex);
+				int iGoal = CalcRequired(SPY_STATE_GATHERING_INTEL, pCity, uiSpyIndex);
+				pCityEspionage->SetActivity(ePlayer, 0, iPotentialRate, iGoal);
+				pCityEspionage->SetLastProgress(ePlayer, iPotentialRate);
+				pCityEspionage->SetLastPotential(ePlayer, iPotentialRate);
+				pSpy->m_bEvaluateReassignment = false;
+			}
 			return NUM_SPY_RESULTS;
 		}
 		else
@@ -1568,18 +1569,23 @@ CvSpyResult CvPlayerEspionage::ProcessSpyFocusResult(PlayerTypes ePlayer, CvCity
 		pSpy->ResetSpySiphon();
 		pCityEspionage->SetSpyResult(ePlayer, uiSpyIndex, NUM_SPY_RESULTS);
 	}
-	//if we were detected, we don't leave anymore. We stay and do it again!
+	//if we were detected, we don't leave anymore. We stay and can choose another mission!
 	else if (eResult == SPY_RESULT_DETECTED)
 	{
 		if (GC.getLogging())
 		{
 			CvString strMsg;
-			strMsg.Format("Detected, sticking around to do this again, , %d,", uiSpyIndex);
+			strMsg.Format("Detected, selecting new mission, , %d,", uiSpyIndex);
 			strMsg += GetLocalizedText(m_aSpyList[uiSpyIndex].GetSpyName(m_pPlayer));
 			LogEspionageMsg(strMsg);
 		}
 
-		pSpy->SetSpyFocus(eEventChoice);
+		pSpy->SetSpyFocus(NO_EVENT_CHOICE_CITY);
+		pSpy->ResetSpySiphon();
+		pSpy->SetSpyState(m_pPlayer->GetID(), uiSpyIndex, SPY_STATE_SURVEILLANCE);
+		pCityEspionage->SetActivity(ePlayer, 1, 1, 1);
+		TriggerSpyFocusSetup(pCity, uiSpyIndex);
+		/*pSpy->SetSpyFocus(eEventChoice);
 		pSpy->SetSpySiphon(eEventChoice);
 		pSpy->SetSpyState(m_pPlayer->GetID(), uiSpyIndex, SPY_STATE_GATHERING_INTEL);
 		pCityEspionage->ResetProgress(ePlayer);
@@ -1587,7 +1593,7 @@ CvSpyResult CvPlayerEspionage::ProcessSpyFocusResult(PlayerTypes ePlayer, CvCity
 		int iGoal = CalcRequired(SPY_STATE_GATHERING_INTEL, pCity, uiSpyIndex);
 		pCityEspionage->SetActivity(ePlayer, 0, iPotentialRate, iGoal);
 		pCityEspionage->SetLastProgress(ePlayer, iPotentialRate);
-		pCityEspionage->SetLastPotential(ePlayer, iPotentialRate);
+		pCityEspionage->SetLastPotential(ePlayer, iPotentialRate);*/
 	}
 
 	//AI should reeval to see if they want to stay.
@@ -6886,6 +6892,9 @@ int CvEspionageAI::GetNumValidSpyMissionsInCityValue(CvCity* pCity)
 					if (pkEventChoiceInfo != NULL)
 					{
 						if (!pkEventChoiceInfo->isParentEvent(eEvent))
+							continue;
+
+						if (pkEventChoiceInfo->isSurveillance())
 							continue;
 
 						if (pCity->IsCityEventChoiceValidEspionageTest(eEventChoice, eEvent, 1, m_pPlayer->GetID()))

--- a/CvGameCoreDLL_Expansion2/CvInfos.cpp
+++ b/CvGameCoreDLL_Expansion2/CvInfos.cpp
@@ -11486,6 +11486,8 @@ CvModEventCityChoiceInfo::CvModEventCityChoiceInfo() :
 	 m_bHasStateReligion(false),
 	 m_bUnhappy(false),
 	 m_bSuperUnhappy(false),
+	 m_bEnemyUnhappy(false),
+	 m_bEnemySuperUnhappy(false),
 	 m_strEventChoiceSoundEffect(""),
 	 m_piConvertReligion(NULL),
 	 m_piConvertReligionPercent(NULL),
@@ -11552,6 +11554,7 @@ CvModEventCityChoiceInfo::CvModEventCityChoiceInfo() :
 	 m_iStealTech(0),
 	 m_iForgeGW(0),
 	 m_iSapCityTurns(0),
+	 m_bIsSurveillance(false),
 	 m_bRequiresCounterSpy(false),
 	 m_bExpiresOnCounterSpyExit(false),
 	 m_bIsMissionSetup(false),
@@ -11669,6 +11672,10 @@ int CvModEventCityChoiceInfo::GetDeathModifier() const
 int CvModEventCityChoiceInfo::GetSpyLevelRequired() const
 {
 	return m_iSpyLevelRequired;
+}
+bool CvModEventCityChoiceInfo::isSurveillance() const
+{
+	return m_bIsSurveillance;
 }
 bool CvModEventCityChoiceInfo::isRequiresCounterSpy() const
 {
@@ -12166,6 +12173,16 @@ bool CvModEventCityChoiceInfo::isSuperUnhappy() const
 	return m_bSuperUnhappy;
 }
 //------------------------------------------------------------------------------
+bool CvModEventCityChoiceInfo::isEnemyUnhappy() const
+{
+	return m_bEnemyUnhappy;
+}
+//------------------------------------------------------------------------------
+bool CvModEventCityChoiceInfo::isEnemySuperUnhappy() const
+{
+	return m_bEnemySuperUnhappy;
+}
+//------------------------------------------------------------------------------
 int CvModEventCityChoiceInfo::getLocalResourceRequired() const
 {
 	return m_iLocalResourceRequired;
@@ -12290,6 +12307,7 @@ bool CvModEventCityChoiceInfo::CacheResults(Database::Results& kResults, CvDatab
 	m_iSpyLevelRequired = kResults.GetInt("SpyLevelRequired");
 	m_iEspDuration = kResults.GetInt("EspionageMissionDuration");
 	m_iSpyExperience = kResults.GetInt("ExperienceGainedModifier");
+	m_bIsSurveillance = kResults.GetBool("IsSurveillance");
 	m_bRequiresCounterSpy = kResults.GetBool("RequiresCounterSpy");
 	m_bExpiresOnCounterSpyExit = kResults.GetBool("ExpiresOnCounterSpyExit");
 	m_bIsMissionSetup = kResults.GetBool("MissionSetup");
@@ -12624,6 +12642,8 @@ bool CvModEventCityChoiceInfo::CacheResults(Database::Results& kResults, CvDatab
 
 	m_bRequiresGarrison = kResults.GetBool("RequiresGarrison");
 	m_bHasStateReligion = kResults.GetBool("RequiresAnyStateReligion");
+	m_bEnemyUnhappy = kResults.GetBool("IsEnemyUnhappy");
+	m_bEnemySuperUnhappy = kResults.GetBool("IsEnemySuperUnhappy");
 	m_bUnhappy = kResults.GetBool("IsUnhappy");
 	m_bSuperUnhappy = kResults.GetBool("IsSuperUnhappy");
 	m_bRequiresIdeology = kResults.GetBool("RequiresIdeology");

--- a/CvGameCoreDLL_Expansion2/CvInfos.h
+++ b/CvGameCoreDLL_Expansion2/CvInfos.h
@@ -3741,10 +3741,13 @@ public:
 	int getStealTech() const;
 	int getForgeGW() const;
 	int getSapCityTurns() const;
+	bool isSurveillance() const;
 	bool isRequiresCounterSpy() const;
 	bool isExpiresOnCounterSpyExit() const;
 	bool isSpyMissionSetup() const;
 	bool IsIgnoreLocalSpies() const;
+	bool isEnemyUnhappy() const;
+	bool isEnemySuperUnhappy() const;
 	EventChoiceTypes GetTriggerPlayerEventChoice() const;
 
 	//Filters
@@ -3872,6 +3875,7 @@ protected:
 	int m_iEspDuration;
 	int m_iSpyExperience;
 	bool m_bIsMissionSetup;
+	bool m_bIsSurveillance;
 	bool m_bRequiresCounterSpy;
 	bool m_bExpiresOnCounterSpyExit;
 	int m_iDamageCity;
@@ -3906,6 +3910,8 @@ protected:
 	bool m_bHasStateReligion;
 	bool m_bUnhappy;
 	bool m_bSuperUnhappy;
+	bool m_bEnemyUnhappy;
+	bool m_bEnemySuperUnhappy;
 	bool m_bIsResistance;
 	bool m_bIsWLTKD;
 	int m_iWonderConstructionMod;

--- a/CvGameCoreDLL_Expansion2/CvPlayerAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayerAI.cpp
@@ -982,6 +982,13 @@ bool CvPlayerAI::AI_DoEspionageEventChoice(CityEventTypes eEvent, int uiSpyIndex
 											iOurFlavor *= 10;
 									}
 
+									if (pkEventChoiceInfo->isSurveillance())
+									{
+										CvCity* pCity = GetEspionage()->GetCityWithSpy(uiSpyIndex);
+										if (pCity && pCity->IsResistance())
+											iOurFlavor *= 10;
+									}
+
 									//counterspy filter selection
 									if (pCity->getOwner() == GetID())
 									{


### PR DESCRIPTION
Here is the implementation of (4-21b) in case you want to include it in the update. 4-21b was part of the two choices in the poll that had the most votes.

Espionage:
- When a spy has completed a mission without being identified, the mission select screen appears and the next mission can be chosen
- An option "Defer mission selection for one turn" has been added. When selected, the mission select screen reappears next turn

Bug fix:
- Fixed "Arm local populace" spy mission requiring the spy owner to be unhappy instead of the targeted civ (#9567)