### PR TITLE
AI route building logic updates

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvAStar.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAStar.cpp
@@ -2165,35 +2165,115 @@ int CityConnectionWaterValid(const CvAStarNode* parent, const CvAStarNode* node,
 }
 
 //	--------------------------------------------------------------------------------
+/// Prefer building routes that can have villages.
+int BuildRouteVillageBonus(CvPlayer* pPlayer, CvPlot* pPlot, RouteTypes eRouteType, CvBuilderTaskingAI* eBuilderTaskingAi)
+{
+	// If we're not the owner of this plot, bail out
+	if (!pPlot->isOwned() || pPlot->getOwner() != pPlayer->GetID())
+		return 0;
+
+	// We will not build a route here so no village bonus applies
+	if (eBuilderTaskingAi->GetSameRouteBenefitFromTrait(pPlot, eRouteType))
+		return 0;
+
+	// No villages on resources
+	if (pPlot->getResourceType() != NO_RESOURCE)
+		return 0;
+
+	int iBonus = 0;
+
+	ImprovementTypes eImprovement = pPlot->getImprovementType();
+	if (eImprovement != NO_IMPROVEMENT)
+	{
+		CvImprovementEntry* pkImprovementInfo = GC.getImprovementInfo(eImprovement);
+		if (pkImprovementInfo != NULL)
+		{
+			for (int iI = 0; iI < NUM_YIELD_TYPES; iI++)
+			{
+				YieldTypes eYield = (YieldTypes)iI;
+
+				// Heavily prioritize building routes over existing villages/towns
+				iBonus += pkImprovementInfo->GetRouteYieldChanges(eRouteType, eYield) * 10;
+			}
+		}
+
+		// If this improvement was built by a Great Person, we don't want to build a village here
+		if (pkImprovementInfo->IsCreatedByGreatPerson())
+			return iBonus;
+	}
+
+	for (int iI = 0; iI < GC.getNumBuildInfos(); iI++)
+	{
+		BuildTypes eBuild = (BuildTypes)iI;
+		CvBuildInfo* pkBuild = GC.getBuildInfo(eBuild);
+		if (!pkBuild)
+			continue;
+
+		// Set bTestEra to true as a hack to ensure that we consider villages even if we can not build the improvement yet
+		if (!pPlayer->canBuild(pPlot, eBuild, true))
+			continue;
+
+		eImprovement = (ImprovementTypes)pkBuild->getImprovement();
+		if (eImprovement == NO_IMPROVEMENT)
+			continue;
+
+		CvImprovementEntry* pkImprovementInfo = GC.getImprovementInfo(eImprovement);
+		if (pkImprovementInfo == NULL)
+			continue;
+
+		if (pkImprovementInfo->IsCreatedByGreatPerson())
+			continue;
+
+		for (int iYield = 0; iYield < NUM_YIELD_TYPES; iYield++)
+		{
+			YieldTypes eYield = (YieldTypes)iYield;
+
+				iBonus += pkImprovementInfo->GetRouteYieldChanges(eRouteType, eYield);
+		}
+	}
+
+	return iBonus;
+}
+
+//	--------------------------------------------------------------------------------
 /// Build route cost
 int BuildRouteCost(const CvAStarNode* /*parent*/, const CvAStarNode* node, const SPathFinderUserData& data, CvAStar*)
 {
 	CvPlot* pPlot = GC.getMap().plotUnchecked(node->m_iX, node->m_iY);
-	CvBuilderTaskingAI* eBuilderTaskingAi = GET_PLAYER(data.ePlayer).GetBuilderTaskingAI();
+	CvPlayer* pPlayer = &GET_PLAYER(data.ePlayer);
+	CvBuilderTaskingAI* eBuilderTaskingAi = pPlayer->GetBuilderTaskingAI();
 	RouteTypes eRouteType = (RouteTypes)data.iTypeParameter;
+	int iCost;
 
-	// if we are planning to or have already built a road here, or get a free road here from our trait, provide a discount (cities always have a road)
 	if(pPlot->isCity() || eBuilderTaskingAi->GetRouteTypeWantedAtPlot(pPlot) >= eRouteType || eBuilderTaskingAi->GetRouteTypeNeededAtPlot(pPlot) >= eRouteType || eBuilderTaskingAi->GetSameRouteBenefitFromTrait(pPlot, eRouteType))
-		return PATH_BUILD_ROUTE_REUSE_EXISTING_WEIGHT;
+	{
+		// if we are planning to or have already built a road here, or get a free road here from our trait, provide a discount (cities always have a road)
+		iCost = PATH_BASE_COST / 3;
+	}
+	else if ((eBuilderTaskingAi->WantRouteAtPlot(pPlot) || eBuilderTaskingAi->NeedRouteAtPlot(pPlot)) && !eBuilderTaskingAi->GetSameRouteBenefitFromTrait(pPlot, ROUTE_ROAD))
+	{
+		// if we are planning to build a lower tier route here, provide a smaller discount
+		iCost = PATH_BASE_COST / 2;
+	}
+	else if (pPlot->getRouteType() >= ROUTE_ROAD)
+	{
+		// if there is already a road here, provide a smaller discount
+		iCost = PATH_BASE_COST - 1;
+	}
+	else
+	{
+		iCost = PATH_BASE_COST;
+	}
 
-	// if we are planning to build a lower tier route here, provide a smaller discount
-	if ((eBuilderTaskingAi->WantRouteAtPlot(pPlot) || eBuilderTaskingAi->NeedRouteAtPlot(pPlot)) && !eBuilderTaskingAi->GetSameRouteBenefitFromTrait(pPlot, ROUTE_ROAD))
-		return PATH_BASE_COST / 2;
+	//too dangerous, might be severed any time
+	if (pPlot->getOwner() == NO_PLAYER && pPlot->IsAdjacentOwnedByTeamOtherThan(pPlayer->getTeam()))
+		iCost *= 3;
 
-	// if there is already a route here, also provide a small discount
-	if (pPlot->getRouteType() >= ROUTE_ROAD)
-		return PATH_BASE_COST / 2;
+	if (data.bIsForCapital)
+		iCost -= BuildRouteVillageBonus(pPlayer, pPlot, eRouteType, eBuilderTaskingAi);
 
-	//should we prefer rough terrain because the gain in movement points is greater?
-	int iCost = PATH_BASE_COST;
-
-	//can't build villages on mountains
-	if (pPlot->isMountain())
-		iCost++;
-
-	//prefer plots without resources so we can build more villages
-	if(pPlot->getResourceType()!=NO_RESOURCE)
-		iCost++;
+	if (iCost < 0)
+		iCost = 0;
 
 	return iCost;
 }
