### PR TITLE
Fix error in cartographic commission quest

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
@@ -9976,13 +9976,13 @@ int CvMinorCivAI::GetExplorePercent(PlayerTypes ePlayer, MinorCivQuestTypes eQue
 			CvPlot* pPlot = GC.getMap().plot(iX, iY);
 			if(pPlot)
 			{
-				CvLandmass* pLandmass = pPlot->landmass();
-				if(pLandmass)
+				CvArea* pArea = pPlot->area();
+				if(pArea)
 				{
-					if(pLandmass->getNumUnrevealedTiles(eTeam) <= 0)
+					if(pArea->getNumUnrevealedTiles(eTeam) <= 0)
 						return 100;
 					
-					return MIN(100, (100 * pLandmass->getNumRevealedTiles(eTeam)) / pLandmass->getNumUnrevealedTiles(eTeam));
+					return MIN(100, (100 * pArea->getNumRevealedTiles(eTeam)) / pArea->getNumUnrevealedTiles(eTeam));
 				}
 			}
 		}


### PR DESCRIPTION
Fix cartographic commission quest starting with 100% explored (#9327).

Reason: When the quest is given (in CvMinorCivAI::GetTargetPlot), an unexplored _area_ is selected
```
// >= 66% revealed? Next!
int iPercent = ((100 * pLoopArea->getNumRevealedTiles(eTeam)) / pLoopArea->getNumUnrevealedTiles(eTeam));
if (iPercent >= 66)
	continue;
```
but in CvMinorCivAI::GetExplorePercent, the percentage of explored _landmass_  was returned.