### PR TITLE
Longest trade route calculation desync fix

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -648,7 +648,10 @@ void CvCity::init(int iID, PlayerTypes eOwner, int iX, int iY, bool bBumpUnits, 
 	pPlot->updateCityRoute();
 
 	//force recalculation of trade routes
-	GC.getGame().GetGameTrade()->InvalidateTradePathCache(eOwner);
+	for(int iPlayer = 0; iPlayer < MAX_PLAYERS; ++iPlayer)
+	{
+		GC.getGame().GetGameTrade()->InvalidateTradePathCache((PlayerTypes) iPlayer);
+	}
 
 	for (iI = 0; iI < MAX_TEAMS; iI++)
 	{

--- a/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
@@ -12868,7 +12868,10 @@ bool CvMinorCivAI::CanMajorProtect(PlayerTypes eMajor, bool bIgnoreMilitaryRequi
 		// This player must be able to build a trade route either by land or sea
 		else if (GET_PLAYER(eMajor).GetTrade()->GetNumTradeRoutesPossible() > 0)
 		{
-			if (GC.getGame().GetGameTrade()->CanCreateTradeRoute(eMajor, GetPlayer()->GetID(), DOMAIN_LAND) || GC.getGame().GetGameTrade()->CanCreateTradeRoute(eMajor, GetPlayer()->GetID(), DOMAIN_SEA))
+			if (
+				GC.getGame().GetGameTrade()->CanCreateTradeRoute(eMajor, GetPlayer()->GetID(), DOMAIN_LAND) || 
+				GC.getGame().GetGameTrade()->CanCreateTradeRoute(eMajor, GetPlayer()->GetID(), DOMAIN_SEA)
+			)
 			{
 				bValid = true;
 			}

--- a/CvGameCoreDLL_Expansion2/CvTradeClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvTradeClasses.h
@@ -359,6 +359,8 @@ public:
 
 	static UnitTypes GetTradeUnit (DomainTypes eDomain, CvPlayer* pPlayer);
 
+	void LogTradeMsg(CvString& strMsg) const;
+
 	std::vector<CvString> GetPlotToolTips (CvPlot* pPlot);
 	std::vector<CvString> GetPlotMouseoverToolTips (CvPlot* pPlot);
 


### PR DESCRIPTION
The desync was so:
- In the beginning of turn Player 'A' initialized its' cache from LUA code
- Then dll logic for AI turn got called, AI founded some new city
- 'A' Player's cache is invalid now because it was calculated without this new city
- From perspective of Player 'B" cache for Player 'A' will be calculated after city founding and it will be valid because it wasn't initially filled from LUA code

So, fixing it by invalidating all trade caches instead of invalidating just city owner's one.

Also calculation now respects max range (was `==` check somewhy instead of `>=`) and added some logging.

Should fix #10002