### PR TITLE
Top Panel Resources Icons Position Fix

### DIFF
--- a/(3a) EUI Compatibility Files/ImprovedTopPanel/TopPanel.lua
+++ b/(3a) EUI Compatibility Files/ImprovedTopPanel/TopPanel.lua
@@ -2884,7 +2884,7 @@ for resource in GameInfo.Resources() do
 		ContextPtr:BuildInstanceForControlAtIndex( "ResourceInstance", instance, Controls.TopPanelDiploStack, 8 )
 		g_resourceString[ resourceID ] = instance
 		IconHookup( resource.PortraitIndex, 45, resource.IconAtlas, instance.Image )
-		instance.Image:SetTextureSizeVal( 32, 32 ) --lower numbers look bigger
+		instance.Image:SetTextureSizeVal( 42, 42 ) --lower numbers look bigger
 		instance.Image:NormalizeTexture()
 
 		instance.Count:SetVoid1( resourceID )

--- a/(3a) EUI Compatibility Files/ImprovedTopPanel/TopPanel.xml
+++ b/(3a) EUI Compatibility Files/ImprovedTopPanel/TopPanel.xml
@@ -155,7 +155,7 @@
 	</ToolTipType>
 
 	<Instance Name="ResourceInstance">
-		<Image ID="Image" Size="32,32" Offset="-12,-12" Sampler="Linear" Hidden="1">
+		<Image ID="Image" Size="32,32" Offset="-10,-10" Sampler="Linear" Hidden="1">
 			<Button ID="Count" Size="28,28" String="?" BranchAlpha="1.5" TextAnchor="R,B" Offset="4,3" Font="TwCenMT16" FontStyle="Stroke" Color0="Beige,255" Color1="Black,155" ToolTipType="TooltipTypeTopPanel" />
 		</Image>
 	</Instance>


### PR DESCRIPTION
One issue remains, all icons beside paper don't have smooth edges if you look closer. If someone knows how to fix this (probably using higher resolution icons) is free to do it.

![Screenshot (69)](https://github.com/LoneGazebo/Community-Patch-DLL/assets/49090452/fb0cd7b7-0f7b-4045-96a9-a6299a249f98)
