### PR TITLE
Use red color for "impossible" deal items

### DIFF
--- a/(1) Community Patch/LUA/TradeLogic.lua
+++ b/(1) Community Patch/LUA/TradeLogic.lua
@@ -1223,7 +1223,7 @@ function ResetDisplay()
 
     	Controls.UsText:SetText( Locale.ConvertTextKey( "TXT_KEY_DIPLO_ITEMS_LABEL", Locale.ConvertTextKey( g_pUs:GetNameKey() ) ) );
 
-        if (pOtherPlayer:IsHuman()) then
+        if (g_pThem:IsHuman()) then
         	Controls.ThemText:SetText( Locale.ConvertTextKey( "TXT_KEY_DIPLO_ITEMS_LABEL", Locale.ConvertTextKey( g_pThem:GetNickName() ) ) );
         else
         	Controls.ThemText:SetText( Locale.ConvertTextKey( "TXT_KEY_DIPLO_ITEMS_LABEL", Locale.ConvertTextKey( g_pThem:GetName() ) ) );
@@ -1379,7 +1379,11 @@ function ResetDisplay()
 		end
 	else
 	    Controls.UsPocketGoldPerTurn:SetDisabled(false);
-	    Controls.UsPocketGoldPerTurn:GetTextControl():SetColorByName("Beige_Black");
+	    if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_GOLD_PER_TURN, g_iUs, false, g_iDealDuration, 1)) then
+			Controls.UsPocketGoldPerTurn:GetTextControl():SetColorByName("Red_Black");
+		else
+			Controls.UsPocketGoldPerTurn:GetTextControl():SetColorByName("Beige_Black");
+		end
 		Controls.UsPocketGoldPerTurn:SetToolTipString(nil);
     end
 
@@ -1407,7 +1411,11 @@ function ResetDisplay()
 		end
 	else
 	    Controls.ThemPocketGoldPerTurn:SetDisabled(false);
-	    Controls.ThemPocketGoldPerTurn:GetTextControl():SetColorByName("Beige_Black");
+	    if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_GOLD_PER_TURN, g_iUs, true, g_iDealDuration, 1)) then
+			Controls.ThemPocketGoldPerTurn:GetTextControl():SetColorByName("Red_Black");
+		else
+			Controls.ThemPocketGoldPerTurn:GetTextControl():SetColorByName("Beige_Black");
+		end
 		Controls.ThemPocketGoldPerTurn:SetToolTipString(nil);
     end
 
@@ -1433,7 +1441,11 @@ function ResetDisplay()
 			end
 		else
 			Controls.UsPocketAllowEmbassy:SetDisabled(false);
-			Controls.UsPocketAllowEmbassy:GetTextControl():SetColorByName("Beige_Black");
+			if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_ALLOW_EMBASSY, g_iUs, false, g_iDealDuration)) then
+				Controls.UsPocketAllowEmbassy:GetTextControl():SetColorByName("Red_Black");
+			else
+				Controls.UsPocketAllowEmbassy:GetTextControl():SetColorByName("Beige_Black");
+			end
 			Controls.UsPocketAllowEmbassy:SetToolTipString(strTooltip);
 		end
 
@@ -1453,7 +1465,11 @@ function ResetDisplay()
 			end
 		else
 			Controls.ThemPocketAllowEmbassy:SetDisabled(false);
-			Controls.ThemPocketAllowEmbassy:GetTextControl():SetColorByName("Beige_Black");
+			if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_ALLOW_EMBASSY, g_iUs, true, g_iDealDuration)) then
+				Controls.ThemPocketAllowEmbassy:GetTextControl():SetColorByName("Red_Black");
+			else
+				Controls.ThemPocketAllowEmbassy:GetTextControl():SetColorByName("Beige_Black");
+			end
 			Controls.ThemPocketAllowEmbassy:SetToolTipString(strTooltip);
 		end
 	end
@@ -1480,7 +1496,11 @@ function ResetDisplay()
 			end
 		else
 			Controls.UsPocketOpenBorders:SetDisabled(false);
-			Controls.UsPocketOpenBorders:GetTextControl():SetColorByName("Beige_Black");
+			if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_OPEN_BORDERS, g_iUs, false, g_iDealDuration)) then
+				Controls.UsPocketOpenBorders:GetTextControl():SetColorByName("Red_Black");
+			else
+				Controls.UsPocketOpenBorders:GetTextControl():SetColorByName("Beige_Black");
+			end
 			Controls.UsPocketOpenBorders:SetToolTipString(strTooltip);
 		end
 
@@ -1500,7 +1520,11 @@ function ResetDisplay()
 			end
 		else
 			Controls.ThemPocketOpenBorders:SetDisabled(false);
-			Controls.ThemPocketOpenBorders:GetTextControl():SetColorByName("Beige_Black");
+			if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_OPEN_BORDERS, g_iUs, true, g_iDealDuration)) then
+				Controls.ThemPocketOpenBorders:GetTextControl():SetColorByName("Red_Black");
+			else
+				Controls.ThemPocketOpenBorders:GetTextControl():SetColorByName("Beige_Black");
+			end
 			Controls.ThemPocketOpenBorders:SetToolTipString(strTooltip);
 		end
 	end
@@ -1533,7 +1557,11 @@ function ResetDisplay()
 			end
 		else
 			Controls.UsPocketDefensivePact:SetDisabled(false);
-			Controls.UsPocketDefensivePact:GetTextControl():SetColorByName("Beige_Black");
+			if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_DEFENSIVE_PACT, g_iUs, false, g_iDealDuration)) then
+				Controls.UsPocketDefensivePact:GetTextControl():SetColorByName("Red_Black");
+			else
+				Controls.UsPocketDefensivePact:GetTextControl():SetColorByName("Beige_Black");
+			end
 			Controls.UsPocketDefensivePact:SetToolTipString(strTooltip);
 		end
 
@@ -1553,7 +1581,11 @@ function ResetDisplay()
 			end
 		else
 			Controls.ThemPocketDefensivePact:SetDisabled(false);
-			Controls.ThemPocketDefensivePact:GetTextControl():SetColorByName("Beige_Black");
+			if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_DEFENSIVE_PACT, g_iUs, true, g_iDealDuration)) then
+				Controls.ThemPocketDefensivePact:GetTextControl():SetColorByName("Red_Black");
+			else
+				Controls.ThemPocketDefensivePact:GetTextControl():SetColorByName("Beige_Black");
+			end
 			Controls.ThemPocketDefensivePact:SetToolTipString(strTooltip);
 		end
 	end
@@ -1580,7 +1612,11 @@ function ResetDisplay()
 			end
 		else
 			Controls.UsPocketResearchAgreement:SetDisabled(false);
-			Controls.UsPocketResearchAgreement:GetTextControl():SetColorByName("Beige_Black");
+			if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_RESEARCH_AGREEMENT, g_iUs, false, g_iDealDuration)) then
+				Controls.UsPocketResearchAgreement:GetTextControl():SetColorByName("Red_Black");
+			else
+				Controls.UsPocketResearchAgreement:GetTextControl():SetColorByName("Beige_Black");
+			end
 			Controls.UsPocketResearchAgreement:SetToolTipString(strTooltip);
 		end
 
