### PR TITLE
'optimize' button, DoMinorBullyAnnex, DoMinorBuyout MP fix

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvCultureClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCultureClasses.cpp
@@ -3107,8 +3107,16 @@ void CvPlayerCulture::MoveWorkIntoSlot (CvGreatWorkInMyEmpire kWork, int iCityID
 				BuildingClassTypes eFromBuildingClass = (BuildingClassTypes)pkFromEntry->GetBuildingClassType();
 				if(pFromCity && eFromBuildingClass != NO_BUILDINGCLASS)
 				{
-					pToCity->GetCityBuildings()->SetBuildingGreatWork(eToBuildingClass, iSlot, kWork.m_iGreatWorkIndex);
-					pFromCity->GetCityBuildings()->SetBuildingGreatWork(eFromBuildingClass, iFromSlot, iFromWork);
+					gDLL->sendMoveGreatWorks(
+						m_pPlayer->GetID(),
+						pToCity->GetID(),
+						eToBuildingClass,
+						iSlot,
+						pFromCity->GetID(),
+						eFromBuildingClass,
+						iFromSlot
+					);
+
 #if defined(MOD_BALANCE_CORE)
 					return true;
 #endif

--- a/CvGameCoreDLL_Expansion2/CvDllNetMessageExt.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDllNetMessageExt.cpp
@@ -29,6 +29,20 @@ namespace NetMessageExt
 					Response::DoCityEventChoice(eActualPlayer, iCityID, eEventChoice, eCityEvent, iSpyID, eSpyOwner);
 					break;
 				}
+				case 1001:
+				{
+					PlayerTypes eActualPlayer = static_cast<PlayerTypes>(ePlayer);
+					PlayerTypes eMinor = static_cast<PlayerTypes>(iArg1);
+					Response::DoMinorBullyAnnex(eActualPlayer, eMinor);
+					break;
+				}
+				case 1002:
+				{
+					PlayerTypes eActualPlayer = static_cast<PlayerTypes>(ePlayer);
+					PlayerTypes eMinor = static_cast<PlayerTypes>(iArg1);
+					Response::DoMinorBuyout(eActualPlayer, eMinor);
+					break;
+				}
 			}
 			return true;
 		}
@@ -44,6 +58,14 @@ namespace NetMessageExt
 		void DoCityEventChoice(PlayerTypes ePlayer, int iCityID, CityEventChoiceTypes eEventChoice, CityEventTypes eCityEvent, int iSpyID, PlayerTypes eSpyOwner)
 		{			
 			gDLL->sendMoveGreatWorks(static_cast<PlayerTypes>(ePlayer), static_cast<int>(eCityEvent), iCityID, static_cast<int>(eEventChoice), iSpyID, static_cast<PlayerTypes>(eSpyOwner), 1000);
+		}
+		void DoMinorBullyAnnex(PlayerTypes ePlayer, PlayerTypes eMinor)
+		{	
+			gDLL->sendMoveGreatWorks(static_cast<PlayerTypes>(ePlayer), static_cast<PlayerTypes>(eMinor), -1, -1, -1, -1, 1001);
+		}
+		void DoMinorBuyout(PlayerTypes ePlayer, PlayerTypes eMinor)
+		{	
+			gDLL->sendMoveGreatWorks(static_cast<PlayerTypes>(ePlayer), static_cast<PlayerTypes>(eMinor), -1, -1, -1, -1, 1002);
 		}
 	}
 
@@ -70,6 +92,14 @@ namespace NetMessageExt
 				}
 
 			}
+		}
+		void DoMinorBullyAnnex(PlayerTypes ePlayer, PlayerTypes eMinor)
+		{	
+			GET_PLAYER(eMinor).GetMinorCivAI()->DoMajorBullyAnnex(ePlayer);
+		}
+		void DoMinorBuyout(PlayerTypes ePlayer, PlayerTypes eMinor)
+		{	
+			GET_PLAYER(eMinor).GetMinorCivAI()->DoBuyout(ePlayer);
 		}
 	}
 }

