### PR TITLE
Fixing some invisible yields issues

### DIFF
--- a/(2) Vox Populi/LUA/YieldIconManager.lua
+++ b/(2) Vox Populi/LUA/YieldIconManager.lua
@@ -120,6 +120,9 @@ function( x, y, isShown )
 			if anchor then
 				-- just show it
 				anchor.Anchor:ChangeParent( ControlsYieldStore )
+				-- updating world position to make it synchronized with current camera position
+				local a,b,c= GridToWorld( x, y )
+				anchor.Anchor:SetWorldPositionVal( a,b,c )
 			else
 				-- create new anchor
 				anchor = TableRemove( g_AvailableAnchors )

--- a/Vox Populi Installer Files/UI_bc1/Improvements/YieldIconManager.lua
+++ b/Vox Populi Installer Files/UI_bc1/Improvements/YieldIconManager.lua
@@ -124,6 +124,9 @@ function( x, y, isShown )
 			if anchor then
 				-- just show it
 				anchor.Anchor:ChangeParent( Controls_YieldStore )
+				-- updating world position to make it synchronized with current camera position
+				local a,b,c= GridToWorld( x, y )
+				anchor.Anchor:SetWorldPositionVal( a,b,c )
 			else
 				-- set up anchor
 				anchor = table_remove( g_AvailableAnchors )


### PR DESCRIPTION
Fixing some longstanding issue with invisible yields. As I find out, there are several issues with invisible yields, this one fixes just only one case.

Here we have the situation when all the world positions are initialized just once, but it is incorrect behaviour. 

World position can differ depending on current active camera. In most cases you are viewing the world from camera 1, but in Civ5 in case of world wrapping (when you can move camera to right side and you will be seamlessly teleported to the left side) there are can be two active cameras. In case of world wrapping, second camera beign active when your viewport intersects world bounds.

When you are calling `GridToWorld` here just once, the camera which will be used could be 2 or 1, we don't know it exactly. In such way some yields beign initialized at camera 2 and they will be visible just only when camera 2 is active.

For example, unfixed version with invisible yields when some yields are initialized at camera 2 and this camera is not active right now:
![unfixed-camera-1](https://github.com/LoneGazebo/Community-Patch-DLL/assets/3791221/07588b36-9656-49ad-97e6-ea0743784cbd)

Unfixed camera with camera 2 is active (the only way to see these yields):
![unfixed-camera-2](https://github.com/LoneGazebo/Community-Patch-DLL/assets/3791221/41fc4e72-830b-47d2-aeb7-0ec3778e99eb)

Fixed version, viewing previously bugged yields with only camera 1 is active:
![fixed](https://github.com/LoneGazebo/Community-Patch-DLL/assets/3791221/7c64b4cf-adb1-441d-85ec-ec81cffc6da7)

