### PR TITLE
Deal and City Governor Fixes

### DIFF
--- a/(1) Community Patch/LUA/TradeLogic.lua
+++ b/(1) Community Patch/LUA/TradeLogic.lua
@@ -121,225 +121,241 @@ function LeaderMessageHandler( iPlayer, iDiploUIState, szLeaderMessage, iAnimati
 	g_iThemTeam = g_pThem:GetTeam();
 	g_pThemTeam = Teams[ g_iThemTeam ];
 
-
-	-- Leader head fix for more than 22 civs DLL...	
-	local playerLeaderInfo = GameInfo.Leaders[Players[iPlayer]:GetLeaderType()];
-	local leaderTextures = {
-		["LEADER_ALEXANDER"] = "alexander.dds",
-		["LEADER_ASKIA"] = "askia.dds",
-		["LEADER_AUGUSTUS"] = "augustus.dds",
-		["LEADER_BISMARCK"] = "bismark.dds",
-		["LEADER_CATHERINE"] = "catherine.dds",
-		["LEADER_DARIUS"] = "darius.dds",
-		["LEADER_ELIZABETH"] = "elizabeth.dds",
-		["LEADER_GANDHI"] = "ghandi.dds",
-		["LEADER_HARUN_AL_RASHID"] = "alrashid.dds",
-		["LEADER_HIAWATHA"] = "hiawatha.dds",
-		["LEADER_MONTEZUMA"] = "montezuma.dds",
-		["LEADER_NAPOLEON"] = "napoleon.dds",
-		["LEADER_ODA_NOBUNAGA"] = "oda.dds",
-		["LEADER_RAMESSES"] = "ramesses.dds",
-		["LEADER_RAMKHAMHAENG"] = "ramkhamaeng.dds",
-		["LEADER_SULEIMAN"] = "sulieman.dds",
-		["LEADER_WASHINGTON"] = "washington.dds",
-		["LEADER_WU_ZETIAN"] = "wu.dds",
-		["LEADER_GENGHIS_KHAN"] = "genghis.dds",
-		["LEADER_ISABELLA"] = "isabella.dds",
-		["LEADER_PACHACUTI"] = "pachacuti.dds",
-		["LEADER_KAMEHAMEHA"] = "kamehameha.dds",
-		["LEADER_HARALD"] = "harald.dds",
-		["LEADER_SEJONG"] = "sejong.dds",
-		["LEADER_NEBUCHADNEZZAR"] = "nebuchadnezzar.dds",
-		["LEADER_ATTILA"] = "attila.dds",
-		["LEADER_BOUDICCA"] = "boudicca.dds",
-		["LEADER_DIDO"] = "dido.dds",
-		["LEADER_GUSTAVUS_ADOLPHUS"] = "gustavus adolphus.dds",
-		["LEADER_MARIA"] = "mariatheresa.dds",
-		["LEADER_PACAL"] = "pacal_the_great.dds",
-		["LEADER_THEODORA"] = "theodora.dds",
-		["LEADER_SELASSIE"] = "haile_selassie.dds",
-		["LEADER_WILLIAM"] = "william_of_orange.dds",		
-		["LEADER_SHAKA"] = "Shaka.dds",
-		["LEADER_POCATELLO"] = "Pocatello.dds",
-		["LEADER_PEDRO"] = "Pedro.dds",
-		["LEADER_MARIA_I"] = "Maria_I.dds",
-		["LEADER_GAJAH_MADA"] = "Gajah.dds",
-		["LEADER_ENRICO_DANDOLO"] = "Dandolo.dds",
-		["LEADER_CASIMIR"] = "Casimir.dds",
-		["LEADER_ASHURBANIPAL"] = "Ashurbanipal.dds",
-		["LEADER_AHMAD_ALMANSUR"] = "Almansur.dds",
-	}
+	-- if the AI offers a deal, its valuation might have changed during the AI's turn. Reevaluate the deal and change deal items if necessary
+	if(g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_OFFER) then
+		local bDealCanceled = g_Deal:DoReevaluateDeal(g_iThem, g_iUs);
+		if(bDealCanceled) then
+			-- it was no longer possible to offer an acceptable deal and the deal has been canceled
+			g_iDiploUIState = DiploUIStateTypes.NO_DIPLO_UI_STATE;
+		end
+		if(g_Deal:IsCheckedForRenewal()) then
+			-- modify leader message if necessary
+			szLeaderMessage = g_Deal:GetRenewDealMessage(g_iThem, g_iUs);
+		end
+	end
 	
-	if iPlayer > 21 then
-		print ("LeaderMessageHandler: Player ID > 21")
-		local backupTexture = "loadingbasegame_9.dds"
-		if leaderTextures[playerLeaderInfo.Type] then
-			backupTexture = leaderTextures[playerLeaderInfo.Type]
-		end
-
-		-- get screen and texture size to set the texture on full screen
-
-		Controls.BackupTexture:SetTexture( backupTexture )
-		local screenW, screenH = Controls.BackupTexture:GetSizeVal() -- works, but maybe there is a direct way to get screen size ?
-			
-		Controls.BackupTexture:SetTextureAndResize( backupTexture )
-		local textureW, textureH = Controls.BackupTexture:GetSizeVal()	
-		
-		print ("Screen Width = " .. tostring(screenW) .. ", Screen Height = " .. tostring(screenH) .. ", Texture Width = " .. tostring(textureW) .. ", Texture Height = " .. tostring(textureH))
-
-		local ratioW = screenW / textureW
-		local ratioH = screenH / textureH
-		
-		print ("Width ratio = " .. tostring(ratioW) .. ", Height ratio = " .. tostring(ratioH))
-
-		local ratio = ratioW
-		if ratioH > ratioW then
-			ratio = ratioH
-		end
-		Controls.BackupTexture:SetSizeVal( math.floor(textureW * ratio), math.floor(textureH * ratio) )
-
-		Controls.BackupTexture:SetHide( false )
+	if(g_iDiploUIState == DiploUIStateTypes.NO_DIPLO_UI_STATE) then
+		OnBack();
 	else
 		
-		Controls.BackupTexture:UnloadTexture()
-		Controls.BackupTexture:SetHide( true )
+		-- Leader head fix for more than 22 civs DLL...	
+		local playerLeaderInfo = GameInfo.Leaders[Players[iPlayer]:GetLeaderType()];
+		local leaderTextures = {
+			["LEADER_ALEXANDER"] = "alexander.dds",
+			["LEADER_ASKIA"] = "askia.dds",
+			["LEADER_AUGUSTUS"] = "augustus.dds",
+			["LEADER_BISMARCK"] = "bismark.dds",
+			["LEADER_CATHERINE"] = "catherine.dds",
+			["LEADER_DARIUS"] = "darius.dds",
+			["LEADER_ELIZABETH"] = "elizabeth.dds",
+			["LEADER_GANDHI"] = "ghandi.dds",
+			["LEADER_HARUN_AL_RASHID"] = "alrashid.dds",
+			["LEADER_HIAWATHA"] = "hiawatha.dds",
+			["LEADER_MONTEZUMA"] = "montezuma.dds",
+			["LEADER_NAPOLEON"] = "napoleon.dds",
+			["LEADER_ODA_NOBUNAGA"] = "oda.dds",
+			["LEADER_RAMESSES"] = "ramesses.dds",
+			["LEADER_RAMKHAMHAENG"] = "ramkhamaeng.dds",
+			["LEADER_SULEIMAN"] = "sulieman.dds",
+			["LEADER_WASHINGTON"] = "washington.dds",
+			["LEADER_WU_ZETIAN"] = "wu.dds",
+			["LEADER_GENGHIS_KHAN"] = "genghis.dds",
+			["LEADER_ISABELLA"] = "isabella.dds",
+			["LEADER_PACHACUTI"] = "pachacuti.dds",
+			["LEADER_KAMEHAMEHA"] = "kamehameha.dds",
+			["LEADER_HARALD"] = "harald.dds",
+			["LEADER_SEJONG"] = "sejong.dds",
+			["LEADER_NEBUCHADNEZZAR"] = "nebuchadnezzar.dds",
+			["LEADER_ATTILA"] = "attila.dds",
+			["LEADER_BOUDICCA"] = "boudicca.dds",
+			["LEADER_DIDO"] = "dido.dds",
+			["LEADER_GUSTAVUS_ADOLPHUS"] = "gustavus adolphus.dds",
+			["LEADER_MARIA"] = "mariatheresa.dds",
+			["LEADER_PACAL"] = "pacal_the_great.dds",
+			["LEADER_THEODORA"] = "theodora.dds",
+			["LEADER_SELASSIE"] = "haile_selassie.dds",
+			["LEADER_WILLIAM"] = "william_of_orange.dds",		
+			["LEADER_SHAKA"] = "Shaka.dds",
+			["LEADER_POCATELLO"] = "Pocatello.dds",
+			["LEADER_PEDRO"] = "Pedro.dds",
+			["LEADER_MARIA_I"] = "Maria_I.dds",
+			["LEADER_GAJAH_MADA"] = "Gajah.dds",
+			["LEADER_ENRICO_DANDOLO"] = "Dandolo.dds",
+			["LEADER_CASIMIR"] = "Casimir.dds",
+			["LEADER_ASHURBANIPAL"] = "Ashurbanipal.dds",
+			["LEADER_AHMAD_ALMANSUR"] = "Almansur.dds",
+		}
+		
+		if iPlayer > 21 then
+			print ("LeaderMessageHandler: Player ID > 21")
+			local backupTexture = "loadingbasegame_9.dds"
+			if leaderTextures[playerLeaderInfo.Type] then
+				backupTexture = leaderTextures[playerLeaderInfo.Type]
+			end
 
-	end
-	-- End of leader head fix
-	
-	local bMyMode = false;
-	
-	-- Are we in Trade Mode?
-	if (iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE) then
-		bMyMode = true;
-	elseif (iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_DEMAND) then
-		bMyMode = true;
-	elseif (iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_REQUEST) then
-		bMyMode = true;
-	elseif (iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_HUMAN_OFFERS_CONCESSIONS) then
-		bMyMode = true;
-	elseif (iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_OFFER) then
-		bMyMode = true;
-	elseif (iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_ACCEPTS_OFFER) then
-		bMyMode = true;
-	elseif (iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_REJECTS_OFFER) then
-		bMyMode = true;
-	elseif (iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_HUMAN_DEMAND) then
-		bMyMode = true;
-	end
-	
-	if (bMyMode) then
-		
-		--print("TradeScreen: It's MY mode!");
-		
-		if (ContextPtr:IsHidden()) then
-			UIManager:QueuePopup( ContextPtr, PopupPriority.LeaderTrade );
-		end
-		
-		--print("Handling LeaderMessage: " .. iDiploUIState .. ", ".. szLeaderMessage);
-	    
-		g_Deal:SetFromPlayer(g_iUs);
-		g_Deal:SetToPlayer(g_iThem);
-		
-		-- Unhide our pocket, in case the last thing we were doing in this screen was a human demand
-		Controls.UsPanel:SetHide(false);
-		Controls.UsGlass:SetHide(false);
-		
-		local bClearTableAndDisplayDeal = false;
-		
-		-- Is this a UI State where we should be displaying a deal?
-		if (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE) then
-			--print("DiploUIState: Default Trade");
-			bClearTableAndDisplayDeal = true;
-		elseif (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_DEMAND) then
-			--print("DiploUIState: AI making demand");
-			bClearTableAndDisplayDeal = true;
+			-- get screen and texture size to set the texture on full screen
+
+			Controls.BackupTexture:SetTexture( backupTexture )
+			local screenW, screenH = Controls.BackupTexture:GetSizeVal() -- works, but maybe there is a direct way to get screen size ?
+				
+			Controls.BackupTexture:SetTextureAndResize( backupTexture )
+			local textureW, textureH = Controls.BackupTexture:GetSizeVal()	
 			
-			DoDemandState(true);
+			print ("Screen Width = " .. tostring(screenW) .. ", Screen Height = " .. tostring(screenH) .. ", Texture Width = " .. tostring(textureW) .. ", Texture Height = " .. tostring(textureH))
+
+			local ratioW = screenW / textureW
+			local ratioH = screenH / textureH
 			
-		elseif (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_REQUEST) then
-			--print("DiploUIState: AI making Request");
-			bClearTableAndDisplayDeal = true;
-			
-			DoDemandState(true);
-			
-		elseif (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_HUMAN_DEMAND) then
-			bClearTableAndDisplayDeal = true;
-			-- If we're demanding something, there's no need to show OUR items
-			Controls.UsPanel:SetHide(true);
-			Controls.UsGlass:SetHide(true);
-			
-		elseif (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_HUMAN_OFFERS_CONCESSIONS) then
-			--print("DiploUIState: Human offers concessions");
-			bClearTableAndDisplayDeal = true;
-		elseif (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_OFFER) then
-			--print("DiploUIState: AI making offer");
-			bClearTableAndDisplayDeal = true;
-			g_bAIMakingOffer = true;
-		elseif (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_ACCEPTS_OFFER) then
-			--print("DiploUIState: AI accepted offer");
-			g_iConcessionsPreviousDiploUIState = -1;		-- Clear out the fact that we were offering concessions if the AI has agreed to a deal
-			bClearTableAndDisplayDeal = true;
-			
-		-- If the AI rejects a deal, don't clear the table: keep the items where they are in case the human wants to change things
-		elseif (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_REJECTS_OFFER) then
-			--print("DiploUIState: AI rejects offer");
-			bClearTableAndDisplayDeal = false;
+			print ("Width ratio = " .. tostring(ratioW) .. ", Height ratio = " .. tostring(ratioH))
+
+			local ratio = ratioW
+			if ratioH > ratioW then
+				ratio = ratioH
+			end
+			Controls.BackupTexture:SetSizeVal( math.floor(textureW * ratio), math.floor(textureH * ratio) )
+
+			Controls.BackupTexture:SetHide( false )
 		else
-			--print("DiploUIState: ?????");
+			
+			Controls.BackupTexture:UnloadTexture()
+			Controls.BackupTexture:SetHide( true )
+
+		end
+		-- End of leader head fix
+		
+		local bMyMode = false;
+		
+		-- Are we in Trade Mode?
+		if (iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE) then
+			bMyMode = true;
+		elseif (iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_DEMAND) then
+			bMyMode = true;
+		elseif (iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_REQUEST) then
+			bMyMode = true;
+		elseif (iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_HUMAN_OFFERS_CONCESSIONS) then
+			bMyMode = true;
+		elseif (iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_OFFER) then
+			bMyMode = true;
+		elseif (iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_ACCEPTS_OFFER) then
+			bMyMode = true;
+		elseif (iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_REJECTS_OFFER) then
+			bMyMode = true;
+		elseif (iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_HUMAN_DEMAND) then
+			bMyMode = true;
 		end
 		
-		-- Clear table and display the deal currently stored in InterfaceBuddy
-		if (bClearTableAndDisplayDeal) then
-			g_bMessageFromDiploAI = true;
+		if (bMyMode) then
 			
-			Controls.DiscussionText:SetText( szLeaderMessage );
-		    
-			DoClearTable();
-			DisplayDeal();
-
-			if (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_HUMAN_DEMAND) then
-				-- Hide Defensive Pact/Research Agreement on their side
-				Controls.ThemPocketDefensivePact:SetHide(true);
-				Controls.ThemPocketResearchAgreement:SetHide(true);
+			--print("TradeScreen: It's MY mode!");
+			
+			if (ContextPtr:IsHidden()) then
+				UIManager:QueuePopup( ContextPtr, PopupPriority.LeaderTrade );
 			end
 			
-		-- Don't clear the table, leave things as they are
+			--print("Handling LeaderMessage: " .. iDiploUIState .. ", ".. szLeaderMessage);
+			
+			g_Deal:SetFromPlayer(g_iUs);
+			g_Deal:SetToPlayer(g_iThem);
+			
+			-- Unhide our pocket, in case the last thing we were doing in this screen was a human demand
+			Controls.UsPanel:SetHide(false);
+			Controls.UsGlass:SetHide(false);
+			
+			local bClearTableAndDisplayDeal = false;
+			
+			-- Is this a UI State where we should be displaying a deal?
+			if (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE) then
+				--print("DiploUIState: Default Trade");
+				bClearTableAndDisplayDeal = true;
+			elseif (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_DEMAND) then
+				--print("DiploUIState: AI making demand");
+				bClearTableAndDisplayDeal = true;
+				
+				DoDemandState(true);
+				
+			elseif (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_REQUEST) then
+				--print("DiploUIState: AI making Request");
+				bClearTableAndDisplayDeal = true;
+				
+				DoDemandState(true);
+				
+			elseif (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_HUMAN_DEMAND) then
+				bClearTableAndDisplayDeal = true;
+				-- If we're demanding something, there's no need to show OUR items
+				Controls.UsPanel:SetHide(true);
+				Controls.UsGlass:SetHide(true);
+				
+			elseif (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_HUMAN_OFFERS_CONCESSIONS) then
+				--print("DiploUIState: Human offers concessions");
+				bClearTableAndDisplayDeal = true;
+			elseif (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_OFFER) then
+				--print("DiploUIState: AI making offer");
+				bClearTableAndDisplayDeal = true;
+				g_bAIMakingOffer = true;
+			elseif (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_ACCEPTS_OFFER) then
+				--print("DiploUIState: AI accepted offer");
+				g_iConcessionsPreviousDiploUIState = -1;		-- Clear out the fact that we were offering concessions if the AI has agreed to a deal
+				bClearTableAndDisplayDeal = true;
+				
+			-- If the AI rejects a deal, don't clear the table: keep the items where they are in case the human wants to change things
+			elseif (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_REJECTS_OFFER) then
+				--print("DiploUIState: AI rejects offer");
+				bClearTableAndDisplayDeal = false;
+			else
+				--print("DiploUIState: ?????");
+			end
+			
+			-- Clear table and display the deal currently stored in InterfaceBuddy
+			if (bClearTableAndDisplayDeal) then
+				g_bMessageFromDiploAI = true;
+				
+				Controls.DiscussionText:SetText( szLeaderMessage );
+				
+				DoClearTable();
+				DisplayDeal();
+
+				if (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_HUMAN_DEMAND) then
+					-- Hide Defensive Pact/Research Agreement on their side
+					Controls.ThemPocketDefensivePact:SetHide(true);
+					Controls.ThemPocketResearchAgreement:SetHide(true);
+				end
+				
+			-- Don't clear the table, leave things as they are
+			else
+				
+				--print("NOT clearing table");
+				
+				g_bMessageFromDiploAI = true;
+				
+				Controls.DiscussionText:SetText( szLeaderMessage );
+			end
+			
+			-- Resize the height of the box to fit the text
+			local contentSize = Controls.DiscussionText:GetSize().y + offsetOfString + bonusPadding;
+			local frameSize = {};
+			frameSize.x = innerFrameWidth;
+			frameSize.y = contentSize;
+			Controls.LeaderSpeechBorderFrame:SetSize( frameSize );
+			frameSize.x = outerFrameWidth;
+			frameSize.y = contentSize - offsetsBetweenFrames;
+			Controls.LeaderSpeechFrame:SetSize( frameSize );
+			
+			DoUpdateButtons();
+			
+		-- Not in trade mode
 		else
 			
-			--print("NOT clearing table");
+			--print("TradeScreen: NOT my mode! Hiding!");
+			--print("iDiploUIState: " .. iDiploUIState);
 			
-			g_bMessageFromDiploAI = true;
-			
-			Controls.DiscussionText:SetText( szLeaderMessage );
-		end
-		
-		-- Resize the height of the box to fit the text
-		local contentSize = Controls.DiscussionText:GetSize().y + offsetOfString + bonusPadding;
-		local frameSize = {};
-		frameSize.x = innerFrameWidth;
-		frameSize.y = contentSize;
-		Controls.LeaderSpeechBorderFrame:SetSize( frameSize );
-		frameSize.x = outerFrameWidth;
-		frameSize.y = contentSize - offsetsBetweenFrames;
-		Controls.LeaderSpeechFrame:SetSize( frameSize );
-		
-		DoUpdateButtons();
-		
-	-- Not in trade mode
-	else
-		
-		--print("TradeScreen: NOT my mode! Hiding!");
-		--print("iDiploUIState: " .. iDiploUIState);
-		
-        g_Deal:ClearItems();
+			g_Deal:ClearItems();
 
-		if (not ContextPtr:IsHidden()) then
-			ContextPtr:SetHide( true );
-	    end
-	
+			if (not ContextPtr:IsHidden()) then
+				ContextPtr:SetHide( true );
+			end
+		
+		end
 	end
-	
 end
 --Events.AILeaderMessage.Add( LeaderMessageHandler );
 

--- a/(2) Vox Populi/LUA/TradeLogic.lua
+++ b/(2) Vox Populi/LUA/TradeLogic.lua
@@ -132,236 +132,252 @@ function LeaderMessageHandler( iPlayer, iDiploUIState, szLeaderMessage, iAnimati
 	g_pThem = Players[ g_iThem ];
 	g_iThemTeam = g_pThem:GetTeam();
 	g_pThemTeam = Teams[ g_iThemTeam ];
-
-
-	-- Leader head fix for more than 22 civs DLL...	
-	local playerLeaderInfo = GameInfo.Leaders[Players[iPlayer]:GetLeaderType()];
-	local leaderTextures = {
-		["LEADER_ALEXANDER"] = "alexander.dds",
-		["LEADER_ASKIA"] = "askia.dds",
-		["LEADER_AUGUSTUS"] = "augustus.dds",
-		["LEADER_BISMARCK"] = "bismark.dds",
-		["LEADER_CATHERINE"] = "catherine.dds",
-		["LEADER_DARIUS"] = "darius.dds",
-		["LEADER_ELIZABETH"] = "elizabeth.dds",
-		["LEADER_GANDHI"] = "ghandi.dds",
-		["LEADER_HARUN_AL_RASHID"] = "alrashid.dds",
-		["LEADER_HIAWATHA"] = "hiawatha.dds",
-		["LEADER_MONTEZUMA"] = "montezuma.dds",
-		["LEADER_NAPOLEON"] = "napoleon.dds",
-		["LEADER_ODA_NOBUNAGA"] = "oda.dds",
-		["LEADER_RAMESSES"] = "ramesses.dds",
-		["LEADER_RAMKHAMHAENG"] = "ramkhamaeng.dds",
-		["LEADER_SULEIMAN"] = "sulieman.dds",
-		["LEADER_WASHINGTON"] = "washington.dds",
-		["LEADER_WU_ZETIAN"] = "wu.dds",
-		["LEADER_GENGHIS_KHAN"] = "genghis.dds",
-		["LEADER_ISABELLA"] = "isabella.dds",
-		["LEADER_PACHACUTI"] = "pachacuti.dds",
-		["LEADER_KAMEHAMEHA"] = "kamehameha.dds",
-		["LEADER_HARALD"] = "harald.dds",
-		["LEADER_SEJONG"] = "sejong.dds",
-		["LEADER_NEBUCHADNEZZAR"] = "nebuchadnezzar.dds",
-		["LEADER_ATTILA"] = "attila.dds",
-		["LEADER_BOUDICCA"] = "boudicca.dds",
-		["LEADER_DIDO"] = "dido.dds",
-		["LEADER_GUSTAVUS_ADOLPHUS"] = "gustavus adolphus.dds",
-		["LEADER_MARIA"] = "mariatheresa.dds",
-		["LEADER_PACAL"] = "pacal_the_great.dds",
-		["LEADER_THEODORA"] = "theodora.dds",
-		["LEADER_SELASSIE"] = "haile_selassie.dds",
-		["LEADER_WILLIAM"] = "william_of_orange.dds",		
-		["LEADER_SHAKA"] = "Shaka.dds",
-		["LEADER_POCATELLO"] = "Pocatello.dds",
-		["LEADER_PEDRO"] = "Pedro.dds",
-		["LEADER_MARIA_I"] = "Maria_I.dds",
-		["LEADER_GAJAH_MADA"] = "Gajah.dds",
-		["LEADER_ENRICO_DANDOLO"] = "Dandolo.dds",
-		["LEADER_CASIMIR"] = "Casimir.dds",
-		["LEADER_ASHURBANIPAL"] = "Ashurbanipal.dds",
-		["LEADER_AHMAD_ALMANSUR"] = "Almansur.dds",
-	}
 	
-	if iPlayer > 21 then
-		print ("LeaderMessageHandler: Player ID > 21")
-		local backupTexture = "loadingbasegame_9.dds"
-		if leaderTextures[playerLeaderInfo.Type] then
-			backupTexture = leaderTextures[playerLeaderInfo.Type]
+	-- if the AI offers a deal, its valuation might have changed during the AI's turn. Reevaluate the deal and change deal items if necessary
+	if(g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_OFFER) then
+		local bDealCanceled = g_Deal:DoReevaluateDeal(g_iThem, g_iUs);
+		if(bDealCanceled) then
+			-- it was no longer possible to offer an acceptable deal and the deal has been canceled
+			g_iDiploUIState = DiploUIStateTypes.NO_DIPLO_UI_STATE;
 		end
-
-		-- get screen and texture size to set the texture on full screen
-
-		Controls.BackupTexture:SetTexture( backupTexture )
-		local screenW, screenH = Controls.BackupTexture:GetSizeVal() -- works, but maybe there is a direct way to get screen size ?
-			
-		Controls.BackupTexture:SetTextureAndResize( backupTexture )
-		local textureW, textureH = Controls.BackupTexture:GetSizeVal()	
-		
-		print ("Screen Width = " .. tostring(screenW) .. ", Screen Height = " .. tostring(screenH) .. ", Texture Width = " .. tostring(textureW) .. ", Texture Height = " .. tostring(textureH))
-
-		local ratioW = screenW / textureW
-		local ratioH = screenH / textureH
-		
-		print ("Width ratio = " .. tostring(ratioW) .. ", Height ratio = " .. tostring(ratioH))
-
-		local ratio = ratioW
-		if ratioH > ratioW then
-			ratio = ratioH
+		if(g_Deal:IsCheckedForRenewal()) then
+			-- modify leader message if necessary
+			szLeaderMessage = g_Deal:GetRenewDealMessage(g_iThem, g_iUs);
 		end
-		Controls.BackupTexture:SetSizeVal( math.floor(textureW * ratio), math.floor(textureH * ratio) )
-
-		Controls.BackupTexture:SetHide( false )
+	end
+	
+	if(g_iDiploUIState == DiploUIStateTypes.NO_DIPLO_UI_STATE) then
+		OnBack();
 	else
-		
-		Controls.BackupTexture:UnloadTexture()
-		Controls.BackupTexture:SetHide( true )
 
-	end
-	-- End of leader head fix
+		-- Leader head fix for more than 22 civs DLL...	
+		local playerLeaderInfo = GameInfo.Leaders[Players[iPlayer]:GetLeaderType()];
+		local leaderTextures = {
+			["LEADER_ALEXANDER"] = "alexander.dds",
+			["LEADER_ASKIA"] = "askia.dds",
+			["LEADER_AUGUSTUS"] = "augustus.dds",
+			["LEADER_BISMARCK"] = "bismark.dds",
+			["LEADER_CATHERINE"] = "catherine.dds",
+			["LEADER_DARIUS"] = "darius.dds",
+			["LEADER_ELIZABETH"] = "elizabeth.dds",
+			["LEADER_GANDHI"] = "ghandi.dds",
+			["LEADER_HARUN_AL_RASHID"] = "alrashid.dds",
+			["LEADER_HIAWATHA"] = "hiawatha.dds",
+			["LEADER_MONTEZUMA"] = "montezuma.dds",
+			["LEADER_NAPOLEON"] = "napoleon.dds",
+			["LEADER_ODA_NOBUNAGA"] = "oda.dds",
+			["LEADER_RAMESSES"] = "ramesses.dds",
+			["LEADER_RAMKHAMHAENG"] = "ramkhamaeng.dds",
+			["LEADER_SULEIMAN"] = "sulieman.dds",
+			["LEADER_WASHINGTON"] = "washington.dds",
+			["LEADER_WU_ZETIAN"] = "wu.dds",
+			["LEADER_GENGHIS_KHAN"] = "genghis.dds",
+			["LEADER_ISABELLA"] = "isabella.dds",
+			["LEADER_PACHACUTI"] = "pachacuti.dds",
+			["LEADER_KAMEHAMEHA"] = "kamehameha.dds",
+			["LEADER_HARALD"] = "harald.dds",
+			["LEADER_SEJONG"] = "sejong.dds",
+			["LEADER_NEBUCHADNEZZAR"] = "nebuchadnezzar.dds",
+			["LEADER_ATTILA"] = "attila.dds",
+			["LEADER_BOUDICCA"] = "boudicca.dds",
+			["LEADER_DIDO"] = "dido.dds",
+			["LEADER_GUSTAVUS_ADOLPHUS"] = "gustavus adolphus.dds",
+			["LEADER_MARIA"] = "mariatheresa.dds",
+			["LEADER_PACAL"] = "pacal_the_great.dds",
+			["LEADER_THEODORA"] = "theodora.dds",
+			["LEADER_SELASSIE"] = "haile_selassie.dds",
+			["LEADER_WILLIAM"] = "william_of_orange.dds",		
+			["LEADER_SHAKA"] = "Shaka.dds",
+			["LEADER_POCATELLO"] = "Pocatello.dds",
+			["LEADER_PEDRO"] = "Pedro.dds",
+			["LEADER_MARIA_I"] = "Maria_I.dds",
+			["LEADER_GAJAH_MADA"] = "Gajah.dds",
+			["LEADER_ENRICO_DANDOLO"] = "Dandolo.dds",
+			["LEADER_CASIMIR"] = "Casimir.dds",
+			["LEADER_ASHURBANIPAL"] = "Ashurbanipal.dds",
+			["LEADER_AHMAD_ALMANSUR"] = "Almansur.dds",
+		}
+		
+		if iPlayer > 21 then
+			print ("LeaderMessageHandler: Player ID > 21")
+			local backupTexture = "loadingbasegame_9.dds"
+			if leaderTextures[playerLeaderInfo.Type] then
+				backupTexture = leaderTextures[playerLeaderInfo.Type]
+			end
 
-	local bMyMode = false;
+			-- get screen and texture size to set the texture on full screen
 
-	-- Are we in Trade Mode?
-	if (iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE) then
-		bMyMode = true;
-	elseif (iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_DEMAND) then
-		bMyMode = true;
-	elseif (iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_REQUEST) then
-		bMyMode = true;
-	elseif (iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_HUMAN_OFFERS_CONCESSIONS) then
-		bMyMode = true;
-	elseif (iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_OFFER) then
-		bMyMode = true;
-	elseif (iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_ACCEPTS_OFFER) then
-		bMyMode = true;
-	elseif (iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_REJECTS_OFFER) then
-		bMyMode = true;
-	elseif (iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_HUMAN_DEMAND) then
-		bMyMode = true;
-	-- Putmalk: Open trade window when AI is giving the player a gift
-	elseif (iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_GENEROUS_OFFER) then
-		bMyMode = true;
-	end
-	
-	if (bMyMode) then
-		
-		--print("TradeScreen: It's MY mode!");
-		
-		if (ContextPtr:IsHidden()) then
-			UIManager:QueuePopup( ContextPtr, PopupPriority.LeaderTrade );
-		end
-		
-		--print("Handling LeaderMessage: " .. iDiploUIState .. ", ".. szLeaderMessage);
-	    
-		g_Deal:SetFromPlayer(g_iUs);
-		g_Deal:SetToPlayer(g_iThem);
-		
-		-- Unhide our pocket, in case the last thing we were doing in this screen was a human demand
-		Controls.UsPanel:SetHide(false);
-		Controls.UsGlass:SetHide(false);
-		
-		local bClearTableAndDisplayDeal = false;
-		
-		-- Is this a UI State where we should be displaying a deal?
-		if (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE) then
-			--print("DiploUIState: Default Trade");
-			bClearTableAndDisplayDeal = true;
-		elseif (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_DEMAND) then
-			--print("DiploUIState: AI making demand");
-			bClearTableAndDisplayDeal = true;
+			Controls.BackupTexture:SetTexture( backupTexture )
+			local screenW, screenH = Controls.BackupTexture:GetSizeVal() -- works, but maybe there is a direct way to get screen size ?
+				
+			Controls.BackupTexture:SetTextureAndResize( backupTexture )
+			local textureW, textureH = Controls.BackupTexture:GetSizeVal()	
 			
-			DoDemandState(true);
+			print ("Screen Width = " .. tostring(screenW) .. ", Screen Height = " .. tostring(screenH) .. ", Texture Width = " .. tostring(textureW) .. ", Texture Height = " .. tostring(textureH))
+
+			local ratioW = screenW / textureW
+			local ratioH = screenH / textureH
 			
-		elseif (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_REQUEST) then
-			--print("DiploUIState: AI making Request");
-			bClearTableAndDisplayDeal = true;
-			
-			DoDemandState(true);
-			
-		-- Putmalk: Open Trade window when AI is giving a gift and set it to the demand state
-		elseif (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_GENEROUS_OFFER) then
-			--print("DiploUIState: AI making Offer");
-			bClearTableAndDisplayDeal = true;
-			
-			DoDemandState(true);
-			
-		elseif (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_HUMAN_DEMAND) then
-			bClearTableAndDisplayDeal = true;
-			-- If we're demanding something, there's no need to show OUR items
-			Controls.UsPanel:SetHide(true);
-			Controls.UsGlass:SetHide(true);
-			
-		elseif (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_HUMAN_OFFERS_CONCESSIONS) then
-			--print("DiploUIState: Human offers concessions");
-			bClearTableAndDisplayDeal = true;
-		elseif (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_OFFER) then
-			--print("DiploUIState: AI making offer");
-			bClearTableAndDisplayDeal = true;
-			g_bAIMakingOffer = true;
-		elseif (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_ACCEPTS_OFFER) then
-			--print("DiploUIState: AI accepted offer");
-			g_iConcessionsPreviousDiploUIState = -1;		-- Clear out the fact that we were offering concessions if the AI has agreed to a deal
-			bClearTableAndDisplayDeal = true;
-			
-		-- If the AI rejects a deal, don't clear the table: keep the items where they are in case the human wants to change things
-		elseif (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_REJECTS_OFFER) then
-			--print("DiploUIState: AI rejects offer");
-			bClearTableAndDisplayDeal = false;
+			print ("Width ratio = " .. tostring(ratioW) .. ", Height ratio = " .. tostring(ratioH))
+
+			local ratio = ratioW
+			if ratioH > ratioW then
+				ratio = ratioH
+			end
+			Controls.BackupTexture:SetSizeVal( math.floor(textureW * ratio), math.floor(textureH * ratio) )
+
+			Controls.BackupTexture:SetHide( false )
 		else
-			--print("DiploUIState: ?????");
+			
+			Controls.BackupTexture:UnloadTexture()
+			Controls.BackupTexture:SetHide( true )
+
+		end
+		-- End of leader head fix
+
+		local bMyMode = false;
+
+		-- Are we in Trade Mode?
+		if (iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE) then
+			bMyMode = true;
+		elseif (iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_DEMAND) then
+			bMyMode = true;
+		elseif (iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_REQUEST) then
+			bMyMode = true;
+		elseif (iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_HUMAN_OFFERS_CONCESSIONS) then
+			bMyMode = true;
+		elseif (iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_OFFER) then
+			bMyMode = true;
+		elseif (iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_ACCEPTS_OFFER) then
+			bMyMode = true;
+		elseif (iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_REJECTS_OFFER) then
+			bMyMode = true;
+		elseif (iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_HUMAN_DEMAND) then
+			bMyMode = true;
+		-- Putmalk: Open trade window when AI is giving the player a gift
+		elseif (iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_GENEROUS_OFFER) then
+			bMyMode = true;
 		end
 		
-		-- Clear table and display the deal currently stored in InterfaceBuddy
-		if (bClearTableAndDisplayDeal) then
-			g_bMessageFromDiploAI = true;
+		if (bMyMode) then
 			
-			Controls.DiscussionText:SetText( szLeaderMessage );
-		    
-			DoClearTable();
-			DisplayDeal();
-
-			if (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_HUMAN_DEMAND) then
-				-- Hide Defensive Pact/Research Agreement on their side
-				Controls.ThemPocketDefensivePact:SetHide(true);
-				Controls.ThemPocketResearchAgreement:SetHide(true);
+			--print("TradeScreen: It's MY mode!");
+			
+			if (ContextPtr:IsHidden()) then
+				UIManager:QueuePopup( ContextPtr, PopupPriority.LeaderTrade );
 			end
 			
-		-- Don't clear the table, leave things as they are
+			--print("Handling LeaderMessage: " .. iDiploUIState .. ", ".. szLeaderMessage);
+			
+			g_Deal:SetFromPlayer(g_iUs);
+			g_Deal:SetToPlayer(g_iThem);
+			
+			-- Unhide our pocket, in case the last thing we were doing in this screen was a human demand
+			Controls.UsPanel:SetHide(false);
+			Controls.UsGlass:SetHide(false);
+			
+			local bClearTableAndDisplayDeal = false;
+			
+			-- Is this a UI State where we should be displaying a deal?
+			if (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE) then
+				--print("DiploUIState: Default Trade");
+				bClearTableAndDisplayDeal = true;
+			elseif (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_DEMAND) then
+				--print("DiploUIState: AI making demand");
+				bClearTableAndDisplayDeal = true;
+				
+				DoDemandState(true);
+				
+			elseif (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_REQUEST) then
+				--print("DiploUIState: AI making Request");
+				bClearTableAndDisplayDeal = true;
+				
+				DoDemandState(true);
+				
+			-- Putmalk: Open Trade window when AI is giving a gift and set it to the demand state
+			elseif (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_GENEROUS_OFFER) then
+				--print("DiploUIState: AI making Offer");
+				bClearTableAndDisplayDeal = true;
+				
+				DoDemandState(true);
+				
+			elseif (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_HUMAN_DEMAND) then
+				bClearTableAndDisplayDeal = true;
+				-- If we're demanding something, there's no need to show OUR items
+				Controls.UsPanel:SetHide(true);
+				Controls.UsGlass:SetHide(true);
+				
+			elseif (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_HUMAN_OFFERS_CONCESSIONS) then
+				--print("DiploUIState: Human offers concessions");
+				bClearTableAndDisplayDeal = true;
+			elseif (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_OFFER) then
+				--print("DiploUIState: AI making offer");
+				bClearTableAndDisplayDeal = true;
+				g_bAIMakingOffer = true;
+			elseif (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_ACCEPTS_OFFER) then
+				--print("DiploUIState: AI accepted offer");
+				g_iConcessionsPreviousDiploUIState = -1;		-- Clear out the fact that we were offering concessions if the AI has agreed to a deal
+				bClearTableAndDisplayDeal = true;
+				
+			-- If the AI rejects a deal, don't clear the table: keep the items where they are in case the human wants to change things
+			elseif (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_REJECTS_OFFER) then
+				--print("DiploUIState: AI rejects offer");
+				bClearTableAndDisplayDeal = false;
+			else
+				--print("DiploUIState: ?????");
+			end
+			
+			-- Clear table and display the deal currently stored in InterfaceBuddy
+			if (bClearTableAndDisplayDeal) then
+				g_bMessageFromDiploAI = true;
+				
+				Controls.DiscussionText:SetText( szLeaderMessage );
+				
+				DoClearTable();
+				DisplayDeal();
+
+				if (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_HUMAN_DEMAND) then
+					-- Hide Defensive Pact/Research Agreement on their side
+					Controls.ThemPocketDefensivePact:SetHide(true);
+					Controls.ThemPocketResearchAgreement:SetHide(true);
+				end
+				
+			-- Don't clear the table, leave things as they are
+			else
+				
+				--print("NOT clearing table");
+				
+				g_bMessageFromDiploAI = true;
+				
+				Controls.DiscussionText:SetText( szLeaderMessage );
+			end
+			
+			-- Resize the height of the box to fit the text
+			local contentSize = Controls.DiscussionText:GetSize().y + offsetOfString + bonusPadding;
+			local frameSize = {};
+			frameSize.x = innerFrameWidth;
+			frameSize.y = contentSize;
+			Controls.LeaderSpeechBorderFrame:SetSize( frameSize );
+			frameSize.x = outerFrameWidth;
+			frameSize.y = contentSize - offsetsBetweenFrames;
+			Controls.LeaderSpeechFrame:SetSize( frameSize );
+			
+			DoUpdateButtons();
+			
+		-- Not in trade mode
 		else
 			
-			--print("NOT clearing table");
+			--print("TradeScreen: NOT my mode! Hiding!");
+			--print("iDiploUIState: " .. iDiploUIState);
 			
-			g_bMessageFromDiploAI = true;
-			
-			Controls.DiscussionText:SetText( szLeaderMessage );
-		end
-		
-		-- Resize the height of the box to fit the text
-		local contentSize = Controls.DiscussionText:GetSize().y + offsetOfString + bonusPadding;
-		local frameSize = {};
-		frameSize.x = innerFrameWidth;
-		frameSize.y = contentSize;
-		Controls.LeaderSpeechBorderFrame:SetSize( frameSize );
-		frameSize.x = outerFrameWidth;
-		frameSize.y = contentSize - offsetsBetweenFrames;
-		Controls.LeaderSpeechFrame:SetSize( frameSize );
-		
-		DoUpdateButtons();
-		
-	-- Not in trade mode
-	else
-		
-		--print("TradeScreen: NOT my mode! Hiding!");
-		--print("iDiploUIState: " .. iDiploUIState);
-		
-        g_Deal:ClearItems();
+			g_Deal:ClearItems();
 
-		if (not ContextPtr:IsHidden()) then
-			ContextPtr:SetHide( true );
-	    end
-	
+			if (not ContextPtr:IsHidden()) then
+				ContextPtr:SetHide( true );
+			end
+		
+		end
 	end
-	
 end
 --Events.AILeaderMessage.Add( LeaderMessageHandler );
 

--- a/(3a) EUI Compatibility Files/LUA/TradeLogic.lua
+++ b/(3a) EUI Compatibility Files/LUA/TradeLogic.lua
@@ -149,219 +149,236 @@ function LeaderMessageHandler( iPlayer, iDiploUIState, szLeaderMessage, iAnimati
 	g_pThemTeam = Teams[ g_iThemTeam ];
 
 
-	-- Leader head fix for more than 22 civs DLL...	
-	local playerLeaderInfo = GameInfo.Leaders[Players[iPlayer]:GetLeaderType()];
-	local leaderTextures = {
-		["LEADER_ALEXANDER"] = "alexander.dds",
-		["LEADER_ASKIA"] = "askia.dds",
-		["LEADER_AUGUSTUS"] = "augustus.dds",
-		["LEADER_BISMARCK"] = "bismark.dds",
-		["LEADER_CATHERINE"] = "catherine.dds",
-		["LEADER_DARIUS"] = "darius.dds",
-		["LEADER_ELIZABETH"] = "elizabeth.dds",
-		["LEADER_GANDHI"] = "ghandi.dds",
-		["LEADER_HARUN_AL_RASHID"] = "alrashid.dds",
-		["LEADER_HIAWATHA"] = "hiawatha.dds",
-		["LEADER_MONTEZUMA"] = "montezuma.dds",
-		["LEADER_NAPOLEON"] = "napoleon.dds",
-		["LEADER_ODA_NOBUNAGA"] = "oda.dds",
-		["LEADER_RAMESSES"] = "ramesses.dds",
-		["LEADER_RAMKHAMHAENG"] = "ramkhamaeng.dds",
-		["LEADER_SULEIMAN"] = "sulieman.dds",
-		["LEADER_WASHINGTON"] = "washington.dds",
-		["LEADER_WU_ZETIAN"] = "wu.dds",
-		["LEADER_GENGHIS_KHAN"] = "genghis.dds",
-		["LEADER_ISABELLA"] = "isabella.dds",
-		["LEADER_PACHACUTI"] = "pachacuti.dds",
-		["LEADER_KAMEHAMEHA"] = "kamehameha.dds",
-		["LEADER_HARALD"] = "harald.dds",
-		["LEADER_SEJONG"] = "sejong.dds",
-		["LEADER_NEBUCHADNEZZAR"] = "nebuchadnezzar.dds",
-		["LEADER_ATTILA"] = "attila.dds",
-		["LEADER_BOUDICCA"] = "boudicca.dds",
-		["LEADER_DIDO"] = "dido.dds",
-		["LEADER_GUSTAVUS_ADOLPHUS"] = "gustavus adolphus.dds",
-		["LEADER_MARIA"] = "mariatheresa.dds",
-		["LEADER_PACAL"] = "pacal_the_great.dds",
-		["LEADER_THEODORA"] = "theodora.dds",
-		["LEADER_SELASSIE"] = "haile_selassie.dds",
-		["LEADER_WILLIAM"] = "william_of_orange.dds",		
-		["LEADER_SHAKA"] = "Shaka.dds",
-		["LEADER_POCATELLO"] = "Pocatello.dds",
-		["LEADER_PEDRO"] = "Pedro.dds",
-		["LEADER_MARIA_I"] = "Maria_I.dds",
-		["LEADER_GAJAH_MADA"] = "Gajah.dds",
-		["LEADER_ENRICO_DANDOLO"] = "Dandolo.dds",
-		["LEADER_CASIMIR"] = "Casimir.dds",
-		["LEADER_ASHURBANIPAL"] = "Ashurbanipal.dds",
-		["LEADER_AHMAD_ALMANSUR"] = "Almansur.dds",
-	}
+	-- if the AI offers a deal, its valuation might have changed during the AI's turn. Reevaluate the deal and change deal items if necessary
+	if(g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_OFFER) then
+		local bDealCanceled = g_Deal:DoReevaluateDeal(g_iThem, g_iUs);
+		if(bDealCanceled) then
+			-- it was no longer possible to offer an acceptable deal and the deal has been canceled
+			g_iDiploUIState = DiploUIStateTypes.NO_DIPLO_UI_STATE;
+		end
+		if(g_Deal:IsCheckedForRenewal()) then
+			-- modify leader message if necessary
+			szLeaderMessage = g_Deal:GetRenewDealMessage(g_iThem, g_iUs);
+		end
+	end
 	
-	if iPlayer > 21 then
-		print ("LeaderMessageHandler: Player ID > 21")
-		local backupTexture = "loadingbasegame_9.dds"
-		if leaderTextures[playerLeaderInfo.Type] then
-			backupTexture = leaderTextures[playerLeaderInfo.Type]
-		end
-
-		-- get screen and texture size to set the texture on full screen
-
-		Controls.BackupTexture:SetTexture( backupTexture )
-		local screenW, screenH = Controls.BackupTexture:GetSizeVal() -- works, but maybe there is a direct way to get screen size ?
-			
-		Controls.BackupTexture:SetTextureAndResize( backupTexture )
-		local textureW, textureH = Controls.BackupTexture:GetSizeVal()	
-		
-		print ("Screen Width = " .. tostring(screenW) .. ", Screen Height = " .. tostring(screenH) .. ", Texture Width = " .. tostring(textureW) .. ", Texture Height = " .. tostring(textureH))
-
-		local ratioW = screenW / textureW
-		local ratioH = screenH / textureH
-		
-		print ("Width ratio = " .. tostring(ratioW) .. ", Height ratio = " .. tostring(ratioH))
-
-		local ratio = ratioW
-		if ratioH > ratioW then
-			ratio = ratioH
-		end
-		Controls.BackupTexture:SetSizeVal( math.floor(textureW * ratio), math.floor(textureH * ratio) )
-
-		Controls.BackupTexture:SetHide( false )
+	if(g_iDiploUIState == DiploUIStateTypes.NO_DIPLO_UI_STATE) then
+		OnBack();
 	else
 		
-		Controls.BackupTexture:UnloadTexture()
-		Controls.BackupTexture:SetHide( true )
-
-	end
-	-- End of leader head fix
-	
-	
-	-- Are we in Trade Mode?
-	if iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE
-		or iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_DEMAND
-		or iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_REQUEST
-		or iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_HUMAN_OFFERS_CONCESSIONS
-		or iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_OFFER
-		or iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_ACCEPTS_OFFER
-		or iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_REJECTS_OFFER
-		or iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_HUMAN_DEMAND
-		or iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_GENEROUS_OFFER
-	then
-
-		--print("TradeScreen: It's MY mode!");
-
-		if (ContextPtr:IsHidden()) then
-			UIManager:QueuePopup( ContextPtr, PopupPriority.LeaderTrade );
-		end
-
-		--print("Handling LeaderMessage: " .. iDiploUIState .. ", ".. szLeaderMessage);
-
-		g_Deal:SetFromPlayer(g_iUs);
-		g_Deal:SetToPlayer(g_iThem);
-
-		-- Unhide our pocket, in case the last thing we were doing in this screen was a human demand
-		Controls.UsPanel:SetHide(false);
-		Controls.UsGlass:SetHide(false);
-
-		local bClearTableAndDisplayDeal = false;
-
-		-- Is this a UI State where we should be displaying a deal?
-		if (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE) then
-			--print("DiploUIState: Default Trade");
-			bClearTableAndDisplayDeal = true;
-		elseif (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_DEMAND) then
-			--print("DiploUIState: AI making demand");
-			bClearTableAndDisplayDeal = true;
-
-			DoDemandState(true);
-
-		elseif (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_REQUEST) then
-			--print("DiploUIState: AI making Request");
-			bClearTableAndDisplayDeal = true;
-
-			DoDemandState(true);
-		-- Putmalk: Open Trade window when AI is giving a gift and set it to the demand state
-		elseif (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_GENEROUS_OFFER) then
-			--print("DiploUIState: AI making Offer");
-			bClearTableAndDisplayDeal = true;
-			
-			DoDemandState(true);
-		elseif (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_HUMAN_DEMAND) then
-			bClearTableAndDisplayDeal = true;
-			-- If we're demanding something, there's no need to show OUR items
-			Controls.UsPanel:SetHide(true);
-			Controls.UsGlass:SetHide(true);
-
-		elseif (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_HUMAN_OFFERS_CONCESSIONS) then
-			--print("DiploUIState: Human offers concessions");
-			bClearTableAndDisplayDeal = true;
-		elseif (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_OFFER) then
-			--print("DiploUIState: AI making offer");
-			bClearTableAndDisplayDeal = true;
-			g_bAIMakingOffer = true;
-		elseif (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_ACCEPTS_OFFER) then
-			--print("DiploUIState: AI accepted offer");
-			g_iConcessionsPreviousDiploUIState = -1;		-- Clear out the fact that we were offering concessions if the AI has agreed to a deal
-			bClearTableAndDisplayDeal = true;
-
-		-- If the AI rejects a deal, don't clear the table: keep the items where they are in case the human wants to change things
-		elseif (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_REJECTS_OFFER) then
-			--print("DiploUIState: AI rejects offer");
-			bClearTableAndDisplayDeal = false;
-		else
-			--print("DiploUIState: ?????");
-		end
-
-		-- Clear table and display the deal currently stored in InterfaceBuddy
-		if (bClearTableAndDisplayDeal) then
-			g_bMessageFromDiploAI = true;
-
-			Controls.DiscussionText:SetText( szLeaderMessage );
-
-			DoClearTable();
-			DisplayDeal();
-
-			if (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_HUMAN_DEMAND) then
-				-- Hide Defensive Pact/Research Agreement on their side
-				Controls.ThemPocketDefensivePact:SetHide(true);
-				Controls.ThemPocketResearchAgreement:SetHide(true);
+		-- Leader head fix for more than 22 civs DLL...	
+		local playerLeaderInfo = GameInfo.Leaders[Players[iPlayer]:GetLeaderType()];
+		local leaderTextures = {
+			["LEADER_ALEXANDER"] = "alexander.dds",
+			["LEADER_ASKIA"] = "askia.dds",
+			["LEADER_AUGUSTUS"] = "augustus.dds",
+			["LEADER_BISMARCK"] = "bismark.dds",
+			["LEADER_CATHERINE"] = "catherine.dds",
+			["LEADER_DARIUS"] = "darius.dds",
+			["LEADER_ELIZABETH"] = "elizabeth.dds",
+			["LEADER_GANDHI"] = "ghandi.dds",
+			["LEADER_HARUN_AL_RASHID"] = "alrashid.dds",
+			["LEADER_HIAWATHA"] = "hiawatha.dds",
+			["LEADER_MONTEZUMA"] = "montezuma.dds",
+			["LEADER_NAPOLEON"] = "napoleon.dds",
+			["LEADER_ODA_NOBUNAGA"] = "oda.dds",
+			["LEADER_RAMESSES"] = "ramesses.dds",
+			["LEADER_RAMKHAMHAENG"] = "ramkhamaeng.dds",
+			["LEADER_SULEIMAN"] = "sulieman.dds",
+			["LEADER_WASHINGTON"] = "washington.dds",
+			["LEADER_WU_ZETIAN"] = "wu.dds",
+			["LEADER_GENGHIS_KHAN"] = "genghis.dds",
+			["LEADER_ISABELLA"] = "isabella.dds",
+			["LEADER_PACHACUTI"] = "pachacuti.dds",
+			["LEADER_KAMEHAMEHA"] = "kamehameha.dds",
+			["LEADER_HARALD"] = "harald.dds",
+			["LEADER_SEJONG"] = "sejong.dds",
+			["LEADER_NEBUCHADNEZZAR"] = "nebuchadnezzar.dds",
+			["LEADER_ATTILA"] = "attila.dds",
+			["LEADER_BOUDICCA"] = "boudicca.dds",
+			["LEADER_DIDO"] = "dido.dds",
+			["LEADER_GUSTAVUS_ADOLPHUS"] = "gustavus adolphus.dds",
+			["LEADER_MARIA"] = "mariatheresa.dds",
+			["LEADER_PACAL"] = "pacal_the_great.dds",
+			["LEADER_THEODORA"] = "theodora.dds",
+			["LEADER_SELASSIE"] = "haile_selassie.dds",
+			["LEADER_WILLIAM"] = "william_of_orange.dds",		
+			["LEADER_SHAKA"] = "Shaka.dds",
+			["LEADER_POCATELLO"] = "Pocatello.dds",
+			["LEADER_PEDRO"] = "Pedro.dds",
+			["LEADER_MARIA_I"] = "Maria_I.dds",
+			["LEADER_GAJAH_MADA"] = "Gajah.dds",
+			["LEADER_ENRICO_DANDOLO"] = "Dandolo.dds",
+			["LEADER_CASIMIR"] = "Casimir.dds",
+			["LEADER_ASHURBANIPAL"] = "Ashurbanipal.dds",
+			["LEADER_AHMAD_ALMANSUR"] = "Almansur.dds",
+		}
+		
+		if iPlayer > 21 then
+			print ("LeaderMessageHandler: Player ID > 21")
+			local backupTexture = "loadingbasegame_9.dds"
+			if leaderTextures[playerLeaderInfo.Type] then
+				backupTexture = leaderTextures[playerLeaderInfo.Type]
 			end
 
-		-- Don't clear the table, leave things as they are
+			-- get screen and texture size to set the texture on full screen
+
+			Controls.BackupTexture:SetTexture( backupTexture )
+			local screenW, screenH = Controls.BackupTexture:GetSizeVal() -- works, but maybe there is a direct way to get screen size ?
+				
+			Controls.BackupTexture:SetTextureAndResize( backupTexture )
+			local textureW, textureH = Controls.BackupTexture:GetSizeVal()	
+			
+			print ("Screen Width = " .. tostring(screenW) .. ", Screen Height = " .. tostring(screenH) .. ", Texture Width = " .. tostring(textureW) .. ", Texture Height = " .. tostring(textureH))
+
+			local ratioW = screenW / textureW
+			local ratioH = screenH / textureH
+			
+			print ("Width ratio = " .. tostring(ratioW) .. ", Height ratio = " .. tostring(ratioH))
+
+			local ratio = ratioW
+			if ratioH > ratioW then
+				ratio = ratioH
+			end
+			Controls.BackupTexture:SetSizeVal( math.floor(textureW * ratio), math.floor(textureH * ratio) )
+
+			Controls.BackupTexture:SetHide( false )
+		else
+			
+			Controls.BackupTexture:UnloadTexture()
+			Controls.BackupTexture:SetHide( true )
+
+		end
+		-- End of leader head fix
+		
+		
+		-- Are we in Trade Mode?
+		if iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE
+			or iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_DEMAND
+			or iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_REQUEST
+			or iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_HUMAN_OFFERS_CONCESSIONS
+			or iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_OFFER
+			or iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_ACCEPTS_OFFER
+			or iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_REJECTS_OFFER
+			or iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_HUMAN_DEMAND
+			or iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_GENEROUS_OFFER
+		then
+
+			--print("TradeScreen: It's MY mode!");
+
+			if (ContextPtr:IsHidden()) then
+				UIManager:QueuePopup( ContextPtr, PopupPriority.LeaderTrade );
+			end
+
+			--print("Handling LeaderMessage: " .. iDiploUIState .. ", ".. szLeaderMessage);
+
+			g_Deal:SetFromPlayer(g_iUs);
+			g_Deal:SetToPlayer(g_iThem);
+
+			-- Unhide our pocket, in case the last thing we were doing in this screen was a human demand
+			Controls.UsPanel:SetHide(false);
+			Controls.UsGlass:SetHide(false);
+
+			local bClearTableAndDisplayDeal = false;
+
+			-- Is this a UI State where we should be displaying a deal?
+			if (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE) then
+				--print("DiploUIState: Default Trade");
+				bClearTableAndDisplayDeal = true;
+			elseif (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_DEMAND) then
+				--print("DiploUIState: AI making demand");
+				bClearTableAndDisplayDeal = true;
+
+				DoDemandState(true);
+
+			elseif (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_REQUEST) then
+				--print("DiploUIState: AI making Request");
+				bClearTableAndDisplayDeal = true;
+
+				DoDemandState(true);
+			-- Putmalk: Open Trade window when AI is giving a gift and set it to the demand state
+			elseif (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_GENEROUS_OFFER) then
+				--print("DiploUIState: AI making Offer");
+				bClearTableAndDisplayDeal = true;
+				
+				DoDemandState(true);
+			elseif (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_HUMAN_DEMAND) then
+				bClearTableAndDisplayDeal = true;
+				-- If we're demanding something, there's no need to show OUR items
+				Controls.UsPanel:SetHide(true);
+				Controls.UsGlass:SetHide(true);
+
+			elseif (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_HUMAN_OFFERS_CONCESSIONS) then
+				--print("DiploUIState: Human offers concessions");
+				bClearTableAndDisplayDeal = true;
+			elseif (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_MAKES_OFFER) then
+				--print("DiploUIState: AI making offer");
+				bClearTableAndDisplayDeal = true;
+				g_bAIMakingOffer = true;
+			elseif (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_ACCEPTS_OFFER) then
+				--print("DiploUIState: AI accepted offer");
+				g_iConcessionsPreviousDiploUIState = -1;		-- Clear out the fact that we were offering concessions if the AI has agreed to a deal
+				bClearTableAndDisplayDeal = true;
+
+			-- If the AI rejects a deal, don't clear the table: keep the items where they are in case the human wants to change things
+			elseif (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_TRADE_AI_REJECTS_OFFER) then
+				--print("DiploUIState: AI rejects offer");
+				bClearTableAndDisplayDeal = false;
+			else
+				--print("DiploUIState: ?????");
+			end
+
+			-- Clear table and display the deal currently stored in InterfaceBuddy
+			if (bClearTableAndDisplayDeal) then
+				g_bMessageFromDiploAI = true;
+
+				Controls.DiscussionText:SetText( szLeaderMessage );
+
+				DoClearTable();
+				DisplayDeal();
+
+				if (g_iDiploUIState == DiploUIStateTypes.DIPLO_UI_STATE_HUMAN_DEMAND) then
+					-- Hide Defensive Pact/Research Agreement on their side
+					Controls.ThemPocketDefensivePact:SetHide(true);
+					Controls.ThemPocketResearchAgreement:SetHide(true);
+				end
+
+			-- Don't clear the table, leave things as they are
+			else
+
+				--print("NOT clearing table");
+
+				g_bMessageFromDiploAI = true;
+
+				Controls.DiscussionText:SetText( szLeaderMessage );
+			end
+
+			-- Resize the height of the box to fit the text
+			local contentSize = Controls.DiscussionText:GetSize().y + offsetOfString + bonusPadding;
+			local frameSize = {};
+			frameSize.x = innerFrameWidth;
+			frameSize.y = contentSize;
+			Controls.LeaderSpeechBorderFrame:SetSize( frameSize );
+			frameSize.x = outerFrameWidth;
+			frameSize.y = contentSize - offsetsBetweenFrames;
+			Controls.LeaderSpeechFrame:SetSize( frameSize );
+
+			DoUpdateButtons();
+
+		-- Not in trade mode
 		else
 
-			--print("NOT clearing table");
+			--print("TradeScreen: NOT my mode! Hiding!");
+			--print("iDiploUIState: " .. iDiploUIState);
 
-			g_bMessageFromDiploAI = true;
+			g_Deal:ClearItems();
 
-			Controls.DiscussionText:SetText( szLeaderMessage );
+			if (not ContextPtr:IsHidden()) then
+				ContextPtr:SetHide( true );
+			end
+
 		end
-
-		-- Resize the height of the box to fit the text
-		local contentSize = Controls.DiscussionText:GetSize().y + offsetOfString + bonusPadding;
-		local frameSize = {};
-		frameSize.x = innerFrameWidth;
-		frameSize.y = contentSize;
-		Controls.LeaderSpeechBorderFrame:SetSize( frameSize );
-		frameSize.x = outerFrameWidth;
-		frameSize.y = contentSize - offsetsBetweenFrames;
-		Controls.LeaderSpeechFrame:SetSize( frameSize );
-
-		DoUpdateButtons();
-
-	-- Not in trade mode
-	else
-
-		--print("TradeScreen: NOT my mode! Hiding!");
-		--print("iDiploUIState: " .. iDiploUIState);
-
-		g_Deal:ClearItems();
-
-		if (not ContextPtr:IsHidden()) then
-			ContextPtr:SetHide( true );
-		end
-
 	end
-
 end
 --Events.AILeaderMessage.Add( LeaderMessageHandler );
 

--- a/CvGameCoreDLL_Expansion2/CvCityCitizens.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCityCitizens.cpp
@@ -906,7 +906,7 @@ int CvCityCitizens::GetSpecialistValue(SpecialistTypes eSpecialist, const SPreco
 			iYield100 = m_pCity->GetCultureFromSpecialist(eSpecialist) * 100;
 
 		if ((eSpecialist != (SpecialistTypes)GD_INT_GET(DEFAULT_SPECIALIST)) && (eYield == YIELD_FOOD))
-			iYield100 -= (m_pCity->foodConsumptionSpecialistTimes100() - m_pCity->foodConsumptionNonSpecialistTimes100());
+			iYield100 += (m_pCity->foodConsumptionSpecialistTimes100() - m_pCity->foodConsumptionNonSpecialistTimes100());
 
 		if (iYield100 > 0)
 		{
@@ -1522,7 +1522,7 @@ int CvCityCitizens::GetExcessFoodThreshold100() const
 	{
 		CityAIFocusTypes eFocus = GetFocusType();
 		if (eFocus == NO_CITY_AI_FOCUS_TYPE)
-			return max(200, m_pCity->getPopulation() * 25);
+			return max(200, m_pCity->getPopulation() * max(25, 50 - m_pCity->getPopulation()/2));
 		else if (eFocus == CITY_AI_FOCUS_TYPE_PROD_GROWTH || eFocus == CITY_AI_FOCUS_TYPE_GOLD_GROWTH)
 			return max(200, m_pCity->getPopulation() * 50);
 		else if (eFocus == CITY_AI_FOCUS_TYPE_FOOD)

--- a/CvGameCoreDLL_Expansion2/CvDealAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDealAI.cpp
@@ -150,11 +150,11 @@ bool CvDealAI::WithinAcceptableRange(PlayerTypes ePlayer, int iMaxValue, int iNe
 	int iMaxDeviation = iMaxValue * iLeewayPercent + min(100, iMaxValue) * 15;
 	iMaxDeviation /= 100;
 
-	// a deal value of less than half the value of 1 GPT should always be acceptable, to avoid deals that can't be equalized with GPT
+	// a deal value of less than or equal to half the value of 1 GPT should always be acceptable, to avoid deals that can't be equalized with GPT
 	int iGPTValue = GetOneGPTValue();
 
 	//put some sanity checks
-	return abs(iNetValue) < min(max(iMaxDeviation,iGPTValue/2),500);
+	return abs(iNetValue) <= min(max(iMaxDeviation,iGPTValue/2),500);
 }
 
 bool CvDealAI::BothSidesIncluded(CvDeal* pDeal)

--- a/CvGameCoreDLL_Expansion2/CvDealAI.h
+++ b/CvGameCoreDLL_Expansion2/CvDealAI.h
@@ -63,6 +63,7 @@ public:
 
 	// What is something worth? - bUseEvenValue will see what the mean is between two AI players (us and eOtherPlayer) - will NOT work with a human involved
 
+	int GetOneGPTValue() const;
 	int GetDealValue(CvDeal* pDeal, bool bLogging = false);
 	int GetTradeItemValue(TradeableItems eItem, bool bFromMe, PlayerTypes eOtherPlayer, int iData1, int iData2, int iData3, bool bFlag1, int iDuration, bool bLogging = false);
 
@@ -86,34 +87,34 @@ public:
 
 	// Potential items an AI can try to add to a deal to even it out - bUseEvenValue will see what the mean is between two AI players (us and eOtherPlayer) - will NOT work with a human involved
 
-	void DoAddVoteCommitmentToThem(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue);
-	void DoAddVoteCommitmentToUs(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue);
+	void DoAddVoteCommitmentToThem(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue, int iThresholdValue);
+	void DoAddVoteCommitmentToUs(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue, int iThresholdValue);
 
-	void DoAddThirdPartyWarToThem(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue);
-	void DoAddThirdPartyWarToUs(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue);
+	void DoAddThirdPartyWarToThem(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue, int iThresholdValue);
+	void DoAddThirdPartyWarToUs(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue, int iThresholdValue);
 
-	void DoAddThirdPartyPeaceToThem(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue);
-	void DoAddThirdPartyPeaceToUs(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue);
+	void DoAddThirdPartyPeaceToThem(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue, int iThresholdValue);
+	void DoAddThirdPartyPeaceToUs(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue, int iThresholdValue);
 
-	void DoAddLuxuryResourceToThem(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue);
-	void DoAddLuxuryResourceToUs(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue);
+	void DoAddLuxuryResourceToThem(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue, int iThresholdValue);
+	void DoAddLuxuryResourceToUs(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue, int iThresholdValue);
 
-	void DoAddStrategicResourceToThem(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue);
-	void DoAddStrategicResourceToUs(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue);
+	void DoAddStrategicResourceToThem(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue, int iThresholdValue);
+	void DoAddStrategicResourceToUs(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue, int iThresholdValue);
 
-	void DoAddEmbassyToThem(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue);
-	void DoAddEmbassyToUs(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue);
+	void DoAddEmbassyToThem(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue, int iThresholdValue);
+	void DoAddEmbassyToUs(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue, int iThresholdValue);
 
-	void DoAddOpenBordersToThem(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue);
-	void DoAddOpenBordersToUs(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue);
+	void DoAddOpenBordersToThem(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue, int iThresholdValue);
+	void DoAddOpenBordersToUs(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue, int iThresholdValue);
 
-	void DoAddCitiesToThem(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue);
-	void DoAddCitiesToUs(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue);
+	void DoAddCitiesToThem(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue, int iThresholdValue);
+	void DoAddCitiesToUs(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue, int iThresholdValue);
 
-	void DoAddGoldToThem(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue);
+	void DoAddGoldToThem(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue, int iDemandValue = 0);
 	void DoAddGoldToUs(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue);
 
-	void DoAddGPTToThem(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue);
+	void DoAddGPTToThem(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue, int iDemandValue = 0);
 	void DoAddGPTToUs(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue);
 
 	void DoRemoveGPTFromThem(CvDeal* pDeal, PlayerTypes eThem, int iNumToRemove);
@@ -122,8 +123,8 @@ public:
 	void DoRemoveGoldFromThem(CvDeal* pDeal, PlayerTypes eThem, int& iNumGoldAlreadyInTrade);
 	void DoRemoveGoldFromUs(CvDeal* pDeal, int& iNumGoldAlreadyInTrade);
 
-	void DoAddItemsToThem(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue);
-	void DoAddItemsToUs(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue);
+	void DoAddItemsToThem(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue, int iThresholdValue = 0, bool bGoldOnly = false);
+	void DoAddItemsToUs(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue, int iThresholdValue = 0, bool bGoldOnly = false);
 
 	// Possible deals the AI can offer
 	bool IsOfferPeace(PlayerTypes eOtherPlayer, CvDeal* pDeal, bool bEqualizingDeals);
@@ -168,15 +169,15 @@ public:
 	bool IsMakeOfferForRevokeVassalage(PlayerTypes eOtherPlayer, CvDeal* pDeal);
 
 	// Will adding item to deal even it out?
-	void DoAddTechToThem(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue);
-	void DoAddTechToUs(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue);
-	void DoAddMapsToThem(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue);
-	void DoAddMapsToUs(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue);
+	void DoAddTechToThem(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue, int iThresholdValue);
+	void DoAddTechToUs(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue, int iThresholdValue);
+	void DoAddMapsToThem(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue, int iThresholdValue);
+	void DoAddMapsToUs(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue, int iThresholdValue);
 
-	void DoAddVassalageToUs(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue);
-	void DoAddVassalageToThem(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue);
+	void DoAddVassalageToUs(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue, int iThresholdValue);
+	void DoAddVassalageToThem(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue, int iThresholdValue);
 
-	void DoAddRevokeVassalageToThem(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue);
+	void DoAddRevokeVassalageToThem(CvDeal* pDeal, PlayerTypes eThem, int& iTotalValue, int iThresholdValue);
 
 protected:
 	void UpdateResearchRateCache(PlayerTypes eOther);

--- a/CvGameCoreDLL_Expansion2/CvDealClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDealClasses.cpp
@@ -56,6 +56,7 @@ CvTradedItem::CvTradedItem()
 	m_eFromPlayer = NO_PLAYER;
 	m_iValue = INT_MAX;
 	m_bValueIsEven = false;
+	m_bDoNotRemove = false;
 }
 
 /// Equals operator
@@ -137,8 +138,6 @@ CvDeal::CvDeal(PlayerTypes eFromPlayer, PlayerTypes eToPlayer)
 	m_bCheckedForRenewal = false;
 
 	m_bIsGift = false;
-	m_bDoNotModifyFrom = false;
-	m_bDoNotModifyTo = false;
 	m_iFromPlayerValue = -1;
 	m_iToPlayerValue = -1;
 }
@@ -158,8 +157,6 @@ CvDeal::CvDeal(const CvDeal& source)
 	m_bConsideringForRenewal = source.m_bConsideringForRenewal;
 	m_bCheckedForRenewal = source.m_bCheckedForRenewal;
 	m_bIsGift = source.m_bIsGift;
-	m_bDoNotModifyFrom = source.m_bDoNotModifyFrom;
-	m_bDoNotModifyTo = source.m_bDoNotModifyTo;
 	m_iFromPlayerValue = source.m_iFromPlayerValue;
 	m_iToPlayerValue = source.m_iToPlayerValue;
 	m_TradedItems = source.m_TradedItems;
@@ -185,8 +182,6 @@ bool CvDeal::operator==(const CvDeal& other) const
 		m_bConsideringForRenewal == other.m_bConsideringForRenewal &&
 		m_bCheckedForRenewal == other.m_bCheckedForRenewal &&
 		m_bIsGift == other.m_bIsGift &&
-		m_bDoNotModifyFrom == other.m_bDoNotModifyFrom &&
-		m_bDoNotModifyTo == other.m_bDoNotModifyTo &&
 		m_iFromPlayerValue == other.m_iFromPlayerValue &&
 		m_iToPlayerValue == other.m_iToPlayerValue &&
 		m_TradedItems == other.m_TradedItems;
@@ -207,8 +202,6 @@ CvDeal& CvDeal::operator=(const CvDeal& source)
 	m_bConsideringForRenewal = source.m_bConsideringForRenewal;
 	m_bCheckedForRenewal = source.m_bCheckedForRenewal;
 	m_bIsGift = source.m_bIsGift;
-	m_bDoNotModifyFrom = source.m_bDoNotModifyFrom;
-	m_bDoNotModifyTo = source.m_bDoNotModifyTo;
 	m_iFromPlayerValue = source.m_iFromPlayerValue;
 	m_iToPlayerValue = source.m_iToPlayerValue;
 	m_TradedItems = source.m_TradedItems;
@@ -226,8 +219,6 @@ void CvDeal::ClearItems()
 	m_bConsideringForRenewal = false;
 	m_bCheckedForRenewal = false;
 	m_bIsGift = false;
-	m_bDoNotModifyFrom = false;
-	m_bDoNotModifyTo = false;
 	m_iFromPlayerValue = -1;
 	m_iToPlayerValue = -1;
 
@@ -300,16 +291,6 @@ void CvDeal::ChangeToPlayerValue(int iValue)
 void CvDeal::SetDuration(int iValue)
 {
 	m_iDuration = iValue;
-}
-
-void CvDeal::SetDoNotModifyFrom(bool bValue)
-{
-	m_bDoNotModifyFrom = bValue;
-}
-
-void CvDeal::SetDoNotModifyTo(bool bValue)
-{
-	m_bDoNotModifyTo = bValue;
 }
 
 
@@ -444,7 +425,11 @@ bool CvDeal::IsPossibleToTradeItem(PlayerTypes ePlayer, PlayerTypes eToPlayer, T
 	if (BlockTemporaryForPermanentTrade(eItem, ePlayer, eToPlayer))
 		return false;
 
-	std::vector<CvDeal*> pRenewDeals = pFromPlayer->GetDiplomacyAI()->GetDealsToRenew(eToPlayer);
+	std::vector<CvDeal*> pRenewDeals;
+	pRenewDeals = pFromPlayer->GetDiplomacyAI()->GetDealsToRenew(eToPlayer);
+	std::vector<CvDeal*> pTheirRenewDeals;
+	pTheirRenewDeals = pToPlayer->GetDiplomacyAI()->GetDealsToRenew(ePlayer);
+	pRenewDeals.insert(pRenewDeals.end(), pTheirRenewDeals.begin(), pTheirRenewDeals.end());
 
 	////////////////////////////////////////////////////
 	//////// INDIVIDUAL TRADE ITEMS ////////////////////
@@ -532,7 +517,6 @@ bool CvDeal::IsPossibleToTradeItem(PlayerTypes ePlayer, PlayerTypes eToPlayer, T
 			int iGoldRate = pFromPlayer->calculateGoldRate();
 
 			// If this is a renewal deal, account for the gold already included in the renewal
-			// Recursive: Is this identifying the correct deal?
 			for (uint i = 0; i < pRenewDeals.size(); i++)
 			{
 				CvDeal* pRenewDeal = pRenewDeals[i];
@@ -591,7 +575,6 @@ bool CvDeal::IsPossibleToTradeItem(PlayerTypes ePlayer, PlayerTypes eToPlayer, T
 				int iNumAvailableToUs = pFromPlayer->getNumResourceAvailable(eResource, /*bIncludeImport*/ false), iNumAvailableToOther = eUsage == RESOURCEUSAGE_LUXURY ? pToPlayer->getNumResourceAvailable(eResource, /*bIncludeImport*/ true) : 0;
 
 				// If a renewal deal, add/subtract the resources already included in the renewal.
-				// Recursive: Is this identifying the correct deal?
 				if (pRenewDeals.size() > 0)
 				{
 					for (uint i = 0; i < pRenewDeals.size(); i++)
@@ -741,7 +724,6 @@ bool CvDeal::IsPossibleToTradeItem(PlayerTypes ePlayer, PlayerTypes eToPlayer, T
 
 			bool bIgnoreExistingOB = false;
 			// Renewing an Open Borders deal?
-			// Recursive: Is this identifying the correct deal?
 			for (uint i = 0; i < pRenewDeals.size(); i++)
 			{
 				CvDeal* pRenewDeal = pRenewDeals[i];
@@ -789,7 +771,6 @@ bool CvDeal::IsPossibleToTradeItem(PlayerTypes ePlayer, PlayerTypes eToPlayer, T
 
 			bool bIgnoreExistingDP = false;
 			// Renewing a Defensive Pact deal?
-			// Recursive: Is this identifying the correct deal?
 			for (uint i = 0; i < pRenewDeals.size(); i++)
 			{
 				CvDeal* pRenewDeal = pRenewDeals[i];
@@ -1674,7 +1655,6 @@ CvString CvDeal::GetReasonsItemUntradeable(PlayerTypes ePlayer, PlayerTypes eToP
 		{
 			bool bIgnoreExistingOB = false;
 			// Renewing an Open Borders deal?
-			// Recursive: Is this identifying the correct deal?
 			for (uint i = 0; i < pRenewDeals.size(); i++)
 			{
 				CvDeal* pRenewDeal = pRenewDeals[i];
@@ -1761,7 +1741,6 @@ CvString CvDeal::GetReasonsItemUntradeable(PlayerTypes ePlayer, PlayerTypes eToP
 		{
 			bool bIgnoreExistingDP = false;
 			// Renewing a Defensive Pact deal?
-			// Recursive: Is this identifying the correct deal?
 			for (uint i = 0; i < pRenewDeals.size(); i++)
 			{
 				CvDeal* pRenewDeal = pRenewDeals[i];
@@ -3148,7 +3127,7 @@ void CvDeal::SetRequestingPlayer(PlayerTypes ePlayer)
 // METHODS TO ADD A CvTradedItem TO A DEAL
 
 /// Insert an immediate gold trade
-void CvDeal::AddGoldTrade(PlayerTypes eFrom, int iAmount)
+void CvDeal::AddGoldTrade(PlayerTypes eFrom, int iAmount, bool bDoNotRemove)
 {
 	CvAssertMsg(iAmount >= 0, "DEAL: Trying to add a negative amount of Gold to a deal.  Please send Jon this with your last 5 autosaves and what changelist # you're playing.");
 	CvAssertMsg(eFrom == m_eFromPlayer || eFrom == m_eToPlayer, "DEAL: Adding deal item for a player that's not actually in this deal!  Please send Jon this with your last 5 autosaves and what changelist # you're playing.");
@@ -3161,12 +3140,13 @@ void CvDeal::AddGoldTrade(PlayerTypes eFrom, int iAmount)
 		item.m_iFinalTurn = -1;
 		item.m_iData1 = iAmount;
 		item.m_eFromPlayer = eFrom;
+		item.m_bDoNotRemove = bDoNotRemove;
 		m_TradedItems.push_back(item);
 	}
 }
 
 /// Insert a gold per turn trade
-void CvDeal::AddGoldPerTurnTrade(PlayerTypes eFrom, int iAmount, int iDuration)
+void CvDeal::AddGoldPerTurnTrade(PlayerTypes eFrom, int iAmount, int iDuration, bool bDoNotRemove)
 {
 	CvAssertMsg(iAmount >= 0, "DEAL: Trying to add a negative amount of GPT to a deal.  Please send Jon this with your last 5 autosaves and what changelist # you're playing.");
 	CvAssertMsg(iDuration >= 0, "DEAL: Trying to add a negative duration to a TradeItem.  Please send Jon this with your last 5 autosaves and what changelist # you're playing.");
@@ -3182,6 +3162,7 @@ void CvDeal::AddGoldPerTurnTrade(PlayerTypes eFrom, int iAmount, int iDuration)
 		item.m_iFinalTurn = -1;
 		item.m_iData1 = iAmount;
 		item.m_eFromPlayer = eFrom;
+		item.m_bDoNotRemove = bDoNotRemove;
 		m_TradedItems.push_back(item);
 	}
 	else
@@ -3191,7 +3172,7 @@ void CvDeal::AddGoldPerTurnTrade(PlayerTypes eFrom, int iAmount, int iDuration)
 }
 
 /// Insert a map trade
-void CvDeal::AddMapTrade(PlayerTypes eFrom)
+void CvDeal::AddMapTrade(PlayerTypes eFrom, bool bDoNotRemove)
 {
 	CvAssertMsg(eFrom == m_eFromPlayer || eFrom == m_eToPlayer, "DEAL: Adding deal item for a player that's not actually in this deal!  Please send Jon this with your last 5 autosaves and what changelist # you're playing.");
 
@@ -3202,6 +3183,7 @@ void CvDeal::AddMapTrade(PlayerTypes eFrom)
 		item.m_iDuration = 0;
 		item.m_iFinalTurn = -1;
 		item.m_eFromPlayer = eFrom;
+		item.m_bDoNotRemove = bDoNotRemove;
 		m_TradedItems.push_back(item);
 	}
 	else
@@ -3211,7 +3193,7 @@ void CvDeal::AddMapTrade(PlayerTypes eFrom)
 }
 
 /// Insert a resource trade
-void CvDeal::AddResourceTrade(PlayerTypes eFrom, ResourceTypes eResource, int iAmount, int iDuration)
+void CvDeal::AddResourceTrade(PlayerTypes eFrom, ResourceTypes eResource, int iAmount, int iDuration, bool bDoNotRemove)
 {
 	CvAssertMsg(iAmount >= 0, "DEAL: Trying to add a negative amount of a Resource to a deal.  Please send Jon this with your last 5 autosaves and what changelist # you're playing.");
 	CvAssertMsg(iDuration >= 0, "DEAL: Trying to add a negative duration to a TradeItem.  Please send Jon this with your last 5 autosaves and what changelist # you're playing.");
@@ -3228,6 +3210,7 @@ void CvDeal::AddResourceTrade(PlayerTypes eFrom, ResourceTypes eResource, int iA
 		item.m_iData1 = (int)eResource;
 		item.m_iData2 = iAmount;
 		item.m_eFromPlayer = eFrom;
+		item.m_bDoNotRemove = bDoNotRemove;
 		m_TradedItems.push_back(item);
 	}
 	else
@@ -3237,7 +3220,7 @@ void CvDeal::AddResourceTrade(PlayerTypes eFrom, ResourceTypes eResource, int iA
 }
 
 /// Insert a city trade
-void CvDeal::AddCityTrade(PlayerTypes eFrom, int iCityID)
+void CvDeal::AddCityTrade(PlayerTypes eFrom, int iCityID, bool bDoNotRemove)
 {
 	CvAssertMsg(eFrom == m_eFromPlayer || eFrom == m_eToPlayer, "DEAL: Adding deal item for a player that's not actually in this deal!  Please send Jon this with your last 5 autosaves and what changelist # you're playing.");
 
@@ -3259,6 +3242,7 @@ void CvDeal::AddCityTrade(PlayerTypes eFrom, int iCityID)
 		item.m_iData2 = y;
 
 		item.m_eFromPlayer = eFrom;
+		item.m_bDoNotRemove = bDoNotRemove;
 		m_TradedItems.push_back(item);
 	}
 	else
@@ -3268,7 +3252,7 @@ void CvDeal::AddCityTrade(PlayerTypes eFrom, int iCityID)
 }
 
 /// Insert adding an embassy to the deal
-void CvDeal::AddAllowEmbassy(PlayerTypes eFrom)
+void CvDeal::AddAllowEmbassy(PlayerTypes eFrom, bool bDoNotRemove)
 {
 	CvAssertMsg(eFrom == m_eFromPlayer || eFrom == m_eToPlayer, "DEAL: Adding deal item for a player that's not actually in this deal!  Please send Jon this with your last 5 autosaves and what changelist # you're playing.");
 
@@ -3277,6 +3261,7 @@ void CvDeal::AddAllowEmbassy(PlayerTypes eFrom)
 		CvTradedItem item;
 		item.m_eItemType = TRADE_ITEM_ALLOW_EMBASSY;
 		item.m_eFromPlayer = eFrom;
+		item.m_bDoNotRemove = bDoNotRemove;
 		m_TradedItems.push_back(item);
 	}
 	else
@@ -3286,7 +3271,7 @@ void CvDeal::AddAllowEmbassy(PlayerTypes eFrom)
 }
 
 /// Insert an open borders pact
-void CvDeal::AddOpenBorders(PlayerTypes eFrom, int iDuration)
+void CvDeal::AddOpenBorders(PlayerTypes eFrom, int iDuration, bool bDoNotRemove)
 {
 	CvAssertMsg(iDuration >= 0, "DEAL: Trying to add a negative duration to a TradeItem.  Please send Jon this with your last 5 autosaves and what changelist # you're playing.");
 	CvAssertMsg(iDuration < GC.getGame().getEstimateEndTurn() * 2, "DEAL: Trade item has a crazy long duration (probably invalid).  Please send Jon this with your last 5 autosaves and what changelist # you're playing.");
@@ -3300,6 +3285,7 @@ void CvDeal::AddOpenBorders(PlayerTypes eFrom, int iDuration)
 		//item.m_iFinalTurn = iDuration + GC.getGame().getGameTurn();
 		item.m_iFinalTurn = -1;
 		item.m_eFromPlayer = eFrom;
+		item.m_bDoNotRemove = bDoNotRemove;
 		m_TradedItems.push_back(item);
 	}
 	else
@@ -3309,7 +3295,7 @@ void CvDeal::AddOpenBorders(PlayerTypes eFrom, int iDuration)
 }
 
 /// Insert a defensive pact
-void CvDeal::AddDefensivePact(PlayerTypes eFrom, int iDuration)
+void CvDeal::AddDefensivePact(PlayerTypes eFrom, int iDuration, bool bDoNotRemove)
 {
 	CvAssertMsg(iDuration >= 0, "DEAL: Trying to add a negative duration to a TradeItem.  Please send Jon this with your last 5 autosaves and what changelist # you're playing.");
 	CvAssertMsg(iDuration < GC.getGame().getEstimateEndTurn() * 2, "DEAL: Trade item has a crazy long duration (probably invalid).  Please send Jon this with your last 5 autosaves and what changelist # you're playing.");
@@ -3323,6 +3309,7 @@ void CvDeal::AddDefensivePact(PlayerTypes eFrom, int iDuration)
 		//item.m_iFinalTurn = iDuration + GC.getGame().getGameTurn();
 		item.m_iFinalTurn = -1;
 		item.m_eFromPlayer = eFrom;
+		item.m_bDoNotRemove = bDoNotRemove;
 		m_TradedItems.push_back(item);
 	}
 	else
@@ -3332,7 +3319,7 @@ void CvDeal::AddDefensivePact(PlayerTypes eFrom, int iDuration)
 }
 
 /// Insert a Research Agreement
-void CvDeal::AddResearchAgreement(PlayerTypes eFrom, int iDuration)
+void CvDeal::AddResearchAgreement(PlayerTypes eFrom, int iDuration, bool bDoNotRemove)
 {
 	CvAssertMsg(iDuration >= 0, "DEAL: Trying to add a negative duration to a TradeItem.  Please send Jon this with your last 5 autosaves and what changelist # you're playing.");
 	CvAssertMsg(iDuration < GC.getGame().getEstimateEndTurn() * 2, "DEAL: Trade item has a crazy long duration (probably invalid).  Please send Jon this with your last 5 autosaves and what changelist # you're playing.");
@@ -3346,6 +3333,7 @@ void CvDeal::AddResearchAgreement(PlayerTypes eFrom, int iDuration)
 		//item.m_iFinalTurn = iDuration + GC.getGame().getGameTurn();
 		item.m_iFinalTurn = -1;
 		item.m_eFromPlayer = eFrom;
+		item.m_bDoNotRemove = bDoNotRemove;
 		m_TradedItems.push_back(item);
 	}
 	else
@@ -3355,7 +3343,7 @@ void CvDeal::AddResearchAgreement(PlayerTypes eFrom, int iDuration)
 }
 
 /// Insert ending a war
-void CvDeal::AddPeaceTreaty(PlayerTypes eFrom, int iDuration)
+void CvDeal::AddPeaceTreaty(PlayerTypes eFrom, int iDuration, bool bDoNotRemove)
 {
 	CvAssertMsg(eFrom == m_eFromPlayer || eFrom == m_eToPlayer, "DEAL: Adding deal item for a player that's not actually in this deal!  Please send Jon this with your last 5 autosaves and what changelist # you're playing.");
 
@@ -3366,6 +3354,7 @@ void CvDeal::AddPeaceTreaty(PlayerTypes eFrom, int iDuration)
 		item.m_iDuration = iDuration;
 		item.m_iFinalTurn = -1;
 		item.m_eFromPlayer = eFrom;
+		item.m_bDoNotRemove = bDoNotRemove;
 		m_TradedItems.push_back(item);
 	}
 	else
@@ -3375,7 +3364,7 @@ void CvDeal::AddPeaceTreaty(PlayerTypes eFrom, int iDuration)
 }
 
 /// Insert going to peace with a third party
-void CvDeal::AddThirdPartyPeace(PlayerTypes eFrom, TeamTypes eThirdPartyTeam, int iDuration)
+void CvDeal::AddThirdPartyPeace(PlayerTypes eFrom, TeamTypes eThirdPartyTeam, int iDuration, bool bDoNotRemove)
 {
 	CvAssertMsg(eFrom == m_eFromPlayer || eFrom == m_eToPlayer, "DEAL: Adding deal item for a player that's not actually in this deal!  Please send Jon this with your last 5 autosaves and what changelist # you're playing.");
 
@@ -3387,6 +3376,7 @@ void CvDeal::AddThirdPartyPeace(PlayerTypes eFrom, TeamTypes eThirdPartyTeam, in
 		item.m_iFinalTurn = -1;
 		item.m_iData1 = eThirdPartyTeam;
 		item.m_eFromPlayer = eFrom;
+		item.m_bDoNotRemove = bDoNotRemove;
 		m_TradedItems.push_back(item);
 	}
 	else
@@ -3396,7 +3386,7 @@ void CvDeal::AddThirdPartyPeace(PlayerTypes eFrom, TeamTypes eThirdPartyTeam, in
 }
 
 /// Insert going to war with a third party
-void CvDeal::AddThirdPartyWar(PlayerTypes eFrom, TeamTypes eThirdPartyTeam)
+void CvDeal::AddThirdPartyWar(PlayerTypes eFrom, TeamTypes eThirdPartyTeam, bool bDoNotRemove)
 {
 	CvAssertMsg(eFrom == m_eFromPlayer || eFrom == m_eToPlayer, "DEAL: Adding deal item for a player that's not actually in this deal!  Please send Jon this with your last 5 autosaves and what changelist # you're playing.");
 
@@ -3408,6 +3398,7 @@ void CvDeal::AddThirdPartyWar(PlayerTypes eFrom, TeamTypes eThirdPartyTeam)
 		item.m_iFinalTurn = -1;
 		item.m_iData1 = eThirdPartyTeam;
 		item.m_eFromPlayer = eFrom;
+		item.m_bDoNotRemove = bDoNotRemove;
 		m_TradedItems.push_back(item);
 	}
 	else
@@ -3417,7 +3408,7 @@ void CvDeal::AddThirdPartyWar(PlayerTypes eFrom, TeamTypes eThirdPartyTeam)
 }
 
 /// Insert adding a declaration of peace to the deal
-void CvDeal::AddDeclarationOfFriendship(PlayerTypes eFrom)
+void CvDeal::AddDeclarationOfFriendship(PlayerTypes eFrom, bool bDoNotRemove)
 {
 	CvAssertMsg(eFrom == m_eFromPlayer || eFrom == m_eToPlayer, "DEAL: Adding deal item for a player that's not actually in this deal!");
 
@@ -3428,6 +3419,7 @@ void CvDeal::AddDeclarationOfFriendship(PlayerTypes eFrom)
 			CvTradedItem item;
 			item.m_eItemType = TRADE_ITEM_DECLARATION_OF_FRIENDSHIP;
 			item.m_eFromPlayer = eFrom;
+			item.m_bDoNotRemove = bDoNotRemove;
 			m_TradedItems.push_back(item);
 		}
 	}
@@ -3438,7 +3430,7 @@ void CvDeal::AddDeclarationOfFriendship(PlayerTypes eFrom)
 }
 
 /// Insert a vote commitment to the deal
-void CvDeal::AddVoteCommitment(PlayerTypes eFrom, int iResolutionID, int iVoteChoice, int iNumVotes, bool bRepeal)
+void CvDeal::AddVoteCommitment(PlayerTypes eFrom, int iResolutionID, int iVoteChoice, int iNumVotes, bool bRepeal, bool bDoNotRemove)
 {
 	CvAssertMsg(eFrom == m_eFromPlayer || eFrom == m_eToPlayer, "DEAL: Adding deal item for a player that's not actually in this deal!");
 
@@ -3451,6 +3443,7 @@ void CvDeal::AddVoteCommitment(PlayerTypes eFrom, int iResolutionID, int iVoteCh
 		item.m_iData2 = iVoteChoice;
 		item.m_iData3 = iNumVotes;
 		item.m_bFlag1 = bRepeal;
+		item.m_bDoNotRemove = bDoNotRemove;
 		m_TradedItems.push_back(item);
 	}
 	else
@@ -3769,8 +3762,13 @@ bool CvDeal::IsPotentiallyRenewable()
 	return false;
 }
 
+bool CvDeal::IsCheckedForRenewal()
+{
+	return m_bCheckedForRenewal;
+}
+
 /// Delete all items from a given player
-bool CvDeal::RemoveAllByPlayer(PlayerTypes eOffering)
+void CvDeal::RemoveAllPossibleItems()
 {
 	//have to do this in a nested fashion to avoid invalidating the iterator
 	bool bFound = false;
@@ -3782,8 +3780,7 @@ bool CvDeal::RemoveAllByPlayer(PlayerTypes eOffering)
 		TradedItemList::iterator it;
 		for (it = m_TradedItems.begin(); it != m_TradedItems.end(); ++it)
 		{
-			//do not remove items which need to be on both sides to make sense
-			if (eOffering == it->m_eFromPlayer && !it->IsTwoSided())
+			if (!it->m_bDoNotRemove)
 			{
 				m_TradedItems.erase(it);
 				bFound = true;
@@ -3793,8 +3790,6 @@ bool CvDeal::RemoveAllByPlayer(PlayerTypes eOffering)
 		}
 	}
 	while (bFound);
-
-	return bChange;
 }
 
 /// Delete a SINGLE trade item that can be identified by type alone
@@ -3969,7 +3964,7 @@ FDataStream& operator<<(FDataStream& saveTo, const CvDeal& readFrom)
 }
 
 /// Insert a tech trade
-void CvDeal::AddTechTrade(PlayerTypes eFrom, TechTypes eTech)
+void CvDeal::AddTechTrade(PlayerTypes eFrom, TechTypes eTech, bool bDoNotRemove)
 {
 	CvAssertMsg(eFrom == m_eFromPlayer || eFrom == m_eToPlayer, "DEAL: Adding deal item for a player that's not actually in this deal!  Please send Jon this with your last 5 autosaves and what changelist # you're playing.");
 
@@ -3981,6 +3976,7 @@ void CvDeal::AddTechTrade(PlayerTypes eFrom, TechTypes eTech)
 		item.m_iFinalTurn = -1;
 		item.m_iData1 = (int)eTech;
 		item.m_eFromPlayer = eFrom;
+		item.m_bDoNotRemove = bDoNotRemove;
 		m_TradedItems.push_back(item);
 	}
 	else
@@ -3990,7 +3986,7 @@ void CvDeal::AddTechTrade(PlayerTypes eFrom, TechTypes eTech)
 }
 
 /// Insert Vassalage Trade
-void CvDeal::AddVassalageTrade(PlayerTypes eFrom)
+void CvDeal::AddVassalageTrade(PlayerTypes eFrom, bool bDoNotRemove)
 {
 	CvAssertMsg(eFrom == m_eFromPlayer || eFrom == m_eToPlayer, "DEAL: Adding deal item for a player that's not actually in this deal!  Please send Jon this with your last 5 autosaves and what changelist # you're playing.");
 
@@ -3999,6 +3995,7 @@ void CvDeal::AddVassalageTrade(PlayerTypes eFrom)
 		CvTradedItem item;
 		item.m_eItemType = TRADE_ITEM_VASSALAGE;
 		item.m_eFromPlayer = eFrom;
+		item.m_bDoNotRemove = bDoNotRemove;
 		m_TradedItems.push_back(item);
 	}
 	else
@@ -4008,7 +4005,7 @@ void CvDeal::AddVassalageTrade(PlayerTypes eFrom)
 }
 
 /// Insert Vassalage Trade
-void CvDeal::AddRevokeVassalageTrade(PlayerTypes eFrom)
+void CvDeal::AddRevokeVassalageTrade(PlayerTypes eFrom, bool bDoNotRemove)
 {
 	CvAssertMsg(eFrom == m_eFromPlayer || eFrom == m_eToPlayer, "DEAL: Adding deal item for a player that's not actually in this deal!  Please send Jon this with your last 5 autosaves and what changelist # you're playing.");
 
@@ -4017,6 +4014,7 @@ void CvDeal::AddRevokeVassalageTrade(PlayerTypes eFrom)
 		CvTradedItem item;
 		item.m_eItemType = TRADE_ITEM_VASSALAGE_REVOKE;
 		item.m_eFromPlayer = eFrom;
+		item.m_bDoNotRemove = bDoNotRemove;
 		m_TradedItems.push_back(item);
 	}
 	else
@@ -4495,6 +4493,9 @@ void CvGameDeals::ActivateDeal(PlayerTypes eFromPlayer, PlayerTypes eToPlayer, C
 	kDeal.m_iDuration = iLongestDuration;
 	kDeal.m_iFinalTurn = iLatestItemLastTurn;
 	kDeal.m_iStartTurn = GC.getGame().getGameTurn();
+	// reset this
+	kDeal.m_bConsideringForRenewal = false;
+	kDeal.m_bCheckedForRenewal = false;
 
 	// Add to current deals
 	m_CurrentDeals.push_back(kDeal);
@@ -5984,6 +5985,8 @@ void CvGameDeals::PrepareRenewDeal(CvDeal* pOldDeal)
 			continue;
 		}
 
+		oldDealItemIter->m_bDoNotRemove = true;
+
 		TradeableItems eItemType = oldDealItemIter->m_eItemType;
 		if (eItemType == TRADE_ITEM_RESOURCES)
 		{
@@ -6838,7 +6841,7 @@ uint CvGameDeals::GetNumHistoricDealsWithPlayer(PlayerTypes ePlayer, PlayerTypes
 
 // ------------------------------------------------------------------------
 // ------------------------------------------------------------------------
-std::vector<CvDeal*> CvGameDeals::GetRenewableDealsWithPlayer(PlayerTypes ePlayer, PlayerTypes eOtherPlayer, uint iMaxCount)
+std::vector<CvDeal*> CvGameDeals::GetRenewableDealsWithPlayer(PlayerTypes ePlayer, PlayerTypes eOtherPlayer, uint iMaxCount, bool bOnlyCheckedDeals)
 {
 
 	std::vector<CvDeal*> renewDeals;
@@ -6847,6 +6850,9 @@ std::vector<CvDeal*> CvGameDeals::GetRenewableDealsWithPlayer(PlayerTypes ePlaye
 		CvDeal& kDeal = m_CurrentDeals[i];
 
 		if (!kDeal.m_bConsideringForRenewal)
+			continue;
+
+		if (!kDeal.m_bCheckedForRenewal && bOnlyCheckedDeals)
 			continue;
 
 		if ((kDeal.m_eToPlayer == ePlayer || kDeal.m_eFromPlayer == ePlayer) &&

--- a/CvGameCoreDLL_Expansion2/CvDealClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvDealClasses.h
@@ -67,6 +67,7 @@ struct CvTradedItem
 	PlayerTypes m_eFromPlayer;      // Which player is giving up this item?
 	int m_iValue;					// not serialized, only temporary
 	bool m_bValueIsEven;			// not serialized, only temporary
+	bool m_bDoNotRemove;			// not serialized, only temporary. Is set to true when the AI makes an offer for a particular deal item or when a human player adds something to a deal. Is false for all items added by the AI when trying to equalize a deal. The AI can't remove items with bNoNotRemove == true when trying to equalize a deal. Human players can always remove all items.
 };
 FDataStream& operator>>(FDataStream&, CvTradedItem&);
 FDataStream& operator<<(FDataStream&, const CvTradedItem&);
@@ -120,8 +121,6 @@ public:
 	bool m_bConsideringForRenewal; // is currently considering renewing this deal
 	bool m_bCheckedForRenewal; // this deal has been discussed with the player for renewal
 	bool m_bIsGift;
-	bool m_bDoNotModifyFrom;
-	bool m_bDoNotModifyTo;
 
 	TradedItemList m_TradedItems;
 
@@ -140,8 +139,6 @@ public:
 
 	void SetDuration(int iValue);
 
-	void SetDoNotModifyFrom(bool bValue);
-	void SetDoNotModifyTo(bool bValue);
 
 	PlayerTypes GetOtherPlayer(PlayerTypes eFromPlayer) const;
 	PlayerTypes GetToPlayer()   const
@@ -173,15 +170,6 @@ public:
 		return m_iToPlayerValue;
 	};
 
-	bool DoNotModifyFrom() const
-	{
-		return m_bDoNotModifyFrom;
-	};
-
-	bool DoNotModifyTo() const
-	{
-		return m_bDoNotModifyTo;
-	};
 
 	// Peace Treaty stuff
 	PeaceTreatyTypes GetPeaceTreatyType() const;
@@ -217,24 +205,24 @@ public:
 	int GetNumCitiesInDeal(PlayerTypes ePlayer);
 
 	// Methods to add a CvTradedItem to a deal
-	void AddGoldTrade(PlayerTypes eFrom, int iAmount);
-	void AddGoldPerTurnTrade(PlayerTypes eFrom, int iAmount, int iDuration);
-	void AddMapTrade(PlayerTypes eFrom);
-	void AddResourceTrade(PlayerTypes eFrom, ResourceTypes eResource, int iAmount, int iDuration);
-	void AddCityTrade(PlayerTypes eFrom, int iCityID);
-	void AddAllowEmbassy(PlayerTypes eFrom);
-	void AddOpenBorders(PlayerTypes eFrom, int iDuration);
-	void AddDefensivePact(PlayerTypes eFrom, int iDuration);
-	void AddResearchAgreement(PlayerTypes eFrom, int iDuration);
-	void AddPeaceTreaty(PlayerTypes eFrom, int iDuration);
-	void AddThirdPartyPeace(PlayerTypes eFrom, TeamTypes eThirdPartyTeam, int iDuration);
-	void AddThirdPartyWar(PlayerTypes eFrom, TeamTypes eThirdPartyTeam);
-	void AddDeclarationOfFriendship(PlayerTypes eFrom);
-	void AddVoteCommitment(PlayerTypes eFrom, int iResolutionID, int iVoteChoice, int iNumVotes, bool bRepeal);
+	void AddGoldTrade(PlayerTypes eFrom, int iAmount, bool bDoNotRemove = true);
+	void AddGoldPerTurnTrade(PlayerTypes eFrom, int iAmount, int iDuration, bool bDoNotRemove = true);
+	void AddMapTrade(PlayerTypes eFrom, bool bDoNotRemove = true);
+	void AddResourceTrade(PlayerTypes eFrom, ResourceTypes eResource, int iAmount, int iDuration, bool bDoNotRemove = true);
+	void AddCityTrade(PlayerTypes eFrom, int iCityID, bool bDoNotRemove = true);
+	void AddAllowEmbassy(PlayerTypes eFrom, bool bDoNotRemove = true);
+	void AddOpenBorders(PlayerTypes eFrom, int iDuration, bool bDoNotRemove = true);
+	void AddDefensivePact(PlayerTypes eFrom, int iDuration, bool bDoNotRemove = true);
+	void AddResearchAgreement(PlayerTypes eFrom, int iDuration, bool bDoNotRemove = true);
+	void AddPeaceTreaty(PlayerTypes eFrom, int iDuration, bool bDoNotRemove = true);
+	void AddThirdPartyPeace(PlayerTypes eFrom, TeamTypes eThirdPartyTeam, int iDuration, bool bDoNotRemove = true);
+	void AddThirdPartyWar(PlayerTypes eFrom, TeamTypes eThirdPartyTeam, bool bDoNotRemove = true);
+	void AddDeclarationOfFriendship(PlayerTypes eFrom, bool bDoNotRemove = true);
+	void AddVoteCommitment(PlayerTypes eFrom, int iResolutionID, int iVoteChoice, int iNumVotes, bool bRepeal, bool bDoNotRemove = true);
 
-	void AddTechTrade(PlayerTypes eFrom, TechTypes eTech);
-	void AddVassalageTrade(PlayerTypes eFrom);
-	void AddRevokeVassalageTrade(PlayerTypes eFrom);
+	void AddTechTrade(PlayerTypes eFrom, TechTypes eTech, bool bDoNotRemove = true);
+	void AddVassalageTrade(PlayerTypes eFrom, bool bDoNotRemove = true);
+	void AddRevokeVassalageTrade(PlayerTypes eFrom, bool bDoNotRemove = true);
 
 	void RemoveTechTrade(TechTypes eTech);
 
@@ -269,9 +257,11 @@ public:
 	bool IsVoteCommitmentTrade(PlayerTypes eFrom);
 	static DealRenewStatus GetItemTradeableState(TradeableItems eItem);
 	bool IsPotentiallyRenewable();
+	bool IsCheckedForRenewal();
 
-	//return true if anything was removed
-	bool RemoveAllByPlayer(PlayerTypes eFrom);
+	void RemoveAllPossibleItems();
+
+	//return true if the item was removed
 	void RemoveByType(TradeableItems eType, PlayerTypes eFrom = NO_PLAYER);
 	void RemoveResourceTrade(ResourceTypes eResource);
 	void RemoveCityTrade(PlayerTypes eFrom, int iCityID);
@@ -336,7 +326,7 @@ public:
 	CvDeal* GetHistoricDealWithPlayer(PlayerTypes ePlayer, PlayerTypes eOtherPlayer, uint indx);
 	uint GetNumCurrentDealsWithPlayer(PlayerTypes ePlayer, PlayerTypes eOtherPlayer);
 	uint GetNumHistoricDealsWithPlayer(PlayerTypes ePlayer, PlayerTypes eOtherPlayer, uint iMaxCount = UINT_MAX);
-	std::vector<CvDeal*> GetRenewableDealsWithPlayer(PlayerTypes ePlayer, PlayerTypes eOtherPlayer, uint iMaxCount = UINT_MAX);
+	std::vector<CvDeal*> GetRenewableDealsWithPlayer(PlayerTypes ePlayer, PlayerTypes eOtherPlayer, uint iMaxCount = UINT_MAX, bool bOnlyCheckedDeals = false);
 	bool IsReceivingItemsFromPlayer(PlayerTypes ePlayer, PlayerTypes eOtherPlayer, bool bMutual);
 	int GetDealValueWithPlayer(PlayerTypes ePlayer, PlayerTypes eOtherPlayer, bool bConsiderDuration = true);
 	int GetTurnsBeforeRegainingLuxury(PlayerTypes ePlayer, ResourceTypes eResource);

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.h
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.h
@@ -1383,7 +1383,7 @@ public:
 	void DoThirdPartyWarTrade(PlayerTypes ePlayer, DiploStatementTypes& eStatement, CvDeal* pDeal);
 	void DoThirdPartyPeaceTrade(PlayerTypes ePlayer, DiploStatementTypes& eStatement, CvDeal* pDeal);
 	void DoVoteTrade(PlayerTypes ePlayer, DiploStatementTypes& eStatement, CvDeal* pDeal);
-	std::vector<CvDeal*> DoRenewExpiredDeal(PlayerTypes ePlayer, DiploStatementTypes& eStatement);
+	CvDeal* DoRenewExpiredDeal(PlayerTypes ePlayer, DiploStatementTypes& eStatement);
 
 	void DoRequest(PlayerTypes ePlayer, DiploStatementTypes& eStatement, CvDeal* pDeal);
 	void DoGift(PlayerTypes ePlayer, DiploStatementTypes& eStatement, CvDeal* pDeal);
@@ -1766,8 +1766,8 @@ public:
 	void LogMinorCivQuestCancelled(PlayerTypes eMinor, int iOldFriendshipTimes100, int iNewFriendshipTimes100, MinorCivQuestTypes eType);
 	void LogMinorCivBuyout(PlayerTypes eMinor, int iGoldPaid, bool bSaving);
 
-	std::vector<CvDeal*> GetDealsToRenew(PlayerTypes eOtherPlayer = NO_PLAYER);
-	void CancelRenewDeal(PlayerTypes eOtherPlayer = NO_PLAYER, RenewalReason eReason = NO_REASON, bool bJustLogging = false, CvDeal* pPassDeal = NULL);
+	std::vector<CvDeal*> GetDealsToRenew(PlayerTypes eOtherPlayer = NO_PLAYER, bool bOnlyCheckedDeals = false);
+	void CancelRenewDeal(PlayerTypes eOtherPlayer = NO_PLAYER, RenewalReason eReason = NO_REASON, bool bJustLogging = false, CvDeal* pPassDeal = NULL, bool bOnlyCheckedDeals = false);
 
 	// Methods for injecting tests
 	void TestUIDiploStatement(PlayerTypes eToPlayer, DiploStatementTypes eStatement, int iArg1);

--- a/CvGameCoreDLL_Expansion2/CvGame.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGame.cpp
@@ -8923,7 +8923,7 @@ UnitTypes CvGame::GetRandomSpawnUnitType(PlayerTypes ePlayer, bool bIncludeUUs, 
 
 //	--------------------------------------------------------------------------------
 /// Pick a random a Unit type that is ranked by unit power and restricted to units available to ePlayer's technology
-UnitTypes CvGame::GetCompetitiveSpawnUnitType(PlayerTypes ePlayer, bool bIncludeUUs, bool bIncludeRanged, bool bIncludeShips, bool bNoResource, bool bIncludeOwnUUsOnly)
+UnitTypes CvGame::GetCompetitiveSpawnUnitType(PlayerTypes ePlayer, bool bIncludeUUs, bool bIncludeRanged, bool bIncludeShips, bool bNoResource, bool bIncludeOwnUUsOnly, bool bRandom)
 {
 	CvAssertMsg(ePlayer >= 0, "ePlayer is expected to be non-negative (invalid Index)");
 	CvAssertMsg(ePlayer < MAX_CIV_PLAYERS, "ePlayer is expected to be within maximum bounds (invalid Index)");
@@ -9098,7 +9098,7 @@ UnitTypes CvGame::GetCompetitiveSpawnUnitType(PlayerTypes ePlayer, bool bInclude
 
 	// Choose from weighted unit types
 	veUnitRankings.StableSortItems();
-	int iNumChoices = /*5*/ GD_INT_GET(UNIT_SPAWN_NUM_CHOICES);
+	int iNumChoices = bRandom ? /*5*/ GD_INT_GET(UNIT_SPAWN_NUM_CHOICES) : 1;
 	RandomNumberDelegate randFn = MakeDelegate(&GC.getGame(), &CvGame::getJonRandNum);
 	UnitTypes eChosenUnit = veUnitRankings.ChooseFromTopChoices(iNumChoices, &randFn, "Choosing competitive unit from top choices");
 

--- a/CvGameCoreDLL_Expansion2/CvGame.h
+++ b/CvGameCoreDLL_Expansion2/CvGame.h
@@ -602,7 +602,7 @@ public:
 	void SetBarbarianReleaseTurn(int iValue);
 
 	UnitTypes GetRandomSpawnUnitType(PlayerTypes ePlayer, bool bIncludeUUs, bool bIncludeRanged);
-	UnitTypes GetCompetitiveSpawnUnitType(PlayerTypes ePlayer, bool bIncludeUUs, bool bIncludeRanged, bool bIncludeShips, bool bNoResource = false, bool bIncludeOwnUUsOnly = false);
+	UnitTypes GetCompetitiveSpawnUnitType(PlayerTypes ePlayer, bool bIncludeUUs, bool bIncludeRanged, bool bIncludeShips, bool bNoResource = false, bool bIncludeOwnUUsOnly = false, bool bRandom = true);
 	UnitTypes GetCsGiftSpawnUnitType(PlayerTypes ePlayer, bool bIncludeShips);
 
 	UnitTypes GetRandomUniqueUnitType(bool bIncludeCivsInGame, bool bIncludeStartEra, bool bIncludeOldEras, bool bIncludeRanged, bool bCoastal, int iPlotX, int iPlotY);

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaDeal.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaDeal.cpp
@@ -9,6 +9,8 @@
 #include "CvGameCoreDLLPCH.h"
 #include "../CvGameCoreDLLPCH.h"
 #include "../CustomMods.h"
+#include "../CvDealAI.h"
+#include "../CvDiplomacyAI.h"
 #include "CvLuaSupport.h"
 #include "CvLuaDeal.h"
 
@@ -55,6 +57,9 @@ void CvLuaDeal::PushMethods(lua_State* L, int t)
 	Method(GetReasonsItemUntradeable);
 	Method(BlockTemporaryForPermanentTrade);
 
+	Method(IsCheckedForRenewal);
+	Method(GetRenewDealMessage);
+	Method(DoReevaluateDeal);
 	Method(AddGoldTrade);
 	Method(AddGoldPerTurnTrade);
 	Method(AddMapTrade);
@@ -197,6 +202,179 @@ int CvLuaDeal::lGetNextItem(lua_State* L)
 	return 8;
 }
 
+//------------------------------------------------------------------------------
+int CvLuaDeal::lGetRenewDealMessage(lua_State* L)
+{
+	CvDeal* pkDeal = GetInstance(L);
+	const PlayerTypes eFromPlayer = (PlayerTypes)lua_tointeger(L, 2);
+	const PlayerTypes eOtherPlayer = (PlayerTypes)lua_tointeger(L, 3);
+	CvPlayerAI* pkThisPlayer = &GET_PLAYER(eFromPlayer);
+
+	int iDealValueToMe = 0;
+	bool bCantMatchOffer = false;
+	bool bDealAcceptable = GET_PLAYER(eFromPlayer).GetDealAI()->IsDealWithHumanAcceptable(pkDeal, eOtherPlayer, iDealValueToMe, &bCantMatchOffer, false);
+	DiploMessageTypes eMessage = bDealAcceptable ? DIPLO_MESSAGE_RENEW_DEAL : DIPLO_MESSAGE_WANT_MORE_RENEW_DEAL;
+	lua_pushstring(L, GET_PLAYER(eFromPlayer).GetDiplomacyAI()->GetDiploStringForMessage(eMessage));
+	return 1;
+}
+//------------------------------------------------------------------------------
+int CvLuaDeal::lDoReevaluateDeal(lua_State* L)
+{
+	CvDeal* pkDeal = GetInstance(L);
+	const PlayerTypes eFromPlayer = (PlayerTypes)lua_tointeger(L, 2);
+	const PlayerTypes eOtherPlayer = (PlayerTypes)lua_tointeger(L, 3);
+	CvPlayerAI* pkThisPlayer = &GET_PLAYER(eFromPlayer);
+
+	bool bDealCanceled = false;
+	// don't change any items in a renew deal, but cancel the deal if it's now valued impossible
+	if (pkDeal->m_bCheckedForRenewal)
+	{
+		if (pkThisPlayer->GetDealAI()->GetDealValue(pkDeal) == INT_MAX)
+		{
+			pkThisPlayer->GetDiplomacyAI()->CancelRenewDeal(eOtherPlayer, REASON_CANNOT_COMPROMISE, false, pkDeal);
+			bDealCanceled = true;
+		}
+	}
+	else
+	{
+		bool bUselessReferenceVariable = false;
+		bool bCantMatchOffer = false;
+		bool bDealCanceled = !pkThisPlayer->GetDealAI()->DoEqualizeDealWithHuman(pkDeal, eOtherPlayer, bUselessReferenceVariable, bCantMatchOffer);
+	}
+	lua_pushboolean(L, bDealCanceled);
+	return 1;
+}
+//------------------------------------------------------------------------------
+int CvLuaDeal::lAddGoldTrade(lua_State* L)
+{
+	CvDeal* pkDeal = GetInstance(L);
+	const PlayerTypes eFromPlayer = (PlayerTypes)lua_tointeger(L, 2);
+	const int iAmount = lua_tointeger(L, 3);
+
+	pkDeal->AddGoldTrade(eFromPlayer, iAmount);
+	return 0;
+}
+//------------------------------------------------------------------------------
+int CvLuaDeal::lAddGoldPerTurnTrade(lua_State* L)
+{
+	CvDeal* pkDeal = GetInstance(L);
+	const PlayerTypes eFromPlayer = (PlayerTypes)lua_tointeger(L, 2);
+	const int iAmount = lua_tointeger(L, 3);
+	const int iDuration = lua_tointeger(L, 4);
+
+	pkDeal->AddGoldPerTurnTrade(eFromPlayer, iAmount, iDuration);
+	return 0;
+}
+//------------------------------------------------------------------------------
+int CvLuaDeal::lAddMapTrade(lua_State* L)
+{
+	CvDeal* pkDeal = GetInstance(L);
+	const PlayerTypes eFromPlayer = (PlayerTypes)lua_tointeger(L, 2);
+
+	pkDeal->AddMapTrade(eFromPlayer);
+	return 0;
+}
+//------------------------------------------------------------------------------
+int CvLuaDeal::lAddResourceTrade(lua_State* L)
+{
+	CvDeal* pkDeal = GetInstance(L);
+	const PlayerTypes eFromPlayer = (PlayerTypes)lua_tointeger(L, 2);
+	const ResourceTypes eResource = (ResourceTypes)lua_tointeger(L, 3);
+	const int iAmount = lua_tointeger(L, 4);
+	const int iDuration = lua_tointeger(L, 5);
+
+	pkDeal->AddResourceTrade(eFromPlayer, eResource, iAmount, iDuration);
+	return 0;
+}
+//------------------------------------------------------------------------------
+int CvLuaDeal::lAddCityTrade(lua_State* L)
+{
+	CvDeal* pkDeal = GetInstance(L);
+	const PlayerTypes eFromPlayer = (PlayerTypes)lua_tointeger(L, 2);
+	const int iCityID = lua_tointeger(L, 3);
+
+	pkDeal->AddCityTrade(eFromPlayer, iCityID);
+	return 0;
+}
+//------------------------------------------------------------------------------
+int CvLuaDeal::lAddAllowEmbassy(lua_State* L)
+{
+	CvDeal* pkDeal = GetInstance(L);
+	const PlayerTypes eFromPlayer = (PlayerTypes)lua_tointeger(L, 2);
+
+	pkDeal->AddAllowEmbassy(eFromPlayer);
+	return 0;
+}
+//------------------------------------------------------------------------------
+int CvLuaDeal::lAddOpenBorders(lua_State* L)
+{
+	CvDeal* pkDeal = GetInstance(L);
+	const PlayerTypes eFromPlayer = (PlayerTypes)lua_tointeger(L, 2);
+	const int iDuration = lua_tointeger(L, 3);
+
+	pkDeal->AddOpenBorders(eFromPlayer, iDuration);
+	return 0;
+}
+//------------------------------------------------------------------------------
+int CvLuaDeal::lAddDefensivePact(lua_State* L)
+{
+	CvDeal* pkDeal = GetInstance(L);
+	const PlayerTypes eFromPlayer = (PlayerTypes)lua_tointeger(L, 2);
+	const int iDuration = lua_tointeger(L, 3);
+
+	pkDeal->AddDefensivePact(eFromPlayer, iDuration);
+	return 0;
+}
+//------------------------------------------------------------------------------
+int CvLuaDeal::lAddResearchAgreement(lua_State* L)
+{
+	CvDeal* pkDeal = GetInstance(L);
+	const PlayerTypes eFromPlayer = (PlayerTypes)lua_tointeger(L, 2);
+	const int iDuration = lua_tointeger(L, 3);
+
+	pkDeal->AddResearchAgreement(eFromPlayer, iDuration);
+	return 0;
+}
+//------------------------------------------------------------------------------
+int CvLuaDeal::lAddPeaceTreaty(lua_State* L)
+{
+	CvDeal* pkDeal = GetInstance(L);
+	const PlayerTypes eFromPlayer = (PlayerTypes)lua_tointeger(L, 2);
+	const int iDuration = lua_tointeger(L, 3);
+
+	pkDeal->AddPeaceTreaty(eFromPlayer, iDuration);
+	return 0;
+}
+//------------------------------------------------------------------------------
+int CvLuaDeal::lAddThirdPartyPeace(lua_State* L)
+{
+	CvDeal* pkDeal = GetInstance(L);
+	const PlayerTypes eFromPlayer = (PlayerTypes)lua_tointeger(L, 2);
+	const TeamTypes eThirdPartyTeam = (TeamTypes)lua_tointeger(L, 3);
+	const int iDuration = lua_tointeger(L, 4);
+
+	pkDeal->AddThirdPartyPeace(eFromPlayer, eThirdPartyTeam, iDuration);
+	return 0;
+}
+//------------------------------------------------------------------------------
+int CvLuaDeal::lAddThirdPartyWar(lua_State* L)
+{
+	CvDeal* pkDeal = GetInstance(L);
+	const PlayerTypes eFromPlayer = (PlayerTypes)lua_tointeger(L, 2);
+	const TeamTypes eThirdPartyTeam = (TeamTypes)lua_tointeger(L, 3);
+
+	pkDeal->AddThirdPartyWar(eFromPlayer, eThirdPartyTeam);
+	return 0;
+}
+//------------------------------------------------------------------------------
+int CvLuaDeal::lAddDeclarationOfFriendship(lua_State* L)
+{
+	CvDeal* pkDeal = GetInstance(L);
+	const PlayerTypes eFromPlayer = (PlayerTypes)lua_tointeger(L, 2);
+
+	pkDeal->AddDeclarationOfFriendship(eFromPlayer);
+	return 0;
+}
 //------------------------------------------------------------------------------
 int CvLuaDeal::lAddVoteCommitment(lua_State* L)
 {

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaDeal.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaDeal.h
@@ -105,62 +105,27 @@ protected:
 	static int lGetReasonsItemUntradeable(lua_State* L);
 	static int lBlockTemporaryForPermanentTrade(lua_State* L);
 
-	static int lAddGoldTrade(lua_State* L)
-	{
-		return BasicLuaMethod(L, &CvDeal::AddGoldTrade);
-	};
-	static int lAddGoldPerTurnTrade(lua_State* L)
-	{
-		return BasicLuaMethod(L, &CvDeal::AddGoldPerTurnTrade);
-	};
-	static int lAddMapTrade(lua_State* L)
-	{
-		return BasicLuaMethod(L, &CvDeal::AddMapTrade);
-	};
-	static int lAddResourceTrade(lua_State* L)
-	{
-		return BasicLuaMethod(L, &CvDeal::AddResourceTrade);
-	};
-	static int lAddCityTrade(lua_State* L)
-	{
-		return BasicLuaMethod(L, &CvDeal::AddCityTrade);
-	};
-	static int lAddAllowEmbassy(lua_State* L)
-	{
-		return BasicLuaMethod(L, &CvDeal::AddAllowEmbassy);
-	};
-	static int lAddOpenBorders(lua_State* L)
-	{
-		return BasicLuaMethod(L, &CvDeal::AddOpenBorders);
-	};
-	static int lAddDefensivePact(lua_State* L)
-	{
-		return BasicLuaMethod(L, &CvDeal::AddDefensivePact);
-	};
-	static int lAddResearchAgreement(lua_State* L)
-	{
-		return BasicLuaMethod(L, &CvDeal::AddResearchAgreement);
-	};
-	static int lAddPeaceTreaty(lua_State* L)
-	{
-		return BasicLuaMethod(L, &CvDeal::AddPeaceTreaty);
-	};
-	static int lAddThirdPartyPeace(lua_State* L)
-	{
-		return BasicLuaMethod(L, &CvDeal::AddThirdPartyPeace);
-	};
-	static int lAddThirdPartyWar(lua_State* L)
-	{
-		return BasicLuaMethod(L, &CvDeal::AddThirdPartyWar);
-	};
+	static int lAddGoldTrade(lua_State* L);
+	static int lAddGoldPerTurnTrade(lua_State* L);
+	static int lAddMapTrade(lua_State* L);
+	static int lAddResourceTrade(lua_State* L);
+	static int lAddCityTrade(lua_State* L);
+	static int lAddAllowEmbassy(lua_State* L);
+	static int lAddOpenBorders(lua_State* L);
+	static int lAddDefensivePact(lua_State* L);
+	static int lAddResearchAgreement(lua_State* L);
+	static int lAddPeaceTreaty(lua_State* L);
+	static int lAddThirdPartyPeace(lua_State* L);
+	static int lAddThirdPartyWar(lua_State* L);
+	static int lAddDeclarationOfFriendship(lua_State* L);
+	static int lAddVoteCommitment(lua_State* L);
 
-	static int lAddDeclarationOfFriendship(lua_State* L)
+	static int lDoReevaluateDeal(lua_State* L);
+	static int lGetRenewDealMessage(lua_State* L);
+	static int lIsCheckedForRenewal(lua_State* L)
 	{
-		return BasicLuaMethod(L, &CvDeal::AddDeclarationOfFriendship);
+		return BasicLuaMethod(L, &CvDeal::IsCheckedForRenewal);
 	};
-
-	static int lAddVoteCommitment(lua_State* L); // Too many args for template, defined in cpp
-
 	static int lChangeGoldTrade(lua_State* L)
 	{
 		return BasicLuaMethod(L, &CvDeal::ChangeGoldTrade);


### PR DESCRIPTION
Fixed the remaining deal AI bugs:
- Fixed AI offering deals with starting terms that are not "acceptable"
- Fixed incorrect text when offering to renew a deal
- Improved ability of the AI to equalize deals
- When an open borders deal is renewed, units are no longer moved out
- When a deal offer to an AI player is rejected, other active deals with that AI are no longer canceled
- Fixed AI being unable to make demands
- Revert the change that the valuation of each strategic resource is rounded to multiples of 1 GPT. Instead, each deal with a deal value of 1/2 GPT or less is now "acceptable"

City Governor:
- City Governor will try to have a higher food surplus than before, in particular in cities with a low population