@@ -1600,7 +1636,11 @@ function ResetDisplay()
 			end
 		else
 			Controls.ThemPocketResearchAgreement:SetDisabled(false);
-			Controls.ThemPocketResearchAgreement:GetTextControl():SetColorByName("Beige_Black");
+			if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_RESEARCH_AGREEMENT, g_iUs, true, g_iDealDuration)) then
+				Controls.ThemPocketResearchAgreement:GetTextControl():SetColorByName("Red_Black");
+			else
+				Controls.ThemPocketResearchAgreement:GetTextControl():SetColorByName("Beige_Black");
+			end
 			Controls.ThemPocketResearchAgreement:SetToolTipString(strTooltip);
 		end
 	end
@@ -1766,6 +1806,9 @@ function ResetDisplay()
 			pResource = GameInfo.Resources[resType];
 			iResourceCount = g_pUs:GetNumResourceAvailable(resType, false);
 			strString = pResource.IconString .. " " .. Locale.ConvertTextKey(pResource.Description) .. " (" .. iResourceCount .. ")";
+			if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_RESOURCES, g_iUs, false, g_iDealDuration, resType, 1)) then
+				strString = "[COLOR_NEGATIVE_TEXT]" .. strString .."[ENDCOLOR]";
+			end
 			instance.Button:SetText(strString);
 		else
 			instance.Button:SetHide(true);
@@ -1840,6 +1883,9 @@ function ResetDisplay()
 			pResource = GameInfo.Resources[resType];
 			iResourceCount = g_pThem:GetNumResourceAvailable(resType, false);
 			strString = pResource.IconString .. " " .. Locale.ConvertTextKey(pResource.Description) .. " (" .. iResourceCount .. ")";
+			if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_RESOURCES, g_iUs, true, g_iDealDuration, resType, 1)) then
+				strString = "[COLOR_NEGATIVE_TEXT]" .. strString .."[ENDCOLOR]";
+			end
 			instance.Button:SetText(strString);
 
 			local WLTKDTT = g_pUs:GetWLTKDResourceTT(resType);
@@ -3067,6 +3113,9 @@ function RefreshPocketVotes(iIsUs)
 					g_bAnyVoteUs = true;
 					local cInstance = g_UsPocketVoteIM:GetInstance();
 					cInstance.ProposalLabel:SetText(sProposalText);
+					if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_VOTE_COMMITMENT, g_iUs, false, g_iDealDuration, tVote.ID, tVote.VoteChoice, iNumUsVotes, tVote.Repeal)) then
+						sChoiceText = "[COLOR_NEGATIVE_TEXT]" .. sChoiceText .. "[ENDCOLOR]";
+					end
 					cInstance.VoteLabel:SetText(sChoiceText);
 					cInstance.Button:SetToolTipString(sTooltip);
 					cInstance.Button:SetVoids(g_iUs, i);
@@ -3082,6 +3131,9 @@ function RefreshPocketVotes(iIsUs)
 					g_bAnyVoteThem = true;
 					local cInstance = g_ThemPocketVoteIM:GetInstance();
 					cInstance.ProposalLabel:SetText(sProposalText);
+					if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_VOTE_COMMITMENT, g_iUs, true, g_iDealDuration, tVote.ID, tVote.VoteChoice, iNumUsVotes, tVote.Repeal)) then
+						sChoiceText = "[COLOR_NEGATIVE_TEXT]" .. sChoiceText .. "[ENDCOLOR]";
+					end
 					cInstance.VoteLabel:SetText(sChoiceText);
 					cInstance.Button:SetToolTipString(sTooltip);
 					cInstance.Button:SetVoids(g_iThem, i);
@@ -3267,9 +3319,13 @@ function ShowCityChooser( isUs )
         
         if ( g_Deal:IsPossibleToTradeItem( m_iFrom, m_iTo, TradeableItems.TRADE_ITEM_CITIES, pCity:GetX(), pCity:GetY() ) ) then
             local instance = m_pIM:GetInstance();
-            
-            instance.CityName:SetText( pCity:GetName() );
-            instance.CityPop:SetText( pCity:GetPopulation() );
+            if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_CITIES, g_iUs, isUs==0, g_iDealDuration, pCity:GetX(), pCity:GetY())) then
+				instance.CityName:SetText("[COLOR_NEGATIVE_TEXT]" ..  pCity:GetName()  .."[ENDCOLOR]")
+				instance.CityPop:SetText("[COLOR_NEGATIVE_TEXT]" ..  pCity:GetPopulation()  .."[ENDCOLOR]");
+			else
+				instance.CityName:SetText( pCity:GetName() );
+				instance.CityPop:SetText( pCity:GetPopulation() );
+			end
             instance.Button:SetVoids( m_iFrom, iCityID );
             instance.Button:RegisterCallback( Mouse.eLClick, OnChooseCity );
             
@@ -3361,8 +3417,19 @@ function ShowOtherPlayerChooser(isUs, type)
 				otherPlayerButtonSubTableNameButton:SetHide(false);
 				local strTooltip = "";
 
+				local szName;
+				if( pLoopPlayer:IsHuman() ) then
+					szName = pLoopPlayer:GetNickName();
+				else
+					szName = pLoopPlayer:GetName();
+				end
+				szName = szName .. " (" .. Locale.ConvertTextKey(GameInfo.Civilizations[pLoopPlayer:GetCivilizationType()].ShortDescription) .. ")";
+					
 				if (g_Deal:IsPossibleToTradeItem(iFromPlayer, iToPlayer, tradeType, iLoopTeam)) then
 					otherPlayerButtonSubTableNameButton:SetDisabled(false);
+					if(g_pThem:IsTradeItemValuedImpossible(tradeType, g_iUs, isUs==0, g_iDealDuration, iLoopTeam)) then
+						szName = "[COLOR_NEGATIVE_TEXT]" .. szName .. "[ENDCOLOR]";
+					end
 					otherPlayerButtonSubTableNameButton:SetAlpha(1);
 				else
 					otherPlayerButtonSubTableNameButton:SetDisabled(true);
@@ -3375,6 +3442,7 @@ function ShowOtherPlayerChooser(isUs, type)
 					end
 				end
 
+				TruncateString(otherPlayerButton[SubTableName].Name, otherPlayerButton[SubTableName].ButtonSize:GetSizeX() - otherPlayerButton[SubTableName].Name:GetOffsetX(), szName);
 				otherPlayerButtonSubTableNameButton:SetToolTipString(strTooltip);
 			end
 		end

--- a/(2) Vox Populi/LUA/TradeLogic.lua
+++ b/(2) Vox Populi/LUA/TradeLogic.lua
@@ -1468,7 +1468,11 @@ function ResetDisplay()
 		end
 	else
 	    Controls.UsPocketGoldPerTurn:SetDisabled(false);