--- a/CvGameCoreDLL_Expansion2/CvDllNetMessageExt.h
+++ b/CvGameCoreDLL_Expansion2/CvDllNetMessageExt.h
@@ -14,6 +14,8 @@ namespace NetMessageExt
 	{
 		void DoEventChoice(PlayerTypes ePlayer, EventChoiceTypes eEventChoice, EventTypes eEvent);
 		void DoCityEventChoice(PlayerTypes ePlayer, int iCityID, CityEventChoiceTypes eEventChoice, CityEventTypes eCityEvent, int iSpyID, PlayerTypes eSpyOwner);
+		void DoMinorBullyAnnex(PlayerTypes ePlayer, PlayerTypes eMinor);
+		void DoMinorBuyout(PlayerTypes ePlayer, PlayerTypes eMinor);
 		//void RefreshTradeRouteCache(PlayerTypes ePlayer);
 	}
 
@@ -22,6 +24,8 @@ namespace NetMessageExt
 	{
 		void DoEventChoice(PlayerTypes ePlayer, EventChoiceTypes eEventChoice, EventTypes eEvent);
 		void DoCityEventChoice(PlayerTypes ePlayer, int iCityID, CityEventChoiceTypes eEventChoice, CityEventTypes eCityEvent, int iSpyID, PlayerTypes eSpyOwner);
+		void DoMinorBullyAnnex(PlayerTypes ePlayer, PlayerTypes eMinor);
+		void DoMinorBuyout(PlayerTypes ePlayer, PlayerTypes eMinor);
 		//void RefreshTradeRouteCache(PlayerTypes ePlayer);
 	}
 }

--- a/CvGameCoreDLL_Expansion2/CvDllNetMessageHandler.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDllNetMessageHandler.cpp
@@ -685,6 +685,7 @@ if (!GC.getGame().isFinalInitialized())
 		return;
 
 	// hijacks message for MP events since it has a few args and is sent to everyone
+	// also handles DoMinorBullyAnnex, DoMinorBuyout
 	if (NetMessageExt::Process::ResponseMoveGreatWorks(ePlayer, iCity1, iBuildingClass1, iWorkIndex1, iCity2, iBuildingClass2, iWorkIndex2))
 		return;
 

--- a/CvGameCoreDLL_Expansion2/CvGame.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGame.cpp
@@ -33,6 +33,7 @@
 #include "CvAdvisorRecommender.h"
 #include "CvWorldBuilderMapLoader.h"
 #include "CvTypes.h"
+#include "CvDllNetMessageExt.h"
 
 #include "cvStopWatch.h"
 #include "CvUnitMission.h"
@@ -12791,7 +12792,7 @@ void CvGame::DoMinorBullyAnnex(PlayerTypes eMajor, PlayerTypes eMinor)
 	if (eMajor < 0 || eMajor >= MAX_MAJOR_CIVS) return;
 	if (eMinor < MAX_MAJOR_CIVS || eMinor >= MAX_CIV_PLAYERS) return;
 
-	GET_PLAYER(eMinor).GetMinorCivAI()->DoMajorBullyAnnex(eMajor);
+	NetMessageExt::Send::DoMinorBullyAnnex(eMajor, eMinor);
 }
 //	--------------------------------------------------------------------------------
 /// Do the action of a major buying out a minor and marrying it
@@ -12800,7 +12801,7 @@ void CvGame::DoMinorMarriage(PlayerTypes eMajor, PlayerTypes eMinor)
 	if (eMajor < 0 || eMajor >= MAX_MAJOR_CIVS) return;
 	if (eMinor < MAX_MAJOR_CIVS || eMinor >= MAX_CIV_PLAYERS) return;
 
