### PR TITLE
Fix incorrect unit cost scaling

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvTreasury.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTreasury.cpp
@@ -539,11 +539,11 @@ int CvTreasury::CalculateUnitCost()
 
 	// Multiplicative increase - helps scale costs as game goes on - the HIGHER this number the more is paid
 	double fMultiplier = 0.0f;
-	fMultiplier += 1.0f + (iGameProgressFactor * /*8*/ GD_INT_GET(UNIT_MAINTENANCE_GAME_MULTIPLIER) / 100);
+	fMultiplier += 1.0f + ((float)iGameProgressFactor * /*8*/ GD_INT_GET(UNIT_MAINTENANCE_GAME_MULTIPLIER) / 100);
 
 	// Exponential increase - this one really punishes those with a HUGE military - the LOWER this number the more is paid
 	double fExponent = 0.0f;
-	fExponent += 1.0f + (iGameProgressFactor / /*7 in CP, 6 in VP*/ GD_INT_GET(UNIT_MAINTENANCE_GAME_EXPONENT_DIVISOR) / 100);
+	fExponent += 1.0f + ((float)iGameProgressFactor / /*7 in CP, 6 in VP*/ GD_INT_GET(UNIT_MAINTENANCE_GAME_EXPONENT_DIVISOR) / 100);
 
 	double dTempCost = 0.00f;
 	dTempCost += fMultiplier * iBaseUnitCost / 100;


### PR DESCRIPTION
This is quite a huge bug. Integer calculations are used in the calculation of the exponential increase of unit costs, which means that the exponent is always equal to 1, the exponential increase is never applied. Also the linear scaling factor is rounded down to integer values.