### PR TITLE
Fix Spy Missions not Starting Golden Age

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -4658,7 +4658,7 @@ bool CvCity::IsCityEventChoiceValid(CityEventChoiceTypes eChosenEventChoice, Cit
 	return true;
 }
 
-bool CvCity::IsCityEventChoiceValidEspionage(CityEventChoiceTypes eEventChoice, CityEventTypes eEvent, int uiSpyIndex, PlayerTypes eSpyOwner)
+bool CvCity::IsCityEventChoiceValidEspionage(CityEventChoiceTypes eEventChoice, CityEventTypes eEvent, int uiSpyIndex, PlayerTypes eSpyOwner, bool bStartMission)
 {
 	if (eSpyOwner == NO_PLAYER)
 		return false;
@@ -4736,19 +4736,23 @@ bool CvCity::IsCityEventChoiceValidEspionage(CityEventChoiceTypes eEventChoice, 
 		}
 	}
 
-	if (pkEventInfo->getStealTech() > 0)
+	if (bStartMission)
 	{
-		GET_PLAYER(eSpyOwner).GetEspionage()->BuildStealableTechList(getOwner());
-		int iNumTechsWeDontHave = GET_PLAYER(eSpyOwner).GetEspionage()->GetNumTechsToSteal(getOwner());
-		if (iNumTechsWeDontHave < pkEventInfo->getStealTech())
-			return false;
-	}
+		// these missions can be started only if a tech/GW is available to steal, but they are not canceled if that changes during the mission
+		if (pkEventInfo->getStealTech() > 0)
+		{
+			GET_PLAYER(eSpyOwner).GetEspionage()->BuildStealableTechList(getOwner());
+			int iNumTechsWeDontHave = GET_PLAYER(eSpyOwner).GetEspionage()->GetNumTechsToSteal(getOwner());
+			if (iNumTechsWeDontHave < pkEventInfo->getStealTech())
+				return false;
+		}
 
-	if (pkEventInfo->getForgeGW() > 0)
-	{
-		int iNumGWInCity = GetCityCulture()->GetNumGreatWorks();
-		if (iNumGWInCity < pkEventInfo->getForgeGW())
-			return false;
+		if (pkEventInfo->getForgeGW() > 0)
+		{
+			int iNumGWInCity = GetCityCulture()->GetNumGreatWorks();
+			if (iNumGWInCity < pkEventInfo->getForgeGW())
+				return false;
+		}
 	}
 
 	for (int iI = 0; iI < NUM_YIELD_TYPES; iI++)
@@ -6833,7 +6837,7 @@ void CvCity::DoEventChoice(CityEventChoiceTypes eEventChoice, CityEventTypes eCi
 				}
 				else
 				{
-					int iGoldenAgeTurns = GET_PLAYER(eSpyOwner).getGoldenAgeLength(pkEventChoiceInfo->getForgeGW() * 10);
+					int iGoldenAgeTurns = GET_PLAYER(eSpyOwner).getGoldenAgeLength(pkEventChoiceInfo->getStealTech() * 10);
 					GET_PLAYER(eSpyOwner).changeGoldenAgeTurns(iGoldenAgeTurns);
 				}
 			}

--- a/CvGameCoreDLL_Expansion2/CvCity.h
+++ b/CvGameCoreDLL_Expansion2/CvCity.h
@@ -151,7 +151,7 @@ public:
 	void DoEvents(bool bEspionageOnly = false);
 	bool IsCityEventValid(CityEventTypes eEvent);
 	bool IsCityEventChoiceValid(CityEventChoiceTypes eEventChoice, CityEventTypes eParentEvent, bool bIgnoreActive = false, bool bIgnorePlayer = false);
-	bool IsCityEventChoiceValidEspionage(CityEventChoiceTypes eEventChoice, CityEventTypes eEvent, int uiSpyIndex, PlayerTypes eSpyOwner);
+	bool IsCityEventChoiceValidEspionage(CityEventChoiceTypes eEventChoice, CityEventTypes eEvent, int uiSpyIndex, PlayerTypes eSpyOwner, bool bStartMission = true);
 	bool IsCityEventChoiceValidEspionageTest(CityEventChoiceTypes eEventChoice, CityEventTypes eEvent, int iAssumedLevel, PlayerTypes eSpyOwner);
 	void DoCancelEventChoice(CityEventChoiceTypes eEventChoice);
 	void DoStartEvent(CityEventTypes eEvent);

--- a/CvGameCoreDLL_Expansion2/CvEspionageClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvEspionageClasses.cpp
@@ -1010,7 +1010,7 @@ void CvPlayerEspionage::ProcessSpyFocus()
 					CityEventChoiceTypes eEventChoice = pSpy->m_eSpyFocus;
 					if (eEventChoice != NO_EVENT_CHOICE_CITY)
 					{
-						if (!pCity->IsCityEventChoiceValidEspionage(eEventChoice, NO_EVENT_CITY, uiSpy, m_pPlayer->GetID()))
+						if (!pCity->IsCityEventChoiceValidEspionage(eEventChoice, NO_EVENT_CITY, uiSpy, m_pPlayer->GetID(), false))
 						{
 						
 							pSpy->SetSpyFocus(NO_EVENT_CHOICE_CITY);


### PR DESCRIPTION
Fix the spy missions to steal a GW / tech being canceled during mission preparation if nothing can be stolen. They should continue, and a Golden Age should start if no tech/GW is available when the mission is completed.