-	GET_PLAYER(eMinor).GetMinorCivAI()->DoBuyout(eMajor);
+	NetMessageExt::Send::DoMinorBuyout(eMajor, eMinor);
 }
 
 //	--------------------------------------------------------------------------------

--- a/CvGameCoreDLL_Expansion2/CvSerialize.h
+++ b/CvGameCoreDLL_Expansion2/CvSerialize.h
@@ -203,9 +203,11 @@ public:
 	typedef typename VarTraits::ValueType ValueType;
 	typedef typename VarTraits::ContainerType ContainerType;
 	typedef typename VarTraits::SyncVarsType SyncVarsType;
+	std::string nameStr;
 
 	CvSyncVar()
-		: CvSyncVarBase<ValueType>(EmptyString, getContainer().getSyncArchive(), currentValue())
+		: CvSyncVarBase<ValueType>(nameStr, getContainer().getSyncArchive(), currentValue()),
+		nameStr(VarTraits::name())
 	{}
 	~CvSyncVar() {}
 
@@ -273,6 +275,12 @@ public:
 		ValueType other;
 		otherValue >> other;
 		const bool result = other == currentValue();
+
+		if (!result) {
+			// std::string desyncValues = std::string("Desync values, current ") + FSerialization::toString(currentValue()) + "; other " + FSerialization::toString(other) + std::string("\n");
+			// gGlobals.getDLLIFace()->netMessageDebugLog(desyncValues);
+		}
+
 		return result; // Place a conditional breakpoint here to help debug sync errors.
 	}
 	virtual void reset()
@@ -281,7 +289,7 @@ public:
 	}
 	virtual const std::string& name() const
 	{
-		return EmptyString;
+		return nameStr;
 	}
 	virtual void setStackTraceRemark()
 	{
@@ -407,6 +415,7 @@ public:
 		typedef CvSyncArchive<ContainerType>::SyncVars SyncVarsType; \
 		static inline const ValueType& Get(const ContainerType& container) { return container.memberName; } \
 		static inline ValueType& Get(ContainerType& container) { return container.memberName; } \
+		static inline const char* name() { return #memberName; } \
 		static inline const SyncVarsType& GetStorage(const CvSyncVar<memberName##_Traits>& var) { \
 			return *reinterpret_cast<const SyncVarsType*>(reinterpret_cast<const char*>(&var) - offsetof(SyncVarsType, memberName)); \
 		} \

--- a/CvGameCoreDLL_Expansion2/VoxPopuli.vcxproj
+++ b/CvGameCoreDLL_Expansion2/VoxPopuli.vcxproj
@@ -61,7 +61,7 @@
       <AdditionalIncludeDirectories>$(SolutionDir)CvGameCoreDLL_Expansion2\;$(SolutionDir)CvWorldBuilderMap\include\;$(SolutionDir)CvGameCoreDLLUtil\include\;$(SolutionDir)CvLocalization\include\;$(SolutionDir)CvGameDatabase\include\;$(SolutionDir)FirePlace\include\;$(SolutionDir)FirePlace\include\FireWorks\;$(SolutionDir)ThirdPartyLibs\Lua51\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>CvGameCoreDLLPCH.h</PrecompiledHeaderFile>
-      <AdditionalOptions>/Zm211 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Zm250 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <TargetMachine>MachineX86</TargetMachine>

--- a/FirePlace/include/FireWorks/FAutoVariableBase.h
+++ b/FirePlace/include/FireWorks/FAutoVariableBase.h
@@ -67,6 +67,11 @@ namespace FSerialization
 		static const std::string result("UNKNOWN");
 		return result;
 	}
+
+	template<typename ValueType>
+	std::string toString(const CvString & source) {
+		return source.c_str();
+	}
 }
 
 class FAutoVariableBase


### PR DESCRIPTION
Allows to use Rome's UA in MP (tested), allows to use 'optimize' button (tested), allows to use DoMinorBuyout in MP (wasn't tested). Also adds desynced variable name in `net_message_debug.log`.