### PR TITLE
Fix venice puppets having no local happiness

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -22457,7 +22457,7 @@ int CvCity::updateNetHappiness()
 		m_iHappinessDelta = -getPopulation();
 		return m_iHappinessDelta;
 	}
-	else if (IsPuppet())
+	else if (IsPuppet() && !kPlayer.GetPlayerTraits()->IsNoAnnexing())
 	{
 		m_iHappinessDelta = 0;
 		return 0;


### PR DESCRIPTION
The net happiness of Venetian puppets shouldn't be 0 (part of their trait is that puppets can get happiness). If `m_iHappinessDelta` is 0, they don't get growth bonuses or additional GAP points from happiness. 