-	    Controls.UsPocketGoldPerTurn:GetTextControl():SetColorByName("Beige_Black");
+		if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_GOLD_PER_TURN, g_iUs, false, g_iDealDuration, 1)) then
+			Controls.UsPocketGoldPerTurn:GetTextControl():SetColorByName("Red_Black");
+		else
+			Controls.UsPocketGoldPerTurn:GetTextControl():SetColorByName("Beige_Black");
+		end
 		Controls.UsPocketGoldPerTurn:SetToolTipString(nil);
     end
 
@@ -1498,7 +1502,11 @@ function ResetDisplay()
 		end
 	else
 	    Controls.ThemPocketGoldPerTurn:SetDisabled(false);
-	    Controls.ThemPocketGoldPerTurn:GetTextControl():SetColorByName("Beige_Black");
+		if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_GOLD_PER_TURN, g_iUs, true, g_iDealDuration, 1)) then
+			Controls.ThemPocketGoldPerTurn:GetTextControl():SetColorByName("Red_Black");
+		else
+			Controls.ThemPocketGoldPerTurn:GetTextControl():SetColorByName("Beige_Black");
+		end
 		Controls.ThemPocketGoldPerTurn:SetToolTipString(nil);
     end
 
@@ -1526,7 +1534,11 @@ function ResetDisplay()
 			end
 		else
 			Controls.UsPocketAllowEmbassy:SetDisabled(false);
-			Controls.UsPocketAllowEmbassy:GetTextControl():SetColorByName("Beige_Black");
+			if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_ALLOW_EMBASSY, g_iUs, false, g_iDealDuration)) then
+				Controls.UsPocketAllowEmbassy:GetTextControl():SetColorByName("Red_Black");
+			else
+				Controls.UsPocketAllowEmbassy:GetTextControl():SetColorByName("Beige_Black");
+			end
 			Controls.UsPocketAllowEmbassy:SetToolTipString(strTooltip);
 		end
 
@@ -1548,7 +1560,11 @@ function ResetDisplay()
 			end
 		else
 			Controls.ThemPocketAllowEmbassy:SetDisabled(false);
-			Controls.ThemPocketAllowEmbassy:GetTextControl():SetColorByName("Beige_Black");
+			if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_ALLOW_EMBASSY, g_iUs, true, g_iDealDuration)) then
+				Controls.ThemPocketAllowEmbassy:GetTextControl():SetColorByName("Red_Black");
+			else
+				Controls.ThemPocketAllowEmbassy:GetTextControl():SetColorByName("Beige_Black");
+			end
 			Controls.ThemPocketAllowEmbassy:SetToolTipString(strTooltip);
 		end
 	end
@@ -1577,7 +1593,11 @@ function ResetDisplay()
 			end
 		else
 			Controls.UsPocketOpenBorders:SetDisabled(false);
-			Controls.UsPocketOpenBorders:GetTextControl():SetColorByName("Beige_Black");
+			if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_OPEN_BORDERS, g_iUs, false, g_iDealDuration)) then
+				Controls.UsPocketOpenBorders:GetTextControl():SetColorByName("Red_Black");
+			else
+				Controls.UsPocketOpenBorders:GetTextControl():SetColorByName("Beige_Black");
+			end
 			Controls.UsPocketOpenBorders:SetToolTipString(strTooltip);
 		end
 
@@ -1599,7 +1619,11 @@ function ResetDisplay()
 			end
 		else
 			Controls.ThemPocketOpenBorders:SetDisabled(false);
-			Controls.ThemPocketOpenBorders:GetTextControl():SetColorByName("Beige_Black");
+			if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_OPEN_BORDERS, g_iUs, true, g_iDealDuration)) then
+				Controls.ThemPocketOpenBorders:GetTextControl():SetColorByName("Red_Black");
+			else
+				Controls.ThemPocketOpenBorders:GetTextControl():SetColorByName("Beige_Black");
+			end
 			Controls.ThemPocketOpenBorders:SetToolTipString(strTooltip);
 		end
 	end
@@ -1634,7 +1658,11 @@ function ResetDisplay()
 			end
 		else
 			Controls.UsPocketDefensivePact:SetDisabled(false);
-			Controls.UsPocketDefensivePact:GetTextControl():SetColorByName("Beige_Black");
+			if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_DEFENSIVE_PACT, g_iUs, false, g_iDealDuration)) then
+				Controls.UsPocketDefensivePact:GetTextControl():SetColorByName("Red_Black");
+			else
+				Controls.UsPocketDefensivePact:GetTextControl():SetColorByName("Beige_Black");
+			end
 			Controls.UsPocketDefensivePact:SetToolTipString(strTooltip);
 		end
 
@@ -1656,7 +1684,11 @@ function ResetDisplay()
 			end
 		else
 			Controls.ThemPocketDefensivePact:SetDisabled(false);
-			Controls.ThemPocketDefensivePact:GetTextControl():SetColorByName("Beige_Black");
+			if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_DEFENSIVE_PACT, g_iUs, true, g_iDealDuration)) then
+				Controls.ThemPocketDefensivePact:GetTextControl():SetColorByName("Red_Black");
+			else
+				Controls.ThemPocketDefensivePact:GetTextControl():SetColorByName("Beige_Black");
+			end
 			Controls.ThemPocketDefensivePact:SetToolTipString(strTooltip);
 		end
 	end
@@ -1685,7 +1717,11 @@ function ResetDisplay()
 			end
 		else
 			Controls.UsPocketResearchAgreement:SetDisabled(false);
-			Controls.UsPocketResearchAgreement:GetTextControl():SetColorByName("Beige_Black");
+			if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_RESEARCH_AGREEMENT, g_iUs, false, g_iDealDuration)) then
+				Controls.UsPocketResearchAgreement:GetTextControl():SetColorByName("Red_Black");
+			else
+				Controls.UsPocketResearchAgreement:GetTextControl():SetColorByName("Beige_Black");
+			end
 			Controls.UsPocketResearchAgreement:SetToolTipString(strTooltip);
 		end
 
@@ -1707,7 +1743,11 @@ function ResetDisplay()
 			end
 		else
 			Controls.ThemPocketResearchAgreement:SetDisabled(false);
-			Controls.ThemPocketResearchAgreement:GetTextControl():SetColorByName("Beige_Black");
+			if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_RESEARCH_AGREEMENT, g_iUs, true, g_iDealDuration)) then
+				Controls.ThemPocketResearchAgreement:GetTextControl():SetColorByName("Red_Black");
+			else
+				Controls.ThemPocketResearchAgreement:GetTextControl():SetColorByName("Beige_Black");
+			end
 			Controls.ThemPocketResearchAgreement:SetToolTipString(strTooltip);
 		end
 	end
@@ -1880,11 +1920,13 @@ function ResetDisplay()
 
 			pResource = GameInfo.Resources[resType];
 			iResourceCount = g_pUs:GetNumResourceAvailable(resType, false);
