### PR TITLE
Added more getResourceInfo/getBuildingInfo nullchecks

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvAIOperation.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAIOperation.cpp
@@ -1711,7 +1711,12 @@ CvPlot* CvAIOperationPillageEnemy::FindBestTarget(CvPlot** ppMuster) const
 		for (int iResourceLoop = 0; iResourceLoop < iNumResourceInfos; iResourceLoop++)
 		{
 			ResourceTypes eResource = (ResourceTypes)iResourceLoop;
-			ResourceUsageTypes eResourceUsage = GC.getResourceInfo(eResource)->getResourceUsage();
+			CvResourceInfo* pkResourceInfo = GC.getResourceInfo(eResource);
+			if (!pkResourceInfo) {
+				continue;
+			}
+
+			ResourceUsageTypes eResourceUsage = pkResourceInfo->getResourceUsage();
 			if (eResourceUsage==RESOURCEUSAGE_LUXURY || eResourceUsage==RESOURCEUSAGE_STRATEGIC)
 				iValue += pLoopCity->CountNumWorkedResource(eResource);
 		}

--- a/CvGameCoreDLL_Expansion2/CvAdvisorCounsel.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAdvisorCounsel.cpp
@@ -1665,7 +1665,7 @@ void CvAdvisorCounsel::BuildCounselList(PlayerTypes ePlayer)
 					continue;
 				}
 
