### PR TITLE
Fix Vassal Overview display bug

### DIFF
--- a/(2) Vox Populi/C4DF/LUA/VassalageOverview.lua
+++ b/(2) Vox Populi/C4DF/LUA/VassalageOverview.lua
@@ -299,13 +299,13 @@ function MasterSelected( ePlayer )
 	-- Can't request? Set up tooltip
 	if( not bCanRequestIndependence ) then
 		local iMinimumTurns = 0;
-		if ( g_pTeam:IsVoluntaryVassal(iVassalTeam) ) then
+		if ( g_pTeam:IsVoluntaryVassal(iMasterTeam) ) then
 			iMinimumTurns = Game.GetMinimumVoluntaryVassalTurns();
 		else 
 			iMinimumTurns = Game.GetMinimumVassalTurns();
 		end
 
-		local iNumTurnsIsVassal = g_pTeam:GetNumTurnsIsVassal( iVassalTeam );
+		local iNumTurnsIsVassal = g_pTeam:GetNumTurnsIsVassal();
 
 		if(iNumTurnsIsVassal < iMinimumTurns) then
 			strTooltip = strTooltip .. "[NEWLINE][NEWLINE]" .. Locale.ConvertTextKey( "TXT_KEY_VO_REQUEST_INDEPENDENCE_TOO_SOON", iMinimumTurns, iMinimumTurns - iNumTurnsIsVassal);


### PR DESCRIPTION
The Vassal Overview was displaying the number of turns left for capitulation when a human vassal visits the Vassalage Overview. This corrects this bug and makes it correctly display the number of turns left for voluntary vassalage (Which is 10 turns).