+			strString = pResource.IconString .. " " .. Locale.ConvertTextKey(pResource.Description) .. " (" .. iResourceCount .. ")";
+			if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_RESOURCES, g_iUs, false, g_iDealDuration, resType, 1)) then
+				strString = "[COLOR_NEGATIVE_TEXT]" .. strString .."[ENDCOLOR]";
+			end
 			-- VP Dutch UA. This use hardcoded stuff ok dont rework the UA or ur stinky add a method or something
 			if (g_pUs:GetCivilizationType() == GameInfoTypes.CIVILIZATION_NETHERLANDS and (g_pUs:GetResourceExport(resType) > 0 or g_pUs:GetResourceImport(resType) > 0) and pResource.ResourceUsage == 2) then
-				strString = "[ICON_CHECKBOX] " .. pResource.IconString .. " " .. Locale.ConvertTextKey(pResource.Description) .. " (" .. iResourceCount .. ")";
-			else
-				strString = pResource.IconString .. " " .. Locale.ConvertTextKey(pResource.Description) .. " (" .. iResourceCount .. ")";
+				strString = "[ICON_CHECKBOX] " .. strString;
 			end
 			instance.Button:SetText(strString);
 		else
@@ -1963,11 +2005,13 @@ function ResetDisplay()
 			
 			pResource = GameInfo.Resources[resType];
 			iResourceCount = g_pThem:GetNumResourceAvailable(resType, false);
+			strString = pResource.IconString .. " " .. Locale.ConvertTextKey(pResource.Description) .. " (" .. iResourceCount .. ")";
+			if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_RESOURCES, g_iUs, true, g_iDealDuration, resType, 1)) then
+				strString = "[COLOR_NEGATIVE_TEXT]" .. strString .."[ENDCOLOR]";
+			end
 			-- VP Dutch UA / City-State stuff. Checks if you already own one.
 			if (g_pUs:IsShowImports() and (g_pUs:GetResourceExport(resType) > 0 or g_pUs:GetResourceImport(resType) > 0) and pResource.ResourceUsage == 2) then
-				strString = "[ICON_CHECKBOX] " .. pResource.IconString .. " " .. Locale.ConvertTextKey(pResource.Description) .. " (" .. iResourceCount .. ")";
-			else 
-				strString = pResource.IconString .. " " .. Locale.ConvertTextKey(pResource.Description) .. " (" .. iResourceCount .. ")";
+				strString = "[ICON_CHECKBOX] " .. strString;
 			end
 			
 			-- Add a happy face if WLTKD procs something here I guess
@@ -2142,7 +2186,11 @@ function ResetDisplay()
 			end
 		else
 			Controls.UsPocketTradeMap:SetDisabled(false);
-			Controls.UsPocketTradeMap:GetTextControl():SetColorByName("Beige_Black");
+			if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_MAPS, g_iUs, false, g_iDealDuration)) then
+				Controls.UsPocketTradeMap:GetTextControl():SetColorByName("Red_Black");
+			else
+				Controls.UsPocketTradeMap:GetTextControl():SetColorByName("Beige_Black");
+			end
 			Controls.UsPocketTradeMap:SetToolTipString(strTooltip);
 		end
 
@@ -2164,7 +2212,11 @@ function ResetDisplay()
 			end
 		else
 			Controls.ThemPocketTradeMap:SetDisabled(false);
-			Controls.ThemPocketTradeMap:GetTextControl():SetColorByName("Beige_Black");
+			if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_MAPS, g_iUs, true, g_iDealDuration)) then
+				Controls.ThemPocketTradeMap:GetTextControl():SetColorByName("Red_Black");
+			else
+				Controls.ThemPocketTradeMap:GetTextControl():SetColorByName("Beige_Black");
+			end
 			Controls.ThemPocketTradeMap:SetToolTipString(strTooltip);
 		end
 	end
@@ -2201,7 +2253,11 @@ function ResetDisplay()
 			end
 		else
 			Controls.UsPocketVassalage:SetDisabled(false);
-			Controls.UsPocketVassalage:GetTextControl():SetColorByName("Beige_Black");
+			if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_VASSALAGE, g_iUs, false, g_iDealDuration)) then
+				Controls.UsPocketVassalage:GetTextControl():SetColorByName("Red_Black");
+			else
+				Controls.UsPocketVassalage:GetTextControl():SetColorByName("Beige_Black");
+			end
 			Controls.UsPocketVassalage:SetToolTipString(strTooltip);
 		end
 
@@ -2223,7 +2279,11 @@ function ResetDisplay()
 			end
 		else
 			Controls.ThemPocketVassalage:SetDisabled(false);
-			Controls.ThemPocketVassalage:GetTextControl():SetColorByName("Beige_Black");
+			if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_VASSALAGE, g_iUs, true, g_iDealDuration)) then
+				Controls.ThemPocketVassalage:GetTextControl():SetColorByName("Red_Black");
+			else
+				Controls.ThemPocketVassalage:GetTextControl():SetColorByName("Beige_Black");
+			end
 			Controls.ThemPocketVassalage:SetToolTipString(strTooltip);
 		end
 	end
@@ -2252,7 +2312,11 @@ function ResetDisplay()
 			end
 		else
 			Controls.UsPocketRevokeVassalage:SetDisabled(false);
-			Controls.UsPocketRevokeVassalage:GetTextControl():SetColorByName("Beige_Black");
+			if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_VASSALAGE_REVOKE, g_iUs, false, g_iDealDuration)) then
+				Controls.UsPocketRevokeVassalage:GetTextControl():SetColorByName("Red_Black");
+			else
+				Controls.UsPocketRevokeVassalage:GetTextControl():SetColorByName("Beige_Black");
+			end
 			Controls.UsPocketRevokeVassalage:SetToolTipString(strTooltip);
 		end
 
@@ -2274,7 +2338,11 @@ function ResetDisplay()
 			end
 		else
 			Controls.ThemPocketRevokeVassalage:SetDisabled(false);
-			Controls.ThemPocketRevokeVassalage:GetTextControl():SetColorByName("Beige_Black");
+			if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_VASSALAGE_REVOKE, g_iUs, true, g_iDealDuration)) then
+				Controls.ThemPocketRevokeVassalage:GetTextControl():SetColorByName("Red_Black");
+			else
+				Controls.ThemPocketRevokeVassalage:GetTextControl():SetColorByName("Beige_Black");
+			end
 			Controls.ThemPocketRevokeVassalage:SetToolTipString(strTooltip);
 		end
 	end
@@ -2297,7 +2365,11 @@ function ResetDisplay()
 				bFoundTech = true;
 				instance.Button:SetHide(false);
 				pTech = GameInfo.Technologies[techType];
-				instance.Button:SetText(Locale.ConvertTextKey(pTech.Description));
+				strString =  Locale.ConvertTextKey(pTech.Description);
+				if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_TECHS, g_iUs, false, g_iDealDuration, techType)) then
+					strString = "[COLOR_NEGATIVE_TEXT]" .. strString .."[ENDCOLOR]";
+				end
+				instance.Button:SetText(strString);
 				instance.Button:SetToolTipString(GetShortHelpTextForTech(pTech.ID, false));
 			else
 				instance.Button:SetHide(true);