-				if(GC.getBuildingClassInfo(eBuildingClass)->GetType() == strBuildingClass)
+				if(pkBuildingClassInfo->GetType() == strBuildingClass)
 				{
 					eScienceBuildingClass = eBuildingClass;
 					break;
@@ -1733,9 +1733,15 @@ void CvAdvisorCounsel::BuildCounselList(PlayerTypes ePlayer)
 		{
 			continue;
 		}
+		CvResourceInfo* pkResourceInfo = GC.getResourceInfo(eResource);
+		if (!pkResourceInfo) {
+			continue;
+		}
 
-		if(GC.getResourceInfo(eResource)->getResourceUsage() == RESOURCEUSAGE_LUXURY || GC.getResourceInfo(eResource)->getResourceUsage() == RESOURCEUSAGE_STRATEGIC)
-		{
+		if(
+			pkResourceInfo->getResourceUsage() == RESOURCEUSAGE_LUXURY || 
+			pkResourceInfo->getResourceUsage() == RESOURCEUSAGE_STRATEGIC
+		) {
 			// if we don't have any of this resource
 			if(GET_PLAYER(ePlayer).getNumResourceTotal(eResource) < iNumOfResource)
 			{
@@ -1895,8 +1901,8 @@ void CvAdvisorCounsel::BuildCounselList(PlayerTypes ePlayer)
 
 				if(eTradableResource != NO_RESOURCE)
 				{
-					ResourceUsageTypes eTradableResourceUsage = GC.getResourceInfo(eTradableResource)->getResourceUsage();
-					ResourceUsageTypes eResourceUsage = GC.getResourceInfo(eResource)->getResourceUsage();
+					ResourceUsageTypes eTradableResourceUsage = pkTradeResourceInfo->getResourceUsage();
+					ResourceUsageTypes eResourceUsage = pResourceInfo->getResourceUsage();
 
 					// prefer trading luxury to strategic
 					if(eTradableResourceUsage == RESOURCEUSAGE_STRATEGIC && eResourceUsage == RESOURCEUSAGE_LUXURY)

--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
@@ -1029,6 +1029,11 @@ void CvBuilderTaskingAI::AddImprovingResourcesDirectives(vector<OptionWithScore<
 	if(eResource == NO_RESOURCE)
 		return;
 
+	CvResourceInfo* pkResource = GC.getResourceInfo(eResource);
+	if (!pkResource) {
+		return;
+	}
+
 	ImprovementTypes eExistingPlotImprovement = pPlot->getImprovementType();
 	if (eExistingPlotImprovement != NO_IMPROVEMENT)
 	{
@@ -1043,8 +1048,6 @@ void CvBuilderTaskingAI::AddImprovingResourcesDirectives(vector<OptionWithScore<
 	// if city owning this plot is being razed, ignore this plot
 	if (pCity && pCity->IsRazing())
 		return;
-
-	CvResourceInfo* pkResource = GC.getResourceInfo(eResource);
 
 	// loop through the build types to find one that we can use
 	for(int iBuildIndex = 0; iBuildIndex < GC.getNumBuildInfos(); iBuildIndex++)

--- a/CvGameCoreDLL_Expansion2/CvBuildingClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuildingClasses.cpp
@@ -5363,7 +5363,7 @@ void CvCityBuildings::SetNumFreeBuilding(BuildingTypes eIndex, int iNewValue)
 		m_pCity->processBuilding(eIndex, iChangeNumFreeBuilding, true, false, false, true);
 
 		CvBuildingEntry* buildingEntry = GC.getBuildingInfo(eIndex);
-		if(buildingEntry->IsCityWall())
+		if(buildingEntry && buildingEntry->IsCityWall())
 		{
 			CvInterfacePtr<ICvPlot1> pDllPlot(new CvDllPlot(m_pCity->plot()));
 			gDLL->GameplayWallCreated(pDllPlot.get());
@@ -5658,9 +5658,10 @@ bool CvCityBuildings::GetNextAvailableGreatWorkSlot(BuildingClassTypes *eBuildin
 			}
 			if(NO_BUILDING != eBuilding)
 			{
-				if (GetNumBuilding(eBuilding) > 0)
+				CvBuildingEntry* pkBuildingInfo = GC.getBuildingInfo(eBuilding);
+				if (pkBuildingInfo && GetNumBuilding(eBuilding) > 0)
 				{
-					int iNumSlots = GC.getBuildingInfo(eBuilding)->GetGreatWorkCount();
+					int iNumSlots = pkBuildingInfo->GetGreatWorkCount();
 					for (int jJ = 0; jJ < iNumSlots; jJ++)
 					{
 						if (GetBuildingGreatWork (eLoopBuildingClass, jJ) == NO_GREAT_WORK)
@@ -5698,11 +5699,12 @@ bool CvCityBuildings::GetNextAvailableGreatWorkSlot(GreatWorkSlotType eGreatWork
 			}
 			if(NO_BUILDING != eBuilding)
 			{
-				if (GetNumBuilding(eBuilding) > 0)
+				CvBuildingEntry* pkBuildingInfo = GC.getBuildingInfo(eBuilding);
+				if (pkBuildingInfo && GetNumBuilding(eBuilding) > 0)
 				{
-					if (GC.getBuildingInfo(eBuilding)->GetGreatWorkSlotType() == eGreatWorkSlot)
+					if (pkBuildingInfo->GetGreatWorkSlotType() == eGreatWorkSlot)
 					{
-						int iNumSlots = GC.getBuildingInfo(eBuilding)->GetGreatWorkCount();
+						int iNumSlots = pkBuildingInfo->GetGreatWorkCount();
 						for (int jJ = 0; jJ < iNumSlots; jJ++)
 						{
 							if (GetBuildingGreatWork (eLoopBuildingClass, jJ) == NO_GREAT_WORK)

--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -6417,9 +6417,12 @@ CvString CvCity::GetDisabledTooltip(CityEventChoiceTypes eChosenEventChoice, int
 					BuildingTypes eBuildingType = (BuildingTypes)pCivilizationInfo->getCivilizationBuildings((BuildingClassTypes)pkEventInfo->getBuildingRequired());
 					if (eBuildingType != NO_BUILDING)
 					{
-						localizedDurationText = Localization::Lookup("TXT_KEY_NEED_BUILDING_CLASS_LOCAL");
-						localizedDurationText << GC.getBuildingInfo(eBuildingType)->GetDescription();
-						DisabledTT += localizedDurationText.toUTF8();
+						CvBuildingEntry* pkBuildingInfo = GC.getBuildingInfo(eBuildingType);
+						if (pkBuildingInfo) {
+							localizedDurationText = Localization::Lookup("TXT_KEY_NEED_BUILDING_CLASS_LOCAL");
+							localizedDurationText << pkBuildingInfo->GetDescription();
+							DisabledTT += localizedDurationText.toUTF8();
+						}
 					}
 				}
 			}
@@ -12678,8 +12681,7 @@ int CvCity::GetPurchaseCost(BuildingTypes eBuilding)
 	if (MOD_BALANCE_CORE_BUILDING_INVESTMENTS && (NO_BUILDING != eBuilding))
 	{
 		//Have we already invested here?
-		CvBuildingEntry* pGameBuilding = GC.getBuildingInfo(eBuilding);
-		const BuildingClassTypes eBuildingClass = (BuildingClassTypes)(pGameBuilding->GetBuildingClassType());
+		const BuildingClassTypes eBuildingClass = (BuildingClassTypes)(pkBuildingInfo->GetBuildingClassType());
 		if (IsBuildingInvestment(eBuildingClass))
 		{
 			return -1;
@@ -14545,7 +14547,7 @@ void CvCity::processBuilding(BuildingTypes eBuilding, int iChange, bool bFirst, 
 			// Global Pop change
 			if (pBuildingInfo->GetPopulationChange() != 0)
 			{
-				setPopulation(std::max(1, (getPopulation() + iChange * GC.getBuildingInfo(eBuilding)->GetPopulationChange())));
+				setPopulation(std::max(1, (getPopulation() + iChange * pBuildingInfo->GetPopulationChange())));
 			}
 
 			// Capital
@@ -15981,7 +15983,7 @@ void CvCity::processBuilding(BuildingTypes eBuilding, int iChange, bool bFirst, 
 			if (IsHasResourceLocal(eResource, /*bTestVisible*/ false))
 			{
 				// Our Building does give culture with eResource
-				iCulture = GC.getBuildingInfo(eBuilding)->GetResourceCultureChange(eResource);
+				iCulture = pBuildingInfo->GetResourceCultureChange(eResource);
 
 				if (iCulture != 0)
 				{
@@ -15989,7 +15991,7 @@ void CvCity::processBuilding(BuildingTypes eBuilding, int iChange, bool bFirst, 
 				}
 
 				// What about faith?
-				iFaith = GC.getBuildingInfo(eBuilding)->GetResourceFaithChange(eResource);
+				iFaith = pBuildingInfo->GetResourceFaithChange(eResource);
 
 				if (iFaith != 0)
 				{
@@ -16336,12 +16338,12 @@ void CvCity::processBuilding(BuildingTypes eBuilding, int iChange, bool bFirst, 
 
 			for (int iJ = 0; iJ < GC.getNumResourceInfos(); iJ++)
 			{
-				ChangeResourceExtraYield(((ResourceTypes)iJ), eYield, (GC.getBuildingInfo(eBuilding)->GetResourceYieldChange(iJ, eYield) * iChange));
+				ChangeResourceExtraYield(((ResourceTypes)iJ), eYield, (pBuildingInfo->GetResourceYieldChange(iJ, eYield) * iChange));
 			}
 
 			for (int iJ = 0; iJ < GC.getNumFeatureInfos(); iJ++)
 			{
-				ChangeFeatureExtraYield(((FeatureTypes)iJ), eYield, (GC.getBuildingInfo(eBuilding)->GetFeatureYieldChange(iJ, eYield) * iChange));
+				ChangeFeatureExtraYield(((FeatureTypes)iJ), eYield, (pBuildingInfo->GetFeatureYieldChange(iJ, eYield) * iChange));
 			}
 
 			// Is this building part of a Corporation?
@@ -16381,18 +16383,18 @@ void CvCity::processBuilding(BuildingTypes eBuilding, int iChange, bool bFirst, 
 
 			for (int iJ = 0; iJ < GC.getNumTerrainInfos(); iJ++)
 			{
-				ChangeTerrainExtraYield(((TerrainTypes)iJ), eYield, (GC.getBuildingInfo(eBuilding)->GetTerrainYieldChange(iJ, eYield) * iChange));
-				ChangeYieldPerXTerrainFromBuildingsTimes100(((TerrainTypes)iJ), eYield, (GC.getBuildingInfo(eBuilding)->GetYieldPerXTerrain(iJ, eYield) * iChange));
+				ChangeTerrainExtraYield(((TerrainTypes)iJ), eYield, (pBuildingInfo->GetTerrainYieldChange(iJ, eYield) * iChange));
+				ChangeYieldPerXTerrainFromBuildingsTimes100(((TerrainTypes)iJ), eYield, (pBuildingInfo->GetYieldPerXTerrain(iJ, eYield) * iChange));
 			}
 
 			for (int iJ = 0; iJ < GC.getNumPlotInfos(); iJ++)
 			{
-				ChangePlotExtraYield(((PlotTypes)iJ), eYield, (GC.getBuildingInfo(eBuilding)->GetPlotYieldChange(iJ, eYield) * iChange));
+				ChangePlotExtraYield(((PlotTypes)iJ), eYield, (pBuildingInfo->GetPlotYieldChange(iJ, eYield) * iChange));
 			}
 
 			for (int iJ = 0; iJ < GC.getNumFeatureInfos(); iJ++)
 			{
-				ChangeYieldPerXFeatureFromBuildingsTimes100(((FeatureTypes)iJ), eYield, (GC.getBuildingInfo(eBuilding)->GetYieldPerXFeature(iJ, eYield) * iChange));
+				ChangeYieldPerXFeatureFromBuildingsTimes100(((FeatureTypes)iJ), eYield, (pBuildingInfo->GetYieldPerXFeature(iJ, eYield) * iChange));
 			}
 
 			// Research agreements are not active, therefore this building now increases science yield by 25%
@@ -16424,9 +16426,9 @@ void CvCity::processBuilding(BuildingTypes eBuilding, int iChange, bool bFirst, 
 			}
 		}
 
-		if (GC.getBuildingInfo(eBuilding)->GetSpecialistType() != NO_SPECIALIST)
+		if (pBuildingInfo->GetSpecialistType() != NO_SPECIALIST)
 		{
-			GetCityCitizens()->ChangeBuildingGreatPeopleRateChanges((SpecialistTypes)GC.getBuildingInfo(eBuilding)->GetSpecialistType(), pBuildingInfo->GetGreatPeopleRateChange() * iChange);
+			GetCityCitizens()->ChangeBuildingGreatPeopleRateChanges((SpecialistTypes)pBuildingInfo->GetSpecialistType(), pBuildingInfo->GetGreatPeopleRateChange() * iChange);
 		}
 
 		// Process for our player
@@ -31536,6 +31538,10 @@ bool CvCity::IsCanPurchase(const std::vector<int>& vPreExistingBuildings, bool b
 			{
 				//Have we already invested here?
 				CvBuildingEntry* pGameBuilding = GC.getBuildingInfo(eBuildingType);
+				if (!pGameBuilding) {
+					return false;
+				}
+
 				const BuildingClassTypes eBuildingClass = (BuildingClassTypes)(pGameBuilding->GetBuildingClassType());
 				if (IsBuildingInvestment(eBuildingClass))
 				{

--- a/CvGameCoreDLL_Expansion2/CvCultureClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCultureClasses.cpp
@@ -6993,8 +6993,8 @@ CvString CvCityCulture::GetTourismTooltip()
 		CvBuildingEntry *pkBuilding = GC.getBuildingInfo(eBuilding);
 		if (pkBuilding)
 		{
-			int iTechEnhancedTourism = GC.getBuildingInfo(eBuilding)->GetTechEnhancedTourism();
-			if (iTechEnhancedTourism != 0 && GET_TEAM(m_pCity->getTeam()).GetTeamTechs()->HasTech((TechTypes)GC.getBuildingInfo(eBuilding)->GetEnhancedYieldTech()))
+			int iTechEnhancedTourism = pkBuilding->GetTechEnhancedTourism();
+			if (iTechEnhancedTourism != 0 && GET_TEAM(m_pCity->getTeam()).GetTeamTechs()->HasTech((TechTypes)pkBuilding->GetEnhancedYieldTech()))
 			{
 				iTechEnhancedTourism *= m_pCity->GetCityBuildings()->GetNumBuilding(eBuilding);
 

--- a/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
@@ -17050,7 +17050,11 @@ bool CvMinorCivAI::IsLackingGiftableTileImprovementAtPlot(PlayerTypes eMajor, in
 	if (eResource == NO_RESOURCE)
 		return false;
 
-	ResourceUsageTypes eUsage = GC.getResourceInfo(eResource)->getResourceUsage();
+	CvResourceInfo* pkResourceInfo = GC.getResourceInfo(eResource);
+	if (!pkResourceInfo)
+		return false;
+
+	ResourceUsageTypes eUsage = pkResourceInfo->getResourceUsage();
 	if (eUsage != RESOURCEUSAGE_STRATEGIC && eUsage != RESOURCEUSAGE_LUXURY)
 		return false;
 
@@ -18255,7 +18259,7 @@ pair<CvString, CvString> CvMinorCivAI::GetStatusChangeNotificationStrings(Player
 						const CvResourceInfo* pkResourceInfo = GC.getResourceInfo(eResource);
 						if (pkResourceInfo != NULL)
 						{
-							eUsage = GC.getResourceInfo(eResource)->getResourceUsage();
+							eUsage = pkResourceInfo->getResourceUsage();
 
 							if (eUsage == RESOURCEUSAGE_STRATEGIC || eUsage == RESOURCEUSAGE_LUXURY)
 							{

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -4319,7 +4319,7 @@ CvCity* CvPlayer::acquireCity(CvCity* pCity, bool bConquest, bool bGift)
 			pNewCity->GetCityBuildings()->SetNumFreeBuilding(eBuilding, 1);
 
 			// Only deduct if building is not capital only
-			if (pNewCity->GetCityBuildings()->GetNumFreeBuilding(eBuilding) > 0 && !GC.getBuildingInfo(eBuilding)->IsCapitalOnly())
+			if (pNewCity->GetCityBuildings()->GetNumFreeBuilding(eBuilding) > 0 && !pkBuilding->IsCapitalOnly())
 				ChangeNumCitiesFreeChosenBuilding(eBuildingClass, -1);
 		}
 	}
@@ -8142,9 +8142,12 @@ CvString CvPlayer::GetDisabledTooltip(EventChoiceTypes eChosenEventChoice)
 					BuildingTypes eBuildingType = (BuildingTypes)pCivilizationInfo->getCivilizationBuildings((BuildingClassTypes)pkEventInfo->getBuildingRequired());
 					if (eBuildingType != NO_BUILDING)
 					{
-						localizedDurationText = Localization::Lookup("TXT_KEY_NEED_BUILDING_CLASS");
-						localizedDurationText << GC.getBuildingInfo(eBuildingType)->GetDescription();
-						DisabledTT += localizedDurationText.toUTF8();
+						CvBuildingEntry* pkBuildingInfo = GC.getBuildingInfo(eBuildingType);
+						if (pkBuildingInfo) {
+							localizedDurationText = Localization::Lookup("TXT_KEY_NEED_BUILDING_CLASS");
+							localizedDurationText << pkBuildingInfo->GetDescription();
+							DisabledTT += localizedDurationText.toUTF8();
+						}
 					}
 				}
 			}
@@ -8175,9 +8178,12 @@ CvString CvPlayer::GetDisabledTooltip(EventChoiceTypes eChosenEventChoice)
 					BuildingTypes eBuildingType = (BuildingTypes)pCivilizationInfo->getCivilizationBuildings((BuildingClassTypes)pkEventInfo->getBuildingLimiter());
 					if (eBuildingType != NO_BUILDING)
 					{
-						localizedDurationText = Localization::Lookup("TXT_KEY_NEED_NO_BUILDING_CLASS");
-						localizedDurationText << GC.getBuildingInfo(eBuildingType)->GetDescription();
-						DisabledTT += localizedDurationText.toUTF8();
+						CvBuildingEntry* pkBuildingInfo = GC.getBuildingInfo(eBuildingType);
+						if (pkBuildingInfo) {
+							localizedDurationText = Localization::Lookup("TXT_KEY_NEED_NO_BUILDING_CLASS");
+							localizedDurationText << pkBuildingInfo->GetDescription();
+							DisabledTT += localizedDurationText.toUTF8();
+						}
 					}
 				}
 			}
@@ -17253,7 +17259,7 @@ void CvPlayer::processBuilding(BuildingTypes eBuilding, int iChange, bool bFirst
 			{
 				CvBuildingEntry* pkBuilding = GC.getBuildingInfo(eTestBuilding);
 				CvBuildingClassInfo* pkBuildingClassInfo = GC.getBuildingClassInfo(eBuildingClass);
-				if(pkBuilding)
+				if(pkBuilding && pkBuildingClassInfo)
 				{
 					iBuildingCount = pLoopCityBuildings->GetNumBuilding(eTestBuilding);
 					if(iBuildingCount > 0)
@@ -25773,7 +25779,7 @@ void CvPlayer::DoProcessVotes()
 				CvBuildingEntry* pkBuildingInfo = GC.getBuildingInfo(eBuilding);
 			
 				// Has this Building
-				if(pLoopCity->GetCityBuildings()->GetNumBuilding(eBuilding) > 0)
+				if(pkBuildingInfo && pLoopCity->GetCityBuildings()->GetNumBuilding(eBuilding) > 0)
 				{
 					if(pkBuildingInfo->GetFaithToVotes() > 0)
 					{
@@ -29503,19 +29509,22 @@ void CvPlayer::doInstantGreatPersonProgress(InstantYieldType iType, bool bSuppre
 				{
 					if (eBuilding != NO_BUILDING)
 					{
-						TechTypes eTech = (TechTypes)GC.getBuildingInfo(eBuilding)->GetPrereqAndTech();
-						int iEra = 0;
-						if (eTech == NO_TECH)
-						{
-							iEra = 0;
-						}
-						else
-						{
-							iEra = GC.getTechInfo(eTech)->GetEra();
-						}
-						for (int iLoopEra = 0; iLoopEra <= iEra; ++iLoopEra)
-						{
-							iValue += pLoopCity->GetGreatPersonProgressFromConstruction(eGreatPerson, (EraTypes)iLoopEra);
+						CvBuildingEntry* pkBuildingInfo = GC.getBuildingInfo(eBuilding);
+						if (pkBuildingInfo) {
+							TechTypes eTech = (TechTypes)pkBuildingInfo->GetPrereqAndTech();
+							int iEra = 0;
+							if (eTech == NO_TECH)
+							{
+								iEra = 0;
+							}
+							else
+							{
+								iEra = GC.getTechInfo(eTech)->GetEra();
+							}
+							for (int iLoopEra = 0; iLoopEra <= iEra; ++iLoopEra)
+							{
+								iValue += pLoopCity->GetGreatPersonProgressFromConstruction(eGreatPerson, (EraTypes)iLoopEra);
+							}
 						}
 					}
 					break;
@@ -39867,11 +39876,11 @@ bool CvPlayer::WouldGainMonopoly(ResourceTypes eResource, int iExtraResource) co
 	int iExtra = (iExtraResource * 100) / max(1,GC.getMap().getNumResources(eResource));
 
 	const CvResourceInfo* pkResourceInfo = GC.getResourceInfo(eResource);
-	if (pkResourceInfo->getResourceUsage() == RESOURCEUSAGE_LUXURY && !GC.getGame().GetGameLeagues()->IsLuxuryHappinessBanned(GetID(), eResource))
+	if (pkResourceInfo && pkResourceInfo->getResourceUsage() == RESOURCEUSAGE_LUXURY && !GC.getGame().GetGameLeagues()->IsLuxuryHappinessBanned(GetID(), eResource))
 	{
 		return (iCurrent + iExtra) > /*50*/ GD_INT_GET(GLOBAL_RESOURCE_MONOPOLY_THRESHOLD);
 	}
-	else if (pkResourceInfo->getResourceUsage() == RESOURCEUSAGE_STRATEGIC)
+	else if (pkResourceInfo && pkResourceInfo->getResourceUsage() == RESOURCEUSAGE_STRATEGIC)
 	{
 		return (iCurrent + iExtra) > /*25*/ GD_INT_GET(STRATEGIC_RESOURCE_MONOPOLY_THRESHOLD);
 	}
@@ -46054,9 +46063,12 @@ void CvPlayer::processPolicies(PolicyTypes ePolicy, int iChange)
 									pLoopCity->GetCityBuildings()->SetNumFreeBuilding(eBuilding, 1);
 
 									// Only deduct if building is not capital only
-									if (pLoopCity->GetCityBuildings()->GetNumFreeBuilding(eBuilding) > 0 && !GC.getBuildingInfo(eBuilding)->IsCapitalOnly())
+									if (pLoopCity->GetCityBuildings()->GetNumFreeBuilding(eBuilding) > 0)
 									{
-										ChangeNumCitiesFreeChosenBuilding(eBuildingClass, -1);
+										CvBuildingEntry* pkBuilding = GC.getBuildingInfo(eBuilding);
+										if (pkBuilding && pkBuilding->IsCapitalOnly()) {
+											ChangeNumCitiesFreeChosenBuilding(eBuildingClass, -1);
+										}
 									}
 									if (pLoopCity->getFirstBuildingOrder(eBuilding) == 0)
 									{

--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -2031,6 +2031,7 @@ bool CvPlot::canHaveResource(ResourceTypes eResource, bool bIgnoreLatitude, bool
 	}
 
 	CvResourceInfo& thisResourceInfo = *GC.getResourceInfo(eResource);
+
 	if(getFeatureType() != NO_FEATURE)
 	{
 		if(!(thisResourceInfo.isFeature(getFeatureType())))
@@ -9434,10 +9435,11 @@ int CvPlot::calculateNatureYield(YieldTypes eYield, PlayerTypes ePlayer, const C
 	if(eTeam != NO_TEAM)
 	{
 		ResourceTypes eResource = getResourceType(eTeam);
+		CvResourceInfo* pkResourceInfo = GC.getResourceInfo(eResource);
 
-		if(eResource != NO_RESOURCE)
+		if(eResource != NO_RESOURCE && pkResourceInfo)
 		{
-			iYield += GC.getResourceInfo(eResource)->getYieldChange(eYield);
+			iYield += pkResourceInfo->getYieldChange(eYield);
 		}
 	}
 
@@ -10504,7 +10506,7 @@ int CvPlot::calculatePlayerYield(YieldTypes eYield, int iCurrentYield, PlayerTyp
 
 				if (MOD_BALANCE_CORE_RESOURCE_MONOPOLIES && kPlayer.HasGlobalMonopoly(eResource))
 				{
-					int iTemp = GC.getResourceInfo(eResource)->getYieldChangeFromMonopoly(eYield);
+					int iTemp = pkResourceInfo->getYieldChangeFromMonopoly(eYield);
 					if (iTemp > 0)
 					{
 						iTemp += GET_PLAYER(ePlayer).GetMonopolyModFlat();

--- a/CvGameCoreDLL_Expansion2/CvPolicyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPolicyAI.cpp
@@ -3860,7 +3860,8 @@ Firaxis::Array< int, NUM_YIELD_TYPES > CvPolicyAI::WeightPolicyAttributes(CvPlay
 			}
 		}
 
-		if (GC.getResourceInfo(eResource) != NULL && GC.getResourceInfo(eResource)->getPolicyReveal() == ePolicy)
+		CvResourceInfo* pkResourceInfo = GC.getResourceInfo(eResource);
+		if (pkResourceInfo != NULL && pkResourceInfo->getPolicyReveal() == ePolicy)
 		{
 			yield[YIELD_GOLD] += 100;
 		}

--- a/CvGameCoreDLL_Expansion2/CvTraitClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTraitClasses.cpp
@@ -6797,12 +6797,14 @@ int CvPlayerTraits::GetCapitalBuildingDiscount(BuildingTypes eBuilding)
 int CvPlayerTraits::GetWonderProductionToBuildingDiscount(BuildingTypes eBuilding)
 {
 	CvBuildingEntry* thisBuildingEntry = GC.getBuildingInfo(eBuilding);
-	const CvBuildingClassInfo& kBuildingClassInfo = thisBuildingEntry->GetBuildingClassInfo();
-	if(GetWonderProductionModifierToBuilding() > 0)
-	{
-		if(!(::isWorldWonderClass(kBuildingClassInfo) || ::isTeamWonderClass(kBuildingClassInfo) || ::isNationalWonderClass(kBuildingClassInfo)))
+	if (thisBuildingEntry) {
+		const CvBuildingClassInfo& kBuildingClassInfo = thisBuildingEntry->GetBuildingClassInfo();
+		if (GetWonderProductionModifierToBuilding() > 0)
 		{
-			return (GetWonderProductionModifierToBuilding());
+			if (!(::isWorldWonderClass(kBuildingClassInfo) || ::isTeamWonderClass(kBuildingClassInfo) || ::isNationalWonderClass(kBuildingClassInfo)))
+			{
+				return (GetWonderProductionModifierToBuilding());
+			}
 		}
 	}
 	return 0;

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -7586,18 +7586,21 @@ void CvUnit::LogWorkerEvent(BuildTypes eBuildType, bool bStartingConstruction)
 	if(eImprovement != NO_IMPROVEMENT)
 	{
 		ResourceTypes eResource = plot()->getResourceType(getTeam());
-		if(eResource != NO_RESOURCE)
-		{
-			strResource = GC.getResourceInfo(eResource)->GetType();
-			strResource += ",";
-		}
-		else if(plot()->getResourceType(NO_TEAM) != NO_RESOURCE)
-		{
-			eResource = plot()->getResourceType(NO_TEAM);
-			strResource = GC.getResourceInfo(eResource)->GetType();
-			strResource += ",";
+		CvResourceInfo* pkResourceInfo = GC.getResourceInfo(eResource);
+		if (pkResourceInfo) {
+			if (eResource != NO_RESOURCE)
+			{
+				strResource = pkResourceInfo->GetType();
+				strResource += ",";
+			}
+			else if (plot()->getResourceType(NO_TEAM) != NO_RESOURCE)
+			{
+				eResource = plot()->getResourceType(NO_TEAM);
+				strResource = pkResourceInfo->GetType();
+				strResource += ",";
 
-			strCanSee = "Can't see!,";
+				strCanSee = "Can't see!,";
+			}
 		}
 	}
 
@@ -10415,8 +10418,14 @@ bool CvUnit::shouldPillage(const CvPlot* pPlot, bool bConservative) const
 			ResourceTypes eResource = pPlot->getResourceType(getTeam());
 			if (eResource != NO_RESOURCE)
 			{
-				if (GC.getResourceInfo(eResource)->getResourceUsage() == RESOURCEUSAGE_STRATEGIC || GC.getResourceInfo(eResource)->getResourceUsage() == RESOURCEUSAGE_LUXURY)
+				CvResourceInfo* pkResourceInfo = GC.getResourceInfo(eResource);
+				if (
+					pkResourceInfo && 
+					(pkResourceInfo->getResourceUsage() == RESOURCEUSAGE_STRATEGIC ||
+					pkResourceInfo->getResourceUsage() == RESOURCEUSAGE_LUXURY)
+				) {
 					return true;
+				}
 			}
 		}
 

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaCity.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaCity.cpp
@@ -1411,26 +1411,28 @@ int CvLuaCity::lGetPurchaseBuildingTooltip(lua_State* L)
 	{
 		//Have we already invested here?
 		CvBuildingEntry* pGameBuilding = GC.getBuildingInfo(eBuilding);
-		const BuildingClassTypes eBuildingClass = (BuildingClassTypes)(pGameBuilding->GetBuildingClassType());
-		if(pkCity->IsBuildingInvestment(eBuildingClass))
-		{
-			int iValue = (/*-50*/ GD_INT_GET(BALANCE_BUILDING_INVESTMENT_BASELINE) + GET_PLAYER(pkCity->getOwner()).GetPlayerTraits()->GetInvestmentModifier() + GET_PLAYER(pkCity->getOwner()).GetInvestmentModifier());
-			iValue *= -1;
-			const CvBuildingClassInfo& kBuildingClassInfo = pGameBuilding->GetBuildingClassInfo();
-			if(::isWorldWonderClass(kBuildingClassInfo))
+		if (pGameBuilding) {
+			const BuildingClassTypes eBuildingClass = (BuildingClassTypes)(pGameBuilding->GetBuildingClassType());
+			if (pkCity->IsBuildingInvestment(eBuildingClass))
 			{
-				iValue /= 2;
-			}
-			Localization::String localizedText = Localization::Lookup("TXT_KEY_ALREADY_INVESTED");
-			localizedText << iValue;
+				int iValue = (/*-50*/ GD_INT_GET(BALANCE_BUILDING_INVESTMENT_BASELINE) + GET_PLAYER(pkCity->getOwner()).GetPlayerTraits()->GetInvestmentModifier() + GET_PLAYER(pkCity->getOwner()).GetInvestmentModifier());
+				iValue *= -1;
+				const CvBuildingClassInfo& kBuildingClassInfo = pGameBuilding->GetBuildingClassInfo();
+				if (::isWorldWonderClass(kBuildingClassInfo))
+				{
+					iValue /= 2;
+				}
+				Localization::String localizedText = Localization::Lookup("TXT_KEY_ALREADY_INVESTED");
+				localizedText << iValue;
 
-			const char* const localized = localizedText.toUTF8();
-			if(localized)
-			{
-				if(!toolTip.IsEmpty())
-					toolTip += "[NEWLINE]";
+				const char* const localized = localizedText.toUTF8();
+				if (localized)
+				{
+					if (!toolTip.IsEmpty())
+						toolTip += "[NEWLINE]";
 
-				toolTip += localized;
+					toolTip += localized;
+				}
 			}
 		}
 	}
@@ -1768,18 +1770,20 @@ int CvLuaCity::lGetBuildingInvestment(lua_State* L)
 	int iTotalDiscount = 0;
 	const BuildingTypes eBuildingType = (BuildingTypes) lua_tointeger(L, 2);
 	CvBuildingEntry* pGameBuilding = GC.getBuildingInfo(eBuildingType);
-	const BuildingClassTypes eBuildingClass = (BuildingClassTypes)(pGameBuilding->GetBuildingClassType());
-	if(pkCity->IsBuildingInvestment(eBuildingClass))
-	{
-		iResult = GET_PLAYER(pkCity->getOwner()).getProductionNeeded(eBuildingType);
-		iTotalDiscount = (/*-50*/ GD_INT_GET(BALANCE_BUILDING_INVESTMENT_BASELINE) + GET_PLAYER(pkCity->getOwner()).GetPlayerTraits()->GetInvestmentModifier() + GET_PLAYER(pkCity->getOwner()).GetInvestmentModifier());
-		const CvBuildingClassInfo& kBuildingClassInfo = pGameBuilding->GetBuildingClassInfo();
-		if(::isWorldWonderClass(kBuildingClassInfo))
+	if (pGameBuilding) {
+		const BuildingClassTypes eBuildingClass = (BuildingClassTypes)(pGameBuilding->GetBuildingClassType());
+		if (pkCity->IsBuildingInvestment(eBuildingClass))
 		{
-			iTotalDiscount /= 2;
+			iResult = GET_PLAYER(pkCity->getOwner()).getProductionNeeded(eBuildingType);
+			iTotalDiscount = (/*-50*/ GD_INT_GET(BALANCE_BUILDING_INVESTMENT_BASELINE) + GET_PLAYER(pkCity->getOwner()).GetPlayerTraits()->GetInvestmentModifier() + GET_PLAYER(pkCity->getOwner()).GetInvestmentModifier());
+			const CvBuildingClassInfo& kBuildingClassInfo = pGameBuilding->GetBuildingClassInfo();
+			if (::isWorldWonderClass(kBuildingClassInfo))
+			{
+				iTotalDiscount /= 2;
+			}
+			iResult *= (iTotalDiscount + 100);
+			iResult /= 100;
 		}
-		iResult *= (iTotalDiscount + 100);
-		iResult /= 100;
 	}
 
 	lua_pushinteger(L, iResult);
@@ -1793,10 +1797,12 @@ int CvLuaCity::lIsWorldWonder(lua_State* L)
 	bool bResult = false;
 	const BuildingTypes eBuildingType = (BuildingTypes)lua_tointeger(L, 2);
 	CvBuildingEntry* pGameBuilding = GC.getBuildingInfo(eBuildingType);
-	const CvBuildingClassInfo& kBuildingClassInfo = pGameBuilding->GetBuildingClassInfo();
-	if (::isWorldWonderClass(kBuildingClassInfo))
-	{
-		bResult = true;
+	if (pGameBuilding) {
+		const CvBuildingClassInfo& kBuildingClassInfo = pGameBuilding->GetBuildingClassInfo();
+		if (::isWorldWonderClass(kBuildingClassInfo))
+		{
+			bResult = true;
+		}
 	}
 
 	lua_pushboolean(L, bResult);
@@ -1809,51 +1815,53 @@ int CvLuaCity::lGetWorldWonderCost(lua_State* L)
 
 	const BuildingTypes eBuildingType = (BuildingTypes)lua_tointeger(L, 2);
 	CvBuildingEntry* pGameBuilding = GC.getBuildingInfo(eBuildingType);
-	const CvBuildingClassInfo& kBuildingClassInfo = pGameBuilding->GetBuildingClassInfo();
-	if (MOD_BALANCE_CORE_WONDER_COST_INCREASE && ::isWorldWonderClass(kBuildingClassInfo))
+	if (MOD_BALANCE_CORE_WONDER_COST_INCREASE && pGameBuilding)
 	{
-		const CvCity* pLoopCity;
-		int iLoop;
-		for (pLoopCity = GET_PLAYER(pkCity->getOwner()).firstCity(&iLoop); pLoopCity != NULL; pLoopCity = GET_PLAYER(pkCity->getOwner()).nextCity(&iLoop))
-		{
-			if (pLoopCity->getNumWorldWonders() > 0)
+		const CvBuildingClassInfo& kBuildingClassInfo = pGameBuilding->GetBuildingClassInfo();
+		if (::isWorldWonderClass(kBuildingClassInfo)) {
+			const CvCity* pLoopCity;
+			int iLoop;
+			for (pLoopCity = GET_PLAYER(pkCity->getOwner()).firstCity(&iLoop); pLoopCity != NULL; pLoopCity = GET_PLAYER(pkCity->getOwner()).nextCity(&iLoop))
 			{
-				for (int iBuildingLoop = 0; iBuildingLoop < GC.getNumBuildingInfos(); iBuildingLoop++)
+				if (pLoopCity->getNumWorldWonders() > 0)
 				{
-					const BuildingTypes eBuilding = static_cast<BuildingTypes>(iBuildingLoop);
-					CvBuildingEntry* pkeBuildingInfo = GC.getBuildingInfo(eBuilding);
-
-					// Has this Building
-					if (pLoopCity->GetCityBuildings()->GetNumBuilding(eBuilding) > 0)
+					for (int iBuildingLoop = 0; iBuildingLoop < GC.getNumBuildingInfos(); iBuildingLoop++)
 					{
-						if (isWorldWonderClass(pkeBuildingInfo->GetBuildingClassInfo()))
+						const BuildingTypes eBuilding = static_cast<BuildingTypes>(iBuildingLoop);
+						CvBuildingEntry* pkeBuildingInfo = GC.getBuildingInfo(eBuilding);
+
+						// Has this Building
+						if (pkeBuildingInfo && pLoopCity->GetCityBuildings()->GetNumBuilding(eBuilding) > 0)
 						{
-							if (pkeBuildingInfo->GetPrereqAndTech() == NO_TECH)
-								continue;
-
-							CvTechEntry* pkTechInfo = GC.getTechInfo((TechTypes)pkeBuildingInfo->GetPrereqAndTech());
-							if (pkTechInfo)
+							if (isWorldWonderClass(pkeBuildingInfo->GetBuildingClassInfo()))
 							{
-								// Loop through all eras and apply Building production mod based on how much time has passed
-								EraTypes eBuildingUnlockedEra = (EraTypes)pkTechInfo->GetEra();
-
-								if (eBuildingUnlockedEra == NO_ERA)
+								if (pkeBuildingInfo->GetPrereqAndTech() == NO_TECH)
 									continue;
 
-								int iEraDifference = GET_PLAYER(pkCity->getOwner()).GetCurrentEra() - eBuildingUnlockedEra;
-								switch (iEraDifference)
+								CvTechEntry* pkTechInfo = GC.getTechInfo((TechTypes)pkeBuildingInfo->GetPrereqAndTech());
+								if (pkTechInfo)
 								{
-								case 0:
-									iNumWorldWonderPercent += /*25*/ GD_INT_GET(BALANCE_CORE_WORLD_WONDER_SAME_ERA_COST_MODIFIER);
-									break;
-								case 1:
-									iNumWorldWonderPercent += /*15*/ GD_INT_GET(BALANCE_CORE_WORLD_WONDER_PREVIOUS_ERA_COST_MODIFIER);
-									break;
-								case 2:
-									iNumWorldWonderPercent += /*10*/ GD_INT_GET(BALANCE_CORE_WORLD_WONDER_SECOND_PREVIOUS_ERA_COST_MODIFIER);
-									break;
-								default:
-									iNumWorldWonderPercent += /*5*/ GD_INT_GET(BALANCE_CORE_WORLD_WONDER_EARLIER_ERA_COST_MODIFIER);
+									// Loop through all eras and apply Building production mod based on how much time has passed
+									EraTypes eBuildingUnlockedEra = (EraTypes)pkTechInfo->GetEra();
+
+									if (eBuildingUnlockedEra == NO_ERA)
+										continue;
+
+									int iEraDifference = GET_PLAYER(pkCity->getOwner()).GetCurrentEra() - eBuildingUnlockedEra;
+									switch (iEraDifference)
+									{
+									case 0:
+										iNumWorldWonderPercent += /*25*/ GD_INT_GET(BALANCE_CORE_WORLD_WONDER_SAME_ERA_COST_MODIFIER);
+										break;
+									case 1:
+										iNumWorldWonderPercent += /*15*/ GD_INT_GET(BALANCE_CORE_WORLD_WONDER_PREVIOUS_ERA_COST_MODIFIER);
+										break;
+									case 2:
+										iNumWorldWonderPercent += /*10*/ GD_INT_GET(BALANCE_CORE_WORLD_WONDER_SECOND_PREVIOUS_ERA_COST_MODIFIER);
+										break;
+									default:
+										iNumWorldWonderPercent += /*5*/ GD_INT_GET(BALANCE_CORE_WORLD_WONDER_EARLIER_ERA_COST_MODIFIER);
+									}
 								}
 							}
 						}
@@ -3511,14 +3519,15 @@ int CvLuaCity::lGetReligionBuildingClassYieldChange(lua_State* L)
 
 	ReligionTypes eMajority = pkCity->GetCityReligions()->GetReligiousMajority();
 	BeliefTypes eSecondaryPantheon = NO_BELIEF;
-	if(eMajority != NO_RELIGION)
+	if(eMajority != NO_RELIGION && eBuildingClass != NO_BUILDINGCLASS)
 	{
 		const CvReligion* pReligion = GC.getGame().GetGameReligions()->GetReligion(eMajority, pkCity->getOwner());
-		if(pReligion)
+		CvBuildingClassInfo* pInfo = GC.getBuildingClassInfo(eBuildingClass);
+		if(pReligion && pInfo)
 		{	
 			int iFollowers = pkCity->GetCityReligions()->GetNumFollowers(eMajority);
 			iYieldFromBuilding += pReligion->m_Beliefs.GetBuildingClassYieldChange(eBuildingClass, eYieldType, iFollowers, pkCity->getOwner(), pkCity);
-			if (::isWorldWonderClass(*GC.getBuildingClassInfo(eBuildingClass)))
+			if (::isWorldWonderClass(*pInfo))
 			{
 				iYieldFromBuilding += pReligion->m_Beliefs.GetYieldChangeWorldWonder(eYieldType, pkCity->getOwner(), pkCity);
 			}
@@ -3565,13 +3574,15 @@ int CvLuaCity::lGetLeagueBuildingClassYieldChange(lua_State* L)
 	BuildingClassTypes eBuildingClass = (BuildingClassTypes)lua_tointeger(L, 2);
 	YieldTypes eYieldType = (YieldTypes)lua_tointeger(L, 3);
 
-	CvBuildingClassInfo* pInfo = GC.getBuildingClassInfo(eBuildingClass);
-	if (pInfo && pInfo->getMaxGlobalInstances() != -1)
-	{
-		int iYieldChange = GC.getGame().GetGameLeagues()->GetWorldWonderYieldChange(pkCity->getOwner(), eYieldType);
-		if (iYieldChange != 0)
+	if (eBuildingClass != NO_BUILDINGCLASS) {
+		CvBuildingClassInfo* pInfo = GC.getBuildingClassInfo(eBuildingClass);
+		if (pInfo && pInfo->getMaxGlobalInstances() != -1)
 		{
-			iYieldFromBuilding += iYieldChange;
+			int iYieldChange = GC.getGame().GetGameLeagues()->GetWorldWonderYieldChange(pkCity->getOwner(), eYieldType);
+			if (iYieldChange != 0)
+			{
+				iYieldFromBuilding += iYieldChange;
+			}
 		}
 	}
 

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaGame.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaGame.cpp
@@ -38,6 +38,8 @@
 
 #define Method(func) RegisterMethod(L, l##func, #func);
 
+using namespace CvLuaArgs;
+
 //------------------------------------------------------------------------------
 const char* CvLuaGame::GetInstanceName()
 {
@@ -1208,9 +1210,16 @@ int CvLuaGame::lGetNumWorldWonders(lua_State* L)
 //bool isWorldWonderClass(const CvBuildingClassInfo& kBuildingClass);
 int CvLuaGame::lIsWorldWonderClass(lua_State* L)
 {
-	const BuildingClassTypes eBuildingClass = (BuildingClassTypes) lua_tointeger(L, 1);
-	CvBuildingClassInfo* pkBuildingClassInfo = GC.getBuildingClassInfo(eBuildingClass);
-	const bool bResult = ::isWorldWonderClass(*pkBuildingClassInfo);
+	bool bResult = false;
+	const BuildingClassTypes iIndex = toValue<BuildingClassTypes>(L, 2);
+	if(iIndex != NO_BUILDINGCLASS)
+	{
+		CvBuildingClassInfo* pkBuildingClassInfo = GC.getBuildingClassInfo(iIndex);
+		if(pkBuildingClassInfo)
+		{
+			bResult = ::isWorldWonderClass(*pkBuildingClassInfo);
+		}
+	}
 	lua_pushboolean(L, bResult);
 	return 1;
 }
@@ -1996,7 +2005,7 @@ int CvLuaGame::lGetResourceUsageType(lua_State* L)
 	const CvResourceInfo* pkResourceInfo = GC.getResourceInfo(eResource);
 	if (pkResourceInfo)
 	{
-		ResourceUsageTypes eUsage = GC.getResourceInfo(eResource)->getResourceUsage();
+		ResourceUsageTypes eUsage = pkResourceInfo->getResourceUsage();
 		lua_pushinteger(L, eUsage);
 	}
 	else


### PR DESCRIPTION
Just adding more nullchecks across the whole codebase according to this (#9999) issue. 
Should be a little bit safer overall I think. Also maybe fixes some compatibility with other mods.

Initially I thought we can just remove null gaps in these collections (like I said [here](https://github.com/LoneGazebo/Community-Patch-DLL/issues/9999#issuecomment-1646666908)), but I tested it and sadly we can't do it in such way. Looks like sometimes we are referencing "by id" here and we are expecting that sqlite's id == array index. While such logic exists, we have to manage all these horrible nullchecks.