### PR TITLE
Support SetQuestInfluenceDisabled for MP

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvDllNetMessageExt.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDllNetMessageExt.cpp
@@ -40,7 +40,14 @@ namespace NetMessageExt
 				{
 					PlayerTypes eActualPlayer = static_cast<PlayerTypes>(ePlayer);
 					PlayerTypes eMinor = static_cast<PlayerTypes>(iArg1);
-					Response::DoMinorBuyout(eActualPlayer, eMinor);
+					bool booleanFromInt;
+					if (iArg2 == 1) {
+						booleanFromInt = true;
+					}
+					else {
+						booleanFromInt = false;
+					}
+					Response::DoQuestInfluenceDisabled(eActualPlayer, eMinor, booleanFromInt);
 					break;
 				}
 			}
@@ -63,9 +70,15 @@ namespace NetMessageExt
 		{	
 			gDLL->sendMoveGreatWorks(static_cast<PlayerTypes>(ePlayer), static_cast<PlayerTypes>(eMinor), -1, -1, -1, -1, 1001);
 		}
-		void DoMinorBuyout(PlayerTypes ePlayer, PlayerTypes eMinor)
+		void DoQuestInfluenceDisabled(PlayerTypes ePlayer, PlayerTypes eMinor, bool bValue)
 		{	
-			gDLL->sendMoveGreatWorks(static_cast<PlayerTypes>(ePlayer), static_cast<PlayerTypes>(eMinor), -1, -1, -1, -1, 1002);
+			int booleanToInt;
+			if (bValue) {
+				booleanToInt = 1;
+			} else {
+				booleanToInt = 0;
+			}
+			gDLL->sendMoveGreatWorks(static_cast<PlayerTypes>(ePlayer), static_cast<PlayerTypes>(eMinor), booleanToInt, -1, -1, -1, 1002);
 		}
 	}
 
@@ -97,9 +110,9 @@ namespace NetMessageExt
 		{	
 			GET_PLAYER(eMinor).GetMinorCivAI()->DoMajorBullyAnnex(ePlayer);
 		}
-		void DoMinorBuyout(PlayerTypes ePlayer, PlayerTypes eMinor)
+		void DoQuestInfluenceDisabled(PlayerTypes ePlayer, PlayerTypes eMinor, bool bValue)
 		{	
-			GET_PLAYER(eMinor).GetMinorCivAI()->DoBuyout(ePlayer);
+			GET_PLAYER(eMinor).GetMinorCivAI()->SetQuestInfluenceDisabled(ePlayer, bValue);
 		}
 	}
 }

--- a/CvGameCoreDLL_Expansion2/CvDllNetMessageExt.h
+++ b/CvGameCoreDLL_Expansion2/CvDllNetMessageExt.h
@@ -15,7 +15,7 @@ namespace NetMessageExt
 		void DoEventChoice(PlayerTypes ePlayer, EventChoiceTypes eEventChoice, EventTypes eEvent);
 		void DoCityEventChoice(PlayerTypes ePlayer, int iCityID, CityEventChoiceTypes eEventChoice, CityEventTypes eCityEvent, int iSpyID, PlayerTypes eSpyOwner);
 		void DoMinorBullyAnnex(PlayerTypes ePlayer, PlayerTypes eMinor);
-		void DoMinorBuyout(PlayerTypes ePlayer, PlayerTypes eMinor);
+		void DoQuestInfluenceDisabled(PlayerTypes ePlayer, PlayerTypes eMinor, bool bValue);
 		//void RefreshTradeRouteCache(PlayerTypes ePlayer);
 	}
 
@@ -25,7 +25,7 @@ namespace NetMessageExt
 		void DoEventChoice(PlayerTypes ePlayer, EventChoiceTypes eEventChoice, EventTypes eEvent);
 		void DoCityEventChoice(PlayerTypes ePlayer, int iCityID, CityEventChoiceTypes eEventChoice, CityEventTypes eCityEvent, int iSpyID, PlayerTypes eSpyOwner);
 		void DoMinorBullyAnnex(PlayerTypes ePlayer, PlayerTypes eMinor);
-		void DoMinorBuyout(PlayerTypes ePlayer, PlayerTypes eMinor);
+		void DoQuestInfluenceDisabled(PlayerTypes ePlayer, PlayerTypes eMinor, bool bValue);
 		//void RefreshTradeRouteCache(PlayerTypes ePlayer);
 	}
 }

--- a/CvGameCoreDLL_Expansion2/CvGame.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGame.cpp
@@ -12578,7 +12578,7 @@ void CvGame::DoMinorMarriage(PlayerTypes eMajor, PlayerTypes eMinor)
 	if (eMajor < 0 || eMajor >= MAX_MAJOR_CIVS) return;
 	if (eMinor < MAX_MAJOR_CIVS || eMinor >= MAX_CIV_PLAYERS) return;
 
-	NetMessageExt::Send::DoMinorBuyout(eMajor, eMinor);
+	gDLL->sendMinorBuyout(eMajor, eMinor);
 }
 
 //	--------------------------------------------------------------------------------

--- a/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
@@ -14634,10 +14634,6 @@ void CvMinorCivAI::SetQuestInfluenceDisabled(PlayerTypes ePlayer, bool bValue)
 {
 	if (ePlayer < 0 || ePlayer >= MAX_MAJOR_CIVS) return;
 
-	// Not MP compatible yet
-	if (GC.getGame().isGameMultiPlayer())
-		return;
-	
 	if (bValue != m_abQuestInfluenceDisabled[ePlayer])
 	{
 		m_abQuestInfluenceDisabled[ePlayer] = bValue;

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
@@ -29,6 +29,7 @@
 #include "../CvInternalGameCoreUtils.h"
 #include "ICvDLLUserInterface.h"
 #include "CvDllInterfaces.h"
+#include "CvDllNetMessageExt.h"
 
 #pragma warning(disable:4800 ) //forcing value to bool 'true' or 'false'
 
@@ -8563,7 +8564,7 @@ int CvLuaPlayer::lSetQuestInfluenceDisabled(lua_State* L)
 	const PlayerTypes ePlayer = (PlayerTypes) lua_tointeger(L, 2);
 	const bool bValue = lua_toboolean(L, 3);
 
-	pkPlayer->GetMinorCivAI()->SetQuestInfluenceDisabled(ePlayer, bValue);
+	NetMessageExt::Send::DoQuestInfluenceDisabled(ePlayer, pkPlayer->GetID(), bValue);
 	return 1;
 }
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #9951.
Also last time when I edited `NetMessageExt` I missed that `DoMinorBuyout` was already implemented in vanilla exe. So here I just replaced this event with the new one.