@@ -2361,7 +2433,11 @@ function ResetDisplay()
 				bFoundTech = true;
 				instance.Button:SetHide(false);
 				pTech = GameInfo.Technologies[techType];
-				instance.Button:SetText(Locale.ConvertTextKey(pTech.Description));
+				strString =  Locale.ConvertTextKey(pTech.Description);
+				if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_TECHS, g_iUs, true, g_iDealDuration, techType)) then
+					strString = "[COLOR_NEGATIVE_TEXT]" .. strString .."[ENDCOLOR]";
+				end
+				instance.Button:SetText(strString);
 				instance.Button:SetToolTipString(GetShortHelpTextForTech(pTech.ID, false));
 			else
 				instance.Button:SetHide(true);
@@ -3761,6 +3837,9 @@ function RefreshPocketVotes(iIsUs)
 					g_bAnyVoteUs = true;
 					local cInstance = g_UsPocketVoteIM:GetInstance();
 					cInstance.ProposalLabel:SetText(sProposalText);
+					if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_VOTE_COMMITMENT, g_iUs, false, g_iDealDuration, tVote.ID, tVote.VoteChoice, iNumUsVotes, tVote.Repeal)) then
+						sChoiceText = "[COLOR_NEGATIVE_TEXT]" .. sChoiceText .. "[ENDCOLOR]";
+					end
 					cInstance.VoteLabel:SetText(sChoiceText);
 					cInstance.Button:SetToolTipString(sTooltip);
 					cInstance.Button:SetVoids(g_iUs, i);
@@ -3776,6 +3855,9 @@ function RefreshPocketVotes(iIsUs)
 					g_bAnyVoteThem = true;
 					local cInstance = g_ThemPocketVoteIM:GetInstance();
 					cInstance.ProposalLabel:SetText(sProposalText);
+					if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_VOTE_COMMITMENT, g_iUs, true, g_iDealDuration, tVote.ID, tVote.VoteChoice, iNumUsVotes, tVote.Repeal)) then
+						sChoiceText = "[COLOR_NEGATIVE_TEXT]" .. sChoiceText .. "[ENDCOLOR]";
+					end
 					cInstance.VoteLabel:SetText(sChoiceText);
 					cInstance.Button:SetToolTipString(sTooltip);
 					cInstance.Button:SetVoids(g_iThem, i);
@@ -3961,9 +4043,13 @@ function ShowCityChooser( isUs )
         
         if ( g_Deal:IsPossibleToTradeItem( m_iFrom, m_iTo, TradeableItems.TRADE_ITEM_CITIES, pCity:GetX(), pCity:GetY() ) ) then
             local instance = m_pIM:GetInstance();
-            
-            instance.CityName:SetText( pCity:GetName() );
-            instance.CityPop:SetText( pCity:GetPopulation() );
+            if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_CITIES, g_iUs, isUs==0, g_iDealDuration, pCity:GetX(), pCity:GetY())) then
+				instance.CityName:SetText("[COLOR_NEGATIVE_TEXT]" ..  pCity:GetName()  .."[ENDCOLOR]")
+				instance.CityPop:SetText("[COLOR_NEGATIVE_TEXT]" ..  pCity:GetPopulation()  .."[ENDCOLOR]");
+			else
+				instance.CityName:SetText( pCity:GetName() );
+				instance.CityPop:SetText( pCity:GetPopulation() );
+			end
             instance.Button:SetVoids( m_iFrom, iCityID );
             instance.Button:RegisterCallback( Mouse.eLClick, OnChooseCity );
             
@@ -4056,8 +4142,19 @@ function ShowOtherPlayerChooser(isUs, type)
 				otherPlayerButtonSubTableNameButton:SetHide(false);
 				local strTooltip = "";
 
+				local szName;
+				if( pLoopPlayer:IsHuman() ) then
+					szName = pLoopPlayer:GetNickName();
+				else
+					szName = pLoopPlayer:GetName();
+				end
+				szName = szName .. " (" .. Locale.ConvertTextKey(GameInfo.Civilizations[pLoopPlayer:GetCivilizationType()].ShortDescription) .. ")";
+					
 				if (g_Deal:IsPossibleToTradeItem(iFromPlayer, iToPlayer, tradeType, iLoopTeam)) then
 					otherPlayerButtonSubTableNameButton:SetDisabled(false);
+					if(g_pThem:IsTradeItemValuedImpossible(tradeType, g_iUs, isUs==0, g_iDealDuration, iLoopTeam)) then
+						szName = "[COLOR_NEGATIVE_TEXT]" .. szName .. "[ENDCOLOR]";
+					end
 					otherPlayerButtonSubTableNameButton:SetAlpha(1);
 				else
 					otherPlayerButtonSubTableNameButton:SetDisabled(true);
@@ -4072,6 +4169,7 @@ function ShowOtherPlayerChooser(isUs, type)
 					end
 				end
 
+				TruncateString(otherPlayerButton[SubTableName].Name, otherPlayerButton[SubTableName].ButtonSize:GetSizeX() - otherPlayerButton[SubTableName].Name:GetOffsetX(), szName);
 				otherPlayerButtonSubTableNameButton:SetToolTipString(strTooltip);
 			end
 		end

--- a/(3a) EUI Compatibility Files/LUA/TradeLogic.lua
+++ b/(3a) EUI Compatibility Files/LUA/TradeLogic.lua
@@ -1457,7 +1457,11 @@ function ResetDisplay()
 		end
 	else
 	    Controls.UsPocketGoldPerTurn:SetDisabled(false);
-	    Controls.UsPocketGoldPerTurn:GetTextControl():SetColorByName("Beige_Black");
+		if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_GOLD_PER_TURN, g_iUs, false, g_iDealDuration, 1)) then
+			Controls.UsPocketGoldPerTurn:GetTextControl():SetColorByName("Red_Black");
+		else
+			Controls.UsPocketGoldPerTurn:GetTextControl():SetColorByName("Beige_Black");
+		end
 		Controls.UsPocketGoldPerTurn:SetToolTipString(nil);
     end
 
@@ -1487,7 +1491,11 @@ function ResetDisplay()
 		end
 	else
 	    Controls.ThemPocketGoldPerTurn:SetDisabled(false);
-	    Controls.ThemPocketGoldPerTurn:GetTextControl():SetColorByName("Beige_Black");
+	    if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_GOLD_PER_TURN, g_iUs, true, g_iDealDuration, 1)) then
+			Controls.ThemPocketGoldPerTurn:GetTextControl():SetColorByName("Red_Black");
+		else
+			Controls.ThemPocketGoldPerTurn:GetTextControl():SetColorByName("Beige_Black");
+		end
 		Controls.ThemPocketGoldPerTurn:SetToolTipString(nil);
     end
 
@@ -1515,7 +1523,11 @@ function ResetDisplay()
 			end
 		else
 			Controls.UsPocketAllowEmbassy:SetDisabled(false);
