### PR TITLE
Free roads from trait are considered safe road tiles when planning routes.

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvAStar.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAStar.cpp
@@ -2280,6 +2280,10 @@ int BuildRouteValid(const CvAStarNode* parent, const CvAStarNode* node, const SP
 		}
 	}
 
+	//Free routes from traits are always safe
+	if (thisPlayer.GetBuilderTaskingAI()->GetSameRouteBenefitFromTrait(pNewPlot, eRoute))
+		return TRUE;
+
 	//too dangerous, might be severed any time
 	if (ePlotOwnerPlayer == NO_PLAYER && pNewPlot->IsAdjacentOwnedByTeamOtherThan(thisPlayer.getTeam()))
 		return FALSE;


### PR DESCRIPTION
Iroquois and Songhai will now no longer be afraid of using rivers and woodlands that are otherwise unsafe when planning routes.