### PR TITLE
Mark units which don't have pBestPlot as processed

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
@@ -2303,6 +2303,10 @@ void CvHomelandAI::ReviewUnassignedUnits()
 							continue;
 						}
 					}
+					else {
+						// mark as processed to not hang the game but still do scrap check
+						pUnit->SetTurnProcessed(true);
+					}
 					//Stuck and not at home? Scrap it.
 					if (GC.getGame().getGameTurn() - pUnit->getLastMoveTurn() > 7)
 					{


### PR DESCRIPTION
Fixes hang from [#9885](https://github.com/LoneGazebo/Community-Patch-DLL/issues/9885#issuecomment-1565546596)