-			Controls.UsPocketAllowEmbassy:GetTextControl():SetColorByName("Beige_Black");
+			if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_ALLOW_EMBASSY, g_iUs, false, g_iDealDuration)) then
+				Controls.UsPocketAllowEmbassy:GetTextControl():SetColorByName("Red_Black");
+			else
+				Controls.UsPocketAllowEmbassy:GetTextControl():SetColorByName("Beige_Black");
+			end
 			Controls.UsPocketAllowEmbassy:SetToolTipString(strTooltip);
 		end
 
@@ -1537,7 +1549,11 @@ function ResetDisplay()
 			end
 		else
 			Controls.ThemPocketAllowEmbassy:SetDisabled(false);
-			Controls.ThemPocketAllowEmbassy:GetTextControl():SetColorByName("Beige_Black");
+			if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_ALLOW_EMBASSY, g_iUs, true, g_iDealDuration)) then
+				Controls.ThemPocketAllowEmbassy:GetTextControl():SetColorByName("Red_Black");
+			else
+				Controls.ThemPocketAllowEmbassy:GetTextControl():SetColorByName("Beige_Black");
+			end
 			Controls.ThemPocketAllowEmbassy:SetToolTipString(strTooltip);
 		end
 	end
@@ -1566,7 +1582,11 @@ function ResetDisplay()
 			end
 		else
 			Controls.UsPocketOpenBorders:SetDisabled(false);
-			Controls.UsPocketOpenBorders:GetTextControl():SetColorByName("Beige_Black");
+			if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_OPEN_BORDERS, g_iUs, false, g_iDealDuration)) then
+				Controls.UsPocketOpenBorders:GetTextControl():SetColorByName("Red_Black");
+			else
+				Controls.UsPocketOpenBorders:GetTextControl():SetColorByName("Beige_Black");
+			end
 			Controls.UsPocketOpenBorders:SetToolTipString(strTooltip);
 		end
 
@@ -1588,7 +1608,11 @@ function ResetDisplay()
 			end
 		else
 			Controls.ThemPocketOpenBorders:SetDisabled(false);
-			Controls.ThemPocketOpenBorders:GetTextControl():SetColorByName("Beige_Black");
+			if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_OPEN_BORDERS, g_iUs, true, g_iDealDuration)) then
+				Controls.ThemPocketOpenBorders:GetTextControl():SetColorByName("Red_Black");
+			else
+				Controls.ThemPocketOpenBorders:GetTextControl():SetColorByName("Beige_Black");
+			end
 			Controls.ThemPocketOpenBorders:SetToolTipString(strTooltip);
 		end
 	end
@@ -1623,7 +1647,11 @@ function ResetDisplay()
 			end
 		else
 			Controls.UsPocketDefensivePact:SetDisabled(false);
-			Controls.UsPocketDefensivePact:GetTextControl():SetColorByName("Beige_Black");
+			if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_DEFENSIVE_PACT, g_iUs, false, g_iDealDuration)) then
+				Controls.UsPocketDefensivePact:GetTextControl():SetColorByName("Red_Black");
+			else
+				Controls.UsPocketDefensivePact:GetTextControl():SetColorByName("Beige_Black");
+			end
 			Controls.UsPocketDefensivePact:SetToolTipString(strTooltip);
 		end
 
@@ -1645,7 +1673,11 @@ function ResetDisplay()
 			end
 		else
 			Controls.ThemPocketDefensivePact:SetDisabled(false);
-			Controls.ThemPocketDefensivePact:GetTextControl():SetColorByName("Beige_Black");
+			if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_DEFENSIVE_PACT, g_iUs, true, g_iDealDuration)) then
+				Controls.ThemPocketDefensivePact:GetTextControl():SetColorByName("Red_Black");
+			else
+				Controls.ThemPocketDefensivePact:GetTextControl():SetColorByName("Beige_Black");
+			end
 			Controls.ThemPocketDefensivePact:SetToolTipString(strTooltip);
 		end
 	end
@@ -1674,7 +1706,11 @@ function ResetDisplay()
 			end
 		else
 			Controls.UsPocketResearchAgreement:SetDisabled(false);
-			Controls.UsPocketResearchAgreement:GetTextControl():SetColorByName("Beige_Black");
+			if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_RESEARCH_AGREEMENT, g_iUs, false, g_iDealDuration)) then
+				Controls.UsPocketResearchAgreement:GetTextControl():SetColorByName("Red_Black");
+			else
+				Controls.UsPocketResearchAgreement:GetTextControl():SetColorByName("Beige_Black");
+			end
 			Controls.UsPocketResearchAgreement:SetToolTipString(strTooltip);
 		end
 
@@ -1696,7 +1732,11 @@ function ResetDisplay()
 			end
 		else
 			Controls.ThemPocketResearchAgreement:SetDisabled(false);
-			Controls.ThemPocketResearchAgreement:GetTextControl():SetColorByName("Beige_Black");
+			if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_RESEARCH_AGREEMENT, g_iUs, true, g_iDealDuration)) then
+				Controls.ThemPocketResearchAgreement:GetTextControl():SetColorByName("Red_Black");
+			else
+				Controls.ThemPocketResearchAgreement:GetTextControl():SetColorByName("Beige_Black");
+			end
 			Controls.ThemPocketResearchAgreement:SetToolTipString(strTooltip);
 		end
 	end
@@ -1869,11 +1909,13 @@ function ResetDisplay()
 
 			pResource = GameInfo.Resources[resType];
 			iResourceCount = g_pUs:GetNumResourceAvailable(resType, false);
+			strString = pResource.IconString .. " " .. Locale.ConvertTextKey(pResource.Description) .. " (" .. iResourceCount .. ")";
+			if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_RESOURCES, g_iUs, false, g_iDealDuration, resType, 1)) then
+				strString = "[COLOR_NEGATIVE_TEXT]" .. strString .."[ENDCOLOR]";
+			end
 			-- VP Dutch UA. This use hardcoded stuff ok dont rework the UA or ur stinky add a method or something
 			if (g_pUs:GetCivilizationType() == GameInfoTypes.CIVILIZATION_NETHERLANDS and (g_pUs:GetResourceExport(resType) > 0 or g_pUs:GetResourceImport(resType) > 0) and pResource.ResourceUsage == 2) then
-				strString = "[ICON_CHECKBOX] " .. pResource.IconString .. " " .. Locale.ConvertTextKey(pResource.Description) .. " (" .. iResourceCount .. ")";
-			else
-				strString = pResource.IconString .. " " .. Locale.ConvertTextKey(pResource.Description) .. " (" .. iResourceCount .. ")";
+				strString = "[ICON_CHECKBOX] " .. strString;
 			end
 			instance.Button:SetText(strString);
 		else
@@ -1953,11 +1995,13 @@ function ResetDisplay()
 			pResource = GameInfo.Resources[resType];
 			
 			iResourceCount = g_pThem:GetNumResourceAvailable(resType, false);