@@ -2254,7 +2334,7 @@ int BuildRouteValid(const CvAStarNode* parent, const CvAStarNode* node, const SP
 		return FALSE;
 
 	PlayerTypes ePlotOwnerPlayer = pNewPlot->getOwner();
-	if(ePlotOwnerPlayer != NO_PLAYER && !pNewPlot->IsFriendlyTerritory(ePlayer))
+	if(ePlotOwnerPlayer != NO_PLAYER && pNewPlot->getTeam() != thisPlayer.getTeam())
 	{
 		PlayerTypes eMajorPlayer = NO_PLAYER;
 		PlayerTypes eMinorPlayer = NO_PLAYER;
@@ -2283,10 +2363,6 @@ int BuildRouteValid(const CvAStarNode* parent, const CvAStarNode* node, const SP
 	//Free routes from traits are always safe
 	if (thisPlayer.GetBuilderTaskingAI()->GetSameRouteBenefitFromTrait(pNewPlot, eRoute))
 		return TRUE;
-
-	//too dangerous, might be severed any time
-	if (ePlotOwnerPlayer == NO_PLAYER && pNewPlot->IsAdjacentOwnedByTeamOtherThan(thisPlayer.getTeam()))
-		return FALSE;
 
 	//if the plot and its parent are both too far from our borders, don't build here
 	if (!IsSafeForRoute(pNewPlot, &thisPlayer))
@@ -3638,7 +3714,7 @@ SPathFinderUserData::SPathFinderUserData(const CvUnit* pUnit, int _iFlags, int _
 
 //	---------------------------------------------------------------------------
 //convenience constructor
-SPathFinderUserData::SPathFinderUserData(PlayerTypes _ePlayer, PathType _ePathType, int _iTypeParameter, int _iMaxTurns)
+SPathFinderUserData::SPathFinderUserData(PlayerTypes _ePlayer, PathType _ePathType, int _iTypeParameter, int _iMaxTurns, bool _bIsForCapital)
 {
 	ePathType = _ePathType;
 	iFlags = 0;
@@ -3649,6 +3725,7 @@ SPathFinderUserData::SPathFinderUserData(PlayerTypes _ePlayer, PathType _ePathTy
 	iMaxNormalizedDistance = INT_MAX;
 	iMinMovesLeft = 0;
 	iStartMoves = 0;
+	bIsForCapital = _bIsForCapital;
 }
 
 CvPlot * SPath::get(int i) const

--- a/CvGameCoreDLL_Expansion2/CvAStarNode.h
+++ b/CvGameCoreDLL_Expansion2/CvAStarNode.h
@@ -136,9 +136,9 @@ public:
 //-------------------------------------------------------------------------------------------------
 struct SPathFinderUserData
 {
-	SPathFinderUserData() : ePathType(PT_GENERIC_SAME_AREA), iFlags(0), ePlayer(NO_PLAYER), iUnitID(0), iTypeParameter(-1), iMaxTurns(INT_MAX), iMaxNormalizedDistance(INT_MAX), iMinMovesLeft(0), iStartMoves(60) {}
+	SPathFinderUserData() : ePathType(PT_GENERIC_SAME_AREA), iFlags(0), ePlayer(NO_PLAYER), iUnitID(0), iTypeParameter(-1), bIsForCapital(false), iMaxTurns(INT_MAX), iMaxNormalizedDistance(INT_MAX), iMinMovesLeft(0), iStartMoves(60) {}
 	SPathFinderUserData(const CvUnit* pUnit, int iFlags=0, int iMaxTurns=INT_MAX);
-	SPathFinderUserData(PlayerTypes ePlayer, PathType ePathType, int iTypeParameter=-1, int iMaxTurns=INT_MAX);
+	SPathFinderUserData(PlayerTypes ePlayer, PathType ePathType, int iTypeParameter=-1, int iMaxTurns=INT_MAX, bool bIsForCapital=false);
 
 	//do not compare max turns and max cost ...
 	bool operator==(const SPathFinderUserData& rhs) const 
@@ -147,6 +147,7 @@ struct SPathFinderUserData
 
 	PathType	ePathType;
 	int			iTypeParameter;		//route type dependent parameter
+	bool        bIsForCapital;      //route type dependent parameter
 	int			iFlags;				//see CvUnit::MOVEFLAG*
 	PlayerTypes ePlayer;			//optional
 	int			iUnitID;			//optional

--- a/CvGameCoreDLL_Expansion2/CvCityConnections.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCityConnections.cpp
@@ -126,9 +126,6 @@ void CvCityConnections::UpdatePlotsToConnect(void)
 {
 	m_plotIdsToConnect.clear();
 
-	bool bIsIndustrial = GET_TEAM(m_pPlayer->getTeam()).GetBestPossibleRoute() == GC.getGame().GetIndustrialRoute();
-	bool bHaveGoldToSpare = m_pPlayer->GetTreasury()->CalculateBaseNetGoldTimes100() > 1000;
-
 	vector<PlayerTypes> vTeamPlayers = GET_TEAM(m_pPlayer->getTeam()).getPlayers();
 	for (size_t i = 0; i < vTeamPlayers.size(); i++)
 	{


### PR DESCRIPTION
Make road building node evaluation more complex than just "does the tile have a mountain". Check whether a village can actually be built in the tile.
Now more prone to rebuild road network if there is a more optimal new path. Will heavily prefer to build road networks over existing towns and villages.
Disregard village logic if the route is for a shortcut or strategic route, since these routes generally don't give town/village bonuses.
AI will now build shortcut routes between cities even if they are not both connected to the capital yet.
AI now correctly considers value of railroads between cities in VP version.
AI now slightly more aggressive in removing old routes.
AI can now build routes in unowned tiles bordering other civilizations' borders, but they will avoid it if possible.
AI will no longer plan routes through other civs' borders when they have open border treaties.
AI will no longer remove routes that are earning them gpt if they are losing gpt.
Update route cost evaluation to take into account planned routes rather than existing roads.
Removed logic meant to make AI finish up almost completed routes, since that should not be needed anymore and made AI always build short routes even if they are losing gpt.
Remove two unused variables.