### PR TITLE
Make CvPlot::setRevealed's return value mp-compatible

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -11321,6 +11321,7 @@ bool CvPlot::setRevealed(TeamTypes eTeam, bool bNewValue, CvUnit* pUnit, bool bT
 	bool bRevealed = isRevealed(eTeam) != bNewValue;
 	if(bRevealed)
 	{
+		bVisbilityUpdated = true;
 		m_bfRevealed.ToggleBit(eTeam);
 
 		bool bEligibleForAchievement = MOD_API_ACHIEVEMENTS ? GET_PLAYER(GC.getGame().getActivePlayer()).isHuman() && !GC.getGame().isGameMultiPlayer() : false;
@@ -11543,7 +11544,6 @@ bool CvPlot::setRevealed(TeamTypes eTeam, bool bNewValue, CvUnit* pUnit, bool bT
 
 		if(eTeam == eActiveTeam)
 		{
-			bVisbilityUpdated = true;
 			updateSymbols();
 			updateFog(true);
 			updateVisibility();


### PR DESCRIPTION
Fixes #9966. See description [here](https://github.com/LoneGazebo/Community-Patch-DLL/issues/9966#issuecomment-1614639813).

Currently `setRevealed` returns `true` just in case if plot changed its' visibility and `eTeam == getActiveTeam()`. Otherwise it returns `false` even if plot changed its' visibility and it breaks auto-exploration logic in MP-sessions. Tested and now auto-exploration works same on both ends. `setRevealed`'s return value used just only during auto-exploration, so this change should not break anything.