+			strString = pResource.IconString .. " " .. Locale.ConvertTextKey(pResource.Description) .. " (" .. iResourceCount .. ")";
+			if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_RESOURCES, g_iUs, true, g_iDealDuration, resType, 1)) then
+				strString = "[COLOR_NEGATIVE_TEXT]" .. strString .."[ENDCOLOR]";
+			end
 			-- VP Dutch UA / City-State stuff. Checks if you already own one.
 			if (g_pUs:IsShowImports() and (g_pUs:GetResourceExport(resType) > 0 or g_pUs:GetResourceImport(resType) > 0) and pResource.ResourceUsage == 2) then
-				strString = "[ICON_CHECKBOX] " .. pResource.IconString .. " " .. Locale.ConvertTextKey(pResource.Description) .. " (" .. iResourceCount .. ")";
-			else 
-				strString = pResource.IconString .. " " .. Locale.ConvertTextKey(pResource.Description) .. " (" .. iResourceCount .. ")";
+				strString = "[ICON_CHECKBOX] " .. strString;
 			end
 			
 			-- Add a happy face if WLTKD procs something here I guess
@@ -2132,7 +2176,11 @@ function ResetDisplay()
 			end
 		else
 			Controls.UsPocketTradeMap:SetDisabled(false);
-			Controls.UsPocketTradeMap:GetTextControl():SetColorByName("Beige_Black");
+			if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_MAPS, g_iUs, false, g_iDealDuration)) then
+				Controls.UsPocketTradeMap:GetTextControl():SetColorByName("Red_Black");
+			else
+				Controls.UsPocketTradeMap:GetTextControl():SetColorByName("Beige_Black");
+			end
 			Controls.UsPocketTradeMap:SetToolTipString(strTooltip);
 		end
 
@@ -2154,7 +2202,11 @@ function ResetDisplay()
 			end
 		else
 			Controls.ThemPocketTradeMap:SetDisabled(false);
-			Controls.ThemPocketTradeMap:GetTextControl():SetColorByName("Beige_Black");
+			if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_MAPS, g_iUs, true, g_iDealDuration)) then
+				Controls.ThemPocketTradeMap:GetTextControl():SetColorByName("Red_Black");
+			else
+				Controls.ThemPocketTradeMap:GetTextControl():SetColorByName("Beige_Black");
+			end
 			Controls.ThemPocketTradeMap:SetToolTipString(strTooltip);
 		end
 	end
@@ -2191,7 +2243,11 @@ function ResetDisplay()
 			end
 		else
 			Controls.UsPocketVassalage:SetDisabled(false);
-			Controls.UsPocketVassalage:GetTextControl():SetColorByName("Beige_Black");
+			if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_VASSALAGE, g_iUs, false, g_iDealDuration)) then
+				Controls.UsPocketVassalage:GetTextControl():SetColorByName("Red_Black");
+			else
+				Controls.UsPocketVassalage:GetTextControl():SetColorByName("Beige_Black");
+			end
 			Controls.UsPocketVassalage:SetToolTipString(strTooltip);
 		end
 
@@ -2213,7 +2269,11 @@ function ResetDisplay()
 			end
 		else
 			Controls.ThemPocketVassalage:SetDisabled(false);
-			Controls.ThemPocketVassalage:GetTextControl():SetColorByName("Beige_Black");
+			if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_VASSALAGE, g_iUs, true, g_iDealDuration)) then
+				Controls.ThemPocketVassalage:GetTextControl():SetColorByName("Red_Black");
+			else
+				Controls.ThemPocketVassalage:GetTextControl():SetColorByName("Beige_Black");
+			end
 			Controls.ThemPocketVassalage:SetToolTipString(strTooltip);
 		end
 	end
@@ -2242,7 +2302,11 @@ function ResetDisplay()
 			end
 		else
 			Controls.UsPocketRevokeVassalage:SetDisabled(false);
-			Controls.UsPocketRevokeVassalage:GetTextControl():SetColorByName("Beige_Black");
+			if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_VASSALAGE_REVOKE, g_iUs, false, g_iDealDuration)) then
+				Controls.UsPocketRevokeVassalage:GetTextControl():SetColorByName("Red_Black");
+			else
+				Controls.UsPocketRevokeVassalage:GetTextControl():SetColorByName("Beige_Black");
+			end
 			Controls.UsPocketRevokeVassalage:SetToolTipString(strTooltip);
 		end
 
@@ -2264,7 +2328,11 @@ function ResetDisplay()
 			end
 		else
 			Controls.ThemPocketRevokeVassalage:SetDisabled(false);
-			Controls.ThemPocketRevokeVassalage:GetTextControl():SetColorByName("Beige_Black");
+			if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_VASSALAGE_REVOKE, g_iUs, true, g_iDealDuration)) then
+				Controls.ThemPocketRevokeVassalage:GetTextControl():SetColorByName("Red_Black");
+			else
+				Controls.ThemPocketRevokeVassalage:GetTextControl():SetColorByName("Beige_Black");
+			end
 			Controls.ThemPocketRevokeVassalage:SetToolTipString(strTooltip);
 		end
 	end
@@ -2287,7 +2355,11 @@ function ResetDisplay()
 				bFoundTech = true;
 				instance.Button:SetHide(false);
 				pTech = GameInfo.Technologies[techType];
-				instance.Button:SetText(Locale.ConvertTextKey(pTech.Description));
+				strString =  Locale.ConvertTextKey(pTech.Description);
+				if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_TECHS, g_iUs, false, g_iDealDuration, techType)) then
+					strString = "[COLOR_NEGATIVE_TEXT]" .. strString .."[ENDCOLOR]";
+				end
+				instance.Button:SetText(strString);
 				instance.Button:SetToolTipString(GetShortHelpTextForTech(pTech.ID, false));
 			else
 				instance.Button:SetHide(true);
@@ -2351,7 +2423,11 @@ function ResetDisplay()
 				bFoundTech = true;
 				instance.Button:SetHide(false);
 				pTech = GameInfo.Technologies[techType];
-				instance.Button:SetText(Locale.ConvertTextKey(pTech.Description));
+				strString =  Locale.ConvertTextKey(pTech.Description);
+				if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_TECHS, g_iUs, true, g_iDealDuration, techType)) then
+					strString = "[COLOR_NEGATIVE_TEXT]" .. strString .."[ENDCOLOR]";
+				end
+				instance.Button:SetText(strString);
 				instance.Button:SetToolTipString(GetShortHelpTextForTech(pTech.ID, false));
 			else
 				instance.Button:SetHide(true);
@@ -3765,6 +3841,9 @@ function RefreshPocketVotes(iIsUs)
 					g_bAnyVoteUs = true;
 					local cInstance = g_UsPocketVoteIM:GetInstance();
 					cInstance.ProposalLabel:SetText(sProposalText);
+					if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_VOTE_COMMITMENT, g_iUs, false, g_iDealDuration, tVote.ID, tVote.VoteChoice, iNumUsVotes, tVote.Repeal)) then
+						sChoiceText = "[COLOR_NEGATIVE_TEXT]" .. sChoiceText .. "[ENDCOLOR]";
+					end
 					cInstance.VoteLabel:SetText(sChoiceText);
 					cInstance.Button:SetToolTipString(sTooltip);
 					cInstance.Button:SetVoids(g_iUs, i);
@@ -3780,6 +3859,9 @@ function RefreshPocketVotes(iIsUs)
 					g_bAnyVoteThem = true;
 					local cInstance = g_ThemPocketVoteIM:GetInstance();
 					cInstance.ProposalLabel:SetText(sProposalText);
+					if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_VOTE_COMMITMENT, g_iUs, true, g_iDealDuration, tVote.ID, tVote.VoteChoice, iNumUsVotes, tVote.Repeal)) then
+						sChoiceText = "[COLOR_NEGATIVE_TEXT]" .. sChoiceText .. "[ENDCOLOR]";
+					end
 					cInstance.VoteLabel:SetText(sChoiceText);
 					cInstance.Button:SetToolTipString(sTooltip);
 					cInstance.Button:SetVoids(g_iThem, i);
@@ -3965,9 +4047,14 @@ function ShowCityChooser( isUs )
 
 		if ( g_Deal:IsPossibleToTradeItem( m_iFrom, m_iTo, TradeableItems.TRADE_ITEM_CITIES, pCity:GetX(), pCity:GetY() ) ) then
 			local instance = m_pIM:GetInstance();
-
-			instance.CityName:SetText( pCity:GetName() );
-			instance.CityPop:SetText( pCity:GetPopulation() );
+			if(g_pThem:IsTradeItemValuedImpossible(TradeableItems.TRADE_ITEM_CITIES, g_iUs, isUs==0
+			, g_iDealDuration, pCity:GetX(), pCity:GetY())) then
+				instance.CityName:SetText("[COLOR_NEGATIVE_TEXT]" ..  pCity:GetName()  .."[ENDCOLOR]")
+				instance.CityPop:SetText("[COLOR_NEGATIVE_TEXT]" ..  pCity:GetPopulation()  .."[ENDCOLOR]");
+			else
+				instance.CityName:SetText( pCity:GetName() );
+				instance.CityPop:SetText( pCity:GetPopulation() );
+			end
 			instance.Button:SetVoids( m_iFrom, iCityID );
 			instance.Button:RegisterCallback( Mouse.eLClick, OnChooseCity );
 
@@ -4059,9 +4146,20 @@ function ShowOtherPlayerChooser(isUs, type)
 			if (g_iUsTeam ~= iLoopTeam and g_iThemTeam ~= iLoopTeam and g_pUsTeam:IsHasMet(iLoopTeam) and g_pThemTeam:IsHasMet(iLoopTeam)) then
 				otherPlayerButtonSubTableNameButton:SetHide(false);
 				local strTooltip = "";
-
+				
+				local szName;
+				if( pLoopPlayer:IsHuman() ) then
+					szName = pLoopPlayer:GetNickName();
+				else
+					szName = pLoopPlayer:GetName();
+				end
+				szName = szName .. " (" .. Locale.ConvertTextKey(GameInfo.Civilizations[pLoopPlayer:GetCivilizationType()].ShortDescription) .. ")";
+					
 				if (g_Deal:IsPossibleToTradeItem(iFromPlayer, iToPlayer, tradeType, iLoopTeam)) then
 					otherPlayerButtonSubTableNameButton:SetDisabled(false);
+					if(g_pThem:IsTradeItemValuedImpossible(tradeType, g_iUs, isUs==0, g_iDealDuration, iLoopTeam)) then
+						szName = "[COLOR_NEGATIVE_TEXT]" .. szName .. "[ENDCOLOR]";
+					end
 					otherPlayerButtonSubTableNameButton:SetAlpha(1);
 				else
 					otherPlayerButtonSubTableNameButton:SetDisabled(true);
@@ -4076,6 +4174,7 @@ function ShowOtherPlayerChooser(isUs, type)
 					end
 				end
 
+				TruncateString(otherPlayerButton[SubTableName].Name, otherPlayerButton[SubTableName].ButtonSize:GetSizeX() - otherPlayerButton[SubTableName].Name:GetOffsetX(), szName);
 				otherPlayerButtonSubTableNameButton:SetToolTipString(strTooltip);
 			end
 		end

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
@@ -1152,6 +1152,7 @@ void CvLuaPlayer::PushMethods(lua_State* L, int t)
 
 	Method(GetEspionageCityStatus);
 	Method(IsTradeSanctioned);
+	Method(IsTradeItemValuedImpossible);
 	Method(GetTotalValueToMeNormal);
 	Method(GetTotalValueToMe);
 	Method(GetRandomIntrigue);
@@ -15630,6 +15631,31 @@ int CvLuaPlayer::lIsTradeSanctioned(lua_State* L)
 	}
 
 	lua_pushboolean(L, bResult);
+	return 1;
+}
+//------------------------------------------------------------------------------
+int CvLuaPlayer::lIsTradeItemValuedImpossible(lua_State* L)
+{
+	CvPlayerAI* pkThisPlayer = GetInstance(L);
+	const TradeableItems eItem = (TradeableItems)lua_tointeger(L, 2);
+	const PlayerTypes eOtherPlayer = (PlayerTypes)lua_tointeger(L, 3);
+	const bool bFromMe = lua_toboolean(L, 4);
+	const int iDuration = lua_tointeger(L, 5);
+	const int iData1 = luaL_optint(L, 6, -1);
+	const int iData2 = luaL_optint(L, 7, -1);
+	const int iData3 = luaL_optint(L, 8, -1);
+	const bool bFlag1 = luaL_optbool(L, 9, false);
+
+	if (!GET_PLAYER(pkThisPlayer->GetID()).isHuman())
+	{
+		int iResult = pkThisPlayer->GetDealAI()->GetTradeItemValue(eItem, bFromMe, eOtherPlayer, iData1, iData2, iData3, bFlag1, iDuration);
+		if (iResult == INT_MAX || iResult == (INT_MAX * -1))
+		{
+			lua_pushboolean(L, true);
+			return 1;
+		}
+	}
+	lua_pushboolean(L, false);
 	return 1;
 }
 //------------------------------------------------------------------------------

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.h
@@ -1258,6 +1258,7 @@ protected:
 	static int lGetCachedValueOfPeaceWithHuman(lua_State* L);
 	static int lGetTotalValueToMe(lua_State* L);
 	static int lIsTradeSanctioned(lua_State* L);
+	static int lIsTradeItemValuedImpossible(lua_State* L);
 	static int lGetTotalValueToMeNormal(lua_State* L);
 	static int lGetSpyChanceAtCity(lua_State* L);
 	static int lGetCityPotentialInfo(lua_State* L);


### PR DESCRIPTION
- Deal Items that the AI values "Impossible" are marked in red in the trade screen
![Screenshot (406)](https://github.com/LoneGazebo/Community-Patch-DLL/assets/95587882/9442371e-7f34-4240-bb3b-a9e03b1c4f0a)
- Fix Deal History not showing in Community Patch only (#10003)