### PR TITLE
Random Number Generation rework

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvBarbarians.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBarbarians.cpp
@@ -187,12 +187,12 @@ void CvBarbarians::ActivateBarbSpawner(CvPlot* pPlot)
 	if (pPlot->isCity())
 	{
 		iNumTurnsToSpawn = /*6*/ GD_INT_GET(BARBARIAN_SPAWN_DELAY_FROM_CITY);
-		iNumTurnsToSpawn += kGame.isReallyNetworkMultiPlayer() ? GD_INT_GET(BARBARIAN_SPAWN_DELAY_FROM_CITY_RAND)/2 : kGame.getSmallFakeRandNum(/*5*/ GD_INT_GET(BARBARIAN_SPAWN_DELAY_FROM_CITY_RAND), *pPlot);
+		iNumTurnsToSpawn += kGame.randRangeExclusive(0, /*5*/ GD_INT_GET(BARBARIAN_SPAWN_DELAY_FROM_CITY_RAND), pPlot->GetPseudoRandomSeed());
 	}
 	else
 	{
 		iNumTurnsToSpawn = /*12*/ GD_INT_GET(BARBARIAN_SPAWN_DELAY_FROM_ENCAMPMENT);
-		iNumTurnsToSpawn += kGame.isReallyNetworkMultiPlayer() ? GD_INT_GET(BARBARIAN_SPAWN_DELAY_FROM_ENCAMPMENT_RAND)/2 : kGame.getSmallFakeRandNum(/*10*/ GD_INT_GET(BARBARIAN_SPAWN_DELAY_FROM_ENCAMPMENT_RAND), *pPlot);
+		iNumTurnsToSpawn += kGame.randRangeExclusive(0, /*10*/ GD_INT_GET(BARBARIAN_SPAWN_DELAY_FROM_ENCAMPMENT_RAND), pPlot->GetPseudoRandomSeed());
 	}
 
 	// Chill
@@ -384,13 +384,13 @@ bool CvBarbarians::DoStealFromCity(CvUnit* pUnit, CvCity* pCity)
 		return true;
 
 	//they get x turns worth of yields
-	int iTheftTurns = std::max(1, iDefenderDamage / 30 + GC.getGame().getSmallFakeRandNum(5, pUnit->GetID() + GET_PLAYER(pCity->getOwner()).GetPseudoRandomSeed()));
+	int iTheftTurns = std::max(1, iDefenderDamage / 30 + GC.getGame().randRangeExclusive(0, 5, static_cast<uint>(pUnit->GetID()) + GET_PLAYER(pCity->getOwner()).GetPseudoRandomSeed()));
 
 	//but they lose some health in exchange
-	pUnit->changeDamage( GC.getGame().getSmallFakeRandNum( std::min(pUnit->GetCurrHitPoints(),30), iDefenderDamage + GET_PLAYER(pCity->getOwner()).GetPseudoRandomSeed() ) );
+	pUnit->changeDamage(GC.getGame().randRangeExclusive(0, std::min(pUnit->GetCurrHitPoints(),30), static_cast<uint>(iDefenderDamage) + GET_PLAYER(pCity->getOwner()).GetPseudoRandomSeed()));
 
 	//which yield is affected?
-	int iYield = GC.getGame().getSmallFakeRandNum(10, pUnit->plot()->GetPlotIndex() + GET_PLAYER(pCity->getOwner()).GetPseudoRandomSeed());
+	int iYield = GC.getGame().randRangeExclusive(0, 10, static_cast<uint>(pUnit->plot()->GetPlotIndex()) + GET_PLAYER(pCity->getOwner()).GetPseudoRandomSeed());
 	if (iYield <= 2)
 	{
 		int iGold = std::min(pCity->getBaseYieldRate(YIELD_GOLD) * iTheftTurns, pUnit->GetCurrHitPoints());
@@ -594,7 +594,7 @@ void CvBarbarians::DoCamps()
 		// In Community Patch only, 1/2 chance of spawning a camp each turn (after turn 0)
 		else if (GD_INT_GET(BARBARIAN_CAMP_ODDS_OF_NEW_CAMP_SPAWNING) > 0)
 		{
-			if (kGame.isReallyNetworkMultiPlayer() ? kGame.getGameTurn() % /*2*/ std::max(GD_INT_GET(BARBARIAN_CAMP_ODDS_OF_NEW_CAMP_SPAWNING), 1) == 0 : kGame.getSmallFakeRandNum(/*2*/ std::max(GD_INT_GET(BARBARIAN_CAMP_ODDS_OF_NEW_CAMP_SPAWNING), 1), kGame.getGameTurn()*kGame.getGameTurn()) == 0)
+			if (kGame.randRangeExclusive(0, /*2*/ std::max(GD_INT_GET(BARBARIAN_CAMP_ODDS_OF_NEW_CAMP_SPAWNING), 1), static_cast<uint>(kGame.getGameTurn()) * static_cast<uint>(kGame.getGameTurn())) == 0)
 			{
 				iNumCampsToAdd = /*1*/ GD_INT_GET(BARBARIAN_CAMP_NUM_AFTER_INITIAL);
 				iNumCampsToAdd += kGame.isOption(GAMEOPTION_CHILL_BARBARIANS) ? /*0*/ GD_INT_GET(BARBARIAN_CAMP_NUM_AFTER_INITIAL_CHILL) : 0;
@@ -743,8 +743,8 @@ void CvBarbarians::DoCamps()
 		if (vPotentialPlots.size() > 1)
 		{
 			//do one iteration of a fisher-yates shuffle
-			int iSwap = kGame.isReallyNetworkMultiPlayer() ? vPotentialPlots.size() / 2 : kGame.getSmallFakeRandNum(vPotentialPlots.size(), pLoopPlot->GetPlotIndex()*vPotentialPlots.size()*(iGameTurn+1));
-			std::swap(vPotentialPlots[iSwap],vPotentialPlots.back());
+			uint uSwap = kGame.urandLimitExclusive(vPotentialPlots.size(), static_cast<uint>(pLoopPlot->GetPlotIndex()) * vPotentialPlots.size() * (static_cast<uint>(iGameTurn) + 1));
+			std::swap(vPotentialPlots[uSwap],vPotentialPlots.back());
 		}
 
 		if (pLoopPlot->isCoastalLand())
@@ -754,8 +754,8 @@ void CvBarbarians::DoCamps()
 			if (vPotentialCoastalPlots.size() > 1)
 			{
 				//do one iteration of a fisher-yates shuffle
-				int iSwap = kGame.isReallyNetworkMultiPlayer() ? vPotentialCoastalPlots.size() / 2 : kGame.getSmallFakeRandNum(vPotentialCoastalPlots.size(), pLoopPlot->GetPlotIndex()*vPotentialCoastalPlots.size()*(iGameTurn+1));
-				std::swap(vPotentialCoastalPlots[iSwap],vPotentialCoastalPlots.back());
+				uint uSwap = kGame.urandLimitExclusive(vPotentialCoastalPlots.size(), static_cast<uint>(pLoopPlot->GetPlotIndex()) * vPotentialCoastalPlots.size() * (static_cast<uint>(iGameTurn) + 1));
+				std::swap(vPotentialCoastalPlots[uSwap],vPotentialCoastalPlots.back());
 			}
 		}
 	}
@@ -905,8 +905,8 @@ void CvBarbarians::DoCamps()
 			break;
 
 		// Pick a plot
-		int iIndex = kGame.isReallyNetworkMultiPlayer() ? vRelevantPlots.size() / 2 : kGame.getSmallFakeRandNum(vRelevantPlots.size(), vRelevantPlots.size()*iNumCampsInExistence+GC.getGame().getGameTurn());
-		CvPlot* pPlot = vRelevantPlots[iIndex];
+		uint uIndex = kGame.urandLimitExclusive(vRelevantPlots.size(), vRelevantPlots.size() * static_cast<uint>(iNumCampsInExistence) + static_cast<uint>(GC.getGame().getGameTurn()));
+		CvPlot* pPlot = vRelevantPlots[uIndex];
 
 		// Spawn a camp and units to defend it!
 		pPlot->setRouteType(NO_ROUTE);
@@ -1128,7 +1128,7 @@ void CvBarbarians::SpawnBarbarianUnits(CvPlot* pPlot, int iNumUnits, BarbSpawnRe
 	if (bSpawnOnPlot)
 	{
 		UnitAITypes ePreferredType = (eReason == BARB_SPAWN_FROM_CITY || eReason == BARB_SPAWN_CITY_STATE_CAPTURE) ? UNITAI_RANGED : UNITAI_DEFENSE;
-		UnitTypes eUnit = GetRandomBarbarianUnitType(pPlot, ePreferredType, eUniqueUnitPlayer, vValidResources, pPlot->GetPlotIndex()*iNumUnits+GC.getGame().getGameTurn());
+		UnitTypes eUnit = GetRandomBarbarianUnitType(pPlot, ePreferredType, eUniqueUnitPlayer, vValidResources, pPlot->GetPseudoRandomSeed() * static_cast<uint>(iNumUnits) + static_cast<uint>(GC.getGame().getGameTurn()));
 		CvUnitEntry* pkUnitInfo = GC.getUnitInfo(eUnit);
 		if (pkUnitInfo)
 		{
@@ -1219,12 +1219,12 @@ void CvBarbarians::SpawnBarbarianUnits(CvPlot* pPlot, int iNumUnits, BarbSpawnRe
 				break;
 
 			// Choose a random plot
-			int iIndex = GC.getGame().isReallyNetworkMultiPlayer() ? vBarbSpawnPlots.size() / 2 : GC.getGame().getSmallFakeRandNum(vBarbSpawnPlots.size(), *pPlot);
-			CvPlot* pSpawnPlot = vBarbSpawnPlots[iIndex];
+			uint uIndex = GC.getGame().urandLimitExclusive(vBarbSpawnPlots.size(), pPlot->GetPseudoRandomSeed());
+			CvPlot* pSpawnPlot = vBarbSpawnPlots[uIndex];
 			UnitAITypes eUnitAI = pSpawnPlot->isWater() ? UNITAI_ATTACK_SEA : UNITAI_FAST_ATTACK;
 
 			// Pick a unit
-			UnitTypes eUnit = GetRandomBarbarianUnitType(pSpawnPlot, eUnitAI, eUniqueUnitPlayer, vValidResources, vBarbSpawnPlots.size()*iNumUnits+GC.getGame().getGameTurn()+iNumUnitsSpawned);
+			UnitTypes eUnit = GetRandomBarbarianUnitType(pSpawnPlot, eUnitAI, eUniqueUnitPlayer, vValidResources, vBarbSpawnPlots.size() * static_cast<uint>(iNumUnits) + static_cast<uint>(GC.getGame().getGameTurn()) + static_cast<uint>(iNumUnitsSpawned));
 			CvUnitEntry* pkUnitInfo = GC.getUnitInfo(eUnit);
 			if (pkUnitInfo)
 			{
@@ -1254,7 +1254,7 @@ void CvBarbarians::SpawnBarbarianUnits(CvPlot* pPlot, int iNumUnits, BarbSpawnRe
 			}
 
 			// Make sure to erase the plot we chose from the list!
-			vBarbSpawnPlots.erase(vBarbSpawnPlots.begin() + iIndex);
+			vBarbSpawnPlots.erase(vBarbSpawnPlots.begin() + uIndex);
 		}
 
 		iRingsCompleted++;
@@ -1289,7 +1289,7 @@ void CvBarbarians::SpawnBarbarianUnits(CvPlot* pPlot, int iNumUnits, BarbSpawnRe
 }
 
 //	--------------------------------------------------------------------------------
-UnitTypes CvBarbarians::GetRandomBarbarianUnitType(CvPlot* pPlot, UnitAITypes ePreferredUnitAI, PlayerTypes eUniqueUnitPlayer, vector<ResourceTypes>& vValidResources, int iAdditionalSeed)
+UnitTypes CvBarbarians::GetRandomBarbarianUnitType(CvPlot* pPlot, UnitAITypes ePreferredUnitAI, PlayerTypes eUniqueUnitPlayer, vector<ResourceTypes>& vValidResources, uint uAdditionalSeed)
 {
 	CvPlayerAI& kBarbarianPlayer = GET_PLAYER(BARBARIAN_PLAYER);
 	vector<OptionWithScore<UnitTypes>> candidates;
@@ -1445,7 +1445,7 @@ UnitTypes CvBarbarians::GetRandomBarbarianUnitType(CvPlot* pPlot, UnitAITypes eP
 
 	//choose from top 5
 	int iNumCandidates = /*5*/ range(GD_INT_GET(BARBARIAN_UNIT_SPAWN_NUM_CANDIDATES), 1, candidates.size());
-	UnitTypes eBestUnit = PseudoRandomChoiceByWeight(candidates, NO_UNIT, 5, pPlot->GetPlotIndex()+iAdditionalSeed);
+	UnitTypes eBestUnit = PseudoRandomChoiceByWeight(candidates, NO_UNIT, 5, pPlot->GetPseudoRandomSeed() + uAdditionalSeed);
 
 	//custom override
 	if (MOD_EVENTS_BARBARIANS)

--- a/CvGameCoreDLL_Expansion2/CvBarbarians.h
+++ b/CvGameCoreDLL_Expansion2/CvBarbarians.h
@@ -50,7 +50,7 @@ public:
 	static void SpawnBarbarianUnits(CvPlot* pPlot, int iNumUnits, BarbSpawnReason eReason);
 
 private:
-	static UnitTypes GetRandomBarbarianUnitType(CvPlot* pPlot, UnitAITypes ePreferredUnitAI, PlayerTypes eUniqueUnitPlayer, vector<ResourceTypes>& vValidResources, uint uAdditionalSeed);
+	static UnitTypes GetRandomBarbarianUnitType(CvPlot* pPlot, UnitAITypes ePreferredUnitAI, PlayerTypes eUniqueUnitPlayer, vector<ResourceTypes>& vValidResources, CvSeeder additionalSeed);
 	static short* m_aiBarbSpawnerCounter;
 	static short* m_aiBarbSpawnerNumUnitsSpawned;
 };

--- a/CvGameCoreDLL_Expansion2/CvBarbarians.h
+++ b/CvGameCoreDLL_Expansion2/CvBarbarians.h
@@ -50,7 +50,7 @@ public:
 	static void SpawnBarbarianUnits(CvPlot* pPlot, int iNumUnits, BarbSpawnReason eReason);
 
 private:
-	static UnitTypes GetRandomBarbarianUnitType(CvPlot* pPlot, UnitAITypes ePreferredUnitAI, PlayerTypes eUniqueUnitPlayer, vector<ResourceTypes>& vValidResources, int iAdditionalSeed);
+	static UnitTypes GetRandomBarbarianUnitType(CvPlot* pPlot, UnitAITypes ePreferredUnitAI, PlayerTypes eUniqueUnitPlayer, vector<ResourceTypes>& vValidResources, uint uAdditionalSeed);
 	static short* m_aiBarbSpawnerCounter;
 	static short* m_aiBarbSpawnerNumUnitsSpawned;
 };

--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -3583,7 +3583,7 @@ void CvCity::DoEvents(bool bEspionageOnly)
 	if (veValidEvents.size() > 0)
 	{
 		//		veValidEvents.StableSortItems();
-		uint uRandIndex = GC.getGame().urandLimitExclusive(2500, veValidEvents.size() + static_cast<uint>(GetID()));
+		uint uRandIndex = GC.getGame().urandLimitExclusive(2500, CvSeeder(veValidEvents.size()).mix(GetID()));
 
 		if (GC.getLogging())
 		{
@@ -6772,7 +6772,7 @@ void CvCity::DoEventChoice(CityEventChoiceTypes eEventChoice, CityEventTypes eCi
 					GET_PLAYER(getOwner()).doInstantYield(INSTANT_YIELD_TYPE_INSTANT, false, NO_GREATPERSON, NO_BUILDING, iPassYield, pkEventChoiceInfo->IsEraScaling(), NO_PLAYER, NULL, true, this, false, true, true, eYield);
 				}
 			}
-			uint uRandom = GC.getGame().urandLimitExclusive(100, static_cast<uint>(getFood()));
+			uint uRandom = GC.getGame().urandLimitExclusive(100, CvSeeder(getFood()));
 			int iLimit = pkEventChoiceInfo->getEventChance();
 			if (iLimit > 0 && static_cast<int>(uRandom) > iLimit)
 			{
@@ -6858,7 +6858,7 @@ void CvCity::DoEventChoice(CityEventChoiceTypes eEventChoice, CityEventTypes eCi
 					uint uMinLoop = min(static_cast<uint>(pkEventChoiceInfo->getForgeGW()), GWIDs.size());
 					while (uMinLoop > 0)
 					{
-						uint uGrab = GC.getGame().urandLimitExclusive(uMinLoop - 1, GET_PLAYER(eSpyOwner).GetPseudoRandomSeed() + static_cast<uint>(GWIDs[0]) + static_cast<uint>(GET_PLAYER(getOwner()).GetTreasury()->CalculateGrossGold()));
+						uint uGrab = GC.getGame().urandLimitExclusive(uMinLoop - 1, GET_PLAYER(eSpyOwner).GetPseudoRandomSeed().mix(GWIDs[0]).mix(GET_PLAYER(getOwner()).GetTreasury()->CalculateGrossGold()));
 						if (GET_PLAYER(eSpyOwner).GetEspionage()->DoStealGW(this, GWIDs[uGrab]))
 						{
 							GET_PLAYER(eSpyOwner).GetEspionage()->m_aiNumSpyActionsDone[getOwner()]++;
@@ -10596,7 +10596,7 @@ void CvCity::DoPickResourceDemanded()
 	}
 
 	// Now pick a Luxury we can use
-	uint uVectorIndex = GC.getGame().urandLimitExclusive(veValidLuxuryResources.size(), plot()->GetPseudoRandomSeed() + GET_PLAYER(getOwner()).GetPseudoRandomSeed());
+	uint uVectorIndex = GC.getGame().urandLimitExclusive(veValidLuxuryResources.size(), plot()->GetPseudoRandomSeed().mix(GET_PLAYER(getOwner()).GetPseudoRandomSeed()));
 	ResourceTypes eResource = static_cast<ResourceTypes>(veValidLuxuryResources[uVectorIndex]);
 
 	//hurk! STOP.
@@ -10743,7 +10743,7 @@ void CvCity::DoSeedResourceDemandedCountdown()
 	}
 
 	uint uRand = static_cast<uint>(/*10*/ GD_INT_GET(RESOURCE_DEMAND_COUNTDOWN_RAND));
-	iNumTurns = static_cast<int>(static_cast<uint>(iNumTurns) + GC.getGame().urandLimitExclusive(uRand, plot()->GetPseudoRandomSeed() + GET_PLAYER(getOwner()).GetPseudoRandomSeed()));
+	iNumTurns = static_cast<int>(static_cast<uint>(iNumTurns) + GC.getGame().urandLimitExclusive(uRand, plot()->GetPseudoRandomSeed().mix(GET_PLAYER(getOwner()).GetPseudoRandomSeed())));
 	SetResourceDemandedCountdown(iNumTurns);
 }
 
@@ -15434,7 +15434,7 @@ void CvCity::processBuilding(BuildingTypes eBuilding, int iChange, bool bFirst, 
 						if (vPossibleResources.size() > 0)
 						{
 							//choose one
-							uint uChoice = GC.getGame().urandLimitExclusive(vPossibleResources.size(), plot()->GetPseudoRandomSeed() + GET_PLAYER(getOwner()).GetPseudoRandomSeed());
+							uint uChoice = GC.getGame().urandLimitExclusive(vPossibleResources.size(), plot()->GetPseudoRandomSeed().mix(GET_PLAYER(getOwner()).GetPseudoRandomSeed()));
 							ResourceTypes eResourceToGive = vPossibleResources[uChoice];
 
 							int iNumResourceGiven = 0;
@@ -21721,7 +21721,7 @@ bool CvCity::DoRazingTurn()
 				// Based on city size, but min number scaling with era.
 				const int iMinRebels = GC.getGame().getCurrentEra();
 				const int iMaxRebels = max(iMinRebels, sqrti(getPopulation()));
-				int iNumRebels = GC.getGame().randRangeInclusive(iMinRebels, iMaxRebels, plot()->GetPseudoRandomSeed() + GET_PLAYER(getOwner()).GetPseudoRandomSeed());
+				int iNumRebels = GC.getGame().randRangeInclusive(iMinRebels, iMaxRebels, plot()->GetPseudoRandomSeed().mix(GET_PLAYER(getOwner()).GetPseudoRandomSeed()));
 
 
 				GET_PLAYER(getOwner()).SetSpawnCooldown(iNumRebels * 2);
@@ -28860,7 +28860,7 @@ CvPlot* CvCity::GetNextBuyablePlot(bool bForPurchase)
 	if (aiPlotList.empty())
 		return NULL;
 
-	uint uPickedIndex = GC.getGame().urandLimitExclusive(aiPlotList.size(), static_cast<uint>(getFoodTimes100()) + static_cast<uint>(GET_PLAYER(m_eOwner).GetNumPlots()));
+	uint uPickedIndex = GC.getGame().urandLimitExclusive(aiPlotList.size(), CvSeeder(getFoodTimes100()).mix(GET_PLAYER(m_eOwner).GetNumPlots()));
 	return GC.getMap().plotByIndex(aiPlotList[uPickedIndex]);
 }
 
@@ -31227,7 +31227,7 @@ CvPlot* CvCity::GetPlotForNewUnit(UnitTypes eUnitType, bool bAllowCenterPlot) co
 		{ 0, 5, 4, 2, 1, 3, 6 },
 		{ 0, 3, 6, 4, 1, 2, 5 },
 		{ 0, 1, 2, 4, 5, 6, 3 } };
-	uint uShuffleType = GC.getGame().urandLimitExclusive(3, plot()->GetPseudoRandomSeed() + static_cast<uint>(GET_PLAYER(m_eOwner).getNumUnits()));
+	uint uShuffleType = GC.getGame().urandLimitExclusive(3, plot()->GetPseudoRandomSeed().mix(GET_PLAYER(m_eOwner).getNumUnits()));
 
 	//check city plot and adjacent plots
 	vector<CvPlot*> validChoices;
@@ -34007,14 +34007,22 @@ int CvCity::rangeCombatDamage(const CvUnit* pDefender, bool bIncludeRand, const 
 	int iAttackerStrength = getStrengthValue(true, false, pDefender);
 	int iDefenderStrength = rangeCombatUnitDefense(pDefender, pInPlot, bQuickAndDirty);
 	int iModifier = 0 - pDefender->GetDamageReductionCityAssault(); //watch the minus
-	uint uRandomSeed = bIncludeRand ? (static_cast<uint>(pDefender->plot()->GetPlotIndex()) + static_cast<uint>(iAttackerStrength) + static_cast<uint>(iDefenderStrength)) : 0;
+	CvSeeder randomSeed;
+	if (bIncludeRand)
+	{
+		randomSeed
+			.mixAssign(pDefender->plot()->GetPseudoRandomSeed())
+			.mixAssign(iAttackerStrength)
+			.mixAssign(iDefenderStrength);
+	}
 
 	return CvUnitCombat::DoDamageMath(
 		iAttackerStrength,
 		iDefenderStrength,
 		/*2400*/ GD_INT_GET(RANGE_ATTACK_SAME_STRENGTH_MIN_DAMAGE), //ignore the min part, it's misleading
 		/*1200*/ GD_INT_GET(RANGE_ATTACK_SAME_STRENGTH_POSSIBLE_EXTRA_DAMAGE),
-		uRandomSeed,
+		bIncludeRand,
+		randomSeed,
 		iModifier) / 100;
 }
 
@@ -34036,7 +34044,7 @@ int CvCity::GetAirStrikeDefenseDamage(const CvUnit* pAttacker, bool bIncludeRand
 	}
 
 	if (bIncludeRand)
-		return iBaseValue + GC.getGame().randRangeExclusive(0, 10, plot()->GetPseudoRandomSeed() + GET_PLAYER(getOwner()).GetPseudoRandomSeed());
+		return iBaseValue + GC.getGame().randRangeExclusive(0, 10, plot()->GetPseudoRandomSeed().mix(GET_PLAYER(getOwner()).GetPseudoRandomSeed()));
 	else
 		return iBaseValue;
 }

--- a/CvGameCoreDLL_Expansion2/CvCorporationClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCorporationClasses.cpp
@@ -1063,7 +1063,7 @@ void CvPlayerCorporations::BuildRandomFranchiseInCity()
 				if (pLoopCity->IsHasFranchise(GetFoundedCorporation()))
 					continue;
 
-				int iChance = GC.getGame().getSmallFakeRandNum(100, *pLoopCity->plot()) + GC.getGame().getSmallFakeRandNum(100, pLoopCity->getFood());
+				int iChance = GC.getGame().randRangeExclusive(0, 100, pLoopCity->plot()->GetPseudoRandomSeed()) + GC.getGame().randRangeExclusive(0, 100, static_cast<uint>(pLoopCity->getFood()));
 
 				int iScore = 500 - iChance;
 
@@ -1092,7 +1092,7 @@ void CvPlayerCorporations::BuildRandomFranchiseInCity()
 	}
 	if (pBestCity != NULL && iBestScore != 0)
 	{
-		int iSpreadChance = GC.getGame().getSmallFakeRandNum(100, *pBestCity->plot());
+		int iSpreadChance = GC.getGame().randRangeExclusive(0, 100, pBestCity->plot()->GetPseudoRandomSeed());
 		if (iSpreadChance <= iBaseChance)
 		{
 			CvBuildingEntry* pBuildingInfo = GC.getBuildingInfo(eFranchiseBuilding);

--- a/CvGameCoreDLL_Expansion2/CvCorporationClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCorporationClasses.cpp
@@ -1063,7 +1063,7 @@ void CvPlayerCorporations::BuildRandomFranchiseInCity()
 				if (pLoopCity->IsHasFranchise(GetFoundedCorporation()))
 					continue;
 
-				int iChance = GC.getGame().randRangeExclusive(0, 100, pLoopCity->plot()->GetPseudoRandomSeed()) + GC.getGame().randRangeExclusive(0, 100, static_cast<uint>(pLoopCity->getFood()));
+				int iChance = GC.getGame().randRangeExclusive(0, 100, pLoopCity->plot()->GetPseudoRandomSeed()) + GC.getGame().randRangeExclusive(0, 100, CvSeeder(pLoopCity->getFood()));
 
 				int iScore = 500 - iChance;
 

--- a/CvGameCoreDLL_Expansion2/CvCultureClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCultureClasses.cpp
@@ -5425,7 +5425,7 @@ int CvPlayerCulture::ComputeWarWeariness()
 	if (iLeastPeaceTurns > 1 && iLeastPeaceTurns < INT_MAX)
 	{
 		//apparently we made peace recently ... reduce the value step by step
-		int iReduction = max(1, GC.getGame().randRangeExclusive(0, max(3, iLeastPeaceTurns/2), static_cast<uint>(iHighestWarDamage)));
+		int iReduction = max(1, GC.getGame().randRangeExclusive(0, max(3, iLeastPeaceTurns/2), CvSeeder(iHighestWarDamage)));
 		iFallingWarWeariness = max(iCurrentWarWeariness-iReduction, 0);
 	}
 

--- a/CvGameCoreDLL_Expansion2/CvCultureClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCultureClasses.cpp
@@ -5425,7 +5425,7 @@ int CvPlayerCulture::ComputeWarWeariness()
 	if (iLeastPeaceTurns > 1 && iLeastPeaceTurns < INT_MAX)
 	{
 		//apparently we made peace recently ... reduce the value step by step
-		int iReduction = max(1, GC.getGame().getSmallFakeRandNum( max(3, iLeastPeaceTurns/2), iHighestWarDamage));
+		int iReduction = max(1, GC.getGame().randRangeExclusive(0, max(3, iLeastPeaceTurns/2), static_cast<uint>(iHighestWarDamage)));
 		iFallingWarWeariness = max(iCurrentWarWeariness-iReduction, 0);
 	}
 

--- a/CvGameCoreDLL_Expansion2/CvDealAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDealAI.cpp
@@ -656,7 +656,7 @@ DemandResponseTypes CvDealAI::DoHumanDemand(CvDeal* pDeal)
 				// IMPORTANT NOTE: This APPEARS to be very bad for multiplayer, but the only changes made to the game state are the fact that the human
 				// made a demand, and if the deal went through. These are both sent over the network later in this function.
 
-				int iRand = GC.getGame().randRangeExclusive(0, 100, static_cast<uint>(iValueWillingToGiveUp));
+				int iRand = GC.getGame().randRangeExclusive(0, 100, CvSeeder(iValueWillingToGiveUp));
 
 				// Are they going to say no matter what?
 				if (iRand > iOddsOfGivingIn || iOddsOfGivingIn <= 0)
@@ -2430,7 +2430,7 @@ int CvDealAI::GetCityValueForDeal(CvCity* pCity, PlayerTypes eAssumedOwner)
 	iItemValue += (max(1,iEconomicValue-1000)/3); //tricky to define the correct factor
 
 	//prevent cheesy exploit: founding cities just to sell them
-	if ((GC.getGame().getGameTurn() - pCity->getGameTurnFounded()) < (42 + GC.getGame().randRangeExclusive(0, 5, static_cast<uint>(iEconomicValue))))
+	if ((GC.getGame().getGameTurn() - pCity->getGameTurnFounded()) < (42 + GC.getGame().randRangeExclusive(0, 5, CvSeeder(iEconomicValue))))
 		return INT_MAX;
 
 	//If not as good as any of our cities, we don't want it.
@@ -6030,7 +6030,7 @@ bool CvDealAI::IsMakeOfferForStrategicResource(PlayerTypes eOtherPlayer, CvDeal*
 	{
 		int iAvailable = GET_PLAYER(eOtherPlayer).getNumResourceAvailable(eStratFromThem, false);
 		int iDesired = min(4,max(1,iAvailable/2));
-		iDesired += GC.getGame().randRangeExclusive(0, 3, static_cast<uint>(iCurrentNetGoldOfReceivingPlayer) + static_cast<uint>(eStratFromThem) + static_cast<uint>(eOtherPlayer));
+		iDesired += GC.getGame().randRangeExclusive(0, 3, CvSeeder(iCurrentNetGoldOfReceivingPlayer).mix(eStratFromThem).mix(eOtherPlayer));
 		//if we are in the red we want more!
 		iDesired += GetPlayer()->getResourceShortageValue(eStratFromThem);
 		iDesired = min(iAvailable, iDesired);

--- a/CvGameCoreDLL_Expansion2/CvDealAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDealAI.cpp
@@ -656,7 +656,7 @@ DemandResponseTypes CvDealAI::DoHumanDemand(CvDeal* pDeal)
 				// IMPORTANT NOTE: This APPEARS to be very bad for multiplayer, but the only changes made to the game state are the fact that the human
 				// made a demand, and if the deal went through. These are both sent over the network later in this function.
 
-				int iRand = GC.getGame().getSmallFakeRandNum(100, iValueWillingToGiveUp);
+				int iRand = GC.getGame().randRangeExclusive(0, 100, static_cast<uint>(iValueWillingToGiveUp));
 
 				// Are they going to say no matter what?
 				if (iRand > iOddsOfGivingIn || iOddsOfGivingIn <= 0)
@@ -2430,7 +2430,7 @@ int CvDealAI::GetCityValueForDeal(CvCity* pCity, PlayerTypes eAssumedOwner)
 	iItemValue += (max(1,iEconomicValue-1000)/3); //tricky to define the correct factor
 
 	//prevent cheesy exploit: founding cities just to sell them
-	if ((GC.getGame().getGameTurn() - pCity->getGameTurnFounded()) < (42 + GC.getGame().getSmallFakeRandNum(5, iEconomicValue)))
+	if ((GC.getGame().getGameTurn() - pCity->getGameTurnFounded()) < (42 + GC.getGame().randRangeExclusive(0, 5, static_cast<uint>(iEconomicValue))))
 		return INT_MAX;
 
 	//If not as good as any of our cities, we don't want it.
@@ -3319,7 +3319,7 @@ int CvDealAI::GetThirdPartyWarValue(bool bFromMe, PlayerTypes eOtherPlayer, Team
 		if (iPeaceTreatyTurn > -1)
 		{
 			int iTurnsSincePeace = GC.getGame().getGameTurn() - iPeaceTreatyTurn;
-			int iPeaceDampenerTurns = 23 + GC.getGame().getSmallFakeRandNum( 15, GET_PLAYER(ePlayerDeclaringWar).GetPseudoRandomSeed() );
+			int iPeaceDampenerTurns = 23 + GC.getGame().urandRangeExclusive(0, 15, GET_PLAYER(ePlayerDeclaringWar).GetPseudoRandomSeed() );
 			if (iTurnsSincePeace < iPeaceDampenerTurns)
 			{
 				return INT_MAX;
@@ -6030,7 +6030,7 @@ bool CvDealAI::IsMakeOfferForStrategicResource(PlayerTypes eOtherPlayer, CvDeal*
 	{
 		int iAvailable = GET_PLAYER(eOtherPlayer).getNumResourceAvailable(eStratFromThem, false);
 		int iDesired = min(4,max(1,iAvailable/2));
-		iDesired += GC.getGame().getSmallFakeRandNum(3, iCurrentNetGoldOfReceivingPlayer + eStratFromThem + eOtherPlayer);
+		iDesired += GC.getGame().urandRangeExclusive(0, 3, static_cast<uint>(iCurrentNetGoldOfReceivingPlayer) + static_cast<uint>(eStratFromThem) + static_cast<uint>(eOtherPlayer));
 		//if we are in the red we want more!
 		iDesired += GetPlayer()->getResourceShortageValue(eStratFromThem);
 		iDesired = min(iAvailable, iDesired);

--- a/CvGameCoreDLL_Expansion2/CvDealAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDealAI.cpp
@@ -3319,7 +3319,7 @@ int CvDealAI::GetThirdPartyWarValue(bool bFromMe, PlayerTypes eOtherPlayer, Team
 		if (iPeaceTreatyTurn > -1)
 		{
 			int iTurnsSincePeace = GC.getGame().getGameTurn() - iPeaceTreatyTurn;
-			int iPeaceDampenerTurns = 23 + GC.getGame().urandRangeExclusive(0, 15, GET_PLAYER(ePlayerDeclaringWar).GetPseudoRandomSeed() );
+			int iPeaceDampenerTurns = 23 + GC.getGame().randRangeExclusive(0, 15, GET_PLAYER(ePlayerDeclaringWar).GetPseudoRandomSeed() );
 			if (iTurnsSincePeace < iPeaceDampenerTurns)
 			{
 				return INT_MAX;
@@ -6030,7 +6030,7 @@ bool CvDealAI::IsMakeOfferForStrategicResource(PlayerTypes eOtherPlayer, CvDeal*
 	{
 		int iAvailable = GET_PLAYER(eOtherPlayer).getNumResourceAvailable(eStratFromThem, false);
 		int iDesired = min(4,max(1,iAvailable/2));
-		iDesired += GC.getGame().urandRangeExclusive(0, 3, static_cast<uint>(iCurrentNetGoldOfReceivingPlayer) + static_cast<uint>(eStratFromThem) + static_cast<uint>(eOtherPlayer));
+		iDesired += GC.getGame().randRangeExclusive(0, 3, static_cast<uint>(iCurrentNetGoldOfReceivingPlayer) + static_cast<uint>(eStratFromThem) + static_cast<uint>(eOtherPlayer));
 		//if we are in the red we want more!
 		iDesired += GetPlayer()->getResourceShortageValue(eStratFromThem);
 		iDesired = min(iAvailable, iDesired);

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
@@ -1881,7 +1881,7 @@ bool CvDiplomacyAI::IsNuclearGandhi(bool bPotentially) const
 // ************************************
 
 /// Returns a personality weight with a small random element
-int CvDiplomacyAI::GetRandomPersonalityWeight(int iOriginalValue, int& iSeed)
+int CvDiplomacyAI::GetRandomPersonalityWeight(int iOriginalValue, CvSeeder& seed)
 {
 	int ID = (int) GetID();
 	int iPlusMinus = min(max(/*2*/ GD_INT_GET(FLAVOR_RANDOMIZATION_RANGE), 0), (INT_MAX - 1) / 2);
@@ -1891,10 +1891,10 @@ int CvDiplomacyAI::GetRandomPersonalityWeight(int iOriginalValue, int& iSeed)
 		return range(iOriginalValue, 1, 10);
 
 	// Increment the random seed
-	iSeed += (iOriginalValue * ID) * 256;
+	seed.mixAssign(iOriginalValue).mixAssign(ID);
 
 	// Randomize!
-	int iAdjust = GC.getGame().randRangeExclusive(0, (iPlusMinus * 2 + 1), (static_cast<uint>(iOriginalValue) * static_cast<uint>(iSeed) * static_cast<uint>(ID)));
+	int iAdjust = GC.getGame().randRangeExclusive(0, (iPlusMinus * 2 + 1), seed);
 	int iRtnValue = iOriginalValue + iAdjust - iPlusMinus;
 
 	return range(iRtnValue, 1, 10);
@@ -1916,37 +1916,37 @@ void CvDiplomacyAI::DoInitializePersonality(bool bFirstInit)
 			CvLeaderHeadInfo* pkLeaderHeadInfo = GC.getLeaderHeadInfo(leader);
 			if (pkLeaderHeadInfo)
 			{
-				int iSeed = ID * ID * ID;
+				CvSeeder seed(ID);
 
 				// Some flavors can be set to -12 to guarantee that the AI will pursue a specific victory condition, if it is enabled.
 				// These should be treated as a 10 for all other purposes.
-				m_iBoldness = pkLeaderHeadInfo->GetBoldness() == -12 ? 10 : GetRandomPersonalityWeight(pkLeaderHeadInfo->GetBoldness(), iSeed);
-				m_iMinorCivCompetitiveness = pkLeaderHeadInfo->GetMinorCivCompetitiveness() == -12 ? 10 : GetRandomPersonalityWeight(pkLeaderHeadInfo->GetMinorCivCompetitiveness(), iSeed);
-				m_iWonderCompetitiveness = pkLeaderHeadInfo->GetWonderCompetitiveness() == -12 ? 10 : GetRandomPersonalityWeight(pkLeaderHeadInfo->GetWonderCompetitiveness(), iSeed);
-				m_iWarmongerHate = pkLeaderHeadInfo->GetWarmongerHate() == -12 ? 10 : GetRandomPersonalityWeight(pkLeaderHeadInfo->GetWarmongerHate(), iSeed);
+				m_iBoldness = pkLeaderHeadInfo->GetBoldness() == -12 ? 10 : GetRandomPersonalityWeight(pkLeaderHeadInfo->GetBoldness(), seed);
+				m_iMinorCivCompetitiveness = pkLeaderHeadInfo->GetMinorCivCompetitiveness() == -12 ? 10 : GetRandomPersonalityWeight(pkLeaderHeadInfo->GetMinorCivCompetitiveness(), seed);
+				m_iWonderCompetitiveness = pkLeaderHeadInfo->GetWonderCompetitiveness() == -12 ? 10 : GetRandomPersonalityWeight(pkLeaderHeadInfo->GetWonderCompetitiveness(), seed);
+				m_iWarmongerHate = pkLeaderHeadInfo->GetWarmongerHate() == -12 ? 10 : GetRandomPersonalityWeight(pkLeaderHeadInfo->GetWarmongerHate(), seed);
 
-				m_iVictoryCompetitiveness = GetRandomPersonalityWeight(pkLeaderHeadInfo->GetVictoryCompetitiveness(), iSeed);
-				m_iDiploBalance = GetRandomPersonalityWeight(pkLeaderHeadInfo->GetDiploBalance(), iSeed);
-				m_iDoFWillingness = GetRandomPersonalityWeight(pkLeaderHeadInfo->GetDoFWillingness(), iSeed);
-				m_iDenounceWillingness = GetRandomPersonalityWeight(pkLeaderHeadInfo->GetDenounceWillingness(), iSeed);
-				m_iLoyalty = GetRandomPersonalityWeight(pkLeaderHeadInfo->GetLoyalty(), iSeed);
-				m_iForgiveness = GetRandomPersonalityWeight(pkLeaderHeadInfo->GetForgiveness(), iSeed);
-				m_iNeediness = GetRandomPersonalityWeight(pkLeaderHeadInfo->GetNeediness(), iSeed);
-				m_iMeanness = GetRandomPersonalityWeight(pkLeaderHeadInfo->GetMeanness(), iSeed);
-				m_iChattiness = GetRandomPersonalityWeight(pkLeaderHeadInfo->GetChattiness(), iSeed);
+				m_iVictoryCompetitiveness = GetRandomPersonalityWeight(pkLeaderHeadInfo->GetVictoryCompetitiveness(), seed);
+				m_iDiploBalance = GetRandomPersonalityWeight(pkLeaderHeadInfo->GetDiploBalance(), seed);
+				m_iDoFWillingness = GetRandomPersonalityWeight(pkLeaderHeadInfo->GetDoFWillingness(), seed);
+				m_iDenounceWillingness = GetRandomPersonalityWeight(pkLeaderHeadInfo->GetDenounceWillingness(), seed);
+				m_iLoyalty = GetRandomPersonalityWeight(pkLeaderHeadInfo->GetLoyalty(), seed);
+				m_iForgiveness = GetRandomPersonalityWeight(pkLeaderHeadInfo->GetForgiveness(), seed);
+				m_iNeediness = GetRandomPersonalityWeight(pkLeaderHeadInfo->GetNeediness(), seed);
+				m_iMeanness = GetRandomPersonalityWeight(pkLeaderHeadInfo->GetMeanness(), seed);
+				m_iChattiness = GetRandomPersonalityWeight(pkLeaderHeadInfo->GetChattiness(), seed);
 
-				m_aiMajorCivApproachBiases[CIV_APPROACH_WAR] = GetRandomPersonalityWeight(pkLeaderHeadInfo->GetWarBias(false), iSeed);
-				m_aiMajorCivApproachBiases[CIV_APPROACH_HOSTILE] = GetRandomPersonalityWeight(pkLeaderHeadInfo->GetHostileBias(false), iSeed);
-				m_aiMajorCivApproachBiases[CIV_APPROACH_DECEPTIVE] = GetRandomPersonalityWeight(pkLeaderHeadInfo->GetDeceptiveBias(), iSeed);
-				m_aiMajorCivApproachBiases[CIV_APPROACH_GUARDED] = GetRandomPersonalityWeight(pkLeaderHeadInfo->GetGuardedBias(), iSeed);
-				m_aiMajorCivApproachBiases[CIV_APPROACH_AFRAID] = GetRandomPersonalityWeight(pkLeaderHeadInfo->GetAfraidBias(), iSeed);
-				m_aiMajorCivApproachBiases[CIV_APPROACH_NEUTRAL] = GetRandomPersonalityWeight(pkLeaderHeadInfo->GetNeutralBias(false), iSeed);
-				m_aiMajorCivApproachBiases[CIV_APPROACH_FRIENDLY] = GetRandomPersonalityWeight(pkLeaderHeadInfo->GetFriendlyBias(false), iSeed);
+				m_aiMajorCivApproachBiases[CIV_APPROACH_WAR] = GetRandomPersonalityWeight(pkLeaderHeadInfo->GetWarBias(false), seed);
+				m_aiMajorCivApproachBiases[CIV_APPROACH_HOSTILE] = GetRandomPersonalityWeight(pkLeaderHeadInfo->GetHostileBias(false), seed);
+				m_aiMajorCivApproachBiases[CIV_APPROACH_DECEPTIVE] = GetRandomPersonalityWeight(pkLeaderHeadInfo->GetDeceptiveBias(), seed);
+				m_aiMajorCivApproachBiases[CIV_APPROACH_GUARDED] = GetRandomPersonalityWeight(pkLeaderHeadInfo->GetGuardedBias(), seed);
+				m_aiMajorCivApproachBiases[CIV_APPROACH_AFRAID] = GetRandomPersonalityWeight(pkLeaderHeadInfo->GetAfraidBias(), seed);
+				m_aiMajorCivApproachBiases[CIV_APPROACH_NEUTRAL] = GetRandomPersonalityWeight(pkLeaderHeadInfo->GetNeutralBias(false), seed);
+				m_aiMajorCivApproachBiases[CIV_APPROACH_FRIENDLY] = GetRandomPersonalityWeight(pkLeaderHeadInfo->GetFriendlyBias(false), seed);
 
-				m_aiMinorCivApproachBiases[CIV_APPROACH_WAR] = GetRandomPersonalityWeight(pkLeaderHeadInfo->GetWarBias(true), iSeed);
-				m_aiMinorCivApproachBiases[CIV_APPROACH_HOSTILE] = GetRandomPersonalityWeight(pkLeaderHeadInfo->GetHostileBias(true), iSeed);
-				m_aiMinorCivApproachBiases[CIV_APPROACH_NEUTRAL] = GetRandomPersonalityWeight(pkLeaderHeadInfo->GetNeutralBias(true), iSeed);
-				m_aiMinorCivApproachBiases[CIV_APPROACH_FRIENDLY] = GetRandomPersonalityWeight(pkLeaderHeadInfo->GetFriendlyBias(true), iSeed);
+				m_aiMinorCivApproachBiases[CIV_APPROACH_WAR] = GetRandomPersonalityWeight(pkLeaderHeadInfo->GetWarBias(true), seed);
+				m_aiMinorCivApproachBiases[CIV_APPROACH_HOSTILE] = GetRandomPersonalityWeight(pkLeaderHeadInfo->GetHostileBias(true), seed);
+				m_aiMinorCivApproachBiases[CIV_APPROACH_NEUTRAL] = GetRandomPersonalityWeight(pkLeaderHeadInfo->GetNeutralBias(true), seed);
+				m_aiMinorCivApproachBiases[CIV_APPROACH_FRIENDLY] = GetRandomPersonalityWeight(pkLeaderHeadInfo->GetFriendlyBias(true), seed);
 
 				// Minimal loyalty? We're willing to backstab.
 				if (GetLoyalty() <= 2)
@@ -2402,9 +2402,9 @@ void CvDiplomacyAI::SelectDefaultVictoryPursuits()
 	vector<int> VictoryScores(NUM_VICTORY_PURSUITS, 0);
 
 	// ...and some randomness
-	uint uID = static_cast<uint>(GetID()); // Used to randomize values between different AIs
-	uint uRandom = GC.getGame().isOption(GAMEOPTION_RANDOM_PERSONALITIES) ? 20 : 10; // Max. random weight added to each victory condition
-	uint uSeed = (uID * uID * uID) + (static_cast<uint>(GetBoldness()) * static_cast<uint>(GetMeanness()) * static_cast<uint>(GetMajorCivApproachBias(CIV_APPROACH_WAR)) * uID); // Random seed to ensure the fake RNG doesn't return the same value repeatedly
+	const PlayerTypes ID = GetID(); // Used to randomize values between different AIs
+	const uint uRandom = GC.getGame().isOption(GAMEOPTION_RANDOM_PERSONALITIES) ? 20 : 10; // Max. random weight added to each victory condition
+	CvSeeder seed = CvSeeder(ID).mix(GetBoldness()).mix(GetMeanness()).mix(GetMajorCivApproachBias(CIV_APPROACH_WAR)); // Random seed to ensure the fake RNG doesn't return the same value repeatedly
 
 	// Base likelihood depends on the difference between this civ's major approach biases
 	VictoryScores[VICTORY_PURSUIT_DOMINATION] = max(GetMajorCivApproachBias(CIV_APPROACH_WAR), GetMajorCivApproachBias(CIV_APPROACH_HOSTILE)) - max(GetMajorCivApproachBias(CIV_APPROACH_FRIENDLY), GetMajorCivApproachBias(CIV_APPROACH_AFRAID));
@@ -2419,8 +2419,12 @@ void CvDiplomacyAI::SelectDefaultVictoryPursuits()
 		VictoryScores[VICTORY_PURSUIT_DOMINATION] += GetMeanness();
 		VictoryScores[VICTORY_PURSUIT_DOMINATION] += pFlavorMgr->GetPersonalityFlavorForDiplomacy((FlavorTypes)GC.getInfoTypeForString("FLAVOR_OFFENSE")) / 2;
 		VictoryScores[VICTORY_PURSUIT_DOMINATION] += pFlavorMgr->GetPersonalityFlavorForDiplomacy((FlavorTypes)GC.getInfoTypeForString("FLAVOR_EXPANSION")) / 2;
-		VictoryScores[VICTORY_PURSUIT_DOMINATION] += static_cast<int>(GC.getGame().urandLimitExclusive(uRandom, uSeed));
-		uSeed += (static_cast<uint>(VictoryScores[VICTORY_PURSUIT_DOMINATION]) * uRandom * uID * 256) + (static_cast<uint>(GetDiploBalance()) * static_cast<uint>(GetMinorCivCompetitiveness()) * static_cast<uint>(GetMajorCivApproachBias(CIV_APPROACH_DECEPTIVE)) * uID);
+		VictoryScores[VICTORY_PURSUIT_DOMINATION] += static_cast<int>(GC.getGame().urandLimitExclusive(uRandom, seed));
+		seed
+			.mixAssign(VictoryScores[VICTORY_PURSUIT_DOMINATION])
+			.mixAssign(GetDiploBalance())
+			.mixAssign(GetMinorCivCompetitiveness())
+			.mixAssign(GetMajorCivApproachBias(CIV_APPROACH_DECEPTIVE));
 	}
 	else
 	{
@@ -2434,8 +2438,12 @@ void CvDiplomacyAI::SelectDefaultVictoryPursuits()
 		VictoryScores[VICTORY_PURSUIT_DIPLOMACY] += GetMinorCivCompetitiveness();
 		VictoryScores[VICTORY_PURSUIT_DIPLOMACY] += pFlavorMgr->GetPersonalityFlavorForDiplomacy((FlavorTypes)GC.getInfoTypeForString("FLAVOR_DIPLOMACY")) / 2;
 		VictoryScores[VICTORY_PURSUIT_DIPLOMACY] += pFlavorMgr->GetPersonalityFlavorForDiplomacy((FlavorTypes)GC.getInfoTypeForString("FLAVOR_GOLD")) / 2;
-		VictoryScores[VICTORY_PURSUIT_DIPLOMACY] += static_cast<int>(GC.getGame().urandLimitExclusive(uRandom, uSeed));
-		uSeed += (static_cast<uint>(VictoryScores[VICTORY_PURSUIT_DOMINATION]) * uRandom * uID * 259) + static_cast<uint>(VictoryScores[VICTORY_PURSUIT_DOMINATION]) + (static_cast<uint>(GetDoFWillingness()) * static_cast<uint>(GetWonderCompetitiveness()) * static_cast<uint>(GetMajorCivApproachBias(CIV_APPROACH_FRIENDLY)) * uID);
+		VictoryScores[VICTORY_PURSUIT_DIPLOMACY] += static_cast<int>(GC.getGame().urandLimitExclusive(uRandom, seed));
+		seed
+			.mixAssign(VictoryScores[VICTORY_PURSUIT_DIPLOMACY])
+			.mixAssign(GetLoyalty())
+			.mixAssign(GetWarmongerHate())
+			.mixAssign(GetMajorCivApproachBias(CIV_APPROACH_FRIENDLY));
 	}
 	else
 	{
@@ -2449,8 +2457,12 @@ void CvDiplomacyAI::SelectDefaultVictoryPursuits()
 		VictoryScores[VICTORY_PURSUIT_CULTURE] += GetWonderCompetitiveness();
 		VictoryScores[VICTORY_PURSUIT_CULTURE] += pFlavorMgr->GetPersonalityFlavorForDiplomacy((FlavorTypes)GC.getInfoTypeForString("FLAVOR_WONDER")) / 2;
 		VictoryScores[VICTORY_PURSUIT_CULTURE] += pFlavorMgr->GetPersonalityFlavorForDiplomacy((FlavorTypes)GC.getInfoTypeForString("FLAVOR_CULTURE")) / 2;
-		VictoryScores[VICTORY_PURSUIT_CULTURE] += static_cast<int>(GC.getGame().urandLimitExclusive(uRandom, uSeed));
-		uSeed += (static_cast<uint>(VictoryScores[VICTORY_PURSUIT_DOMINATION]) * uRandom * uID * 259) + static_cast<uint>(VictoryScores[VICTORY_PURSUIT_DOMINATION]) + static_cast<uint>(VictoryScores[VICTORY_PURSUIT_DIPLOMACY]) + (static_cast<uint>(GetLoyalty()) * static_cast<uint>(GetWarmongerHate()) * static_cast<uint>(GetMajorCivApproachBias(CIV_APPROACH_FRIENDLY)) * uID);
+		VictoryScores[VICTORY_PURSUIT_CULTURE] += static_cast<int>(GC.getGame().urandLimitExclusive(uRandom, seed));
+		seed
+			.mixAssign(VictoryScores[VICTORY_PURSUIT_CULTURE])
+			.mixAssign(GetForgiveness())
+			.mixAssign(GetChattiness())
+			.mixAssign(GetMajorCivApproachBias(CIV_APPROACH_NEUTRAL));
 	}
 	else
 	{
@@ -2464,7 +2476,7 @@ void CvDiplomacyAI::SelectDefaultVictoryPursuits()
 		VictoryScores[VICTORY_PURSUIT_SCIENCE] += GetWarmongerHate();
 		VictoryScores[VICTORY_PURSUIT_SCIENCE] += pFlavorMgr->GetPersonalityFlavorForDiplomacy((FlavorTypes)GC.getInfoTypeForString("FLAVOR_SCIENCE")) / 2;
 		VictoryScores[VICTORY_PURSUIT_SCIENCE] += pFlavorMgr->GetPersonalityFlavorForDiplomacy((FlavorTypes)GC.getInfoTypeForString("FLAVOR_GROWTH")) / 2;
-		VictoryScores[VICTORY_PURSUIT_SCIENCE] += static_cast<int>(GC.getGame().urandLimitExclusive(uRandom, uSeed));
+		VictoryScores[VICTORY_PURSUIT_SCIENCE] += static_cast<int>(GC.getGame().urandLimitExclusive(uRandom, seed));
 	}
 	else
 	{
@@ -21107,40 +21119,39 @@ void CvDiplomacyAI::SelectBestApproachTowardsMajorCiv(PlayerTypes ePlayer, bool 
 		if (GC.getGame().isOption(GAMEOPTION_RANDOM_PERSONALITIES))
 			iRandom = range((iRandom*2), 0, 100);
 
-		uint uID = static_cast<uint>(GetID());
 		int iNumber = (iRandom * 2) + 1;
-		uint uSeed = static_cast<uint>(iWarMod) * static_cast<uint>(iFriendlyMod) * uID * static_cast<uint>(iGameTurn);
-		int iChange = GC.getGame().randRangeExclusive(0, iNumber, uSeed) - iRandom;
+		CvSeeder seed = CvSeeder(iWarMod).mix(GetID()).mix(iGameTurn);
+		int iChange = GC.getGame().randRangeExclusive(0, iNumber, seed) - iRandom;
 		vApproachScores[CIV_APPROACH_FRIENDLY] *= 100 + iChange;
 		vApproachScores[CIV_APPROACH_FRIENDLY] /= 100;
 
-		uSeed += static_cast<uint>(iHostileMod) * static_cast<uint>(iNeutralMod) * uID * static_cast<uint>(iGameTurn);
-		iChange = GC.getGame().randRangeExclusive(0, iNumber, uSeed) - iRandom;
+		seed.mixAssign(iFriendlyMod);
+		iChange = GC.getGame().randRangeExclusive(0, iNumber, seed) - iRandom;
 		vApproachScores[CIV_APPROACH_NEUTRAL] *= 100 + iChange;
 		vApproachScores[CIV_APPROACH_NEUTRAL] /= 100;
 
-		uSeed += static_cast<uint>(iDeceptiveMod) * static_cast<uint>(iAfraidMod) * uID * static_cast<uint>(iGameTurn);
-		iChange = GC.getGame().randRangeExclusive(0, iNumber, uSeed) - iRandom;
+		seed.mixAssign(iDeceptiveMod);
+		iChange = GC.getGame().randRangeExclusive(0, iNumber, seed) - iRandom;
 		vApproachScores[CIV_APPROACH_AFRAID] *= 100 + iChange;
 		vApproachScores[CIV_APPROACH_AFRAID] /= 100;
 
-		uSeed += static_cast<uint>(iGuardedMod) * static_cast<uint>(iGuardedMod) * uID * static_cast<uint>(iGameTurn);
-		iChange = GC.getGame().randRangeExclusive(0, iNumber, uSeed) - iRandom;
+		seed.mixAssign(iGuardedMod);
+		iChange = GC.getGame().randRangeExclusive(0, iNumber, seed) - iRandom;
 		vApproachScores[CIV_APPROACH_GUARDED] *= 100 + iChange;
 		vApproachScores[CIV_APPROACH_GUARDED] /= 100;
 
-		uSeed += static_cast<uint>(iDeceptiveMod) * static_cast<uint>(iDeceptiveMod) * uID * static_cast<uint>(iGameTurn);
-		iChange = GC.getGame().randRangeExclusive(0, iNumber, uSeed) - iRandom;
+		seed.mixAssign(iAfraidMod);
+		iChange = GC.getGame().randRangeExclusive(0, iNumber, seed) - iRandom;
 		vApproachScores[CIV_APPROACH_DECEPTIVE] *= 100 + iChange;
 		vApproachScores[CIV_APPROACH_DECEPTIVE] /= 100;
 
-		uSeed += static_cast<uint>(iAfraidMod) * static_cast<uint>(iHostileMod) * uID * static_cast<uint>(iGameTurn);
-		iChange = GC.getGame().randRangeExclusive(0, iNumber, uSeed) - iRandom;
+		seed.mixAssign(iNeutralMod);
+		iChange = GC.getGame().randRangeExclusive(0, iNumber, seed) - iRandom;
 		vApproachScores[CIV_APPROACH_HOSTILE] *= 100 + iChange;
 		vApproachScores[CIV_APPROACH_HOSTILE] /= 100;
 
-		uSeed += static_cast<uint>(iNeutralMod) * static_cast<uint>(iWarMod) * uID * static_cast<uint>(iGameTurn);
-		iChange = GC.getGame().randRangeExclusive(0, iNumber, uSeed) - iRandom;
+		seed.value = ~seed.value;
+		iChange = GC.getGame().randRangeExclusive(0, iNumber, seed) - iRandom;
 		vApproachScores[CIV_APPROACH_WAR] *= 100 + iChange;
 		vApproachScores[CIV_APPROACH_WAR] /= 100;
 	}
@@ -28095,7 +28106,7 @@ bool CvDiplomacyAI::IsMakeRequest(PlayerTypes ePlayer, CvDeal* pDeal, bool& bRan
 		if(bWantsSomething)
 		{
 			// Random element
-			int iRand = GC.getGame().randRangeExclusive(0, 10, m_pPlayer->GetPseudoRandomSeed() + static_cast<uint>(GC.getGame().GetCultureMedian()));
+			int iRand = GC.getGame().randRangeExclusive(0, 10, m_pPlayer->GetPseudoRandomSeed().mix(GC.getGame().GetCultureMedian()));
 
 			iRand += iWeightBias;
 
@@ -30137,7 +30148,7 @@ void CvDiplomacyAI::DoSendStatementToPlayer(PlayerTypes ePlayer, DiploStatementT
 					bool bValid = false;
 					if (GET_TEAM(GetTeam()).canDeclareWar(GET_PLAYER(ePlayer).getTeam(), GetID()))
 					{
-						if (GC.getGame().randRangeExclusive(0, 10, m_pPlayer->GetPseudoRandomSeed() + static_cast<uint>(GC.getGame().GetCultureMedian())) < GET_PLAYER(ePlayer).GetDiplomacyAI()->GetWarmongerHate())
+						if (GC.getGame().randRangeExclusive(0, 10, m_pPlayer->GetPseudoRandomSeed().mix(GC.getGame().GetCultureMedian())) < GET_PLAYER(ePlayer).GetDiplomacyAI()->GetWarmongerHate())
 						{
 							bValid = true;
 						}
@@ -30198,7 +30209,7 @@ void CvDiplomacyAI::DoSendStatementToPlayer(PlayerTypes ePlayer, DiploStatementT
 					bool bValid = false;
 					if (GET_TEAM(GetTeam()).canDeclareWar(GET_PLAYER(ePlayer).getTeam(), GetID()))
 					{
-						if (GC.getGame().randRangeExclusive(0, 10, m_pPlayer->GetPseudoRandomSeed() + static_cast<uint>(GC.getGame().GetCultureMedian())) < GET_PLAYER(ePlayer).GetDiplomacyAI()->GetWarmongerHate())
+						if (GC.getGame().randRangeExclusive(0, 10, m_pPlayer->GetPseudoRandomSeed().mix(GC.getGame().GetCultureMedian())) < GET_PLAYER(ePlayer).GetDiplomacyAI()->GetWarmongerHate())
 						{
 							bValid = true;
 						}
@@ -30745,7 +30756,7 @@ void CvDiplomacyAI::DoSendStatementToPlayer(PlayerTypes ePlayer, DiploStatementT
 			bool bValid = false;
 			if (GET_TEAM(GetTeam()).canDeclareWar(GET_PLAYER(ePlayer).getTeam(), GetID()))
 			{
-				if (GC.getGame().randRangeExclusive(0, 10, m_pPlayer->GetPseudoRandomSeed() + static_cast<uint>(GC.getGame().GetCultureMedian())) < GET_PLAYER(ePlayer).GetDiplomacyAI()->GetWarmongerHate())
+				if (GC.getGame().randRangeExclusive(0, 10, m_pPlayer->GetPseudoRandomSeed().mix(GC.getGame().GetCultureMedian())) < GET_PLAYER(ePlayer).GetDiplomacyAI()->GetWarmongerHate())
 				{
 					bValid = true;
 				}
@@ -32574,7 +32585,7 @@ void CvDiplomacyAI::DoContactMinorCivs()
 	else
 	{
 		int iThreshold = iDiplomacyFlavor;
-		int iRandRoll = GC.getGame().randRangeExclusive(0, 10, static_cast<uint>(iDiplomacyFlavor) + m_pPlayer->GetPseudoRandomSeed() + static_cast<uint>(GC.getGame().GetCultureMedian()));
+		int iRandRoll = GC.getGame().randRangeExclusive(0, 10, m_pPlayer->GetPseudoRandomSeed().mix(iDiplomacyFlavor).mix(GC.getGame().GetCultureMedian()));
 
 		// Threshold will be 15 for a player (3 flavor * 5)
 		// Threshold will be 5 for non-diplomatic player (2 flavor * 5)
@@ -32618,7 +32629,7 @@ void CvDiplomacyAI::DoContactMinorCivs()
 			else
 			{
 				int iThreshold = iTileImprovementFlavor; //antonjs: todo: XML
-				int iRandRoll = GC.getGame().randRangeExclusive(0, 10, static_cast<uint>(iTileImprovementFlavor) + m_pPlayer->GetPseudoRandomSeed() + static_cast<uint>(GC.getGame().GetCultureMedian()));
+				int iRandRoll = GC.getGame().randRangeExclusive(0, 10, m_pPlayer->GetPseudoRandomSeed().mix(GC.getGame().GetCultureMedian()).mix(iTileImprovementFlavor));
 
 				if (iRandRoll < iThreshold)
 					bWantsToBullyUnit = true;
@@ -32645,7 +32656,7 @@ void CvDiplomacyAI::DoContactMinorCivs()
 	else
 	{
 		int iThreshold = iGoldFlavor; //antonjs: todo: XML
-		int iRandRoll = GC.getGame().randRangeExclusive(0, 10, static_cast<uint>(iGoldFlavor) + m_pPlayer->GetPseudoRandomSeed() + static_cast<uint>(GC.getGame().GetCultureMedian()));
+		int iRandRoll = GC.getGame().randRangeExclusive(0, 10, m_pPlayer->GetPseudoRandomSeed().mix(GC.getGame().GetCultureMedian()).mix(iGoldFlavor));
 
 		if(iRandRoll < iThreshold)
 			bWantsToBullyGold = true;
@@ -35353,7 +35364,7 @@ void CvDiplomacyAI::DoWarmongerStatement(PlayerTypes ePlayer, DiploStatementType
 				bSendStatement = false;
 
 			// 2 in 3 chance we don't actually send the message (don't want to bombard the player from all sides)
-			if (4 < GC.getGame().randRangeExclusive(0, 10, static_cast<uint>(ePlayer) + m_pPlayer->GetPseudoRandomSeed() + static_cast<uint>(GC.getGame().GetCultureMedian())))
+			if (4 < GC.getGame().randRangeExclusive(0, 10, m_pPlayer->GetPseudoRandomSeed().mix(ePlayer).mix(GC.getGame().GetCultureMedian())))
 				bSendStatement = false;
 
 			DiploStatementTypes eTempStatement = DIPLO_STATEMENT_WARMONGER;
@@ -35499,7 +35510,7 @@ void CvDiplomacyAI::DoAngryBefriendedEnemy(PlayerTypes ePlayer, DiploStatementTy
 
 				// Found a match!
 				int iWeight = GetMeanness();		// Usually ranges from 3 to 7
-				iWeight += GC.getGame().randRangeExclusive(0, 10, static_cast<uint>(iWeight) + m_pPlayer->GetPseudoRandomSeed() + static_cast<uint>(GC.getGame().GetCultureMedian()));
+				iWeight += GC.getGame().randRangeExclusive(0, 10, m_pPlayer->GetPseudoRandomSeed().mix(GC.getGame().GetCultureMedian()).mix(iWeight));
 
 				// We're mean enough to say something
 				if(iWeight >= 10)
@@ -35576,7 +35587,7 @@ void CvDiplomacyAI::DoAngryDenouncedFriend(PlayerTypes ePlayer, DiploStatementTy
 
 				// Found a match!
 				int iWeight = GetMeanness();		// Usually ranges from 3 to 7
-				iWeight += GC.getGame().randRangeExclusive(0, 10, static_cast<uint>(iWeight) + m_pPlayer->GetPseudoRandomSeed() + static_cast<uint>(GC.getGame().GetCultureMedian()));
+				iWeight += GC.getGame().randRangeExclusive(0, 10, m_pPlayer->GetPseudoRandomSeed().mix(GC.getGame().GetCultureMedian()).mix(iWeight));
 
 				// We're mean enough to say something
 				if(iWeight >= 10)
@@ -35646,7 +35657,7 @@ void CvDiplomacyAI::DoHappyDenouncedEnemy(PlayerTypes ePlayer, DiploStatementTyp
 
 				// Found a match!
 				int iWeight = GetChattiness();		// Usually ranges from 3 to 7
-				iWeight += GC.getGame().randRangeExclusive(0, 10, static_cast<uint>(iWeight) + m_pPlayer->GetPseudoRandomSeed() + static_cast<uint>(GC.getGame().GetCultureMedian()));
+				iWeight += GC.getGame().randRangeExclusive(0, 10, m_pPlayer->GetPseudoRandomSeed().mix(GC.getGame().GetCultureMedian()).mix(iWeight));
 
 				// We're chatty enough to say something
 				if(iWeight >= 10)
@@ -35716,7 +35727,7 @@ void CvDiplomacyAI::DoHappyBefriendedFriend(PlayerTypes ePlayer, DiploStatementT
 
 				// Found a match!
 				int iWeight = GetChattiness();		// Usually ranges from 3 to 7
-				iWeight += GC.getGame().randRangeExclusive(0, 10, static_cast<uint>(iWeight) + m_pPlayer->GetPseudoRandomSeed() + static_cast<uint>(GC.getGame().GetCultureMedian()));
+				iWeight += GC.getGame().randRangeExclusive(0, 10, m_pPlayer->GetPseudoRandomSeed().mix(GC.getGame().GetCultureMedian()).mix(iWeight));
 
 				// We're chatty enough to say something
 				if(iWeight >= 10)
@@ -35844,7 +35855,7 @@ void CvDiplomacyAI::DoFYIBefriendedHumanEnemy(PlayerTypes ePlayer, DiploStatemen
 					iWeight += 10;
 
 				iWeight += GetMeanness();		// Usually ranges from 3 to 7
-				iWeight += GC.getGame().randRangeExclusive(0, 10, static_cast<uint>(iWeight) + m_pPlayer->GetPseudoRandomSeed() + static_cast<uint>(GC.getGame().GetCultureMedian()));
+				iWeight += GC.getGame().randRangeExclusive(0, 10, m_pPlayer->GetPseudoRandomSeed().mix(GC.getGame().GetCultureMedian()).mix(iWeight));
 
 				// We're mean enough to say something
 				if(iWeight >= 10)
@@ -35934,7 +35945,7 @@ void CvDiplomacyAI::DoFYIDenouncedHumanFriend(PlayerTypes ePlayer, DiploStatemen
 					iWeight += 10;
 
 				iWeight += GetMeanness();		// Usually ranges from 3 to 7
-				iWeight += GC.getGame().randRangeExclusive(0, 10, iWeight + m_pPlayer->GetPseudoRandomSeed() + static_cast<uint>(GC.getGame().GetCultureMedian()));
+				iWeight += GC.getGame().randRangeExclusive(0, 10, m_pPlayer->GetPseudoRandomSeed().mix(GC.getGame().GetCultureMedian()).mix(iWeight));
 
 				// We're mean enough to say something
 				if(iWeight >= 10)
@@ -36024,7 +36035,7 @@ void CvDiplomacyAI::DoFYIDenouncedHumanEnemy(PlayerTypes ePlayer, DiploStatement
 					iWeight += 3;
 
 				iWeight += GetChattiness();		// Usually ranges from 3 to 7
-				iWeight += GC.getGame().randRangeExclusive(0, 10, static_cast<uint>(iWeight) + m_pPlayer->GetPseudoRandomSeed() + static_cast<uint>(GC.getGame().GetCultureMedian()));
+				iWeight += GC.getGame().randRangeExclusive(0, 10, m_pPlayer->GetPseudoRandomSeed().mix(GC.getGame().GetCultureMedian()).mix(iWeight));
 
 				// We're mean enough to say something
 				if(iWeight >= 10)
@@ -36125,7 +36136,7 @@ void CvDiplomacyAI::DoFYIBefriendedHumanFriend(PlayerTypes ePlayer, DiploStateme
 					iWeight += 2;
 
 				iWeight += GetChattiness();		// Usually ranges from 3 to 7
-				iWeight += GC.getGame().randRangeExclusive(0, 10, static_cast<uint>(iWeight) + m_pPlayer->GetPseudoRandomSeed() + static_cast<uint>(GC.getGame().GetCultureMedian()));
+				iWeight += GC.getGame().randRangeExclusive(0, 10, m_pPlayer->GetPseudoRandomSeed().mix(GC.getGame().GetCultureMedian()).mix(iWeight));
 
 				// We're mean enough to say something
 				if (iWeight >= 10)
@@ -36173,7 +36184,7 @@ void CvDiplomacyAI::DoHappySamePolicyTree(PlayerTypes ePlayer, DiploStatementTyp
 				bSkip = true;
 
 			// Check chattiness to see if we send the message this turn
-			if (!bSkip && GetChattiness() > GC.getGame().randRangeExclusive(0, 10, m_pPlayer->GetPseudoRandomSeed() + static_cast<uint>(GC.getGame().GetCultureMedian())))
+			if (!bSkip && GetChattiness() > GC.getGame().randRangeExclusive(0, 10, m_pPlayer->GetPseudoRandomSeed().mix(GC.getGame().GetCultureMedian())))
 			{
 				DiploStatementTypes eOtherStatementToCheck = NO_DIPLO_STATEMENT_TYPE;
 
@@ -36618,7 +36629,7 @@ void CvDiplomacyAI::DoWeLikedTheirProposal(PlayerTypes ePlayer, DiploStatementTy
 				bSkip = true;
 			if ((GC.getGame().getGameTurn() - GetWeLikedTheirProposalTurn(ePlayer)) > 10)
 				bSkip = true;
-			if (!bSkip && GetChattiness() > GC.getGame().randRangeExclusive(0, 10, m_pPlayer->GetPseudoRandomSeed() + static_cast<uint>(GC.getGame().GetCultureMedian())))
+			if (!bSkip && GetChattiness() > GC.getGame().randRangeExclusive(0, 10, m_pPlayer->GetPseudoRandomSeed().mix(GC.getGame().GetCultureMedian())))
 			{
 				eTempStatement = DIPLO_STATEMENT_WE_LIKED_THEIR_PROPOSAL;
 				int iTurnsBetweenStatements = /*50*/ GD_INT_GET(OPINION_WEIGHT_WE_LIKED_THEIR_PROPOSAL_NUM_TURNS);
@@ -36672,7 +36683,7 @@ void CvDiplomacyAI::DoWeDislikedTheirProposal(PlayerTypes ePlayer, DiploStatemen
 				bSkip = true;
 			if ((GC.getGame().getGameTurn() - GetWeDislikedTheirProposalTurn(ePlayer)) > 10)
 				bSkip = true;
-			if (!bSkip && GetChattiness() > GC.getGame().randRangeExclusive(0, 10, m_pPlayer->GetPseudoRandomSeed() + static_cast<uint>(GC.getGame().GetCultureMedian())))
+			if (!bSkip && GetChattiness() > GC.getGame().randRangeExclusive(0, 10, m_pPlayer->GetPseudoRandomSeed().mix(GC.getGame().GetCultureMedian())))
 			{
 				eTempStatement = DIPLO_STATEMENT_WE_DISLIKED_THEIR_PROPOSAL;
 				int iTurnsBetweenStatements = /*50*/ GD_INT_GET(OPINION_WEIGHT_WE_DISLIKED_THEIR_PROPOSAL_NUM_TURNS);
@@ -38854,7 +38865,7 @@ void CvDiplomacyAI::DoFromUIDiploEvent(PlayerTypes eFromPlayer, FromUIDiploEvent
 		// Does the AI declare war?
 		bool bDeclareWar = false;
 
-		if (GC.getGame().randRangeExclusive(0, 10, m_pPlayer->GetPseudoRandomSeed() + static_cast<uint>(GC.getGame().GetCultureMedian())) >= ((GetMeanness() + GetBoldness()) / 2))
+		if (GC.getGame().randRangeExclusive(0, 10, m_pPlayer->GetPseudoRandomSeed().mix(GC.getGame().GetCultureMedian())) >= ((GetMeanness() + GetBoldness()) / 2))
 		{
 			bDeclareWar = true;
 		}
@@ -39100,7 +39111,7 @@ void CvDiplomacyAI::DoFromUIDiploEvent(PlayerTypes eFromPlayer, FromUIDiploEvent
 				{
 					iChance -= 5;
 				}
-				if (GC.getGame().randRangeExclusive(0, 10, m_pPlayer->GetPseudoRandomSeed() + static_cast<uint>(GC.getGame().GetCultureMedian())) > (iChance - GetMeanness() - GetBoldness()))
+				if (GC.getGame().randRangeExclusive(0, 10, m_pPlayer->GetPseudoRandomSeed().mix(GC.getGame().GetCultureMedian())) > (iChance - GetMeanness() - GetBoldness()))
 				{
 					bDeclareWar = true;
 				}
@@ -39272,7 +39283,7 @@ void CvDiplomacyAI::DoFromUIDiploEvent(PlayerTypes eFromPlayer, FromUIDiploEvent
 				{
 					iChance -= 3;
 				}
-				if (GC.getGame().randRangeExclusive(0, 10, m_pPlayer->GetPseudoRandomSeed() + static_cast<uint>(GC.getGame().GetCultureMedian())) > (iChance - GetMeanness() - GetBoldness()))
+				if (GC.getGame().randRangeExclusive(0, 10, m_pPlayer->GetPseudoRandomSeed().mix(GC.getGame().GetCultureMedian())) > (iChance - GetMeanness() - GetBoldness()))
 				{
 					bDeclareWar = true;
 				}
@@ -39732,7 +39743,7 @@ void CvDiplomacyAI::DoFromUIDiploEvent(PlayerTypes eFromPlayer, FromUIDiploEvent
 			{
 				iChance += 5;
 			}
-			if (GC.getGame().randRangeExclusive(0, 10, m_pPlayer->GetPseudoRandomSeed() + static_cast<uint>(GC.getGame().GetCultureMedian())) > (iChance - GetMeanness() - GetBoldness()))
+			if (GC.getGame().randRangeExclusive(0, 10, m_pPlayer->GetPseudoRandomSeed().mix(GC.getGame().GetCultureMedian())) > (iChance - GetMeanness() - GetBoldness()))
 			{
 				bDeclareWar = true;
 			}
@@ -43060,7 +43071,7 @@ void CvDiplomacyAI::DoDemandMade(PlayerTypes ePlayer, DemandResponseTypes eRespo
 
 		// See how long it'll be before we might agree to another demand
 		int iNumTurns = /*20*/ GD_INT_GET(DEMAND_TURN_LIMIT_MIN);
-		iNumTurns += GC.getGame().randRangeExclusive(0, /*10*/ GD_INT_GET(DEMAND_TURN_LIMIT_RAND), static_cast<uint>(GetID()));
+		iNumTurns += GC.getGame().randRangeExclusive(0, /*10*/ GD_INT_GET(DEMAND_TURN_LIMIT_RAND), CvSeeder(GetID()));
 		SetDemandTooSoonNumTurns(ePlayer, iNumTurns);
 
 		if (IsVassal(ePlayer))
@@ -57167,7 +57178,7 @@ bool CvDiplomacyAI::IsEndVassalageRequestAcceptable(PlayerTypes ePlayer)
 	if (iChanceToGiveIn <= 3)
 		iChanceToGiveIn = 3;
 
-	if (GC.getGame().randRangeExclusive(0, 10, m_pPlayer->GetPseudoRandomSeed() + static_cast<uint>(GC.getGame().GetCultureMedian())) < iChanceToGiveIn)
+	if (GC.getGame().randRangeExclusive(0, 10, m_pPlayer->GetPseudoRandomSeed().mix(GC.getGame().GetCultureMedian())) < iChanceToGiveIn)
 		return true;
 
 	return false;
@@ -57215,7 +57226,7 @@ void CvDiplomacyAI::DoMapsOffer(PlayerTypes ePlayer, DiploStatementTypes& eState
 
 	//problem: on larger maps evaluating the map value every turn for every player is significant performance overhead
 	//solution: we could cache the value for the active player, saving half the effort, but it's simpler to just not even contemplate the offer every turn
-	int iRandom = GC.getGame().randRangeExclusive(0, 3, static_cast<uint>(ePlayer)) + 3; // either 3 or 4 or 5
+	int iRandom = GC.getGame().randRangeExclusive(0, 3, CvSeeder(ePlayer)) + 3; // either 3 or 4 or 5
 	if (GC.getGame().getGameTurn() % iRandom != 0)
 		return;
 
@@ -57409,7 +57420,7 @@ bool CvDiplomacyAI::IsMakeGenerousOffer(PlayerTypes ePlayer, CvDeal* pDeal, bool
 		if(bWantsToOfferSomething)
 		{
 			// Random element
-			int iRand = GC.getGame().randRangeExclusive(0, 10, m_pPlayer->GetPseudoRandomSeed() + static_cast<uint>(GC.getGame().GetCultureMedian()));
+			int iRand = GC.getGame().randRangeExclusive(0, 10, m_pPlayer->GetPseudoRandomSeed().mix(GC.getGame().GetCultureMedian()));
 
 			// modifier based on AI loyalty
 			int iModifier = (GetLoyalty() - 5);	// +20 for 7 Loyalty, +0 for 5 Loyalty, -30 for 2 Loyalty, +50 for 10 Loyalty
@@ -57715,7 +57726,7 @@ void CvDiplomacyAI::DoHelpRequestMade(PlayerTypes ePlayer, DemandResponseTypes e
 
 		// Decide how long it'll be before we might agree to another help request
 		int iNumTurns = /*20*/ GD_INT_GET(HELP_REQUEST_TURN_LIMIT_MIN);
-		iNumTurns += GC.getGame().randRangeExclusive(0, /*10*/ GD_INT_GET(HELP_REQUEST_TURN_LIMIT_RAND), static_cast<uint>(GetID()));
+		iNumTurns += GC.getGame().randRangeExclusive(0, /*10*/ GD_INT_GET(HELP_REQUEST_TURN_LIMIT_RAND), CvSeeder(GetID()));
 		SetHelpRequestTooSoonNumTurns(ePlayer, iNumTurns);
 	}
 }
@@ -58355,7 +58366,7 @@ MoveTroopsResponseTypes CvDiplomacyAI::GetMoveTroopsRequestResponse(PlayerTypes 
 
 	for(int i=0; i < NUM_MOVE_TROOPS_RESPONSES; i++)
 	{
-		iRand = GC.getGame().randRangeExclusive(0, 5, static_cast<uint>(ePlayer));
+		iRand = GC.getGame().randRangeExclusive(0, 5, CvSeeder(ePlayer));
 		viMoveTroopsWeights[i] += iRand;
 	}
 

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.h
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.h
@@ -112,7 +112,7 @@ public:
 	// Personality Values
 	// ************************************
 
-	int GetRandomPersonalityWeight(int iOriginalValue, int& iSeed);
+	int GetRandomPersonalityWeight(int iOriginalValue, CvSeeder& seed);
 	void DoInitializePersonality(bool bFirstInit);
 	void SelectDefaultVictoryPursuits();
 

--- a/CvGameCoreDLL_Expansion2/CvEconomicAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvEconomicAI.cpp
@@ -3333,7 +3333,7 @@ bool EconomicAIHelpers::IsTestStrategy_EarlyExpansion(EconomicAIStrategyTypes eS
 		return true;
 
 	//some rate limiting - don't need to check this every turn in the lategame
-	if (GC.getGame().getSmallFakeRandNum(3, pPlayer->GetPseudoRandomSeed()) != 0)
+	if (GC.getGame().randRangeExclusive(0, 3, pPlayer->GetPseudoRandomSeed()) != 0)
 		return false;
 
 	//do this check as late as possible, it can be expensive

--- a/CvGameCoreDLL_Expansion2/CvEspionageClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvEspionageClasses.cpp
@@ -1134,7 +1134,7 @@ bool CvPlayerEspionage::DoStealTechnology(PlayerTypes eTargetPlayer)
 
 	TeamTypes eTeam = m_pPlayer->getTeam();
 
-	uint uGrab = GC.getGame().urandLimitExclusive(m_aaPlayerStealableTechList[eTargetPlayer].size(), m_pPlayer->GetPseudoRandomSeed() + static_cast<uint>(GET_PLAYER(eTargetPlayer).GetTreasury()->CalculateGrossGold()));
+	uint uGrab = GC.getGame().urandLimitExclusive(m_aaPlayerStealableTechList[eTargetPlayer].size(), m_pPlayer->GetPseudoRandomSeed().mix(GET_PLAYER(eTargetPlayer).GetTreasury()->CalculateGrossGold()));
 	TechTypes eStolenTech = m_aaPlayerStealableTechList[eTargetPlayer][uGrab];
 
 	GET_TEAM(eTeam).setHasTech(eStolenTech, true, m_pPlayer->GetID(), true, true);
@@ -2118,7 +2118,7 @@ int CvPlayerEspionage::GetDefenseChance(CvEspionageType eEspionage, CvCity* pCit
 
 CvSpyResult CvPlayerEspionage::GetSpyRollResult(CvCity* pCity, CityEventChoiceTypes eEventChoice)
 {
-	int iResult = GC.getGame().randRangeExclusive(1, 100, pCity->plot()->GetPseudoRandomSeed() + static_cast<uint>(m_pPlayer->GetTreasury()->GetLifetimeGrossGold()));
+	int iResult = GC.getGame().randRangeExclusive(1, 100, pCity->plot()->GetPseudoRandomSeed().mix(m_pPlayer->GetTreasury()->GetLifetimeGrossGold()));
 	int iKillChance = GetDefenseChance(ESPIONAGE_TYPE_KILL, pCity, eEventChoice);
 	int iIdentifyChance = GetDefenseChance(ESPIONAGE_TYPE_IDENTIFY, pCity, eEventChoice);
 
@@ -2175,7 +2175,7 @@ void CvPlayerEspionage::UncoverIntrigue(uint uiSpyIndex)
 	// randomize that list
 	for(uint ui = 0; ui < aiMajorCivIndex.size(); ui++)
 	{
-		uint uiTargetSlot = GC.getGame().urandLimitExclusive(aiMajorCivIndex.size(), pCity->plot()->GetPseudoRandomSeed() + ui);
+		uint uiTargetSlot = GC.getGame().urandLimitExclusive(aiMajorCivIndex.size(), pCity->plot()->GetPseudoRandomSeed().mix(ui));
 		int iTempValue = aiMajorCivIndex[ui];
 		aiMajorCivIndex[ui] = aiMajorCivIndex[uiTargetSlot];
 		aiMajorCivIndex[uiTargetSlot] = iTempValue;
@@ -2394,7 +2394,7 @@ void CvPlayerEspionage::GetRandomIntrigue(CvCity* pCity, uint uiSpyIndex)
 	// randomize that list
 	for(uint ui = 0; ui < aiMajorCivIndex.size(); ui++)
 	{
-		uint uiTargetSlot = GC.getGame().urandLimitExclusive(aiMajorCivIndex.size(), pCity->plot()->GetPseudoRandomSeed() + ui);
+		uint uiTargetSlot = GC.getGame().urandLimitExclusive(aiMajorCivIndex.size(), pCity->plot()->GetPseudoRandomSeed().mix(ui));
 		int iTempValue = aiMajorCivIndex[ui];
 		aiMajorCivIndex[ui] = aiMajorCivIndex[uiTargetSlot];
 		aiMajorCivIndex[uiTargetSlot] = iTempValue;
@@ -2554,7 +2554,7 @@ bool pickSpyName(const CvCivilizationInfo& kCivInfo, CvEspionageSpy* pSpy)
 	int iCivSpyNames = kCivInfo.getNumSpyNames();
 	if (iCivSpyNames > 0)
 	{
-		int iOffset = GC.getGame().randRangeExclusive(0, iCivSpyNames, static_cast<uint>(iCivSpyNames));
+		int iOffset = GC.getGame().randRangeExclusive(0, iCivSpyNames, CvSeeder(iCivSpyNames));
 
 		for (int i = 0; i < iCivSpyNames; i++) {
 			const char* szSpyName = kCivInfo.getSpyNames((i + iOffset) % iCivSpyNames);
@@ -6753,7 +6753,7 @@ void CvEspionageAI::AttemptCoups()
 		int iChanceOfSuccess = pEspionage->GetCoupChanceOfSuccess(uiSpy);
 		if (iChanceOfSuccess >= 60 + 10*iSpyRank)
 		{
-			int iRoll = GC.getGame().randRangeExclusive(0, 100, m_pPlayer->GetPseudoRandomSeed() + GET_PLAYER(pCity->getOwner()).GetPseudoRandomSeed() + uiSpy);
+			int iRoll = GC.getGame().randRangeExclusive(0, 100, m_pPlayer->GetPseudoRandomSeed().mix(GET_PLAYER(pCity->getOwner()).GetPseudoRandomSeed()).mix(uiSpy));
 			if (iRoll < iChanceOfSuccess)
 			{
 				pEspionage->AttemptCoup(uiSpy);

--- a/CvGameCoreDLL_Expansion2/CvEspionageClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvEspionageClasses.cpp
@@ -1134,13 +1134,8 @@ bool CvPlayerEspionage::DoStealTechnology(PlayerTypes eTargetPlayer)
 
 	TeamTypes eTeam = m_pPlayer->getTeam();
 
-	int iGrab = GC.getGame().getSmallFakeRandNum((int)m_aaPlayerStealableTechList[eTargetPlayer].size() - 1, m_pPlayer->GetPseudoRandomSeed() + GET_PLAYER(eTargetPlayer).GetTreasury()->CalculateGrossGold());
-	if (iGrab <= 0)
-		iGrab = 0;
-	if (iGrab > (int)m_aaPlayerStealableTechList[eTargetPlayer].size() - 1)
-		iGrab = (int)m_aaPlayerStealableTechList[eTargetPlayer].size() - 1;
-
-	TechTypes eStolenTech = m_aaPlayerStealableTechList[eTargetPlayer][iGrab];
+	uint uGrab = GC.getGame().urandLimitExclusive(m_aaPlayerStealableTechList[eTargetPlayer].size(), m_pPlayer->GetPseudoRandomSeed() + static_cast<uint>(GET_PLAYER(eTargetPlayer).GetTreasury()->CalculateGrossGold()));
+	TechTypes eStolenTech = m_aaPlayerStealableTechList[eTargetPlayer][uGrab];
 
 	GET_TEAM(eTeam).setHasTech(eStolenTech, true, m_pPlayer->GetID(), true, true);
 	GET_TEAM(eTeam).GetTeamTechs()->SetNoTradeTech(eStolenTech, true);
@@ -2123,10 +2118,7 @@ int CvPlayerEspionage::GetDefenseChance(CvEspionageType eEspionage, CvCity* pCit
 
 CvSpyResult CvPlayerEspionage::GetSpyRollResult(CvCity* pCity, CityEventChoiceTypes eEventChoice)
 {
-	int iResult = GC.getGame().getSmallFakeRandNum(100, pCity->plot()->GetPlotIndex() + m_pPlayer->GetTreasury()->GetLifetimeGrossGold());
-	if (iResult <= 0)
-		iResult = 1;
-
+	int iResult = GC.getGame().randRangeExclusive(1, 100, pCity->plot()->GetPseudoRandomSeed() + static_cast<uint>(m_pPlayer->GetTreasury()->GetLifetimeGrossGold()));
 	int iKillChance = GetDefenseChance(ESPIONAGE_TYPE_KILL, pCity, eEventChoice);
 	int iIdentifyChance = GetDefenseChance(ESPIONAGE_TYPE_IDENTIFY, pCity, eEventChoice);
 
@@ -2183,7 +2175,7 @@ void CvPlayerEspionage::UncoverIntrigue(uint uiSpyIndex)
 	// randomize that list
 	for(uint ui = 0; ui < aiMajorCivIndex.size(); ui++)
 	{
-		uint uiTargetSlot = GC.getGame().getSmallFakeRandNum(aiMajorCivIndex.size(),pCity->plot()->GetPlotIndex()+ui);
+		uint uiTargetSlot = GC.getGame().urandLimitExclusive(aiMajorCivIndex.size(), pCity->plot()->GetPseudoRandomSeed() + ui);
 		int iTempValue = aiMajorCivIndex[ui];
 		aiMajorCivIndex[ui] = aiMajorCivIndex[uiTargetSlot];
 		aiMajorCivIndex[uiTargetSlot] = iTempValue;
@@ -2402,7 +2394,7 @@ void CvPlayerEspionage::GetRandomIntrigue(CvCity* pCity, uint uiSpyIndex)
 	// randomize that list
 	for(uint ui = 0; ui < aiMajorCivIndex.size(); ui++)
 	{
-		uint uiTargetSlot = GC.getGame().getSmallFakeRandNum(aiMajorCivIndex.size(),pCity->plot()->GetPlotIndex()+ui);
+		uint uiTargetSlot = GC.getGame().urandLimitExclusive(aiMajorCivIndex.size(), pCity->plot()->GetPseudoRandomSeed() + ui);
 		int iTempValue = aiMajorCivIndex[ui];
 		aiMajorCivIndex[ui] = aiMajorCivIndex[uiTargetSlot];
 		aiMajorCivIndex[uiTargetSlot] = iTempValue;
@@ -2562,11 +2554,7 @@ bool pickSpyName(const CvCivilizationInfo& kCivInfo, CvEspionageSpy* pSpy)
 	int iCivSpyNames = kCivInfo.getNumSpyNames();
 	if (iCivSpyNames > 0)
 	{
-#if defined(MOD_CORE_REDUCE_RANDOMNESS)
-		int iOffset = GC.getGame().getSmallFakeRandNum(iCivSpyNames, iCivSpyNames);
-#else
-		int iOffset = GC.getGame().getJonRandNum(iCivSpyNames, "Spy name offset");
-#endif
+		int iOffset = GC.getGame().randRangeExclusive(0, iCivSpyNames, static_cast<uint>(iCivSpyNames));
 
 		for (int i = 0; i < iCivSpyNames; i++) {
 			const char* szSpyName = kCivInfo.getSpyNames((i + iOffset) % iCivSpyNames);
@@ -2616,7 +2604,7 @@ void CvPlayerEspionage::GetNextSpyName(CvEspionageSpy* pSpy)
 
 	// Try to locate a spy name not in use by a civ not in the game
 	int iMaxCivs = GC.getNumCivilizationInfos();
-	int iCivOffset = GC.getGame().getSmallFakeRandNum(iMaxCivs, m_pPlayer->GetPseudoRandomSeed());
+	int iCivOffset = GC.getGame().randRangeExclusive(0, iMaxCivs, m_pPlayer->GetPseudoRandomSeed());
 	for (int i = 0; i < GC.getNumCivilizationInfos(); i++) {
 		const CivilizationTypes eCiv = static_cast<CivilizationTypes>((i + iCivOffset) % iMaxCivs);
 		CvCivilizationInfo* pkCivilizationInfo = GC.getCivilizationInfo(eCiv);
@@ -2633,7 +2621,7 @@ void CvPlayerEspionage::GetNextSpyName(CvEspionageSpy* pSpy)
 	}
 
 	// Try to locate a spy name not in use by a civ in the game
-	int iPlayerOffset = GC.getGame().getSmallFakeRandNum(MAX_MAJOR_CIVS, m_pPlayer->GetPseudoRandomSeed());
+	int iPlayerOffset = GC.getGame().randRangeExclusive(0, MAX_MAJOR_CIVS, m_pPlayer->GetPseudoRandomSeed());
 
 	for (int i = 0; i < MAX_MAJOR_CIVS; i++) {
 		const PlayerTypes ePlayer = static_cast<PlayerTypes>((i + iPlayerOffset) % MAX_MAJOR_CIVS);
@@ -3916,7 +3904,7 @@ bool CvPlayerEspionage::AttemptCoup(uint uiSpyIndex)
 	}
 
 	bool bAttemptSuccess = false;
-	int iRandRoll = GC.getGame().getSmallFakeRandNum(100, *pCity->plot());
+	int iRandRoll = GC.getGame().randRangeExclusive(0, 100, pCity->plot()->GetPseudoRandomSeed());
 	if(iRandRoll <= GetCoupChanceOfSuccess(uiSpyIndex))
 	{
 		// swap influence from ally to 2nd place ally
@@ -6765,7 +6753,7 @@ void CvEspionageAI::AttemptCoups()
 		int iChanceOfSuccess = pEspionage->GetCoupChanceOfSuccess(uiSpy);
 		if (iChanceOfSuccess >= 60 + 10*iSpyRank)
 		{
-			int iRoll = GC.getGame().getSmallFakeRandNum(100, m_pPlayer->GetPseudoRandomSeed() + GET_PLAYER(pCity->getOwner()).GetPseudoRandomSeed() + uiSpy);
+			int iRoll = GC.getGame().randRangeExclusive(0, 100, m_pPlayer->GetPseudoRandomSeed() + GET_PLAYER(pCity->getOwner()).GetPseudoRandomSeed() + uiSpy);
 			if (iRoll < iChanceOfSuccess)
 			{
 				pEspionage->AttemptCoup(uiSpy);

--- a/CvGameCoreDLL_Expansion2/CvFlavorManager.cpp
+++ b/CvGameCoreDLL_Expansion2/CvFlavorManager.cpp
@@ -456,29 +456,25 @@ void CvFlavorManager::RandomizeWeights()
 	int iPlusMinus = max(/*2*/ GD_INT_GET(FLAVOR_RANDOMIZATION_RANGE), 0);
 
 	// Random seed to ensure the fake RNG doesn't return the same value repeatedly
-	uint uSeed = 0;
+	CvSeeder seed;
 
 	for (int iI = 0; iI < GC.getNumFlavorTypes(); iI++)
 	{
 		// Don't modify it if it's zero-ed out in the XML
 		if (m_piPersonalityFlavor[iI] != 0)
 		{
-			m_piPersonalityFlavor[iI] = GetAdjustedValue(m_piPersonalityFlavor[iI], iPlusMinus, iMin, iMax, uSeed);
+			m_piPersonalityFlavor[iI] = GetAdjustedValue(m_piPersonalityFlavor[iI], iPlusMinus, iMin, iMax, seed);
 		}
 	}
 }
 
 /// Add a random plus/minus to an integer (but keep it in range)
-int CvFlavorManager::GetAdjustedValue(int iOriginalValue, int iPlusMinus, int iMin, int iMax, uint& uSeed)
+int CvFlavorManager::GetAdjustedValue(int iOriginalValue, int iPlusMinus, int iMin, int iMax, CvSeeder& seed)
 {
-	// Increment the random seed (and make sure it's > 0)
-	if (uSeed < 0)
-		uSeed = 0;
-
-	uSeed += (static_cast<uint>(iOriginalValue) + static_cast<uint>(iPlusMinus)) * 200;
+	seed.mixAssign(iOriginalValue).mixAssign(iPlusMinus);
 
 	// Randomize!
-	int iAdjust = GC.getGame().randRangeExclusive(0, (iPlusMinus * 2 + 1), (static_cast<uint>(iOriginalValue) * uSeed));
+	int iAdjust = GC.getGame().randRangeExclusive(0, (iPlusMinus * 2 + 1), seed);
 	int iRtnValue = iOriginalValue + iAdjust - iPlusMinus;
 
 	return range(iRtnValue, iMin, iMax);

--- a/CvGameCoreDLL_Expansion2/CvFlavorManager.cpp
+++ b/CvGameCoreDLL_Expansion2/CvFlavorManager.cpp
@@ -456,29 +456,29 @@ void CvFlavorManager::RandomizeWeights()
 	int iPlusMinus = max(/*2*/ GD_INT_GET(FLAVOR_RANDOMIZATION_RANGE), 0);
 
 	// Random seed to ensure the fake RNG doesn't return the same value repeatedly
-	int iSeed = 0;
+	uint uSeed = 0;
 
 	for (int iI = 0; iI < GC.getNumFlavorTypes(); iI++)
 	{
 		// Don't modify it if it's zero-ed out in the XML
 		if (m_piPersonalityFlavor[iI] != 0)
 		{
-			m_piPersonalityFlavor[iI] = GetAdjustedValue(m_piPersonalityFlavor[iI], iPlusMinus, iMin, iMax, iSeed);
+			m_piPersonalityFlavor[iI] = GetAdjustedValue(m_piPersonalityFlavor[iI], iPlusMinus, iMin, iMax, uSeed);
 		}
 	}
 }
 
 /// Add a random plus/minus to an integer (but keep it in range)
-int CvFlavorManager::GetAdjustedValue(int iOriginalValue, int iPlusMinus, int iMin, int iMax, int& iSeed)
+int CvFlavorManager::GetAdjustedValue(int iOriginalValue, int iPlusMinus, int iMin, int iMax, uint& uSeed)
 {
 	// Increment the random seed (and make sure it's > 0)
-	if (iSeed < 0)
-		iSeed = 0;
+	if (uSeed < 0)
+		uSeed = 0;
 
-	iSeed += (iOriginalValue + iPlusMinus) * 200;
+	uSeed += (static_cast<uint>(iOriginalValue) + static_cast<uint>(iPlusMinus)) * 200;
 
 	// Randomize!
-	int iAdjust = GC.getGame().getSmallFakeRandNum((iPlusMinus * 2 + 1), (iOriginalValue * iSeed));
+	int iAdjust = GC.getGame().randRangeExclusive(0, (iPlusMinus * 2 + 1), (static_cast<uint>(iOriginalValue) * uSeed));
 	int iRtnValue = iOriginalValue + iAdjust - iPlusMinus;
 
 	return range(iRtnValue, iMin, iMax);

--- a/CvGameCoreDLL_Expansion2/CvFlavorManager.h
+++ b/CvGameCoreDLL_Expansion2/CvFlavorManager.h
@@ -88,7 +88,7 @@ public:
 	CvEnumMap<FlavorTypes, int>& GetAllPersonalityFlavors();
 	int GetPersonalityFlavorForDiplomacy(FlavorTypes eType);
 
-	int GetAdjustedValue(int iOriginalValue, int iPlusMinus, int iMin, int iMax, uint& uSeed);
+	int GetAdjustedValue(int iOriginalValue, int iPlusMinus, int iMin, int iMax, CvSeeder& seed);
 
 private:
 

--- a/CvGameCoreDLL_Expansion2/CvFlavorManager.h
+++ b/CvGameCoreDLL_Expansion2/CvFlavorManager.h
@@ -88,7 +88,7 @@ public:
 	CvEnumMap<FlavorTypes, int>& GetAllPersonalityFlavors();
 	int GetPersonalityFlavorForDiplomacy(FlavorTypes eType);
 
-	int GetAdjustedValue(int iOriginalValue, int iPlusMinus, int iMin, int iMax, int& iSeed);
+	int GetAdjustedValue(int iOriginalValue, int iPlusMinus, int iMin, int iMax, uint& uSeed);
 
 private:
 

--- a/CvGameCoreDLL_Expansion2/CvGame.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGame.cpp
@@ -5805,7 +5805,7 @@ Localization::String CvGame::GetDiploResponse(const char* szLeader, const char* 
 
     if(!probabilities.empty())
     {
-		tempRand = randRangeExclusive(0, totbias, probabilities.size());
+		tempRand = randRangeExclusive(0, totbias, CvSeeder(probabilities.size()));
         for (choice=0; choice<biasList.size(); choice++){
             if(tempRand < biasList[choice]){
                 break;
@@ -5836,7 +5836,7 @@ Localization::String CvGame::GetDiploResponse(const char* szLeader, const char* 
 
     if(!probabilities.empty())
     {
-		tempRand = randRangeExclusive(0, totbias, probabilities.size());
+		tempRand = randRangeExclusive(0, totbias, CvSeeder(probabilities.size()));
         for (choice=0; choice<biasList.size(); choice++){
             if(tempRand < biasList[choice]){
                 break;
@@ -8924,7 +8924,7 @@ UnitTypes CvGame::GetRandomSpawnUnitType(PlayerTypes ePlayer, bool bIncludeUUs, 
 				continue;
 
 			// Random weighting
-			iValue = GC.getGame().randRangeInclusive(1, 10, static_cast<uint>(iUnitLoop) + static_cast<uint>(GET_PLAYER(ePlayer).getNumUnits())) * 100;
+			iValue = GC.getGame().randRangeInclusive(1, 10, CvSeeder(iUnitLoop).mix(GET_PLAYER(ePlayer).getNumUnits())) * 100;
 			iValue += iBonusValue;
 
 			if(iValue > iBestValue)
@@ -9175,7 +9175,7 @@ UnitTypes CvGame::GetCsGiftSpawnUnitType(PlayerTypes ePlayer, bool bIncludeShips
 	}
 
 	// Choose from weighted unit types
-	return PseudoRandomChoiceByWeight(veUnitRankings, NO_UNIT, /*5*/ GD_INT_GET(UNIT_SPAWN_NUM_CHOICES), static_cast<uint>(kPlayer.getNumUnits()) + static_cast<uint>(kPlayer.GetTreasury()->GetLifetimeGrossGold()));
+	return PseudoRandomChoiceByWeight(veUnitRankings, NO_UNIT, /*5*/ GD_INT_GET(UNIT_SPAWN_NUM_CHOICES), CvSeeder(kPlayer.getNumUnits()).mix(kPlayer.GetTreasury()->GetLifetimeGrossGold()));
 }
 #endif
 #if defined(MOD_BALANCE_CORE)
@@ -9215,7 +9215,7 @@ bool CvGame::DoSpawnUnitsAroundTargetCity(PlayerTypes ePlayer, CvCity* pCity, in
 		if(pPlot->getNumUnits() > 0)
 			continue;
 
-		int iTempWeight = randRangeExclusive(0, 10, static_cast<uint>(GET_PLAYER(pCity->getOwner()).GetMilitaryMight()) + pPlot->GetPseudoRandomSeed());
+		int iTempWeight = randRangeExclusive(0, 10, CvSeeder(GET_PLAYER(pCity->getOwner()).GetMilitaryMight()).mix(pPlot->GetPseudoRandomSeed()));
 
 		// Add weight if there's an improvement here!
 		if(pPlot->getImprovementType() != NO_IMPROVEMENT)
@@ -9357,7 +9357,7 @@ bool CvGame::DoSpawnUnitsAroundTargetCity(PlayerTypes ePlayer, CvCity* pCity, in
 UnitTypes CvGame::GetRandomUniqueUnitType(bool bIncludeCivsInGame, bool bIncludeStartEra, bool bIncludeOldEras, bool bIncludeRanged, bool bCoastal, int iPlotX, int iPlotY)
 {
 	// Find the unique units that have already been assigned
-	uint uRandomSeed = 0;
+	CvSeeder randomSeed;
 	std::set<UnitTypes> setUniquesAlreadyAssigned;
 	for(int iMinorLoop = MAX_MAJOR_CIVS; iMinorLoop < MAX_CIV_PLAYERS; iMinorLoop++)
 	{
@@ -9365,7 +9365,7 @@ UnitTypes CvGame::GetRandomUniqueUnitType(bool bIncludeCivsInGame, bool bInclude
 		CvPlayer* pMinorLoop = &GET_PLAYER(eMinorLoop);
 		if(pMinorLoop && pMinorLoop->isEverAlive())
 		{
-			uRandomSeed += static_cast<uint>(pMinorLoop->GetID()); //needed later
+			randomSeed.mixAssign(pMinorLoop->GetID()); //needed later
 			UnitTypes eUniqueUnit = pMinorLoop->GetMinorCivAI()->GetUniqueUnit();
 			if(eUniqueUnit != NO_UNIT)
 			{
@@ -9490,7 +9490,7 @@ UnitTypes CvGame::GetRandomUniqueUnitType(bool bIncludeCivsInGame, bool bInclude
 			if (setUniquesAlreadyAssigned.count(eLoopUnit) > 0)
 				continue;
 
-			int iRandom = randRangeExclusive(0, 300, static_cast<uint>(iPlotX) + static_cast<uint>(iPlotY) + static_cast<uint>(iUnitLoop));
+			int iRandom = randRangeExclusive(0, 300, CvSeeder(iPlotX).mix(iPlotY).mix(iUnitLoop));
 
 			//Weight minor civ gift units higher, so they're more likely to spawn each game (Careful, +50 caused Minor Civs Gifts to take up more than 50% of Military UU slots).
 			if (pkUnitInfo->IsMinorCivGift())
@@ -9505,7 +9505,7 @@ UnitTypes CvGame::GetRandomUniqueUnitType(bool bIncludeCivsInGame, bool bInclude
 			break;
 	}
 
-	return PseudoRandomChoiceByWeight(veUnitRankings, NO_UNIT, /*5*/ GD_INT_GET(UNIT_SPAWN_NUM_CHOICES), uRandomSeed);
+	return PseudoRandomChoiceByWeight(veUnitRankings, NO_UNIT, /*5*/ GD_INT_GET(UNIT_SPAWN_NUM_CHOICES), randomSeed);
 }
 
 //	--------------------------------------------------------------------------------
@@ -10347,7 +10347,7 @@ void CvGame::testVictory()
 			{
 				if(isVictoryAvailable(eVictory))
 				{
-					iRand = GC.getGame().randRangeExclusive(0, iNumCompetitionWinners, static_cast<uint>(iNumCompetitionWinners) + static_cast<uint>(iVictoryLoop));
+					iRand = GC.getGame().randRangeExclusive(0, iNumCompetitionWinners, CvSeeder(iNumCompetitionWinners).mix(iVictoryLoop));
 					iTeamLoop = m_aiTeamCompetitionWinnersScratchPad[iRand];
 
 					DoPlaceTeamInVictoryCompetition(eVictory, (TeamTypes) iTeamLoop);
@@ -10483,7 +10483,7 @@ void CvGame::testVictory()
 	// Two things can set this to true: either someone has finished an insta-win victory, or the game-ending tech has been researched and we're now tallying VPs
 	if(bEndGame && !aaiGameWinners.empty())
 	{
-		uint uWinner = urandLimitExclusive(aaiGameWinners.size(), aaiGameWinners.size());
+		uint uWinner = urandLimitExclusive(aaiGameWinners.size(), CvSeeder(aaiGameWinners.size()));
 		CUSTOMLOG("Calling setWinner from testVictory: %i, %i", aaiGameWinners[uWinner][0], aaiGameWinners[uWinner][1]);
 		setWinner(((TeamTypes)aaiGameWinners[uWinner][0]), ((VictoryTypes)aaiGameWinners[uWinner][1]));
 	}
@@ -10554,7 +10554,7 @@ void CvGame::doVictoryRandomization()
 		if (pkVictoryInfo->isConquest())
 			continue;
 
-		int iScore = randRangeExclusive(0, 100, static_cast<uint>(GC.getGame().GetGameCulture()->GetNumGreatWorks()) + static_cast<uint>(iVictoryLoop));
+		int iScore = randRangeExclusive(0, 100, CvSeeder(GC.getGame().GetGameCulture()->GetNumGreatWorks()).mix(iVictoryLoop));
 		
 		if (pkVictoryInfo->isDiploVote())
 		{
@@ -10774,24 +10774,21 @@ unsigned long hash32(unsigned long x)
 }
 */
 
-uint CvGame::randCore(uint extraSeed) const
+uint CvGame::randCore(CvSeeder extraSeed) const
 {
-	// The game's current turn modified in some unusual way is used as the game state seed source.
-	const uint gameStateSeed = static_cast<uint>(getGameTurn()) * 11;
-	const uint finalSeed = gameStateSeed + extraSeed;
-
-	// The final seed value is fed into hash32 to yield a pseudo random number.
-	return hash32(finalSeed);
+	const CvSeeder mapSeed = CvSeeder::fromRaw(CvPreGame::mapRandomSeed());
+	const CvSeeder gameSeed = CvSeeder(static_cast<uint>(getGameTurn()) * 11);
+	return mapSeed.mix(gameSeed).mix(extraSeed);
 }
 
-uint CvGame::urandLimitExclusive(uint limit, uint extraSeed) const
+uint CvGame::urandLimitExclusive(uint limit, CvSeeder extraSeed) const
 {
 	ASSERT(limit != 0);
 	const uint rand = randCore(extraSeed);
 	return rand % limit;
 }
 
-uint CvGame::urandLimitInclusive(uint limit, uint extraSeed) const
+uint CvGame::urandLimitInclusive(uint limit, CvSeeder extraSeed) const
 {
 	const uint rand = randCore(extraSeed);
 	if (limit == UINT_MAX)
@@ -10804,25 +10801,25 @@ uint CvGame::urandLimitInclusive(uint limit, uint extraSeed) const
 	}
 }
 
-uint CvGame::urandRangeExclusive(uint min, uint max, uint extraSeed) const
+uint CvGame::urandRangeExclusive(uint min, uint max, CvSeeder extraSeed) const
 {
 	ASSERT(min < max);
 	return urandLimitExclusive(max - min, extraSeed) + min;
 }
 
-uint CvGame::urandRangeInclusive(uint min, uint max, uint extraSeed) const
+uint CvGame::urandRangeInclusive(uint min, uint max, CvSeeder extraSeed) const
 {
 	ASSERT(min <= max);
 	return urandLimitInclusive(max - min, extraSeed) + min;
 }
 
-int CvGame::randRangeExclusive(int min, int max, uint extraSeed) const
+int CvGame::randRangeExclusive(int min, int max, CvSeeder extraSeed) const
 {
 	ASSERT(min < max);
 	return static_cast<int>(urandLimitExclusive(static_cast<uint>(max) - static_cast<uint>(min), extraSeed) + static_cast<uint>(min));
 }
 
-int CvGame::randRangeInclusive(int min, int max, uint extraSeed) const
+int CvGame::randRangeInclusive(int min, int max, CvSeeder extraSeed) const
 {
 	ASSERT(min <= max);
 	return static_cast<int>(urandLimitInclusive(static_cast<uint>(max) - static_cast<uint>(min), extraSeed) + static_cast<uint>(min));
@@ -13423,7 +13420,7 @@ int CalculateDigSiteWeight(int iIndex, vector<CvArchaeologyData>& inputData, vec
 		if (iBaseWeight > 0)
 		{
 			// add a small random factor
-			iBaseWeight += 10 + GC.getGame().randRangeExclusive(0, 10, static_cast<uint>(iBaseWeight));
+			iBaseWeight += 10 + GC.getGame().randRangeExclusive(0, 10, CvSeeder(iBaseWeight));
 
 			// increase the value if unowned
 			iBaseWeight *= (pPlot->getOwner() == NO_PLAYER) ? 9 : 8;
@@ -13862,7 +13859,7 @@ void CvGame::SpawnArchaeologySitesHistorically()
 			pPlot->SetArtifactType(CvTypes::getARTIFACT_WRITING());
 
 			// Then get a writing and set it
-			int iIndex = urandLimitExclusive(aWorksWriting.size(), aWorksWriting.size() + pPlot->GetPseudoRandomSeed());
+			int iIndex = urandLimitExclusive(aWorksWriting.size(), pPlot->GetPseudoRandomSeed().mix(aWorksWriting.size()));
 			GreatWorkType eWrittenGreatWork = aWorksWriting[iIndex];
 			pPlot->SetArtifactGreatWork((GreatWorkType)eWrittenGreatWork);
 

--- a/CvGameCoreDLL_Expansion2/CvGame.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGame.cpp
@@ -10793,11 +10793,6 @@ uint CvGame::urandLimitExclusive(uint limit, uint extraSeed) const
 
 uint CvGame::urandLimitInclusive(uint limit, uint extraSeed) const
 {
-	if (limit == 0)
-	{
-		return 0;
-	}
-
 	const uint rand = randCore(extraSeed);
 	if (limit == UINT_MAX)
 	{

--- a/CvGameCoreDLL_Expansion2/CvGame.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGame.cpp
@@ -5805,7 +5805,7 @@ Localization::String CvGame::GetDiploResponse(const char* szLeader, const char* 
 
     if(!probabilities.empty())
     {
-		tempRand = getSmallFakeRandNum(totbias, probabilities.size());
+		tempRand = randRangeExclusive(0, totbias, probabilities.size());
         for (choice=0; choice<biasList.size(); choice++){
             if(tempRand < biasList[choice]){
                 break;
@@ -5836,7 +5836,7 @@ Localization::String CvGame::GetDiploResponse(const char* szLeader, const char* 
 
     if(!probabilities.empty())
     {
-		tempRand = getSmallFakeRandNum(totbias, probabilities.size());
+		tempRand = randRangeExclusive(0, totbias, probabilities.size());
         for (choice=0; choice<biasList.size(); choice++){
             if(tempRand < biasList[choice]){
                 break;
@@ -8924,7 +8924,7 @@ UnitTypes CvGame::GetRandomSpawnUnitType(PlayerTypes ePlayer, bool bIncludeUUs, 
 				continue;
 
 			// Random weighting
-			iValue = (1 + GC.getGame().getSmallFakeRandNum(10, iUnitLoop + GET_PLAYER(ePlayer).getNumUnits() )) * 100;
+			iValue = GC.getGame().randRangeInclusive(1, 10, static_cast<uint>(iUnitLoop) + static_cast<uint>(GET_PLAYER(ePlayer).getNumUnits())) * 100;
 			iValue += iBonusValue;
 
 			if(iValue > iBestValue)
@@ -9175,7 +9175,7 @@ UnitTypes CvGame::GetCsGiftSpawnUnitType(PlayerTypes ePlayer, bool bIncludeShips
 	}
 
 	// Choose from weighted unit types
-	return PseudoRandomChoiceByWeight(veUnitRankings, NO_UNIT, /*5*/ GD_INT_GET(UNIT_SPAWN_NUM_CHOICES), kPlayer.getNumUnits() + kPlayer.GetTreasury()->GetLifetimeGrossGold());
+	return PseudoRandomChoiceByWeight(veUnitRankings, NO_UNIT, /*5*/ GD_INT_GET(UNIT_SPAWN_NUM_CHOICES), static_cast<uint>(kPlayer.getNumUnits()) + static_cast<uint>(kPlayer.GetTreasury()->GetLifetimeGrossGold()));
 }
 #endif
 #if defined(MOD_BALANCE_CORE)
@@ -9215,7 +9215,7 @@ bool CvGame::DoSpawnUnitsAroundTargetCity(PlayerTypes ePlayer, CvCity* pCity, in
 		if(pPlot->getNumUnits() > 0)
 			continue;
 
-		int iTempWeight = getSmallFakeRandNum(10, GET_PLAYER(pCity->getOwner()).GetMilitaryMight()+pPlot->GetPlotIndex());
+		int iTempWeight = randRangeExclusive(0, 10, static_cast<uint>(GET_PLAYER(pCity->getOwner()).GetMilitaryMight()) + pPlot->GetPseudoRandomSeed());
 
 		// Add weight if there's an improvement here!
 		if(pPlot->getImprovementType() != NO_IMPROVEMENT)
@@ -9357,7 +9357,7 @@ bool CvGame::DoSpawnUnitsAroundTargetCity(PlayerTypes ePlayer, CvCity* pCity, in
 UnitTypes CvGame::GetRandomUniqueUnitType(bool bIncludeCivsInGame, bool bIncludeStartEra, bool bIncludeOldEras, bool bIncludeRanged, bool bCoastal, int iPlotX, int iPlotY)
 {
 	// Find the unique units that have already been assigned
-	int iRandomSeed = 0;
+	uint uRandomSeed = 0;
 	std::set<UnitTypes> setUniquesAlreadyAssigned;
 	for(int iMinorLoop = MAX_MAJOR_CIVS; iMinorLoop < MAX_CIV_PLAYERS; iMinorLoop++)
 	{
@@ -9365,7 +9365,7 @@ UnitTypes CvGame::GetRandomUniqueUnitType(bool bIncludeCivsInGame, bool bInclude
 		CvPlayer* pMinorLoop = &GET_PLAYER(eMinorLoop);
 		if(pMinorLoop && pMinorLoop->isEverAlive())
 		{
-			iRandomSeed += pMinorLoop->GetID(); //needed later
+			uRandomSeed += static_cast<uint>(pMinorLoop->GetID()); //needed later
 			UnitTypes eUniqueUnit = pMinorLoop->GetMinorCivAI()->GetUniqueUnit();
 			if(eUniqueUnit != NO_UNIT)
 			{
@@ -9490,7 +9490,7 @@ UnitTypes CvGame::GetRandomUniqueUnitType(bool bIncludeCivsInGame, bool bInclude
 			if (setUniquesAlreadyAssigned.count(eLoopUnit) > 0)
 				continue;
 
-			int iRandom = getSmallFakeRandNum(300, iPlotX + iPlotY + iUnitLoop);
+			int iRandom = randRangeExclusive(0, 300, static_cast<uint>(iPlotX) + static_cast<uint>(iPlotY) + static_cast<uint>(iUnitLoop));
 
 			//Weight minor civ gift units higher, so they're more likely to spawn each game (Careful, +50 caused Minor Civs Gifts to take up more than 50% of Military UU slots).
 			if (pkUnitInfo->IsMinorCivGift())
@@ -9505,7 +9505,7 @@ UnitTypes CvGame::GetRandomUniqueUnitType(bool bIncludeCivsInGame, bool bInclude
 			break;
 	}
 
-	return PseudoRandomChoiceByWeight(veUnitRankings, NO_UNIT, /*5*/ GD_INT_GET(UNIT_SPAWN_NUM_CHOICES), iRandomSeed);
+	return PseudoRandomChoiceByWeight(veUnitRankings, NO_UNIT, /*5*/ GD_INT_GET(UNIT_SPAWN_NUM_CHOICES), uRandomSeed);
 }
 
 //	--------------------------------------------------------------------------------
@@ -10347,7 +10347,7 @@ void CvGame::testVictory()
 			{
 				if(isVictoryAvailable(eVictory))
 				{
-					iRand = GC.getGame().getSmallFakeRandNum(iNumCompetitionWinners, iNumCompetitionWinners + iVictoryLoop);
+					iRand = GC.getGame().randRangeExclusive(0, iNumCompetitionWinners, static_cast<uint>(iNumCompetitionWinners) + static_cast<uint>(iVictoryLoop));
 					iTeamLoop = m_aiTeamCompetitionWinnersScratchPad[iRand];
 
 					DoPlaceTeamInVictoryCompetition(eVictory, (TeamTypes) iTeamLoop);
@@ -10483,9 +10483,9 @@ void CvGame::testVictory()
 	// Two things can set this to true: either someone has finished an insta-win victory, or the game-ending tech has been researched and we're now tallying VPs
 	if(bEndGame && !aaiGameWinners.empty())
 	{
-		int iWinner = getSmallFakeRandNum(aaiGameWinners.size(), aaiGameWinners.size());
-		CUSTOMLOG("Calling setWinner from testVictory: %i, %i", aaiGameWinners[iWinner][0], aaiGameWinners[iWinner][1]);
-		setWinner(((TeamTypes)aaiGameWinners[iWinner][0]), ((VictoryTypes)aaiGameWinners[iWinner][1]));
+		uint uWinner = urandLimitExclusive(aaiGameWinners.size(), aaiGameWinners.size());
+		CUSTOMLOG("Calling setWinner from testVictory: %i, %i", aaiGameWinners[uWinner][0], aaiGameWinners[uWinner][1]);
+		setWinner(((TeamTypes)aaiGameWinners[uWinner][0]), ((VictoryTypes)aaiGameWinners[uWinner][1]));
 	}
 
 	if(getVictory() == NO_VICTORY)
@@ -10554,7 +10554,7 @@ void CvGame::doVictoryRandomization()
 		if (pkVictoryInfo->isConquest())
 			continue;
 
-		int iScore = getSmallFakeRandNum(100, GC.getGame().GetGameCulture()->GetNumGreatWorks()+ iVictoryLoop);
+		int iScore = randRangeExclusive(0, 100, static_cast<uint>(GC.getGame().GetGameCulture()->GetNumGreatWorks()) + static_cast<uint>(iVictoryLoop));
 		
 		if (pkVictoryInfo->isDiploVote())
 		{
@@ -10748,7 +10748,6 @@ int CvGame::getAsyncRandNum(int iNum, const char* pszLog)
 	return (int)GC.getASyncRand().get(-iNum, pszLog)*(-1);
 }
 
-#if defined(MOD_CORE_REDUCE_RANDOMNESS)
 //	--------------------------------------------------------------------------------
 // Get a fake random number which depends only on game state
 // for small numbers (e.g. direction rolls) this should be good enough
@@ -10775,123 +10774,65 @@ unsigned long hash32(unsigned long x)
 }
 */
 
-static unsigned long giLastState = 0;
-
-int CvGame::getSmallFakeRandNum(int iNum, const CvPlot& input) const
+uint CvGame::randCore(uint extraSeed) const
 {
-	//do not use turnslice here, it changes after reload!
-	//do not use the active player either, it can be different on both ends of a MP game
-	unsigned long iState = input.getX()*17 + input.getY()*23 + getGameTurn()*37;
+	// The game's current turn modified in some unusual way is used as the game state seed source.
+	const uint gameStateSeed = static_cast<uint>(getGameTurn()) * 11;
+	const uint finalSeed = gameStateSeed + extraSeed;
 
-	/*
-	//safety check
-	if (iState == giLastState)
-		OutputDebugString("warning rng seed repeated\n");
-	giLastState = iState;
-	*/
-	
-	int iResult = 0;
-	if (iNum > 0)
-		iResult = hash32(iState) % iNum;
-	else if (iNum < 0)
-		iResult = -int(hash32(iState) % (-iNum));
-
-	/*
-	FILogFile* pLog = LOGFILEMGR.GetLog("FakeRandCalls1.csv", FILogFile::kDontTimeStamp);
-	if (pLog)
-	{
-		char szOut[1024] = { 0 };
-		sprintf_s(szOut, "turn %d, turnslice %d, max %d, res %d, seed (%d:%d)\n", getGameTurn(), getTurnSlice(), iNum, iResult, input.getX(), input.getY());
-		pLog->Msg(szOut);
-	}
-	*/
-
-	return iResult;
+	// The final seed value is fed into hash32 to yield a pseudo random number.
+	return hash32(finalSeed);
 }
 
-int CvGame::getSmallFakeRandNum(int iNum, int iExtraSeed) const
+uint CvGame::urandLimitExclusive(uint limit, uint extraSeed) const
 {
-	//do not use turnslice here, it changes after reload!
-	//do not use the active player either, it can be different on both ends of a MP game
-	unsigned long iState = getGameTurn()*11 + abs(iExtraSeed);
-
-	/*
-	//safety check
-	if (iState == giLastState)
-		OutputDebugString("warning rng seed repeated\n");
-	giLastState = iState;
-	*/
-
-	int iResult = 0;
-	if (iNum > 0)
-		iResult = hash32(iState) % iNum;
-	else if (iNum < 0)
-		iResult = -int(hash32(iState) % (-iNum));
-
-	/*
-	FILogFile* pLog = LOGFILEMGR.GetLog("FakeRandCalls2.csv", FILogFile::kDontTimeStamp);
-	if (pLog)
-	{
-		char szOut[1024] = { 0 };
-		sprintf_s(
-			szOut, 
-			"turn %d, turnslice %d, activePlayer %d, max %d, res %d, seed %d\n", 
-			getGameTurn(), 
-			getTurnSlice(), 
-			getActivePlayer(),
-			iNum, 
-			iResult, 
-			iExtraSeed
-		);
-		pLog->Msg(szOut);
-	}
-	*/
-
-	return iResult;
+	ASSERT(limit != 0);
+	const uint rand = randCore(extraSeed);
+	return rand % limit;
 }
 
-int CvGame::getSmallFakeRandNum(int iNum, int iExtraSeed, const CvPlot& input) const
+uint CvGame::urandLimitInclusive(uint limit, uint extraSeed) const
 {
-	//do not use turnslice here, it changes after reload!
-	//do not use the active player either, it can be different on both ends of a MP game
-	unsigned long iState = getGameTurn()*29 + abs(iExtraSeed) + input.getX()*41 + input.getY()*13;
-
-	/*
-	//safety check
-	if (iState == giLastState)
-		OutputDebugString("warning rng seed repeated\n");
-	giLastState = iState;
-	*/
-
-	int iResult = 0;
-	if (iNum > 0)
-		iResult = hash32(iState) % iNum;
-	else if (iNum < 0)
-		iResult = -int(hash32(iState) % (-iNum));
-
-	/*
-	FILogFile* pLog = LOGFILEMGR.GetLog("FakeRandCalls2.csv", FILogFile::kDontTimeStamp);
-	if (pLog)
+	if (limit == 0)
 	{
-		char szOut[1024] = { 0 };
-		sprintf_s(
-			szOut, 
-			"turn %d, turnslice %d, activePlayer %d, max %d, res %d, seed %d\n", 
-			getGameTurn(), 
-			getTurnSlice(), 
-			getActivePlayer(),
-			iNum, 
-			iResult, 
-			iExtraSeed
-		);
-		pLog->Msg(szOut);
+		return 0;
 	}
-	*/
 
-	return iResult;
+	const uint rand = randCore(extraSeed);
+	if (limit == UINT_MAX)
+	{
+		return rand;
+	}
+	else
+	{
+		return rand % (limit + 1);
+	}
 }
 
-#endif
+uint CvGame::urandRangeExclusive(uint min, uint max, uint extraSeed) const
+{
+	ASSERT(min < max);
+	return urandLimitExclusive(max - min, extraSeed) + min;
+}
+
+uint CvGame::urandRangeInclusive(uint min, uint max, uint extraSeed) const
+{
+	ASSERT(min <= max);
+	return urandLimitInclusive(max - min, extraSeed) + min;
+}
+
+int CvGame::randRangeExclusive(int min, int max, uint extraSeed) const
+{
+	ASSERT(min < max);
+	return static_cast<int>(urandLimitExclusive(static_cast<uint>(max) - static_cast<uint>(min), extraSeed) + static_cast<uint>(min));
+}
+
+int CvGame::randRangeInclusive(int min, int max, uint extraSeed) const
+{
+	ASSERT(min <= max);
+	return static_cast<int>(urandLimitInclusive(static_cast<uint>(max) - static_cast<uint>(min), extraSeed) + static_cast<uint>(min));
+}
+
 
 //	--------------------------------------------------------------------------------
 int CvGame::calculateSyncChecksum()
@@ -13487,7 +13428,7 @@ int CalculateDigSiteWeight(int iIndex, vector<CvArchaeologyData>& inputData, vec
 		if (iBaseWeight > 0)
 		{
 			// add a small random factor
-			iBaseWeight += 10 + GC.getGame().getSmallFakeRandNum(10, iBaseWeight);
+			iBaseWeight += 10 + GC.getGame().randRangeExclusive(0, 10, static_cast<uint>(iBaseWeight));
 
 			// increase the value if unowned
 			iBaseWeight *= (pPlot->getOwner() == NO_PLAYER) ? 9 : 8;
@@ -13637,9 +13578,9 @@ PlayerTypes GetRandomMajorPlayer(CvPlot* pPlot)
 	}
 
 
-	int iValue = GC.getGame().getSmallFakeRandNum(tempPlayers.size(), *pPlot);
+	uint uValue = GC.getGame().urandLimitExclusive(tempPlayers.size(), pPlot->GetPseudoRandomSeed());
 
-	PlayerTypes ePlayer = (PlayerTypes)tempPlayers[iValue];
+	PlayerTypes ePlayer = static_cast<PlayerTypes>(tempPlayers[uValue]);
 
 	if (ePlayer == NO_PLAYER)
 		return BARBARIAN_PLAYER;
@@ -13666,9 +13607,9 @@ PlayerTypes GetRandomPlayer(CvPlot* pPlot)
 	}
 
 
-	int iValue = GC.getGame().getSmallFakeRandNum(tempPlayers.size(), *pPlot);
+	uint uValue = GC.getGame().urandLimitExclusive(tempPlayers.size(), pPlot->GetPseudoRandomSeed());
 
-	PlayerTypes ePlayer = (PlayerTypes)tempPlayers[iValue];
+	PlayerTypes ePlayer = static_cast<PlayerTypes>(tempPlayers[uValue]);
 
 	if (ePlayer == NO_PLAYER)
 		return BARBARIAN_PLAYER;
@@ -13831,7 +13772,7 @@ void CvGame::SpawnArchaeologySitesHistorically()
 					eEra = eEra > static_cast<EraTypes>(0) ? eEra : static_cast<EraTypes>(0);
 
 					// pick a type of artifact
-					GreatWorkArtifactClass eArtifact = aRandomArtifacts[getSmallFakeRandNum(aRandomArtifactsCount, *pPlot)];
+					GreatWorkArtifactClass eArtifact = aRandomArtifacts[urandLimitExclusive(aRandomArtifactsCount, pPlot->GetPseudoRandomSeed())];
 
 					PopulateDigSite(*pPlot, eEra, eArtifact);
 
@@ -13894,7 +13835,7 @@ void CvGame::SpawnArchaeologySitesHistorically()
 		CvPlot* pPlot = theMap.plotByIndexUnchecked(iBestSite);
 
 		// Hidden site?
-		bool bHiddenSite = GC.getGame().getSmallFakeRandNum(100, *pPlot)  < /*30*/ GD_INT_GET(PERCENT_SITES_HIDDEN);
+		bool bHiddenSite = GC.getGame().randRangeExclusive(0, 100, pPlot->GetPseudoRandomSeed())  < /*30*/ GD_INT_GET(PERCENT_SITES_HIDDEN);
 		if (bHiddenSite)
 		{
 			pPlot->setResourceType(eHiddenArtifactResourceType, 1);
@@ -13914,7 +13855,7 @@ void CvGame::SpawnArchaeologySitesHistorically()
 
 			// pick a type of artifact
 			GreatWorkArtifactClass eArtifact;
-			eArtifact = aRandomArtifacts[getSmallFakeRandNum(aRandomArtifactsCount, *pPlot)];
+			eArtifact = aRandomArtifacts[urandLimitExclusive(aRandomArtifactsCount, pPlot->GetPseudoRandomSeed())];
 
 			PopulateDigSite(*pPlot, eEra, eArtifact);
 		}
@@ -13926,7 +13867,7 @@ void CvGame::SpawnArchaeologySitesHistorically()
 			pPlot->SetArtifactType(CvTypes::getARTIFACT_WRITING());
 
 			// Then get a writing and set it
-			int iIndex = getSmallFakeRandNum(aWorksWriting.size(), aWorksWriting.size()+pPlot->GetPlotIndex());
+			int iIndex = urandLimitExclusive(aWorksWriting.size(), aWorksWriting.size() + pPlot->GetPseudoRandomSeed());
 			GreatWorkType eWrittenGreatWork = aWorksWriting[iIndex];
 			pPlot->SetArtifactGreatWork((GreatWorkType)eWrittenGreatWork);
 

--- a/CvGameCoreDLL_Expansion2/CvGame.h
+++ b/CvGameCoreDLL_Expansion2/CvGame.h
@@ -505,12 +505,43 @@ public:
 	int getJonRandNumVA(int iNum, const char* pszLog, ...);
 	int getAsyncRandNum(int iNum, const char* pszLog);
 
-#if defined(MOD_CORE_REDUCE_RANDOMNESS)
-	//get random number from gamestate without a seed in the generator
-	int	getSmallFakeRandNum(int iNum, const CvPlot& input) const;
-	int	getSmallFakeRandNum(int iNum, int iExtraSeed) const;
-	int	getSmallFakeRandNum(int iNum, int iExtraSeed, const CvPlot& input) const;
-#endif
+	/// Generates a pseudo-random 32-bit number using the game's current state and an extra seed value.
+	///
+	/// Understand that the number returned by this function is pseudo-random, but consistent given the inputs.
+	uint randCore(uint extraSeed) const;
+
+	/// Generates a psuedo-random unsigned integer using `randCore` and bounds it within an exclusive range of `0` and `limit`.
+	///
+	/// The following invariants must be satisfied for the function to operate correctly:
+	/// - `limit != 0`.
+	uint urandLimitExclusive(uint limit, uint extraSeed) const;
+
+	/// Generates a psuedo-random unsigned integer using `randCore` and bounds it within an inclusive range of `0` and `limit`.
+	uint urandLimitInclusive(uint limit, uint extraSeed) const;
+
+	/// Generates a psuedo-random unsigned integer using `randCore` and bounds it within an exclusive range of `min` and `max`.
+	///
+	/// The following invariants must be satisfied for the function to operate correctly:
+	/// - `min < max`.
+	uint urandRangeExclusive(uint min, uint max, uint extraSeed) const;
+
+	/// Generates a psuedo-random unsigned integer using `randCore` and bounds it within an inclusive range of `min` and `max`.
+	///
+	/// The following invariants must be satisfied for the function to operate correctly:
+	/// - `min <= max`.
+	uint urandRangeInclusive(uint min, uint max, uint extraSeed) const;
+
+	/// Generates a psuedo-random signed integer using `randCore` and bounds it within an exclusive range of `min` and `max`.
+	///
+	/// The following invariants must be satisfied for the function to operate correctly:
+	/// - `min < max`.
+	int randRangeExclusive(int min, int max, uint extraSeed) const;
+
+	/// Generates a psuedo-random signed integer using `randCore` and bounds it within an inclusive range of `min` and `max`.
+	///
+	/// The following invariants must be satisfied for the function to operate correctly:
+	/// - `min <= max`.
+	int randRangeInclusive(int min, int max, uint extraSeed) const;
 
 	int calculateSyncChecksum();
 	int calculateOptionsChecksum();

--- a/CvGameCoreDLL_Expansion2/CvGameCoreDLLPCH.h
+++ b/CvGameCoreDLL_Expansion2/CvGameCoreDLLPCH.h
@@ -37,6 +37,7 @@
 #define FLAG_ENUM __attribute__((flag_enum))
 #define BUILTIN_UNREACHABLE() __builtin_unreachable()
 #define BUILTIN_TRAP() __builtin_trap()
+#define BUILTIN_ASSUME(expr) __builtin_assume(expr)
 #elif defined(_MSC_VER)
 #include <intrin.h>
 #define CLOSED_ENUM
@@ -44,6 +45,7 @@
 #define FLAG_ENUM
 #define BUILTIN_UNREACHABLE() __assume(0)
 #define BUILTIN_TRAP() do { __ud2(); __assume(0); } while(0)
+#define BUILTIN_ASSUME(expr) __assume(expr)
 #else
 #error Unrecognized compiler
 #endif // defined(__clang__)
@@ -53,6 +55,12 @@
 #else
 #define ENUM_META_VALUE
 #endif // __cplusplus >= 201103L
+
+#if __cplusplus >= 201703L
+#define NODISCARD [[nodiscard]]
+#else
+#define NODISCARD
+#endif // __cplusplus >= 201703L
 
 /// Asserts that the given expression is true.
 ///

--- a/CvGameCoreDLL_Expansion2/CvGameCoreUtils.h
+++ b/CvGameCoreDLL_Expansion2/CvGameCoreUtils.h
@@ -432,7 +432,7 @@ struct OptionWithScore
 };
 
 template<class T>
-T PseudoRandomChoiceByWeight(vector<OptionWithScore<T>>& candidates, const T& defaultChoice, int maxCandidatesToConsider, uint randomSeed)
+T PseudoRandomChoiceByWeight(vector<OptionWithScore<T>>& candidates, const T& defaultChoice, int maxCandidatesToConsider, CvSeeder randomSeed)
 {
 	if (candidates.empty())
 		return defaultChoice;

--- a/CvGameCoreDLL_Expansion2/CvGameCoreUtils.h
+++ b/CvGameCoreDLL_Expansion2/CvGameCoreUtils.h
@@ -432,7 +432,7 @@ struct OptionWithScore
 };
 
 template<class T>
-T PseudoRandomChoiceByWeight(vector<OptionWithScore<T>>& candidates, const T& defaultChoice, int maxCandidatesToConsider, int randomSeed)
+T PseudoRandomChoiceByWeight(vector<OptionWithScore<T>>& candidates, const T& defaultChoice, int maxCandidatesToConsider, uint randomSeed)
 {
 	if (candidates.empty())
 		return defaultChoice;
@@ -447,7 +447,7 @@ T PseudoRandomChoiceByWeight(vector<OptionWithScore<T>>& candidates, const T& de
 	for (size_t i = 0; i < maxCandidates; i++)
 		totalWeight += candidates[i].score;
 
-	int index = GC.getGame().getSmallFakeRandNum(10, randomSeed);
+	int index = GC.getGame().randRangeExclusive(0, 10, randomSeed);
 	int selectedWeight = (totalWeight*index) / 10;
 
 	int weight = 0;

--- a/CvGameCoreDLL_Expansion2/CvGameQueries.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGameQueries.cpp
@@ -105,7 +105,7 @@ UnitClassTypes CvGameQueries::GetLeastAdvancedUnitClassNobodyHas(bool bUseRandom
 			// Add a random bit so that the same Unit isn't ALWAYS picked
 			if (bUseRandom)
 			{
-				iWeight += GC.getGame().randRangeInclusive(0, iWeight / 10, static_cast<uint>(iWeight) + static_cast<uint>(i));
+				iWeight += GC.getGame().randRangeInclusive(0, iWeight / 10, CvSeeder(iWeight).mix(i));
 			}
 
 			UnitClassesVector.push_back(i, iWeight);

--- a/CvGameCoreDLL_Expansion2/CvGameQueries.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGameQueries.cpp
@@ -105,7 +105,7 @@ UnitClassTypes CvGameQueries::GetLeastAdvancedUnitClassNobodyHas(bool bUseRandom
 			// Add a random bit so that the same Unit isn't ALWAYS picked
 			if (bUseRandom)
 			{
-				iWeight += GC.getGame().getSmallFakeRandNum(iWeight / 10, iWeight + i);
+				iWeight += GC.getGame().randRangeInclusive(0, iWeight / 10, static_cast<uint>(iWeight) + static_cast<uint>(i));
 			}
 
 			UnitClassesVector.push_back(i, iWeight);

--- a/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
@@ -2459,8 +2459,8 @@ void CvHomelandAI::ExecuteFirstTurnSettlerMoves()
 		CvPlot* pLoopPlotSearch = NULL;
 		for (int iI = 0; iI < 3; iI++)
 		{
-			int iRandomDirection = GC.getGame().getSmallFakeRandNum(NUM_DIRECTION_TYPES, iI);
-			pLoopPlotSearch = plotDirection(pUnit->plot()->getX(), pUnit->plot()->getY(), ((DirectionTypes)iRandomDirection));
+			uint uRandomDirection = GC.getGame().urandLimitExclusive(static_cast<uint>(NUM_DIRECTION_TYPES), static_cast<uint>(iI));
+			pLoopPlotSearch = plotDirection(pUnit->plot()->getX(), pUnit->plot()->getY(), static_cast<DirectionTypes>(uRandomDirection));
 
 			if (pLoopPlotSearch != NULL && pUnit->GetDanger(pLoopPlotSearch)<INT_MAX)
 			{
@@ -2678,7 +2678,7 @@ bool CvHomelandAI::ExecuteExplorerMoves(CvUnit* pUnit)
 				}
 			}
 
-			int iRandom = GC.getGame().getSmallFakeRandNum(23,*pEvalPlot);
+			int iRandom = GC.getGame().randRangeExclusive(0, 23, pEvalPlot->GetPseudoRandomSeed());
 			int iTotalScore = iScoreBase+iScoreExtra+iScoreBonus+iRandom;
 
 			//careful with plots that are too dangerous

--- a/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
@@ -2459,7 +2459,7 @@ void CvHomelandAI::ExecuteFirstTurnSettlerMoves()
 		CvPlot* pLoopPlotSearch = NULL;
 		for (int iI = 0; iI < 3; iI++)
 		{
-			uint uRandomDirection = GC.getGame().urandLimitExclusive(static_cast<uint>(NUM_DIRECTION_TYPES), static_cast<uint>(iI));
+			uint uRandomDirection = GC.getGame().urandLimitExclusive(static_cast<uint>(NUM_DIRECTION_TYPES), CvSeeder(iI));
 			pLoopPlotSearch = plotDirection(pUnit->plot()->getX(), pUnit->plot()->getY(), static_cast<DirectionTypes>(uRandomDirection));
 
 			if (pLoopPlotSearch != NULL && pUnit->GetDanger(pLoopPlotSearch)<INT_MAX)

--- a/CvGameCoreDLL_Expansion2/CvMap.cpp
+++ b/CvGameCoreDLL_Expansion2/CvMap.cpp
@@ -548,11 +548,11 @@ CvPlot** CvMap::getNeighborsShuffled(const CvPlot* pPlot)
 		{ 3, 0, 4, 1, 2, 5 },
 		{ 1, 2, 4, 5, 0, 3 } };
 
-	int iShuffleType = GC.getGame().getSmallFakeRandNum(3, *pPlot);
+	uint uShuffleType = GC.getGame().urandLimitExclusive(3, pPlot->GetPseudoRandomSeed());
 	int iBaseIndex = plotNum(pPlot->getX(), pPlot->getY())*(NUM_DIRECTION_TYPES + 2);
 
 	for (int i = 0; i < NUM_DIRECTION_TYPES; i++)
-		m_apShuffledNeighbors[i] = m_pPlotNeighbors[iBaseIndex + aiShuffle[iShuffleType][i]];
+		m_apShuffledNeighbors[i] = m_pPlotNeighbors[iBaseIndex + aiShuffle[uShuffleType][i]];
 
 	return m_apShuffledNeighbors;
 }

--- a/CvGameCoreDLL_Expansion2/CvMilitaryAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvMilitaryAI.cpp
@@ -2189,7 +2189,7 @@ void CvMilitaryAI::DoNuke(PlayerTypes ePlayer)
 				if (bRollForNuke)
 				{
 					int iFlavorNuke = m_pPlayer->GetFlavorManager()->GetPersonalityFlavorForDiplomacy((FlavorTypes)GC.getInfoTypeForString("FLAVOR_USE_NUKE"));
-					int iRoll = GC.getGame().getSmallFakeRandNum(10, m_pPlayer->GetPseudoRandomSeed() + GET_PLAYER(ePlayer).GetPseudoRandomSeed());
+					int iRoll = GC.getGame().randRangeExclusive(0, 10, m_pPlayer->GetPseudoRandomSeed() + GET_PLAYER(ePlayer).GetPseudoRandomSeed());
 					if (iRoll <= iFlavorNuke)
 					{
 						bLaunchNuke = true;
@@ -4189,11 +4189,11 @@ CvPlot* MilitaryAIHelpers::GetCoastalWaterNearPlot(CvPlot *pTarget, bool bCheckT
 		{ 0,5,6,3,2,4,1,14,13,17,16,15,11,8,9,18,12,7,10 },
 		{ 0,2,1,5,4,3,6,14,8,15,12,18,16,9,7,11,10,13,17 },
 		{ 0,6,3,2,5,1,4,18,15,16,14,12,17,8,7,10,9,13,11 } };
-	int iShuffleType = GC.getGame().getSmallFakeRandNum(3, *pTarget);
+	uint uShuffleType = GC.getGame().urandLimitExclusive(3, pTarget->GetPseudoRandomSeed());
 
 	for(int iI = RING0_PLOTS; iI < RING2_PLOTS; iI++)
 	{
-		CvPlot* pAdjacentPlot = iterateRingPlots(pTarget->getX(), pTarget->getY(), aiShuffle[iShuffleType][iI]);
+		CvPlot* pAdjacentPlot = iterateRingPlots(pTarget->getX(), pTarget->getY(), aiShuffle[uShuffleType][iI]);
 		if(pAdjacentPlot != NULL && 
 			(!bCheckTeam || pAdjacentPlot->getTeam()==eTeam || pAdjacentPlot->getTeam()==NO_TEAM) && //ownership check
 			pAdjacentPlot->isShallowWater() && //coastal

--- a/CvGameCoreDLL_Expansion2/CvMilitaryAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvMilitaryAI.cpp
@@ -2189,7 +2189,7 @@ void CvMilitaryAI::DoNuke(PlayerTypes ePlayer)
 				if (bRollForNuke)
 				{
 					int iFlavorNuke = m_pPlayer->GetFlavorManager()->GetPersonalityFlavorForDiplomacy((FlavorTypes)GC.getInfoTypeForString("FLAVOR_USE_NUKE"));
-					int iRoll = GC.getGame().randRangeExclusive(0, 10, m_pPlayer->GetPseudoRandomSeed() + GET_PLAYER(ePlayer).GetPseudoRandomSeed());
+					int iRoll = GC.getGame().randRangeExclusive(0, 10, m_pPlayer->GetPseudoRandomSeed().mix(GET_PLAYER(ePlayer).GetPseudoRandomSeed()));
 					if (iRoll <= iFlavorNuke)
 					{
 						bLaunchNuke = true;

--- a/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
@@ -349,12 +349,12 @@ void CvMinorCivQuest::CalculateRewards(PlayerTypes ePlayer, bool bRecalc)
 	{
 		if (ePersonality == MINOR_CIV_PERSONALITY_IRRATIONAL)
 		{
-			iRandomContribution += GC.getGame().getSmallFakeRandNum(pkSmallAwardInfo->GetRandom(), kPlayer.GetPseudoRandomSeed() + m_eType) * 2;
-			iRandomContribution -= GC.getGame().getSmallFakeRandNum(pkSmallAwardInfo->GetRandom(), pMinor->GetPseudoRandomSeed() + m_eType) * 2;
+			iRandomContribution += GC.getGame().randRangeInclusive(0, pkSmallAwardInfo->GetRandom(), kPlayer.GetPseudoRandomSeed() + static_cast<uint>(m_eType)) * 2;
+			iRandomContribution -= GC.getGame().randRangeInclusive(0, pkSmallAwardInfo->GetRandom(), pMinor->GetPseudoRandomSeed() + static_cast<uint>(m_eType)) * 2;
 		}
 		else
 		{
-			iRandomContribution += GC.getGame().getSmallFakeRandNum(pkSmallAwardInfo->GetRandom(), kPlayer.GetPseudoRandomSeed()+m_eType ) * 2;
+			iRandomContribution += GC.getGame().randRangeInclusive(0, pkSmallAwardInfo->GetRandom(), kPlayer.GetPseudoRandomSeed() + static_cast<uint>(m_eType)) * 2;
 		}
 	}
 
@@ -2842,7 +2842,7 @@ void CvMinorCivQuest::DoStartQuest(int iStartTurn, PlayerTypes pCallingPlayer)
 		BuildingTypes eBuilding = pMinor->GetMinorCivAI()->GetBestBuildingForQuest(m_eAssignedPlayer, iDuration);
 
 		int iCities = pAssignedPlayer->getNumCities() - pAssignedPlayer->GetNumPuppetCities();
-		int iActionAmount = GC.getGame().getSmallFakeRandNum(4, pAssignedPlayer->GetPseudoRandomSeed());
+		int iActionAmount = GC.getGame().randRangeExclusive(0, 4, pAssignedPlayer->GetPseudoRandomSeed());
 		if (iActionAmount == 1)
 		{
 			iActionAmount = iCities;
@@ -2854,7 +2854,7 @@ void CvMinorCivQuest::DoStartQuest(int iStartTurn, PlayerTypes pCallingPlayer)
 		else
 		{
 			int iSomewhereInBetween = iCities - (iCities / 2) - 1;
-			iActionAmount = (iCities / 2) + GC.getGame().getSmallFakeRandNum(iSomewhereInBetween, pMinor->GetPseudoRandomSeed());
+			iActionAmount = (iCities / 2) + GC.getGame().randRangeExclusive(0, iSomewhereInBetween, pMinor->GetPseudoRandomSeed());
 		}
 
 		if (iActionAmount > iCities)
@@ -2874,7 +2874,7 @@ void CvMinorCivQuest::DoStartQuest(int iStartTurn, PlayerTypes pCallingPlayer)
 	case MINOR_CIV_QUEST_SPY_ON_MAJOR:
 	{
 		CvCity* pCity = pMinor->GetMinorCivAI()->GetBestSpyTarget(m_eAssignedPlayer, false);
-		int iActionAmount = GC.getGame().getSmallFakeRandNum(3, *pCity->plot());
+		int iActionAmount = GC.getGame().randRangeExclusive(0, 3, pCity->plot()->GetPseudoRandomSeed());
 		if (iActionAmount <= 0)
 			iActionAmount = 1;
 
@@ -4525,9 +4525,7 @@ void CvMinorCivAI::DoPickPersonality()
 	CvFlavorManager* pFlavorManager = m_pPlayer->GetFlavorManager();
 	CvEnumMap<FlavorTypes, int>& pFlavors = pFlavorManager->GetAllPersonalityFlavors();
 
-	MinorCivPersonalityTypes eRandPersonality = (MinorCivPersonalityTypes)GC.getGame().getSmallFakeRandNum(NUM_MINOR_CIV_PERSONALITY_TYPES-1, m_pPlayer->GetID());
-	if (eRandPersonality == NO_MINOR_CIV_PERSONALITY_TYPE)
-		eRandPersonality = MINOR_CIV_PERSONALITY_FRIENDLY;
+	MinorCivPersonalityTypes eRandPersonality = static_cast<MinorCivPersonalityTypes>(GC.getGame().urandLimitExclusive(static_cast<uint>(NUM_MINOR_CIV_PERSONALITY_TYPES), static_cast<uint>(m_pPlayer->GetID())));
 
 	SetPersonality(eRandPersonality);
 #if defined(MOD_BALANCE_CORE)
@@ -4535,15 +4533,15 @@ void CvMinorCivAI::DoPickPersonality()
 #endif
 
 	// Random seed to ensure the fake RNG doesn't return the same value repeatedly
-	int iSeed = 0;
+	uint uSeed = 0;
 
 	switch (eRandPersonality)
 	{
 	case MINOR_CIV_PERSONALITY_FRIENDLY:
 	case MINOR_CIV_PERSONALITY_HOSTILE:
-		pFlavors[eFlavorCityDefense] = pFlavorManager->GetAdjustedValue(pFlavors[eFlavorCityDefense], 2, 0, 10, iSeed);
-		pFlavors[eFlavorDefense] = pFlavorManager->GetAdjustedValue(pFlavors[eFlavorDefense], 2, 0, 10, iSeed);
-		pFlavors[eFlavorOffense] = pFlavorManager->GetAdjustedValue(pFlavors[eFlavorOffense], 2, 0, 10, iSeed);
+		pFlavors[eFlavorCityDefense] = pFlavorManager->GetAdjustedValue(pFlavors[eFlavorCityDefense], 2, 0, 10, uSeed);
+		pFlavors[eFlavorDefense] = pFlavorManager->GetAdjustedValue(pFlavors[eFlavorDefense], 2, 0, 10, uSeed);
+		pFlavors[eFlavorOffense] = pFlavorManager->GetAdjustedValue(pFlavors[eFlavorOffense], 2, 0, 10, uSeed);
 		pFlavorManager->ResetToBasePersonality();
 		break;
 	default:
@@ -4953,7 +4951,8 @@ void CvMinorCivAI::DoFirstContactWithMajor(TeamTypes eTeam, bool bSuppressMessag
 					if (eRealPersonality == MINOR_CIV_PERSONALITY_IRRATIONAL) 
 					{
 						// Assumes MINOR_CIV_PERSONALITY_IRRATIONAL is the last entry in the enum
-						eFakePersonality = (MinorCivPersonalityTypes)GC.getGame().getSmallFakeRandNum(NUM_MINOR_CIV_PERSONALITY_TYPES - 1, m_pPlayer->GetPseudoRandomSeed());
+						ASSERT(static_cast<uint>(MINOR_CIV_PERSONALITY_IRRATIONAL) == static_cast<uint>(NUM_MINOR_CIV_PERSONALITY_TYPES) - 1);
+						eFakePersonality = static_cast<MinorCivPersonalityTypes>(GC.getGame().urandLimitExclusive(static_cast<uint>(MINOR_CIV_PERSONALITY_IRRATIONAL), m_pPlayer->GetPseudoRandomSeed()));
 					}
 					
 		 			// Personality modifiers - friendly = x1.5, hostile = x0.5
@@ -5040,10 +5039,10 @@ void CvMinorCivAI::DoFirstContactWithMajor(TeamTypes eTeam, bool bSuppressMessag
 							CvPlayer* pPlayer = &GET_PLAYER(ePlayer);
 							if (eTrait == MINOR_CIV_TRAIT_MILITARISTIC) {
 								if (iUnitGift > 0) {
-									if (GC.getGame().getSmallFakeRandNum(100, pPlayer->GetPseudoRandomSeed()) < iUnitGift) {
+									if (GC.getGame().randRangeExclusive(0, 100, pPlayer->GetPseudoRandomSeed()) < iUnitGift) {
 										CvUnit* pUnit = DoSpawnUnit(ePlayer, true, true);
 										if (pUnit != NULL) {
-											pUnit->changeExperienceTimes100(100 * (pPlayer->GetCurrentEra() * /*5*/ GD_INT_GET(MINOR_CIV_FIRST_CONTACT_XP_PER_ERA) + GC.getGame().getSmallFakeRandNum(/*5*/ GD_INT_GET(MINOR_CIV_FIRST_CONTACT_XP_RANDOM), pPlayer->getTotalPopulation())));
+											pUnit->changeExperienceTimes100(100 * (pPlayer->GetCurrentEra() * /*5*/ GD_INT_GET(MINOR_CIV_FIRST_CONTACT_XP_PER_ERA) + GC.getGame().randRangeExclusive(0, /*5*/ GD_INT_GET(MINOR_CIV_FIRST_CONTACT_XP_RANDOM), static_cast<uint>(pPlayer->getTotalPopulation()))));
 											iGift = pUnit->getUnitType();
 										}
 									}
@@ -5532,9 +5531,9 @@ void CvMinorCivAI::DoAddStartingResources(CvPlot* pCityPlot)
 			pCityPlot->setResourceType(NO_RESOURCE, 0, true);
 			if (veUniqueLuxuries.size() > 0)
 			{
-				int iRoll = GC.getGame().getSmallFakeRandNum(veUniqueLuxuries.size(), *pCityPlot); // range = [0, size - 1]
+				uint uRoll = GC.getGame().urandLimitExclusive(veUniqueLuxuries.size(), pCityPlot->GetPseudoRandomSeed()); // range = [0, size - 1]
 				int iQuantity = /*1*/ GD_INT_GET(MINOR_CIV_MERCANTILE_RESOURCES_QUANTITY);
-				ResourceTypes eSpecialLuxury = veUniqueLuxuries[iRoll];
+				ResourceTypes eSpecialLuxury = veUniqueLuxuries[uRoll];
 
 				pCityPlot->setResourceType(eSpecialLuxury, iQuantity, true);
 			}
@@ -6070,9 +6069,9 @@ void CvMinorCivAI::DoTestStartGlobalQuest()
 		return;
 
 	// There are valid quests, so pick one at random
-	int iRandSeed = GetNumActiveGlobalQuests() + m_pPlayer->GetPseudoRandomSeed() + GC.getGame().GetCultureMedian() + GC.getGame().GetScienceMedian();
-	int iRandIndex = GC.getGame().getSmallFakeRandNum(veValidQuests.size(), iRandSeed);
-	MinorCivQuestTypes eQuest = veValidQuests[iRandIndex];
+	uint uRandSeed = static_cast<uint>(GetNumActiveGlobalQuests()) + m_pPlayer->GetPseudoRandomSeed() + static_cast<uint>(GC.getGame().GetCultureMedian()) + static_cast<uint>(GC.getGame().GetScienceMedian());
+	uint uRandIndex = GC.getGame().urandLimitExclusive(veValidQuests.size(), uRandSeed);
+	MinorCivQuestTypes eQuest = veValidQuests[uRandIndex];
 
 	// Give out the quest
 	for (int iPlayerLoop = 0; iPlayerLoop < MAX_MAJOR_CIVS; iPlayerLoop++)
@@ -6134,9 +6133,9 @@ void CvMinorCivAI::DoTestStartPersonalQuest(PlayerTypes ePlayer)
 	if (veValidQuests.size() == 0)
 		return;
 
-	int iRandSeed = ePlayer + GetNumActiveQuestsForAllPlayers() + m_pPlayer->GetTreasury()->GetLifetimeGrossGold();
-	int iRandIndex = GC.getGame().getSmallFakeRandNum(veValidQuests.size(), iRandSeed);
-	MinorCivQuestTypes eQuest = veValidQuests[iRandIndex];
+	uint uRandSeed = static_cast<uint>(ePlayer) + static_cast<uint>(GetNumActiveQuestsForAllPlayers()) + static_cast<uint>(m_pPlayer->GetTreasury()->GetLifetimeGrossGold());
+	uint uRandIndex = GC.getGame().urandLimitExclusive(veValidQuests.size(), uRandSeed);
+	MinorCivQuestTypes eQuest = veValidQuests[uRandIndex];
 	AddQuestForPlayer(ePlayer, eQuest, GC.getGame().getGameTurn());
 
 	// Check if we need to seed the countdown timer to allow for another quest
@@ -8956,7 +8955,7 @@ void CvMinorCivAI::DoTestSeedGlobalQuestCountdown(bool bForceSeed)
 	// Quests are now available for the first time?
 	if (GC.getGame().getElapsedGameTurns() == GetFirstPossibleTurnForGlobalQuests())
 	{
-		iNumTurns += GC.getGame().getSmallFakeRandNum(/*20 in CP, 0 in VP*/ GD_INT_GET(MINOR_CIV_GLOBAL_QUEST_FIRST_POSSIBLE_TURN_RAND), m_pPlayer->GetPseudoRandomSeed() * 2);
+		iNumTurns += GC.getGame().randRangeInclusive(0, /*20 in CP, 0 in VP*/ GD_INT_GET(MINOR_CIV_GLOBAL_QUEST_FIRST_POSSIBLE_TURN_RAND), m_pPlayer->GetPseudoRandomSeed() * 2);
 	}
 	else
 	{
@@ -8968,7 +8967,7 @@ void CvMinorCivAI::DoTestSeedGlobalQuestCountdown(bool bForceSeed)
 			iRand *= /*200*/ GD_INT_GET(MINOR_CIV_GLOBAL_QUEST_RAND_TURNS_BETWEEN_HOSTILE_MULTIPLIER);
 			iRand /= 100;
 		}
-		iNumTurns += GC.getGame().getSmallFakeRandNum(iRand, m_pPlayer->GetPseudoRandomSeed() * 5);
+		iNumTurns += GC.getGame().randRangeExclusive(0, iRand, m_pPlayer->GetPseudoRandomSeed() * 5);
 	}
 
 	// Modify for Game Speed
@@ -9016,7 +9015,7 @@ void CvMinorCivAI::DoTestSeedQuestCountdownForPlayer(PlayerTypes ePlayer, bool b
 	// Quests are now available for the first time?
 	if (GC.getGame().getElapsedGameTurns() == GetFirstPossibleTurnForPersonalQuests())
 	{
-		iNumTurns += GC.getGame().getSmallFakeRandNum(/*20 in CP, 0 in VP*/ GD_INT_GET(MINOR_CIV_PERSONAL_QUEST_FIRST_POSSIBLE_TURN_RAND), m_pPlayer->GetPseudoRandomSeed());
+		iNumTurns += GC.getGame().randRangeInclusive(0, /*20 in CP, 0 in VP*/ GD_INT_GET(MINOR_CIV_PERSONAL_QUEST_FIRST_POSSIBLE_TURN_RAND), m_pPlayer->GetPseudoRandomSeed());
 	}
 	else
 	{
@@ -9028,7 +9027,7 @@ void CvMinorCivAI::DoTestSeedQuestCountdownForPlayer(PlayerTypes ePlayer, bool b
 			iRand *= /*200*/ GD_INT_GET(MINOR_CIV_PERSONAL_QUEST_RAND_TURNS_BETWEEN_HOSTILE_MULTIPLIER);
 			iRand /= 100;
 		}
-		iNumTurns += GC.getGame().getSmallFakeRandNum(iRand, m_pPlayer->GetPseudoRandomSeed() * 4);
+		iNumTurns += GC.getGame().randRangeExclusive(0, iRand, m_pPlayer->GetPseudoRandomSeed() * 4);
 	}
 
 	// Modify for Game Speed
@@ -9602,7 +9601,7 @@ PlayerTypes CvMinorCivAI::SpawnRebels()
 			iRebelBuildUp += iWar;
 		}
 
-		iRebelBuildUp += GC.getGame().getSmallFakeRandNum(GC.getGame().getCurrentEra(), m_pPlayer->GetPseudoRandomSeed());
+		iRebelBuildUp += GC.getGame().randRangeExclusive(0, GC.getGame().getCurrentEra(), m_pPlayer->GetPseudoRandomSeed());
 
 		if(iRebelBuildUp >= iRebelBoilPoint)
 		{
@@ -9644,7 +9643,7 @@ void CvMinorCivAI::DoRebellion()
 	int iNumRebels = GetPlayer()->getNumMilitaryUnits() * /*60*/ GD_INT_GET(MINOR_QUEST_REBELLION_BARBS_PER_CS_UNIT); //Based on number of military units of CS.
 	int iExtraRoll = GC.getGame().getCurrentEra(); //Increase possible rebel spawns as game continues.
 	iNumRebels += iExtraRoll * /*0*/ GD_INT_GET(MINOR_QUEST_REBELLION_BARBS_PER_ERA_BASE);
-	iNumRebels += GC.getGame().getSmallFakeRandNum(iExtraRoll,m_pPlayer->GetMilitaryMight()) * /*200*/ GD_INT_GET(MINOR_QUEST_REBELLION_BARBS_PER_ERA_RAND);
+	iNumRebels += GC.getGame().randRangeExclusive(0, iExtraRoll, static_cast<uint>(m_pPlayer->GetMilitaryMight())) * /*200*/ GD_INT_GET(MINOR_QUEST_REBELLION_BARBS_PER_ERA_RAND);
 	iNumRebels /= 100;
 
 	if (iNumRebels < /*2*/ GD_INT_GET(MINOR_QUEST_REBELLION_BARBS_MIN))
@@ -9872,8 +9871,8 @@ ResourceTypes CvMinorCivAI::GetNearbyResourceForQuest(PlayerTypes ePlayer)
 	if (veValidResources.size() == 0)
 		return NO_RESOURCE;
 	
-	int iRandIndex = GC.getGame().getSmallFakeRandNum(veValidResources.size(), m_pPlayer->GetPseudoRandomSeed() + GET_PLAYER(ePlayer).GetPseudoRandomSeed() + veValidResources.size());
-	return veValidResources[iRandIndex];
+	uint uRandIndex = GC.getGame().urandLimitExclusive(veValidResources.size(), m_pPlayer->GetPseudoRandomSeed() + GET_PLAYER(ePlayer).GetPseudoRandomSeed() + veValidResources.size());
+	return veValidResources[uRandIndex];
 }
 
 /// Best wonder for a Quest given to ePlayer?
@@ -10019,8 +10018,8 @@ BuildingTypes CvMinorCivAI::GetBestWorldWonderForQuest(PlayerTypes ePlayer, int 
 	if (veValidBuildings.size() == 0)
 		return NO_BUILDING;
 
-	int iRandIndex = GC.getGame().getSmallFakeRandNum(veValidBuildings.size(), m_pPlayer->GetPseudoRandomSeed() + GET_PLAYER(ePlayer).GetPseudoRandomSeed() + veValidBuildings.size());
-	return veValidBuildings[iRandIndex];
+	uint uRandIndex = GC.getGame().urandLimitExclusive(veValidBuildings.size(), m_pPlayer->GetPseudoRandomSeed() + GET_PLAYER(ePlayer).GetPseudoRandomSeed() + veValidBuildings.size());
+	return veValidBuildings[uRandIndex];
 }
 
 /// Best national wonder for a Quest given to ePlayer?
@@ -10121,8 +10120,8 @@ BuildingTypes CvMinorCivAI::GetBestNationalWonderForQuest(PlayerTypes ePlayer, i
 	if (veValidBuildings.size() == 0)
 		return NO_BUILDING;
 
-	int iRandIndex = GC.getGame().getSmallFakeRandNum(veValidBuildings.size(), m_pPlayer->GetPseudoRandomSeed() + GET_PLAYER(ePlayer).GetPseudoRandomSeed() + veValidBuildings.size());
-	return veValidBuildings[iRandIndex];
+	uint uRandIndex = GC.getGame().urandLimitExclusive(veValidBuildings.size(), m_pPlayer->GetPseudoRandomSeed() + GET_PLAYER(ePlayer).GetPseudoRandomSeed() + veValidBuildings.size());
+	return veValidBuildings[uRandIndex];
 }
 
 /// Anyone that this City State would want ePlayer to liberate?
@@ -10216,8 +10215,8 @@ PlayerTypes CvMinorCivAI::GetBestCityStateLiberate(PlayerTypes ePlayer)
 	if (veValidTargets.size() == 0)
 		return NO_PLAYER;
 
-	int iRandIndex = GC.getGame().getSmallFakeRandNum(veValidTargets.size(), m_pPlayer->GetPseudoRandomSeed() + GET_PLAYER(ePlayer).GetPseudoRandomSeed() + veValidTargets.size());
-	return veValidTargets[iRandIndex];
+	uint uRandIndex = GC.getGame().urandLimitExclusive(veValidTargets.size(), m_pPlayer->GetPseudoRandomSeed() + GET_PLAYER(ePlayer).GetPseudoRandomSeed() + veValidTargets.size());
+	return veValidTargets[uRandIndex];
 }
 
 /// Find a Great Person that a Minor would want a major to spawn
@@ -10307,8 +10306,8 @@ UnitTypes CvMinorCivAI::GetBestGreatPersonForQuest(PlayerTypes ePlayer)
 	if (veValidUnits.size() == 0)
 		return NO_UNIT;
 
-	int iRandIndex = GC.getGame().getSmallFakeRandNum(veValidUnits.size(), m_pPlayer->GetPseudoRandomSeed() + GET_PLAYER(ePlayer).GetPseudoRandomSeed() + veValidUnits.size());
-	return veValidUnits[iRandIndex];
+	uint uRandIndex = GC.getGame().urandLimitExclusive(veValidUnits.size(), m_pPlayer->GetPseudoRandomSeed() + GET_PLAYER(ePlayer).GetPseudoRandomSeed() + veValidUnits.size());
+	return veValidUnits[uRandIndex];
 }
 
 /// Anyone that this City State would want to kill / bully?
@@ -10466,8 +10465,8 @@ PlayerTypes CvMinorCivAI::GetBestCityStateTarget(PlayerTypes ePlayer, bool bKill
 		}
 	}
 
-	int iRandIndex = GC.getGame().getSmallFakeRandNum(veTargetChoices.size(), m_pPlayer->GetPseudoRandomSeed());
-	return veTargetChoices[iRandIndex];
+	uint uRandIndex = GC.getGame().urandLimitExclusive(veTargetChoices.size(), m_pPlayer->GetPseudoRandomSeed());
+	return veTargetChoices[uRandIndex];
 }
 
 CvCity* CvMinorCivAI::GetBestCityForQuest(PlayerTypes ePlayer)
@@ -10680,8 +10679,8 @@ BuildingTypes CvMinorCivAI::GetBestBuildingForQuest(PlayerTypes ePlayer, int iDu
 	if (veValidBuildings.size() == 0)
 		return NO_BUILDING;
 
-	int iRandIndex = GC.getGame().getSmallFakeRandNum(veValidBuildings.size(), m_pPlayer->GetPseudoRandomSeed() + GET_PLAYER(ePlayer).GetPseudoRandomSeed() + veValidBuildings.size());
-	return veValidBuildings[iRandIndex];
+	uint uRandIndex = GC.getGame().urandLimitExclusive(veValidBuildings.size(), m_pPlayer->GetPseudoRandomSeed() + GET_PLAYER(ePlayer).GetPseudoRandomSeed() + veValidBuildings.size());
+	return veValidBuildings[uRandIndex];
 }
 
 UnitTypes CvMinorCivAI::GetBestUnitGiftFromPlayer(PlayerTypes ePlayer)
@@ -10824,8 +10823,8 @@ UnitTypes CvMinorCivAI::GetBestUnitGiftFromPlayer(PlayerTypes ePlayer)
 		}
 	}
 
-	int iRandIndex = GC.getGame().getSmallFakeRandNum(veUnitChoices.size(), m_pPlayer->GetPseudoRandomSeed() + GET_PLAYER(ePlayer).GetPseudoRandomSeed() + veUnitChoices.size());
-	return veUnitChoices[iRandIndex];
+	uint uRandIndex = GC.getGame().urandLimitExclusive(veUnitChoices.size(), m_pPlayer->GetPseudoRandomSeed() + GET_PLAYER(ePlayer).GetPseudoRandomSeed() + veUnitChoices.size());
+	return veUnitChoices[uRandIndex];
 }
 
 int CvMinorCivAI::GetExperienceForUnitGiftQuest(PlayerTypes ePlayer, UnitTypes eUnitType)
@@ -11309,8 +11308,8 @@ PlayerTypes CvMinorCivAI::GetBestPlayerToFind(PlayerTypes ePlayer)
 	if (veValidTargets.size() == 0)
 		return NO_PLAYER;
 
-	int iRandIndex = GC.getGame().getSmallFakeRandNum(veValidTargets.size(), GET_PLAYER(ePlayer).getNumUnits() + GET_PLAYER(ePlayer).GetTreasury()->GetLifetimeGrossGold());
-	return veValidTargets[iRandIndex];
+	uint uRandIndex = GC.getGame().urandLimitExclusive(veValidTargets.size(), GET_PLAYER(ePlayer).getNumUnits() + GET_PLAYER(ePlayer).GetTreasury()->GetLifetimeGrossGold());
+	return veValidTargets[uRandIndex];
 }
 
 /// Any good cities to ask ePlayer to find?
@@ -11437,8 +11436,8 @@ PlayerTypes CvMinorCivAI::GetBestCityStateMeetTarget(PlayerTypes ePlayer)
 	if (veValidTargets.size() == 0)
 		return NO_PLAYER;
 
-	int iRandIndex = GC.getGame().getSmallFakeRandNum(veValidTargets.size(), m_pPlayer->GetPseudoRandomSeed() + GET_PLAYER(ePlayer).GetPseudoRandomSeed() + veValidTargets.size());
-	return veValidTargets[iRandIndex];
+	uint uRandIndex = GC.getGame().urandLimitExclusive(veValidTargets.size(), m_pPlayer->GetPseudoRandomSeed() + GET_PLAYER(ePlayer).GetPseudoRandomSeed() + veValidTargets.size());
+	return veValidTargets[uRandIndex];
 }
 
 
@@ -14729,7 +14728,7 @@ void CvMinorCivAI::DoSeedUnitSpawnCounter(PlayerTypes ePlayer, bool bBias)
 
 	// Add some randomness
 	int iRand = /*3*/ GD_INT_GET(FRIENDS_RAND_TURNS_UNIT_SPAWN);
-	iNumTurns += GC.getGame().getSmallFakeRandNum(iRand, m_pPlayer->GetPseudoRandomSeed());
+	iNumTurns += GC.getGame().randRangeExclusive(0, iRand, m_pPlayer->GetPseudoRandomSeed());
 
 	// If we're biasing the result then decrease the number of turns
 	if (bBias)
@@ -15416,7 +15415,7 @@ void CvMinorCivAI::DoBuyout(PlayerTypes eMajor)
 
 	// Send out notifications to everyone
 	TeamTypes eBuyerTeam = GET_PLAYER(eMajor).getTeam();
-	int iCoinToss = GC.getGame().getSmallFakeRandNum(1, m_pPlayer->GetPseudoRandomSeed()); // Is it a boy or a girl?
+	int iCoinToss = GC.getGame().randRangeInclusive(0, 1, m_pPlayer->GetPseudoRandomSeed()); // Is it a boy or a girl?
 
 	Localization::String strMessage;
 	Localization::String strSummary;
@@ -17702,7 +17701,7 @@ void CvMinorCivAI::DoTeamDeclaredWarOnMe(TeamTypes eEnemyTeam)
 		}
 		else
 		{
-			iRand = GC.getGame().getSmallFakeRandNum(100, m_pPlayer->GetPseudoRandomSeed());
+			iRand = GC.getGame().randRangeExclusive(0, 100, m_pPlayer->GetPseudoRandomSeed());
 
 			if (iRand < /*50 in CP, 40 in VP*/ GD_INT_GET(PERMANENT_WAR_AGGRESSOR_CHANCE))
 			{
@@ -17801,7 +17800,7 @@ void CvMinorCivAI::DoTeamDeclaredWarOnMe(TeamTypes eEnemyTeam)
 			if(GET_TEAM(pOtherMinorCiv->getTeam()).isAtWar(eEnemyTeam))
 				iChance += /*20*/ GD_INT_GET(PERMANENT_WAR_OTHER_AT_WAR);
 
-			iRand = GC.getGame().getSmallFakeRandNum(100, m_pPlayer->GetPseudoRandomSeed() + iMinorCivLoop);
+			iRand = GC.getGame().randRangeExclusive(0, 100, m_pPlayer->GetPseudoRandomSeed() + static_cast<uint>(iMinorCivLoop));
 			if(iRand < iChance)
 			{
 				if(!pOtherMinorCiv->GetMinorCivAI()->IsWaryOfTeam(eEnemyTeam))
@@ -18272,7 +18271,7 @@ TechTypes CvMinorCivAI::GetGoodTechPlayerDoesntHave(PlayerTypes ePlayer, int iRo
 				}
 
 				// Random factor so that the same thing isn't always picked
-				iValue += GC.getGame().getSmallFakeRandNum(iValue / 4, m_pPlayer->GetTreasury()->GetLifetimeGrossGold() + iTechLoop);
+				iValue += GC.getGame().randRangeExclusive(0, iValue / 4, static_cast<uint>(m_pPlayer->GetTreasury()->GetLifetimeGrossGold()) + static_cast<uint>(iTechLoop));
 
 				TechVector.push_back(iTechLoop, iValue);
 			}

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -3374,8 +3374,8 @@ CvCity* CvPlayer::acquireCity(CvCity* pCity, bool bConquest, bool bGift)
 		if (isMajorCiv())
 		{
 			iCaptureGold = /*20*/ GD_INT_GET(BASE_CAPTURE_GOLD) + (iPopulation * /*10*/ GD_INT_GET(CAPTURE_GOLD_PER_POPULATION));
-			iCaptureGold += /*2 to 40*/ GC.getGame().getSmallFakeRandNum(GD_INT_GET(CAPTURE_GOLD_RAND1), pCity->plot()->GetPlotIndex()) * 2;
-			iCaptureGold += /*2 to 40*/ GC.getGame().getSmallFakeRandNum(GD_INT_GET(CAPTURE_GOLD_RAND2), GET_PLAYER(eOldOwner).GetPseudoRandomSeed()) * 2;
+			iCaptureGold += /*2 to 40*/ GC.getGame().randRangeExclusive(0, GD_INT_GET(CAPTURE_GOLD_RAND1), pCity->plot()->GetPseudoRandomSeed()) * 2;
+			iCaptureGold += /*2 to 40*/ GC.getGame().randRangeExclusive(0, GD_INT_GET(CAPTURE_GOLD_RAND2), GET_PLAYER(eOldOwner).GetPseudoRandomSeed()) * 2;
 
 			// Reduce reward if acquired recently by the previous owner
 			if (/*50*/ GD_INT_GET(CAPTURE_GOLD_MAX_TURNS) > 0)
@@ -4846,7 +4846,7 @@ bool CvPlayer::IsValidBuildingForPlayer(CvCity* pCity, BuildingTypes eBuilding, 
 	if (!bConquest || GetPlayerTraits()->IsKeepConqueredBuildings() || IsKeepConqueredBuildings())
 		return true;
 
-	int iConquestChance = GC.getGame().getSmallFakeRandNum(100, pkLoopBuildingInfo->GetID() + GetPseudoRandomSeed(), *pCity->plot());
+	int iConquestChance = GC.getGame().randRangeExclusive(0, 100, static_cast<uint>(pkLoopBuildingInfo->GetID()) + GetPseudoRandomSeed() + pCity->plot()->GetPseudoRandomSeed());
 
 	return iConquestChance <= pkLoopBuildingInfo->GetConquestProbability();
 }
@@ -5715,7 +5715,7 @@ void CvPlayer::DoEvents()
 	if (veValidEvents.size() > 0)
 	{
 		//afw		veValidEvents.StableSortItems();
-		int iRandIndex = GC.getGame().getSmallFakeRandNum(2000, GetTreasury()->GetLifetimeGrossGold()); //afw
+		int iRandIndex = GC.getGame().randRangeExclusive(0, 2000, static_cast<uint>(GetTreasury()->GetLifetimeGrossGold())); //afw
 		if (GC.getLogging())
 		{
 			CvString strBaseString;
@@ -10274,7 +10274,7 @@ void CvPlayer::disbandUnit(bool)
 				if(pLoopUnit->getUnitInfo().GetProductionCost() > 0)
 				{
 					{
-						iValue = (10000 + GC.getGame().getSmallFakeRandNum(1000, pLoopUnit->GetID() + iLoop));
+						iValue = (10000 + GC.getGame().randRangeExclusive(0, 1000, static_cast<uint>(pLoopUnit->GetID()) + static_cast<uint>(iLoop)));
 
 						iValue += (pLoopUnit->getUnitInfo().GetProductionCost() * 5);
 						iValue += (pLoopUnit->getExperienceTimes100() / 100 * 20);
@@ -13546,7 +13546,7 @@ void CvPlayer::receiveGoody(CvPlot* pPlot, GoodyTypes eGoody, CvUnit* pUnit)
 	int iGold = kGoodyInfo.getGold();
 	if (kGoodyInfo.getNumGoldRandRolls() > 0 && kGoodyInfo.getGoldRandAmount() > 0)
 	{
-		iGold += kGoodyInfo.getNumGoldRandRolls() * GC.getGame().getSmallFakeRandNum(kGoodyInfo.getGoldRandAmount(), *pPlot);
+		iGold += kGoodyInfo.getNumGoldRandRolls() * GC.getGame().randRangeExclusive(0, kGoodyInfo.getGoldRandAmount(), pPlot->GetPseudoRandomSeed());
 	}
 
 	if (iGold > 0)
@@ -13889,7 +13889,7 @@ void CvPlayer::receiveGoody(CvPlot* pPlot, GoodyTypes eGoody, CvUnit* pUnit)
 							else
 								iRandLimit = 10000;
 #endif
-							iValue = (1 + GC.getGame().getSmallFakeRandNum(iRandLimit, *pLoopPlot));
+							iValue = (1 + GC.getGame().randRangeExclusive(0, iRandLimit, pLoopPlot->GetPseudoRandomSeed()));
 
 							iValue *= plotDistance(pPlot->getX(), pPlot->getY(), pLoopPlot->getX(), pLoopPlot->getY());
 
@@ -13923,7 +13923,7 @@ void CvPlayer::receiveGoody(CvPlot* pPlot, GoodyTypes eGoody, CvUnit* pUnit)
 				{
 					if(plotDistance(pBestPlot->getX(), pBestPlot->getY(), pLoopPlot->getX(), pLoopPlot->getY()) <= iRange)
 					{
-						if(GC.getGame().getSmallFakeRandNum(100, *pLoopPlot) < kGoodyInfo.getMapProb())
+						if(GC.getGame().randRangeExclusive(0, 100, pLoopPlot->GetPseudoRandomSeed()) < kGoodyInfo.getMapProb())
 						{
 							pLoopPlot->setRevealed(getTeam(), true);
 							iNumPlotsRevealed++;
@@ -14141,7 +14141,7 @@ void CvPlayer::receiveGoody(CvPlot* pPlot, GoodyTypes eGoody, CvUnit* pUnit)
 #endif
 					if(bUseTech)
 					{
-						iValue = (1 + GC.getGame().getSmallFakeRandNum(10, iI));
+						iValue = (1 + GC.getGame().randRangeExclusive(0, 10, static_cast<uint>(iI)));
 
 						if(iValue > iBestValue)
 						{
@@ -14207,7 +14207,7 @@ void CvPlayer::receiveGoody(CvPlot* pPlot, GoodyTypes eGoody, CvUnit* pUnit)
 									{
 										if(pLoopPlot->isRevealed(getTeam()))
 										{
-											iValue = 1 + GC.getGame().getSmallFakeRandNum(6, *pLoopPlot); // okay, I'll admit it, not a great heuristic
+											iValue = GC.getGame().randRangeInclusive(1, 6, pLoopPlot->GetPseudoRandomSeed()); // okay, I'll admit it, not a great heuristic
 
 											if(plotDistance(pPlot->getX(),pPlot->getY(),pLoopPlot->getX(),pLoopPlot->getY()) > 1)
 											{
@@ -14271,7 +14271,7 @@ void CvPlayer::receiveGoody(CvPlot* pPlot, GoodyTypes eGoody, CvUnit* pUnit)
 								{
 									if(pLoopPlot->getNumUnits() == 0)
 									{
-										if((iPass > 0) || (GC.getGame().getSmallFakeRandNum(10, *pLoopPlot) * 10 < kGoodyInfo.getBarbarianUnitProb()))
+										if((iPass > 0) || (GC.getGame().randRangeExclusive(0, 10, pLoopPlot->GetPseudoRandomSeed()) * 10 < kGoodyInfo.getBarbarianUnitProb()))
 										{
 											GET_PLAYER(BARBARIAN_PLAYER).initUnit(eUnit, pLoopPlot->getX(), pLoopPlot->getY(), ((pLoopPlot->isWater()) ? UNITAI_ATTACK_SEA : UNITAI_ATTACK));
 											iBarbCount++;
@@ -14431,12 +14431,8 @@ void CvPlayer::doGoody(CvPlot* pPlot, CvUnit* pUnit)
 			}
 			else
 			{
-#if defined(MOD_CORE_REDUCE_RANDOMNESS)
-				int iRand = GC.getGame().getSmallFakeRandNum(avValidGoodies.size(),*pPlot);
-#else
-				int iRand = GC.getGame().getJonRandNum(avValidGoodies.size(), "Picking a Goody result");
-#endif
-				eGoody = (GoodyTypes) avValidGoodies[iRand];
+				uint uRand = GC.getGame().urandLimitExclusive(avValidGoodies.size(), pPlot->GetPseudoRandomSeed());
+				eGoody = avValidGoodies[uRand];
 				receiveGoody(pPlot, eGoody, pUnit);
 #if defined(MOD_EVENTS_GOODY_CHOICE)
 				if (MOD_EVENTS_GOODY_CHOICE)
@@ -19488,7 +19484,7 @@ void CvPlayer::DoYieldsFromKill(CvUnit* pAttackingUnit, CvUnit* pDefendingUnit, 
 			doInstantGreatPersonProgress(INSTANT_YIELD_TYPE_VICTORY, false, pCapitalCity);
 			if (GetPlayerTraits()->IsRandomGreatPersonProgressFromKills())
 			{
-				std::pair <GreatPersonTypes, int> aResults = GetPlayerTraits()->GetRandomGreatPersonProgressFromKills(pAttackingUnit->GetID() + pAttackingUnit->getMoves() + pDefendingUnit->GetID() + pDefendingUnit->getMoves());
+				std::pair <GreatPersonTypes, int> aResults = GetPlayerTraits()->GetRandomGreatPersonProgressFromKills(static_cast<uint>(pAttackingUnit->GetID()) + static_cast<uint>(pAttackingUnit->getMoves()) + static_cast<uint>(pDefendingUnit->GetID()) + static_cast<uint>(pDefendingUnit->getMoves()));
 				if (aResults.first != NO_GREATPERSON && aResults.second > 0)
 				{
 					doInstantGreatPersonProgress(INSTANT_YIELD_TYPE_VICTORY, false, pCapitalCity, NO_BUILDING, aResults.second, aResults.first);
@@ -19539,8 +19535,8 @@ void CvPlayer::DoTechFromCityConquer(CvCity* pConqueredCity)
 
 	if (!vePossibleTechs.empty())
 	{
-		int iRoll = GC.getGame().getSmallFakeRandNum((int)vePossibleTechs.size(), GET_PLAYER(pConqueredCity->getOwner()).GetPseudoRandomSeed());
-		TechTypes eFreeTech = vePossibleTechs[iRoll];
+		uint uRoll = GC.getGame().urandLimitExclusive(vePossibleTechs.size(), GET_PLAYER(pConqueredCity->getOwner()).GetPseudoRandomSeed());
+		TechTypes eFreeTech = vePossibleTechs[uRoll];
 		CvAssert(eFreeTech != NO_TECH)
 		if (eFreeTech != NO_TECH)
 		{
@@ -19673,7 +19669,7 @@ void CvPlayer::DoFreeGreatWorkOnConquest(PlayerTypes ePlayer, CvCity* pCity)
 			int iNotificationArtwork = -1;
 			if (artChoices.size() > 0)
 			{
-				int iPlunder = GC.getGame().getSmallFakeRandNum(max(1, (iOpenSlots / 5)), GET_PLAYER(pCity->getOwner()).GetPseudoRandomSeed());
+				int iPlunder = GC.getGame().randRangeExclusive(0, max(1, (iOpenSlots / 5)), GET_PLAYER(pCity->getOwner()).GetPseudoRandomSeed());
 				if (iPlunder <= 2)
 				{
 					iPlunder = 2;
@@ -22083,7 +22079,7 @@ void CvPlayer::ChangeUprisingCounter(int iChange)
 /// Uprising countdown - seed
 void CvPlayer::DoResetUprisingCounter(bool bFirstTime)
 {
-	int iTurns = /*4*/ GD_INT_GET(UPRISING_COUNTER_MIN) + GC.getGame().getSmallFakeRandNum(/*3*/ GD_INT_GET(UPRISING_COUNTER_POSSIBLE), GetPseudoRandomSeed());
+	int iTurns = /*4*/ GD_INT_GET(UPRISING_COUNTER_MIN) + GC.getGame().randRangeExclusive(0, /*3*/ GD_INT_GET(UPRISING_COUNTER_POSSIBLE), GetPseudoRandomSeed());
 
 	// Game speed mod
 	int iMod = GC.getGame().getGameSpeedInfo().getTrainPercent();
@@ -22114,7 +22110,7 @@ void CvPlayer::DoUprising()
 {
 	// In hundreds
 	int iNumRebels = /*100*/ GD_INT_GET(UPRISING_NUM_BASE);
-	int iExtra = getNumCities() + GC.getGame().getSmallFakeRandNum(getNumCities(), GetPseudoRandomSeed());
+	int iExtra = getNumCities() + GC.getGame().randRangeExclusive(0, getNumCities(), GetPseudoRandomSeed());
 
 	iNumRebels += iExtra * /*20*/ GD_INT_GET(UPRISING_NUM_CITY_COUNT);
 	iNumRebels /= 100;
@@ -22128,7 +22124,7 @@ void CvPlayer::DoUprising()
 	for (CvCity* pLoopCity = firstCity(&iLoop); pLoopCity != NULL; pLoopCity = nextCity(&iLoop))
 	{
 		int iTempWeight = pLoopCity->getPopulation();
-		iTempWeight += theGame.getSmallFakeRandNum(10, GetPseudoRandomSeed() + pLoopCity->plot()->GetPlotIndex());
+		iTempWeight += theGame.randRangeExclusive(0, 10, GetPseudoRandomSeed() + pLoopCity->plot()->GetPseudoRandomSeed());
 
 		if (iTempWeight > iBestWeight)
 		{
@@ -29494,7 +29490,7 @@ void CvPlayer::doPolicyGEorGM(int iPolicyGEorGM)
 	int iValue = iPolicyGEorGM * iEra * GC.getGame().getGameSpeedInfo().getInstantYieldPercent(); // Game speed mod (note that TrainPercent is a percentage value, will need to divide by 100)
 
 	SpecialistTypes eBestSpecialist = NO_SPECIALIST;
-	int iRandom = GC.getGame().getSmallFakeRandNum(100, GetPseudoRandomSeed()+iPolicyGEorGM);
+	int iRandom = GC.getGame().randRangeExclusive(0, 100, GetPseudoRandomSeed() + static_cast<uint>(iPolicyGEorGM));
 	if (iRandom <= 33)
 	{
 		eBestSpecialist = (SpecialistTypes)GC.getInfoTypeForString("SPECIALIST_ENGINEER");
@@ -30316,7 +30312,7 @@ void CvPlayer::DoSeedGreatPeopleSpawnCounter()
 	}
 
 	int iRand = /*7*/ GD_INT_GET(MINOR_TURNS_GREAT_PEOPLE_SPAWN_RAND);
-	iNumTurns += GC.getGame().getSmallFakeRandNum(iRand, GetPseudoRandomSeed());
+	iNumTurns += GC.getGame().randRangeExclusive(0, iRand, GetPseudoRandomSeed());
 
 	// If we're biasing the result then decrease the number of turns
 	if (bBias)
@@ -30422,7 +30418,7 @@ void CvPlayer::DoSpawnGreatPerson(PlayerTypes eMinor)
 			// No prophets
 			if(!pkUnitEntry->IsFoundReligion())
 			{
-				int iScore = GC.getGame().getSmallFakeRandNum(100, GetPseudoRandomSeed() + iX + iY);
+				int iScore = GC.getGame().randRangeExclusive(0, 100, GetPseudoRandomSeed() + static_cast<uint>(iX) + static_cast<uint>(iY));
 
 				if(iScore > iBestScore)
 				{
@@ -30702,7 +30698,7 @@ void CvPlayer::DoGreatPeopleSpawnTurn()
 				if(GET_PLAYER(eMinor).GetMinorCivAI()->GetAlly() != GetID())
 					continue;
 
-				iScore = GC.getGame().getSmallFakeRandNum(100, GetPseudoRandomSeed() + iMinorLoop);
+				iScore = GC.getGame().randRangeExclusive(0, 100, GetPseudoRandomSeed() + static_cast<uint>(iMinorLoop));
 
 				// Best ally yet?
 				if(eBestMinor == NO_PLAYER || iScore > iBestScore)
@@ -30742,7 +30738,7 @@ CvCity* CvPlayer::GetGreatPersonSpawnCity(UnitTypes eUnit)
 				continue;
 			}
 
-			int iValue = 4 * GC.getGame().getSmallFakeRandNum(getNumCities(), GetPseudoRandomSeed() + iLoop);
+			int iValue = 4 * GC.getGame().randRangeExclusive(0, getNumCities(), GetPseudoRandomSeed() + static_cast<uint>(iLoop));
 
 			for(int i = 0; i < NUM_YIELD_TYPES; i++)
 			{
@@ -32798,10 +32794,10 @@ void CvPlayer::ChangeNumHistoricEvents(HistoricEventTypes eHistoricEvent, int iC
 		}
 
 		//choose one
-		int iChoice = GC.getGame().getSmallFakeRandNum(vPossibleSpecialists.size(), GetPseudoRandomSeed() + GC.getGame().getNumCities() + m_iNumHistoricEvent);
-		SpecialistTypes eBestSpecialist = vPossibleSpecialists.empty() ? NO_SPECIALIST : vPossibleSpecialists[iChoice];
-		if (eBestSpecialist != NO_SPECIALIST)
+		if (!vPossibleSpecialists.empty())
 		{
+			uint uChoice = GC.getGame().urandLimitExclusive(vPossibleSpecialists.size(), GetPseudoRandomSeed() + static_cast<uint>(GC.getGame().getNumCities()) + static_cast<uint>(m_iNumHistoricEvent));
+			SpecialistTypes eBestSpecialist = vPossibleSpecialists[uChoice];
 			CvSpecialistInfo* pkSpecialistInfo = GC.getSpecialistInfo(eBestSpecialist);
 			if (pkSpecialistInfo)
 			{
@@ -34402,7 +34398,7 @@ void CvPlayer::setCombatExperienceTimes100(int iExperienceTimes100)
 					int iLoop = 0;
 					for(CvCity* pLoopCity = firstCity(&iLoop); pLoopCity != NULL; pLoopCity = nextCity(&iLoop))
 					{
-						int iValue = 4 * GC.getGame().getSmallFakeRandNum(getNumCities(), GetPseudoRandomSeed() + iLoop);
+						int iValue = 4 * GC.getGame().randRangeExclusive(0, getNumCities(), GetPseudoRandomSeed() + static_cast<uint>(iLoop));
 
 						for(int i = 0; i < NUM_YIELD_TYPES; i++)
 						{
@@ -34559,7 +34555,7 @@ void CvPlayer::setNavalCombatExperienceTimes100(int iExperienceTimes100)
 							continue;
 						}
 
-						int iValue = 4 * GC.getGame().getSmallFakeRandNum(getNumCities(), GetPseudoRandomSeed() + iLoop);
+						int iValue = 4 * GC.getGame().randRangeExclusive(0, getNumCities(), GetPseudoRandomSeed() + static_cast<uint>(iLoop));
 
 						for(int i = 0; i < NUM_YIELD_TYPES; i++)
 						{
@@ -36914,7 +36910,7 @@ void CvPlayer::DoXPopulationConscription(CvCity* pCity)
 					continue;
 				}
 
-				int iCombatStrength = (pkUnitEntry->GetPower() + GC.getGame().getSmallFakeRandNum(pkUnitEntry->GetPower(), pCity->plot()->GetPlotIndex() + getTotalPopulation()));
+				int iCombatStrength = (pkUnitEntry->GetPower() + GC.getGame().randRangeExclusive(0, pkUnitEntry->GetPower(), pCity->plot()->GetPseudoRandomSeed() + static_cast<uint>(getTotalPopulation())));
 				if (pkUnitEntry->GetRange() > 0)
 				{
 					iCombatStrength *= 50;
@@ -38726,7 +38722,7 @@ void CvPlayer::DoCivilianReturnLogic(bool bReturn, PlayerTypes eToPlayer, int iU
 				iPercent = iPercent * std::min(150, std::max(75, iSmileRatio)) / 100;
 				CUSTOMLOG("Settler defect percent: %i (Approach=%i, Opinion=%i)", iPercent, GetDiplomacyAI()->GetCivApproach(eToPlayer), GetDiplomacyAI()->GetCivOpinion(eToPlayer));
 
-				if (GC.getGame().getSmallFakeRandNum(100, GetPseudoRandomSeed()) < iPercent) {
+				if (GC.getGame().randRangeExclusive(0, 100, GetPseudoRandomSeed()) < iPercent) {
 					if (GC.getGame().getActivePlayer() == GetID()) {
 						CvPopupInfo kPopupInfo(BUTTONPOPUP_TEXT);
 						strcpy_s(kPopupInfo.szText, "TXT_KEY_GRATEFUL_SETTLERS");
@@ -47385,10 +47381,10 @@ CvTreasury* CvPlayer::GetTreasury() const
 	return m_pTreasury;
 }
 
-int CvPlayer::GetPseudoRandomSeed() const
+uint CvPlayer::GetPseudoRandomSeed() const
 {
 	//this should return a different number for each turn (each call would be even better ...)
-	return (static_cast<int>(GetID()) * getNumUnits()) + GC.getGame().getGameTurn() + (m_pTreasury ? m_pTreasury->GetLifetimeGrossGold() : GC.getGame().GetCultureMedian());
+	return (static_cast<uint>(GetID()) * getNumUnits()) + static_cast<uint>(GC.getGame().getGameTurn()) + static_cast<uint>(m_pTreasury ? m_pTreasury->GetLifetimeGrossGold() : GC.getGame().GetCultureMedian());
 }
 
 //	--------------------------------------------------------------------------------
@@ -52033,8 +52029,8 @@ void CvPlayer::DoVassalLevy()
 			int iTotal = GetNumVassals() * 2;
 			for (int iK = 0; iK < iTotal; iK++)
 			{
-				int iUnit = GC.getGame().getSmallFakeRandNum(aExtraUnits.size(), GetPseudoRandomSeed() + GC.getGame().GetCultureMedian() + iK);
-				CvUnit* pNewUnit = initUnit(aExtraUnits[iUnit], pMasterCity->getX(), pMasterCity->getY(), aExtraUnitAITypes[iUnit]);
+				uint uUnit = GC.getGame().urandLimitExclusive(aExtraUnits.size(), GetPseudoRandomSeed() + static_cast<uint>(GC.getGame().GetCultureMedian()) + static_cast<uint>(iK));
+				CvUnit* pNewUnit = initUnit(aExtraUnits[uUnit], pMasterCity->getX(), pMasterCity->getY(), aExtraUnitAITypes[uUnit]);
 				bool bJumpSuccess = pNewUnit->jumpToNearestValidPlot();
 				if (bJumpSuccess)
 				{

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -4846,7 +4846,7 @@ bool CvPlayer::IsValidBuildingForPlayer(CvCity* pCity, BuildingTypes eBuilding, 
 	if (!bConquest || GetPlayerTraits()->IsKeepConqueredBuildings() || IsKeepConqueredBuildings())
 		return true;
 
-	int iConquestChance = GC.getGame().randRangeExclusive(0, 100, static_cast<uint>(pkLoopBuildingInfo->GetID()) + GetPseudoRandomSeed() + pCity->plot()->GetPseudoRandomSeed());
+	int iConquestChance = GC.getGame().randRangeExclusive(0, 100, GetPseudoRandomSeed().mix(pkLoopBuildingInfo->GetID()).mix(pCity->plot()->GetPseudoRandomSeed()));
 
 	return iConquestChance <= pkLoopBuildingInfo->GetConquestProbability();
 }
@@ -5715,7 +5715,7 @@ void CvPlayer::DoEvents()
 	if (veValidEvents.size() > 0)
 	{
 		//afw		veValidEvents.StableSortItems();
-		int iRandIndex = GC.getGame().randRangeExclusive(0, 2000, static_cast<uint>(GetTreasury()->GetLifetimeGrossGold())); //afw
+		int iRandIndex = GC.getGame().randRangeExclusive(0, 2000, CvSeeder(GetTreasury()->GetLifetimeGrossGold())); //afw
 		if (GC.getLogging())
 		{
 			CvString strBaseString;
@@ -10274,7 +10274,7 @@ void CvPlayer::disbandUnit(bool)
 				if(pLoopUnit->getUnitInfo().GetProductionCost() > 0)
 				{
 					{
-						iValue = (10000 + GC.getGame().randRangeExclusive(0, 1000, static_cast<uint>(pLoopUnit->GetID()) + static_cast<uint>(iLoop)));
+						iValue = (10000 + GC.getGame().randRangeExclusive(0, 1000, CvSeeder(pLoopUnit->GetID()).mix(iLoop)));
 
 						iValue += (pLoopUnit->getUnitInfo().GetProductionCost() * 5);
 						iValue += (pLoopUnit->getExperienceTimes100() / 100 * 20);
@@ -14141,7 +14141,7 @@ void CvPlayer::receiveGoody(CvPlot* pPlot, GoodyTypes eGoody, CvUnit* pUnit)
 #endif
 					if(bUseTech)
 					{
-						iValue = (1 + GC.getGame().randRangeExclusive(0, 10, static_cast<uint>(iI)));
+						iValue = (1 + GC.getGame().randRangeExclusive(0, 10, CvSeeder(iI)));
 
 						if(iValue > iBestValue)
 						{
@@ -19484,7 +19484,7 @@ void CvPlayer::DoYieldsFromKill(CvUnit* pAttackingUnit, CvUnit* pDefendingUnit, 
 			doInstantGreatPersonProgress(INSTANT_YIELD_TYPE_VICTORY, false, pCapitalCity);
 			if (GetPlayerTraits()->IsRandomGreatPersonProgressFromKills())
 			{
-				std::pair <GreatPersonTypes, int> aResults = GetPlayerTraits()->GetRandomGreatPersonProgressFromKills(static_cast<uint>(pAttackingUnit->GetID()) + static_cast<uint>(pAttackingUnit->getMoves()) + static_cast<uint>(pDefendingUnit->GetID()) + static_cast<uint>(pDefendingUnit->getMoves()));
+				std::pair <GreatPersonTypes, int> aResults = GetPlayerTraits()->GetRandomGreatPersonProgressFromKills(CvSeeder(pAttackingUnit->GetID()).mix(pAttackingUnit->getMoves()).mix(pDefendingUnit->GetID()).mix(pDefendingUnit->getMoves()));
 				if (aResults.first != NO_GREATPERSON && aResults.second > 0)
 				{
 					doInstantGreatPersonProgress(INSTANT_YIELD_TYPE_VICTORY, false, pCapitalCity, NO_BUILDING, aResults.second, aResults.first);
@@ -22124,7 +22124,7 @@ void CvPlayer::DoUprising()
 	for (CvCity* pLoopCity = firstCity(&iLoop); pLoopCity != NULL; pLoopCity = nextCity(&iLoop))
 	{
 		int iTempWeight = pLoopCity->getPopulation();
-		iTempWeight += theGame.randRangeExclusive(0, 10, GetPseudoRandomSeed() + pLoopCity->plot()->GetPseudoRandomSeed());
+		iTempWeight += theGame.randRangeExclusive(0, 10, GetPseudoRandomSeed().mix(pLoopCity->plot()->GetPseudoRandomSeed()));
 
 		if (iTempWeight > iBestWeight)
 		{
@@ -29490,7 +29490,7 @@ void CvPlayer::doPolicyGEorGM(int iPolicyGEorGM)
 	int iValue = iPolicyGEorGM * iEra * GC.getGame().getGameSpeedInfo().getInstantYieldPercent(); // Game speed mod (note that TrainPercent is a percentage value, will need to divide by 100)
 
 	SpecialistTypes eBestSpecialist = NO_SPECIALIST;
-	int iRandom = GC.getGame().randRangeExclusive(0, 100, GetPseudoRandomSeed() + static_cast<uint>(iPolicyGEorGM));
+	int iRandom = GC.getGame().randRangeExclusive(0, 100, GetPseudoRandomSeed().mix(iPolicyGEorGM));
 	if (iRandom <= 33)
 	{
 		eBestSpecialist = (SpecialistTypes)GC.getInfoTypeForString("SPECIALIST_ENGINEER");
@@ -30418,7 +30418,7 @@ void CvPlayer::DoSpawnGreatPerson(PlayerTypes eMinor)
 			// No prophets
 			if(!pkUnitEntry->IsFoundReligion())
 			{
-				int iScore = GC.getGame().randRangeExclusive(0, 100, GetPseudoRandomSeed() + static_cast<uint>(iX) + static_cast<uint>(iY));
+				int iScore = GC.getGame().randRangeExclusive(0, 100, GetPseudoRandomSeed().mix(iX).mix(iY));
 
 				if(iScore > iBestScore)
 				{
@@ -30698,7 +30698,7 @@ void CvPlayer::DoGreatPeopleSpawnTurn()
 				if(GET_PLAYER(eMinor).GetMinorCivAI()->GetAlly() != GetID())
 					continue;
 
-				iScore = GC.getGame().randRangeExclusive(0, 100, GetPseudoRandomSeed() + static_cast<uint>(iMinorLoop));
+				iScore = GC.getGame().randRangeExclusive(0, 100, GetPseudoRandomSeed().mix(iMinorLoop));
 
 				// Best ally yet?
 				if(eBestMinor == NO_PLAYER || iScore > iBestScore)
@@ -30738,7 +30738,7 @@ CvCity* CvPlayer::GetGreatPersonSpawnCity(UnitTypes eUnit)
 				continue;
 			}
 
-			int iValue = 4 * GC.getGame().randRangeExclusive(0, getNumCities(), GetPseudoRandomSeed() + static_cast<uint>(iLoop));
+			int iValue = 4 * GC.getGame().randRangeExclusive(0, getNumCities(), GetPseudoRandomSeed().mix(iLoop));
 
 			for(int i = 0; i < NUM_YIELD_TYPES; i++)
 			{
@@ -32796,7 +32796,7 @@ void CvPlayer::ChangeNumHistoricEvents(HistoricEventTypes eHistoricEvent, int iC
 		//choose one
 		if (!vPossibleSpecialists.empty())
 		{
-			uint uChoice = GC.getGame().urandLimitExclusive(vPossibleSpecialists.size(), GetPseudoRandomSeed() + static_cast<uint>(GC.getGame().getNumCities()) + static_cast<uint>(m_iNumHistoricEvent));
+			uint uChoice = GC.getGame().urandLimitExclusive(vPossibleSpecialists.size(), GetPseudoRandomSeed().mix(GC.getGame().getNumCities()).mix(m_iNumHistoricEvent));
 			SpecialistTypes eBestSpecialist = vPossibleSpecialists[uChoice];
 			CvSpecialistInfo* pkSpecialistInfo = GC.getSpecialistInfo(eBestSpecialist);
 			if (pkSpecialistInfo)
@@ -34398,7 +34398,7 @@ void CvPlayer::setCombatExperienceTimes100(int iExperienceTimes100)
 					int iLoop = 0;
 					for(CvCity* pLoopCity = firstCity(&iLoop); pLoopCity != NULL; pLoopCity = nextCity(&iLoop))
 					{
-						int iValue = 4 * GC.getGame().randRangeExclusive(0, getNumCities(), GetPseudoRandomSeed() + static_cast<uint>(iLoop));
+						int iValue = 4 * GC.getGame().randRangeExclusive(0, getNumCities(), GetPseudoRandomSeed().mix(iLoop));
 
 						for(int i = 0; i < NUM_YIELD_TYPES; i++)
 						{
@@ -34555,7 +34555,7 @@ void CvPlayer::setNavalCombatExperienceTimes100(int iExperienceTimes100)
 							continue;
 						}
 
-						int iValue = 4 * GC.getGame().randRangeExclusive(0, getNumCities(), GetPseudoRandomSeed() + static_cast<uint>(iLoop));
+						int iValue = 4 * GC.getGame().randRangeExclusive(0, getNumCities(), GetPseudoRandomSeed().mix(iLoop));
 
 						for(int i = 0; i < NUM_YIELD_TYPES; i++)
 						{
@@ -36910,7 +36910,7 @@ void CvPlayer::DoXPopulationConscription(CvCity* pCity)
 					continue;
 				}
 
-				int iCombatStrength = (pkUnitEntry->GetPower() + GC.getGame().randRangeExclusive(0, pkUnitEntry->GetPower(), pCity->plot()->GetPseudoRandomSeed() + static_cast<uint>(getTotalPopulation())));
+				int iCombatStrength = (pkUnitEntry->GetPower() + GC.getGame().randRangeExclusive(0, pkUnitEntry->GetPower(), pCity->plot()->GetPseudoRandomSeed().mix(getTotalPopulation())));
 				if (pkUnitEntry->GetRange() > 0)
 				{
 					iCombatStrength *= 50;
@@ -47381,10 +47381,10 @@ CvTreasury* CvPlayer::GetTreasury() const
 	return m_pTreasury;
 }
 
-uint CvPlayer::GetPseudoRandomSeed() const
+CvSeeder CvPlayer::GetPseudoRandomSeed() const
 {
 	//this should return a different number for each turn (each call would be even better ...)
-	return (static_cast<uint>(GetID()) * getNumUnits()) + static_cast<uint>(GC.getGame().getGameTurn()) + static_cast<uint>(m_pTreasury ? m_pTreasury->GetLifetimeGrossGold() : GC.getGame().GetCultureMedian());
+	return CvSeeder(GetID()).mix(getNumUnits()).mix(GC.getGame().getGameTurn()).mix(m_pTreasury ? m_pTreasury->GetLifetimeGrossGold() : GC.getGame().GetCultureMedian());
 }
 
 //	--------------------------------------------------------------------------------
@@ -52029,7 +52029,7 @@ void CvPlayer::DoVassalLevy()
 			int iTotal = GetNumVassals() * 2;
 			for (int iK = 0; iK < iTotal; iK++)
 			{
-				uint uUnit = GC.getGame().urandLimitExclusive(aExtraUnits.size(), GetPseudoRandomSeed() + static_cast<uint>(GC.getGame().GetCultureMedian()) + static_cast<uint>(iK));
+				uint uUnit = GC.getGame().urandLimitExclusive(aExtraUnits.size(), GetPseudoRandomSeed().mix(GC.getGame().GetCultureMedian()).mix(iK));
 				CvUnit* pNewUnit = initUnit(aExtraUnits[uUnit], pMasterCity->getX(), pMasterCity->getY(), aExtraUnitAITypes[uUnit]);
 				bool bJumpSuccess = pNewUnit->jumpToNearestValidPlot();
 				if (bJumpSuccess)

--- a/CvGameCoreDLL_Expansion2/CvPlayer.h
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.h
@@ -2783,7 +2783,7 @@ public:
 	bool HasActiveDiplomacyRequests() const;
 
 	CvTreasury* GetTreasury() const;
-	uint GetPseudoRandomSeed() const;
+	CvSeeder GetPseudoRandomSeed() const;
 
 	int GetCityDistanceHighwaterMark() const;
 	void SetCityDistanceHighwaterMark(int iNewValue);

--- a/CvGameCoreDLL_Expansion2/CvPlayer.h
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.h
@@ -2783,7 +2783,7 @@ public:
 	bool HasActiveDiplomacyRequests() const;
 
 	CvTreasury* GetTreasury() const;
-	int GetPseudoRandomSeed() const;
+	uint GetPseudoRandomSeed() const;
 
 	int GetCityDistanceHighwaterMark() const;
 	void SetCityDistanceHighwaterMark(int iNewValue);

--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -403,7 +403,7 @@ void CvPlot::doImprovement()
 					{
 						if(thisImprovementInfo->GetImprovementResourceDiscoverRand(iI) > 0)
 						{
-							if (GC.getGame().getSmallFakeRandNum(thisImprovementInfo->GetImprovementResourceDiscoverRand(iI), iI) == 0)
+							if (GC.getGame().randRangeExclusive(0, thisImprovementInfo->GetImprovementResourceDiscoverRand(iI), GetPseudoRandomSeed() + static_cast<uint>(iI)) == 0)
 							{
 								iResourceNum = GC.getMap().getRandomResourceQuantity((ResourceTypes)iI);
 								setResourceType((ResourceTypes)iI, iResourceNum);
@@ -7876,7 +7876,7 @@ void CvPlot::setImprovementType(ImprovementTypes eNewValue, PlayerTypes eBuilder
 					if (getResourceType() == NO_RESOURCE)
 					{
 						// first roll: can we get a resource on this plot?
-						if (GC.getGame().getSmallFakeRandNum(100, GET_PLAYER(getOwner()).GetPseudoRandomSeed() + GC.getGame().getNumCities() + m_iPlotIndex) < iResourceChance)
+						if (GC.getGame().randRangeExclusive(0, 100, GET_PLAYER(getOwner()).GetPseudoRandomSeed() + static_cast<uint>(GC.getGame().getNumCities()) + GetPseudoRandomSeed()) < iResourceChance)
 						{
 							// get list of valid resources for the plot
 							vector<ResourceTypes> vPossibleResources;
@@ -7894,13 +7894,12 @@ void CvPlot::setImprovementType(ImprovementTypes eNewValue, PlayerTypes eBuilder
 								}
 							}
 
-							// second roll: which resource do we get on this plot?
-							int iChoice = GC.getGame().getSmallFakeRandNum(vPossibleResources.size(), GET_PLAYER(getOwner()).GetPseudoRandomSeed() + GC.getGame().getNumCities() + m_iPlotIndex);
-							ResourceTypes eSelectedResource = vPossibleResources.empty() ? NO_RESOURCE : vPossibleResources[iChoice];
-
 							// now let's add a resource.
-							if (eSelectedResource != NO_RESOURCE)
+							if (!vPossibleResources.empty())
 							{
+								// second roll: which resource do we get on this plot?
+								uint uChoice = GC.getGame().urandLimitExclusive(vPossibleResources.size(), GET_PLAYER(getOwner()).GetPseudoRandomSeed() + static_cast<uint>(GC.getGame().getNumCities()) + GetPseudoRandomSeed());
+								ResourceTypes eSelectedResource = vPossibleResources[uChoice];
 								int iResourceQuantity = GC.getMap().getRandomResourceQuantity(eSelectedResource);
 								setResourceType(eSelectedResource, iResourceQuantity); // note we do not need to check resource linking, as it is done in this very function later on
 								// notification stuff
@@ -15349,4 +15348,9 @@ FDataStream& operator>>(FDataStream& loadFrom, SPlotWithTwoScoresL2& writeTo)
 	CvStreamLoadVisitor serialVisitor(loadFrom);
 	SPlotWithTwoScoresL2::Serialize(writeTo, serialVisitor);
 	return loadFrom;
+}
+
+uint CvPlot::GetPseudoRandomSeed() const
+{
+	return static_cast<uint>(getX()) * 17 + static_cast<uint>(getY()) * 23;
 }

--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -403,7 +403,7 @@ void CvPlot::doImprovement()
 					{
 						if(thisImprovementInfo->GetImprovementResourceDiscoverRand(iI) > 0)
 						{
-							if (GC.getGame().randRangeExclusive(0, thisImprovementInfo->GetImprovementResourceDiscoverRand(iI), GetPseudoRandomSeed() + static_cast<uint>(iI)) == 0)
+							if (GC.getGame().randRangeExclusive(0, thisImprovementInfo->GetImprovementResourceDiscoverRand(iI), CvSeeder(GetPseudoRandomSeed()).mix(iI)) == 0)
 							{
 								iResourceNum = GC.getMap().getRandomResourceQuantity((ResourceTypes)iI);
 								setResourceType((ResourceTypes)iI, iResourceNum);
@@ -7876,7 +7876,7 @@ void CvPlot::setImprovementType(ImprovementTypes eNewValue, PlayerTypes eBuilder
 					if (getResourceType() == NO_RESOURCE)
 					{
 						// first roll: can we get a resource on this plot?
-						if (GC.getGame().randRangeExclusive(0, 100, GET_PLAYER(getOwner()).GetPseudoRandomSeed() + static_cast<uint>(GC.getGame().getNumCities()) + GetPseudoRandomSeed()) < iResourceChance)
+						if (GC.getGame().randRangeExclusive(0, 100, GET_PLAYER(getOwner()).GetPseudoRandomSeed().mix(GC.getGame().getNumCities()).mix(GetPseudoRandomSeed())) < iResourceChance)
 						{
 							// get list of valid resources for the plot
 							vector<ResourceTypes> vPossibleResources;
@@ -7898,7 +7898,7 @@ void CvPlot::setImprovementType(ImprovementTypes eNewValue, PlayerTypes eBuilder
 							if (!vPossibleResources.empty())
 							{
 								// second roll: which resource do we get on this plot?
-								uint uChoice = GC.getGame().urandLimitExclusive(vPossibleResources.size(), GET_PLAYER(getOwner()).GetPseudoRandomSeed() + static_cast<uint>(GC.getGame().getNumCities()) + GetPseudoRandomSeed());
+								uint uChoice = GC.getGame().urandLimitExclusive(vPossibleResources.size(), GET_PLAYER(getOwner()).GetPseudoRandomSeed().mix(GC.getGame().getNumCities()).mix(GetPseudoRandomSeed()));
 								ResourceTypes eSelectedResource = vPossibleResources[uChoice];
 								int iResourceQuantity = GC.getMap().getRandomResourceQuantity(eSelectedResource);
 								setResourceType(eSelectedResource, iResourceQuantity); // note we do not need to check resource linking, as it is done in this very function later on
@@ -15350,7 +15350,7 @@ FDataStream& operator>>(FDataStream& loadFrom, SPlotWithTwoScoresL2& writeTo)
 	return loadFrom;
 }
 
-uint CvPlot::GetPseudoRandomSeed() const
+CvSeeder CvPlot::GetPseudoRandomSeed() const
 {
-	return static_cast<uint>(getX()) * 17 + static_cast<uint>(getY()) * 23;
+	return CvSeeder(static_cast<uint>(getX()) * 17 + static_cast<uint>(getY()) * 23);
 }

--- a/CvGameCoreDLL_Expansion2/CvPlot.h
+++ b/CvGameCoreDLL_Expansion2/CvPlot.h
@@ -848,8 +848,8 @@ public:
 
 	bool canPlaceCombatUnit(PlayerTypes ePlayer) const;
 
-	/// Constructs a seed value from the plot suitable for psuedo-random number geeneration.
-	uint GetPseudoRandomSeed() const;
+	/// Constructs a seed value from the plot suitable for psuedo-random number generation.
+	CvSeeder GetPseudoRandomSeed() const;
 
 protected:
 	class PlotBoolField

--- a/CvGameCoreDLL_Expansion2/CvPlot.h
+++ b/CvGameCoreDLL_Expansion2/CvPlot.h
@@ -848,6 +848,9 @@ public:
 
 	bool canPlaceCombatUnit(PlayerTypes ePlayer) const;
 
+	/// Constructs a seed value from the plot suitable for psuedo-random number geeneration.
+	uint GetPseudoRandomSeed() const;
+
 protected:
 	class PlotBoolField
 	{

--- a/CvGameCoreDLL_Expansion2/CvPromotionClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPromotionClasses.cpp
@@ -3510,11 +3510,11 @@ PromotionTypes CvUnitPromotions::ChangePromotionAfterCombat(PromotionTypes eInde
 		}
 	}
 
-	int iNumChoices = aPossiblePromotions.size();
-	if (iNumChoices > 0)
+	uint uNumChoices = aPossiblePromotions.size();
+	if (uNumChoices > 0)
 	{
-		int iChoice = GC.getGame().getSmallFakeRandNum(iNumChoices, pThisUnit->plot()->GetPlotIndex() + pThisUnit->GetID() + pThisUnit->getDamage());
-		return (PromotionTypes)aPossiblePromotions[iChoice];
+		uint uChoice = GC.getGame().urandLimitExclusive(uNumChoices, pThisUnit->plot()->GetPseudoRandomSeed() + static_cast<uint>(pThisUnit->GetID()) + static_cast<uint>(pThisUnit->getDamage()));
+		return static_cast<PromotionTypes>(aPossiblePromotions[uChoice]);
 	}
 
 	return NO_PROMOTION;

--- a/CvGameCoreDLL_Expansion2/CvPromotionClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPromotionClasses.cpp
@@ -3513,7 +3513,7 @@ PromotionTypes CvUnitPromotions::ChangePromotionAfterCombat(PromotionTypes eInde
 	uint uNumChoices = aPossiblePromotions.size();
 	if (uNumChoices > 0)
 	{
-		uint uChoice = GC.getGame().urandLimitExclusive(uNumChoices, pThisUnit->plot()->GetPseudoRandomSeed() + static_cast<uint>(pThisUnit->GetID()) + static_cast<uint>(pThisUnit->getDamage()));
+		uint uChoice = GC.getGame().urandLimitExclusive(uNumChoices, CvSeeder(pThisUnit->plot()->GetPseudoRandomSeed()).mix(pThisUnit->GetID()).mix(pThisUnit->getDamage()));
 		return static_cast<PromotionTypes>(aPossiblePromotions[uChoice]);
 	}
 

--- a/CvGameCoreDLL_Expansion2/CvReligionClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvReligionClasses.cpp
@@ -1035,11 +1035,11 @@ ReligionTypes CvGameReligions::GetReligionToFound(PlayerTypes ePlayer)
 #if defined(MOD_RELIGION_RANDOMISE)
 	// Pick a random religion
 	if (!availableReligions.empty()) {
-		int index = 0;
+		uint index = 0;
 		
 		// Pick a random one if required
 		if (MOD_RELIGION_RANDOMISE) {
-			index = GC.getGame().getSmallFakeRandNum(availableReligions.size(), ePlayer);
+			index = GC.getGame().urandLimitExclusive(availableReligions.size(), static_cast<uint>(ePlayer));
 		}
 		
 		// CUSTOMLOG("GetReligionToFound: Using random %i", availableReligions[index]);
@@ -3239,7 +3239,7 @@ bool CvGameReligions::CheckSpawnGreatProphet(CvPlayer& kPlayer)
 
 	iChance += (iFaith - iCost);
 
-	int iRand = GC.getGame().getSmallFakeRandNum(100, kPlayer.GetPseudoRandomSeed());
+	int iRand = GC.getGame().randRangeExclusive(0, 100, kPlayer.GetPseudoRandomSeed());
 	if(iRand >= iChance)
 	{
 		return false;
@@ -3341,7 +3341,7 @@ bool CvGameReligions::CheckSpawnGreatProphet(CvPlayer& kPlayer)
 			for(pLoopCity = kPlayer.firstCity(&iLoop); pLoopCity != NULL; pLoopCity = kPlayer.nextCity(&iLoop))
 			{
 				iTempWeight = pLoopCity->GetFaithPerTurn() * 5;
-				iTempWeight += theGame.getSmallFakeRandNum(15, kPlayer.GetPseudoRandomSeed() + iLoop);
+				iTempWeight += theGame.randRangeExclusive(0, 15, kPlayer.GetPseudoRandomSeed() + static_cast<uint>(iLoop));
 
 				if(iTempWeight > iBestWeight)
 				{
@@ -10411,10 +10411,10 @@ BuildingClassTypes CvReligionAI::FaithBuildingAvailable(ReligionTypes eReligion,
 				if (eBestBuilding != NO_BUILDINGCLASS)
 					return eBestBuilding;
 				else
-					return choices[GC.getGame().getSmallFakeRandNum(choices.size(), *pCity->plot())];
+					return choices[GC.getGame().urandLimitExclusive(choices.size(), pCity->plot()->GetPseudoRandomSeed())];
 			}
 			else
-				return choices[GC.getGame().getSmallFakeRandNum(choices.size(), *pCity->plot())];
+				return choices[GC.getGame().urandLimitExclusive(choices.size(), pCity->plot()->GetPseudoRandomSeed())];
 		}
 		else
 			return choices[0];

--- a/CvGameCoreDLL_Expansion2/CvReligionClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvReligionClasses.cpp
@@ -1039,7 +1039,7 @@ ReligionTypes CvGameReligions::GetReligionToFound(PlayerTypes ePlayer)
 		
 		// Pick a random one if required
 		if (MOD_RELIGION_RANDOMISE) {
-			index = GC.getGame().urandLimitExclusive(availableReligions.size(), static_cast<uint>(ePlayer));
+			index = GC.getGame().urandLimitExclusive(availableReligions.size(), CvSeeder(ePlayer));
 		}
 		
 		// CUSTOMLOG("GetReligionToFound: Using random %i", availableReligions[index]);
@@ -3239,7 +3239,7 @@ bool CvGameReligions::CheckSpawnGreatProphet(CvPlayer& kPlayer)
 
 	iChance += (iFaith - iCost);
 
-	int iRand = GC.getGame().randRangeExclusive(0, 100, kPlayer.GetPseudoRandomSeed());
+	int iRand = GC.getGame().randRangeExclusive(0, 100, CvSeeder(kPlayer.GetPseudoRandomSeed()));
 	if(iRand >= iChance)
 	{
 		return false;
@@ -3341,7 +3341,7 @@ bool CvGameReligions::CheckSpawnGreatProphet(CvPlayer& kPlayer)
 			for(pLoopCity = kPlayer.firstCity(&iLoop); pLoopCity != NULL; pLoopCity = kPlayer.nextCity(&iLoop))
 			{
 				iTempWeight = pLoopCity->GetFaithPerTurn() * 5;
-				iTempWeight += theGame.randRangeExclusive(0, 15, kPlayer.GetPseudoRandomSeed() + static_cast<uint>(iLoop));
+				iTempWeight += theGame.randRangeExclusive(0, 15, CvSeeder(kPlayer.GetPseudoRandomSeed()).mix(iLoop));
 
 				if(iTempWeight > iBestWeight)
 				{
@@ -10411,10 +10411,10 @@ BuildingClassTypes CvReligionAI::FaithBuildingAvailable(ReligionTypes eReligion,
 				if (eBestBuilding != NO_BUILDINGCLASS)
 					return eBestBuilding;
 				else
-					return choices[GC.getGame().urandLimitExclusive(choices.size(), pCity->plot()->GetPseudoRandomSeed())];
+					return choices[GC.getGame().urandLimitExclusive(choices.size(), CvSeeder(pCity->plot()->GetPseudoRandomSeed()))];
 			}
 			else
-				return choices[GC.getGame().urandLimitExclusive(choices.size(), pCity->plot()->GetPseudoRandomSeed())];
+				return choices[GC.getGame().urandLimitExclusive(choices.size(), CvSeeder(pCity->plot()->GetPseudoRandomSeed()))];
 		}
 		else
 			return choices[0];

--- a/CvGameCoreDLL_Expansion2/CvTacticalAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTacticalAI.cpp
@@ -1862,7 +1862,7 @@ void CvTacticalAI::PlotEmergencyPurchases(CvTacticalDominanceZone* pZone)
 				else
 					//otherwise buy defensive land units
 					if (!MOD_AI_UNIT_PRODUCTION)
-						m_pPlayer->GetMilitaryAI()->BuyEmergencyUnit(GC.getGame().getSmallFakeRandNum(5, *pCity->plot()) < 2 ? UNITAI_COUNTER : UNITAI_DEFENSE, pCity);
+						m_pPlayer->GetMilitaryAI()->BuyEmergencyUnit(GC.getGame().randRangeExclusive(0, 5, pCity->plot()->GetPseudoRandomSeed()) < 2 ? UNITAI_COUNTER : UNITAI_DEFENSE, pCity);
 					else //AI Unit Production : Counter is AA only now
 						m_pPlayer->GetMilitaryAI()->BuyEmergencyUnit(UNITAI_DEFENSE, pCity);
 			}
@@ -3925,9 +3925,9 @@ void CvTacticalAI::ExecuteRepositionMoves()
 		shuffledIndex[i-RING1_PLOTS] = i;
 
 	int iNumPlots = RING4_PLOTS - RING1_PLOTS;
-	for (int i = 0; i < iNumPlots; i++)
+	for (int i = 0; i < iNumPlots - 1; i++)
 	{
-		int iSwapIndex = GC.getGame().getSmallFakeRandNum(iNumPlots - i, m_CurrentMoveUnits.size() + i);
+		int iSwapIndex = GC.getGame().randRangeExclusive(0, iNumPlots - i, m_CurrentMoveUnits.size() + static_cast<uint>(i));
 		std::swap<int>(shuffledIndex[i], shuffledIndex[iSwapIndex]);
 	}
 

--- a/CvGameCoreDLL_Expansion2/CvTacticalAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTacticalAI.cpp
@@ -1862,7 +1862,7 @@ void CvTacticalAI::PlotEmergencyPurchases(CvTacticalDominanceZone* pZone)
 				else
 					//otherwise buy defensive land units
 					if (!MOD_AI_UNIT_PRODUCTION)
-						m_pPlayer->GetMilitaryAI()->BuyEmergencyUnit(GC.getGame().randRangeExclusive(0, 5, pCity->plot()->GetPseudoRandomSeed()) < 2 ? UNITAI_COUNTER : UNITAI_DEFENSE, pCity);
+						m_pPlayer->GetMilitaryAI()->BuyEmergencyUnit(GC.getGame().randRangeExclusive(0, 5, CvSeeder(pCity->plot()->GetPseudoRandomSeed())) < 2 ? UNITAI_COUNTER : UNITAI_DEFENSE, pCity);
 					else //AI Unit Production : Counter is AA only now
 						m_pPlayer->GetMilitaryAI()->BuyEmergencyUnit(UNITAI_DEFENSE, pCity);
 			}
@@ -3927,7 +3927,7 @@ void CvTacticalAI::ExecuteRepositionMoves()
 	int iNumPlots = RING4_PLOTS - RING1_PLOTS;
 	for (int i = 0; i < iNumPlots - 1; i++)
 	{
-		int iSwapIndex = GC.getGame().randRangeExclusive(0, iNumPlots - i, m_CurrentMoveUnits.size() + static_cast<uint>(i));
+		int iSwapIndex = GC.getGame().randRangeExclusive(0, iNumPlots - i, CvSeeder(m_CurrentMoveUnits.size()).mix(i));
 		std::swap<int>(shuffledIndex[i], shuffledIndex[iSwapIndex]);
 	}
 

--- a/CvGameCoreDLL_Expansion2/CvTraitClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTraitClasses.cpp
@@ -5811,7 +5811,7 @@ bool CvPlayerTraits::IsRandomGreatPersonProgressFromKills() const
 }
 
 /// Instant random great person progress when killing enemy units
-std::pair<GreatPersonTypes, int> CvPlayerTraits::GetRandomGreatPersonProgressFromKills(uint uAdditionalSeed) const
+std::pair<GreatPersonTypes, int> CvPlayerTraits::GetRandomGreatPersonProgressFromKills(CvSeeder additionalSeed) const
 {
 	// how many options we have
 	int iSize = m_aiRandomGreatPersonProgressFromKills.size();
@@ -5820,7 +5820,7 @@ std::pair<GreatPersonTypes, int> CvPlayerTraits::GetRandomGreatPersonProgressFro
 	if (iSize > 0)
 	{
 		// get our pseudo RNG seed
-		uChoice = GC.getGame().urandLimitExclusive(m_aiRandomGreatPersonProgressFromKills.size(), m_pPlayer->GetPseudoRandomSeed() + static_cast<uint>(GC.getGame().getNumCities()) + uAdditionalSeed);
+		uChoice = GC.getGame().urandLimitExclusive(m_aiRandomGreatPersonProgressFromKills.size(), additionalSeed.mix(m_pPlayer->GetPseudoRandomSeed()).mix(GC.getGame().getNumCities()));
 
 		// access the element at the position of our RNG seed
 		for (std::map<int, int>::const_iterator it = m_aiRandomGreatPersonProgressFromKills.begin(); it != m_aiRandomGreatPersonProgressFromKills.end(); it++) // find returns the iterator to map::end if the key eIndex is not present in the map
@@ -6476,7 +6476,7 @@ bool CvPlayerTraits::AddUniqueLuxuriesAround(CvCity *pCity, int iNumResourceToGi
 		return false;
 
 	//choose one
-	uint uChoice = GC.getGame().urandLimitExclusive(vPossibleResources.size(), pCity->plot()->GetPseudoRandomSeed() + GET_PLAYER(pCity->getOwner()).GetPseudoRandomSeed() + static_cast<uint>(GC.getGame().GetCultureMedian()));
+	uint uChoice = GC.getGame().urandLimitExclusive(vPossibleResources.size(), CvSeeder(pCity->plot()->GetPseudoRandomSeed()).mix(GET_PLAYER(pCity->getOwner()).GetPseudoRandomSeed()).mix(GC.getGame().GetCultureMedian()));
 	ResourceTypes eResourceToGive = vPossibleResources[uChoice];
 		
 	//first round. place on owned non-city, non-resource plots without improvement
@@ -7796,7 +7796,7 @@ bool CvPlayerTraits::ConvertBarbarianCamp(CvUnit* pByUnit, CvPlot* pPlot)
 	}
 
 	// Roll die to see if it converts
-	if (GC.getGame().randRangeExclusive(0, 100, pPlot->GetPseudoRandomSeed()) < m_iLandBarbarianConversionPercent)
+	if (GC.getGame().randRangeExclusive(0, 100, CvSeeder(pPlot->GetPseudoRandomSeed())) < m_iLandBarbarianConversionPercent)
 	{
 		pPlot->setImprovementType(NO_IMPROVEMENT);
 
@@ -7875,7 +7875,7 @@ bool CvPlayerTraits::ConvertBarbarianNavalUnit(CvUnit* pByUnit, CvUnit* pUnit)
 	}
 
 	// Roll die to see if it converts
-	if(GC.getGame().randRangeExclusive(0, 100, pUnit->plot()->GetPseudoRandomSeed()) < m_iSeaBarbarianConversionPercent)
+	if(GC.getGame().randRangeExclusive(0, 100, CvSeeder(pUnit->plot()->GetPseudoRandomSeed())) < m_iSeaBarbarianConversionPercent)
 	{
 		int iNumGold = /*25*/ GD_INT_GET(GOLD_FROM_BARBARIAN_CONVERSION);
 		m_pPlayer->GetTreasury()->ChangeGold(iNumGold);

--- a/CvGameCoreDLL_Expansion2/CvTraitClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTraitClasses.cpp
@@ -5811,25 +5811,25 @@ bool CvPlayerTraits::IsRandomGreatPersonProgressFromKills() const
 }
 
 /// Instant random great person progress when killing enemy units
-std::pair<GreatPersonTypes, int> CvPlayerTraits::GetRandomGreatPersonProgressFromKills(int iAdditionalSeed) const
+std::pair<GreatPersonTypes, int> CvPlayerTraits::GetRandomGreatPersonProgressFromKills(uint uAdditionalSeed) const
 {
 	// how many options we have
 	int iSize = m_aiRandomGreatPersonProgressFromKills.size();
-	int iChoice = -1;
+	uint uChoice = 0;
 
 	if (iSize > 0)
 	{
 		// get our pseudo RNG seed
-		iChoice = GC.getGame().getSmallFakeRandNum(m_aiRandomGreatPersonProgressFromKills.size(), m_pPlayer->GetPseudoRandomSeed() + GC.getGame().getNumCities() + iAdditionalSeed);
+		uChoice = GC.getGame().urandLimitExclusive(m_aiRandomGreatPersonProgressFromKills.size(), m_pPlayer->GetPseudoRandomSeed() + static_cast<uint>(GC.getGame().getNumCities()) + uAdditionalSeed);
 
 		// access the element at the position of our RNG seed
 		for (std::map<int, int>::const_iterator it = m_aiRandomGreatPersonProgressFromKills.begin(); it != m_aiRandomGreatPersonProgressFromKills.end(); it++) // find returns the iterator to map::end if the key eIndex is not present in the map
 		{
-			if (iChoice == 0)
+			if (uChoice == 0)
 			{
 				return std::make_pair((GreatPersonTypes)it->first, it->second);
 			}
-			iChoice--;
+			uChoice--;
 		}
 	}
 
@@ -6476,8 +6476,8 @@ bool CvPlayerTraits::AddUniqueLuxuriesAround(CvCity *pCity, int iNumResourceToGi
 		return false;
 
 	//choose one
-	int iChoice = GC.getGame().getSmallFakeRandNum( vPossibleResources.size(), pCity->plot()->GetPlotIndex() + GET_PLAYER(pCity->getOwner()).GetPseudoRandomSeed() + GC.getGame().GetCultureMedian() );
-	ResourceTypes eResourceToGive = vPossibleResources[iChoice];
+	uint uChoice = GC.getGame().urandLimitExclusive(vPossibleResources.size(), pCity->plot()->GetPseudoRandomSeed() + GET_PLAYER(pCity->getOwner()).GetPseudoRandomSeed() + static_cast<uint>(GC.getGame().GetCultureMedian()));
+	ResourceTypes eResourceToGive = vPossibleResources[uChoice];
 		
 	//first round. place on owned non-city, non-resource plots without improvement
 	int iNumResourceGiven = 0;
@@ -7796,7 +7796,7 @@ bool CvPlayerTraits::ConvertBarbarianCamp(CvUnit* pByUnit, CvPlot* pPlot)
 	}
 
 	// Roll die to see if it converts
-	if (GC.getGame().getSmallFakeRandNum(100, *pPlot) < m_iLandBarbarianConversionPercent)
+	if (GC.getGame().randRangeExclusive(0, 100, pPlot->GetPseudoRandomSeed()) < m_iLandBarbarianConversionPercent)
 	{
 		pPlot->setImprovementType(NO_IMPROVEMENT);
 
@@ -7875,7 +7875,7 @@ bool CvPlayerTraits::ConvertBarbarianNavalUnit(CvUnit* pByUnit, CvUnit* pUnit)
 	}
 
 	// Roll die to see if it converts
-	if(GC.getGame().getSmallFakeRandNum(100, *pUnit->plot()) < m_iSeaBarbarianConversionPercent)
+	if(GC.getGame().randRangeExclusive(0, 100, pUnit->plot()->GetPseudoRandomSeed()) < m_iSeaBarbarianConversionPercent)
 	{
 		int iNumGold = /*25*/ GD_INT_GET(GOLD_FROM_BARBARIAN_CONVERSION);
 		m_pPlayer->GetTreasury()->ChangeGold(iNumGold);

--- a/CvGameCoreDLL_Expansion2/CvTraitClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvTraitClasses.h
@@ -1774,7 +1774,7 @@ public:
 	};
 	int GetGreatPersonProgressFromKills(GreatPersonTypes eIndex) const;
 	bool IsRandomGreatPersonProgressFromKills() const;
-	std::pair<GreatPersonTypes, int> GetRandomGreatPersonProgressFromKills(int iAdditionalSeed = 0) const;
+	std::pair<GreatPersonTypes, int> GetRandomGreatPersonProgressFromKills(uint uAdditionalSeed) const;
 	int GetFreeUnitClassesDOW(UnitClassTypes eUnitClass) const
 	{
 		return ((uint)eUnitClass < m_aiFreeUnitClassesDOW.size()) ? m_aiFreeUnitClassesDOW[(int)eUnitClass] : 0;

--- a/CvGameCoreDLL_Expansion2/CvTraitClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvTraitClasses.h
@@ -1774,7 +1774,7 @@ public:
 	};
 	int GetGreatPersonProgressFromKills(GreatPersonTypes eIndex) const;
 	bool IsRandomGreatPersonProgressFromKills() const;
-	std::pair<GreatPersonTypes, int> GetRandomGreatPersonProgressFromKills(uint uAdditionalSeed) const;
+	std::pair<GreatPersonTypes, int> GetRandomGreatPersonProgressFromKills(CvSeeder additionalSeed) const;
 	int GetFreeUnitClassesDOW(UnitClassTypes eUnitClass) const
 	{
 		return ((uint)eUnitClass < m_aiFreeUnitClassesDOW.size()) ? m_aiFreeUnitClassesDOW[(int)eUnitClass] : 0;

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -650,14 +650,14 @@ void CvUnit::initWithNameOffset(int iID, UnitTypes eUnit, int iNameOffset, UnitA
 	iUnitName = GC.getGame().getUnitCreatedCount(getUnitType());
 	int iNumNames = getUnitInfo().GetNumUnitNames();
 #if defined(MOD_BALANCE_CORE)
-	if (!bSkipNaming)
+	if (!bSkipNaming && iNumNames > 0)
 	{
 		std::vector<int> vfPossibleUnits;
 #endif
 	{
 		if(iNameOffset == -1)
 		{
-			iNameOffset = GC.getGame().getSmallFakeRandNum(iNumNames, *plot());
+			iNameOffset = GC.getGame().randRangeExclusive(0, iNumNames, plot()->GetPseudoRandomSeed());
 		}
 #if defined(MOD_BALANCE_CORE)
 		CvString strName = NULL;
@@ -676,10 +676,10 @@ void CvUnit::initWithNameOffset(int iID, UnitTypes eUnit, int iNameOffset, UnitA
 		}
 		if(vfPossibleUnits.size() > 0)
 		{
-			int iRoll = GC.getGame().getSmallFakeRandNum(vfPossibleUnits.size(), iID);
-			strName = getUnitInfo().GetUnitNames(vfPossibleUnits[iRoll]);
+			uint uRoll = GC.getGame().urandLimitExclusive(vfPossibleUnits.size(), static_cast<uint>(iID));
+			strName = getUnitInfo().GetUnitNames(vfPossibleUnits[uRoll]);
 			setName(strName);
-			SetGreatWork(getUnitInfo().GetGreatWorks(vfPossibleUnits[iRoll]));
+			SetGreatWork(getUnitInfo().GetGreatWorks(vfPossibleUnits[uRoll]));
 			GC.getGame().addGreatPersonBornName(strName);
 
 			if (MOD_GLOBAL_NO_LOST_GREATWORKS)
@@ -705,10 +705,10 @@ void CvUnit::initWithNameOffset(int iID, UnitTypes eUnit, int iNameOffset, UnitA
 			}
 			if(vfPossibleUnits.size() > 0)
 			{
-				int iRoll = GC.getGame().getSmallFakeRandNum(vfPossibleUnits.size(), iID);
-				strName = getUnitInfo().GetUnitNames(vfPossibleUnits[iRoll]);
+				uint uRoll = GC.getGame().urandLimitExclusive(vfPossibleUnits.size(), static_cast<uint>(iID));
+				strName = getUnitInfo().GetUnitNames(vfPossibleUnits[uRoll]);
 				setName(strName);
-				SetGreatWork(getUnitInfo().GetGreatWorks(vfPossibleUnits[iRoll]));
+				SetGreatWork(getUnitInfo().GetGreatWorks(vfPossibleUnits[uRoll]));
 				GC.getGame().addGreatPersonBornName(strName);
 
 				if (MOD_GLOBAL_NO_LOST_GREATWORKS)
@@ -1133,7 +1133,7 @@ void CvUnit::initWithNameOffset(int iID, UnitTypes eUnit, int iNameOffset, UnitA
 			CvCityReligions *pCityReligions = pPlotCity->GetCityReligions();
 
 			int totalFollowers = pPlotCity->getPopulation();
-			int randFollower = GC.getGame().getSmallFakeRandNum(totalFollowers, GET_PLAYER(pPlotCity->getOwner()).GetPseudoRandomSeed()) + 1;
+			int randFollower = GC.getGame().randRangeInclusive(1, totalFollowers, GET_PLAYER(pPlotCity->getOwner()).GetPseudoRandomSeed());
 
 			for (int i = RELIGION_PANTHEON; i < GC.getNumReligionInfos(); i++)
 			{
@@ -1163,7 +1163,7 @@ void CvUnit::initWithNameOffset(int iID, UnitTypes eUnit, int iNameOffset, UnitA
 			CvCityReligions *pCityReligions = pPlotCity->GetCityReligions();
 
 			int totalFollowers = pPlotCity->getPopulation();
-			int randFollower = GC.getGame().getSmallFakeRandNum(totalFollowers, GET_PLAYER(pPlotCity->getOwner()).GetPseudoRandomSeed()) + 1;
+			int randFollower = GC.getGame().urandRangeInclusive(1, totalFollowers, GET_PLAYER(pPlotCity->getOwner()).GetPseudoRandomSeed());
 
 			for (int i = RELIGION_PANTHEON; i < GC.getNumReligionInfos(); i++)
 			{
@@ -5497,13 +5497,13 @@ int CvUnit::getCombatDamage(int iStrength, int iOpponentStrength, bool bIncludeR
 		iModifier += /*0*/ GD_INT_GET(ATTACKING_CITY_MELEE_DAMAGE_MOD) - 100;
 	}
 
-	int iRandomSeed = bIncludeRand ? (plot()->GetPlotIndex()+GetID()+iStrength+iOpponentStrength) : 0;
+	uint uRandomSeed = bIncludeRand ? (static_cast<uint>(plot()->GetPlotIndex()) + static_cast<uint>(GetID()) + static_cast<uint>(iStrength) + static_cast<uint>(iOpponentStrength)) : 0;
 	return CvUnitCombat::DoDamageMath(
 		iStrength,
 		iOpponentStrength,
 		/*2400*/ GD_INT_GET(ATTACK_SAME_STRENGTH_MIN_DAMAGE), //ignore the min part, it's misleading
 		/*1200*/ GD_INT_GET(ATTACK_SAME_STRENGTH_POSSIBLE_EXTRA_DAMAGE),
-		iRandomSeed,
+		uRandomSeed,
 		iModifier ) / 100;
 }
 
@@ -5790,7 +5790,7 @@ bool CvUnit::jumpToNearestValidPlotWithinRange(int iRange, CvPlot* pStartPlot)
 					if (pLoopPlot->getArea() != plot()->getArea())
 						iValue += 11;
 
-					if (iValue < iBestValue || (iValue == iBestValue && GC.getGame().getSmallFakeRandNum(3, *pLoopPlot) < 2))
+					if (iValue < iBestValue || (iValue == iBestValue && GC.getGame().randRangeExclusive(0, 3, pLoopPlot->GetPseudoRandomSeed()) < 2))
 					{
 						iBestValue = iValue;
 						pBestPlot = pLoopPlot;
@@ -8196,7 +8196,7 @@ void CvUnit::DoAttrition()
 
 		if (isEnemy(pPlot->getTeam(), pPlot) && getEnemyDamageChance() > 0 && getEnemyDamage() > 0)
 		{
-			if (GC.getGame().getSmallFakeRandNum(100, *pPlot) < getEnemyDamageChance())
+			if (GC.getGame().randRangeExclusive(0, 100, pPlot->GetPseudoRandomSeed()) < getEnemyDamageChance())
 			{
 				strAppendText =  GetLocalizedText("TXT_KEY_MISC_YOU_UNIT_WAS_DAMAGED_ATTRITION");
 				changeDamage(getEnemyDamage(), NO_PLAYER, 0.0, &strAppendText);
@@ -8204,7 +8204,7 @@ void CvUnit::DoAttrition()
 		}
 		else if (isEnemy(pPlot->getTeam(), pPlot) && getEnemyDamageChance() > 0 && getEnemyDamage() < 0)
 		{
-			if (GC.getGame().getSmallFakeRandNum(100, *pPlot) <= getEnemyDamageChance())
+			if (GC.getGame().randRangeExclusive(0, 100, pPlot->GetPseudoRandomSeed()) <= getEnemyDamageChance())
 			{
 				strAppendText =  GetLocalizedText("TXT_KEY_MISC_YOU_ENEMY_UNITS_DEFECT");
 				changeDamage(getEnemyDamage(), NO_PLAYER, 0.0, &strAppendText);
@@ -8212,7 +8212,7 @@ void CvUnit::DoAttrition()
 		}
 		else if (getNeutralDamageChance() > 0 && getNeutralDamage() > 0)
 		{
-			if (GC.getGame().getSmallFakeRandNum(100, *pPlot) < getNeutralDamageChance())
+			if (GC.getGame().randRangeExclusive(0, 100, pPlot->GetPseudoRandomSeed()) < getNeutralDamageChance())
 			{
 				strAppendText =  GetLocalizedText("TXT_KEY_MISC_YOU_UNIT_WAS_DAMAGED_ATTRITION");
 				changeDamage(getNeutralDamage(), NO_PLAYER, 0.0, &strAppendText);
@@ -9648,7 +9648,7 @@ bool CvUnit::createFreeLuxury()
 			{
 				if(GC.getMap().getNumResources(eResource) <= 0)
 				{
-					int iRandomFlavor = GC.getGame().getSmallFakeRandNum(100, iResourceLoop);
+					int iRandomFlavor = GC.getGame().randRangeExclusive(0, 100, static_cast<uint>(iResourceLoop));
 					//If we've already got this resource, divide the value by the amount.
 					if(GET_PLAYER(getOwner()).getNumResourceTotal(eResource, false) > 0)
 					{
@@ -9670,7 +9670,7 @@ bool CvUnit::createFreeLuxury()
 				CvResourceInfo* pkResource = GC.getResourceInfo(eResource);
 				if (pkResource != NULL && pkResource->getResourceUsage() == RESOURCEUSAGE_LUXURY)
 				{
-					int iRandomFlavor = GC.getGame().getSmallFakeRandNum(100, iResourceLoop);
+					int iRandomFlavor = GC.getGame().randRangeExclusive(0, 100, static_cast<uint>(iResourceLoop));
 					//If we've already got this resource, divide the value by the amount.
 					if(GET_PLAYER(getOwner()).getNumResourceTotal(eResource, false) > 0)
 					{
@@ -9692,7 +9692,7 @@ bool CvUnit::createFreeLuxury()
 				CvResourceInfo* pkResource = GC.getResourceInfo(eResource);
 				if (pkResource != NULL && pkResource->getResourceUsage() == RESOURCEUSAGE_LUXURY)
 				{
-					int iRandomFlavor = GC.getGame().getSmallFakeRandNum(100, iResourceLoop);
+					int iRandomFlavor = GC.getGame().randRangeExclusive(0, 100, static_cast<uint>(iResourceLoop));
 					if(iRandomFlavor > iBestFlavor)
 					{
 						eResourceToGive = eResource;
@@ -10601,12 +10601,12 @@ bool CvUnit::pillage()
 					if (iEra <= 0)
 						iEra = 1;
 
-					iPillageGold += 3 + (pkImprovement->GetPillageGold() * iEra * (((75 + max(1, GC.getGame().getSmallFakeRandNum(50, *plot()))) / 100)));
+					iPillageGold += 3 + (pkImprovement->GetPillageGold() * iEra * (((75 + max(1, GC.getGame().randRangeExclusive(0, 50, plot()->GetPseudoRandomSeed()))) / 100)));
 					iPillageGold += (getPillageChange() * iPillageGold) / 100;
 				}
 				else
 				{
-					iPillageGold += GC.getGame().getSmallFakeRandNum(pkImprovement->GetPillageGold(), *plot());
+					iPillageGold += GC.getGame().randRangeExclusive(0, pkImprovement->GetPillageGold(), plot()->GetPseudoRandomSeed());
 					iPillageGold += (getPillageChange() * iPillageGold) / 100;
 				}
 #if defined(HH_MOD_BUILDINGS_FRUITLESS_PILLAGE)
@@ -17871,13 +17871,13 @@ int CvUnit::GetRangeCombatDamage(const CvUnit* pDefender, const CvCity* pCity, b
 		iDefenderStrength = GetBaseCombatStrength()*100;
 	}
 
-	int iRandomSeed = bIncludeRand ? (plot()->GetPlotIndex()+GetID()+iAttackerStrength+iDefenderStrength) : 0;
+	uint uRandomSeed = bIncludeRand ? (static_cast<uint>(plot()->GetPlotIndex()) + static_cast<uint>(GetID()) + static_cast<uint>(iAttackerStrength) + static_cast<uint>(iDefenderStrength)) : 0;
 	int iDamage = CvUnitCombat::DoDamageMath(
 		iAttackerStrength,
 		iDefenderStrength,
 		/*2400*/ GD_INT_GET(RANGE_ATTACK_SAME_STRENGTH_MIN_DAMAGE), //ignore the min part, it's misleading
 		/*1200*/ GD_INT_GET(RANGE_ATTACK_SAME_STRENGTH_POSSIBLE_EXTRA_DAMAGE),
-		iRandomSeed,
+		uRandomSeed,
 		0 ) / 100;
 
 	//extra damage with special promotion
@@ -17933,7 +17933,7 @@ int CvUnit::GetAirStrikeDefenseDamage(const CvUnit* pAttacker, bool bIncludeRand
 		}
 
 		if (bIncludeRand)
-			return iBaseValue + GC.getGame().getSmallFakeRandNum(iMaxRandom, *plot());
+			return iBaseValue + GC.getGame().randRangeExclusive(0, iMaxRandom, plot()->GetPseudoRandomSeed());
 		else
 			return iBaseValue;
 	}
@@ -17947,7 +17947,7 @@ int CvUnit::GetAirStrikeDefenseDamage(const CvUnit* pAttacker, bool bIncludeRand
 		}
 
 		if (bIncludeRand)
-			return iVal + GC.getGame().getSmallFakeRandNum(iVal/2, *plot());
+			return iVal + GC.getGame().randRangeExclusive(0, iVal / 2, plot()->GetPseudoRandomSeed());
 		else
 			return iVal+2;
 	}	
@@ -18005,13 +18005,13 @@ int CvUnit::GetInterceptionDamage(const CvUnit* pInterceptedAttacker, bool bIncl
 	iInterceptorStrength *= (100 + GetInterceptionCombatModifier());
 	iInterceptorStrength /= 100;
 
-	int iRandomSeed = bIncludeRand ? (pTargetPlot->GetPlotIndex()+GetID()+iInterceptorStrength+iInterceptedAttackerStrength) : 0;
+	uint uRandomSeed = bIncludeRand ? (static_cast<uint>(pTargetPlot->GetPlotIndex()) + static_cast<uint>(GetID())+ static_cast<uint>(iInterceptorStrength) + static_cast<uint>(iInterceptedAttackerStrength)) : 0;
 	return CvUnitCombat::DoDamageMath(
 		iInterceptorStrength,
 		iInterceptedAttackerStrength,
 		/*2400*/ GD_INT_GET(INTERCEPTION_SAME_STRENGTH_MIN_DAMAGE), //ignore the min part, it's misleading
 		/*1200*/ GD_INT_GET(INTERCEPTION_SAME_STRENGTH_POSSIBLE_EXTRA_DAMAGE),
-		iRandomSeed,
+		uRandomSeed,
 		pInterceptedAttacker->GetInterceptionDefenseDamageModifier() ) / 100;
 }
 
@@ -24717,7 +24717,7 @@ void CvUnit::DoConvertReligiousUnitsToMilitary(const CvPlot* pPlot)
 		if (getTeam() != GET_TEAM(kPlayer.getTeam()).GetID())
 		{
 			CvUnit* pConvertUnit = NULL;
-			if (GC.getGame().getSmallFakeRandNum(100, *pPlot) <= iChanceToConvertReligiousUnit)
+			if (GC.getGame().randRangeExclusive(0, 100, pPlot->GetPseudoRandomSeed()) <= iChanceToConvertReligiousUnit)
 			{
 				UnitTypes eBestLandUnit = NO_UNIT;
 				int iStrengthBestLandCombat = 0;
@@ -31152,7 +31152,7 @@ void CvUnit::DoPlagueTransfer(CvUnit& defender)
 		CvPromotionEntry* pkPlaguePromotionInfo = GC.getPromotionInfo(eInflictedPlague);
 
 		// Is the plague inflicted?
-		int iRoll = GC.getGame().getSmallFakeRandNum(100, (int)GetID() + ((int)defender.GetID() / 2) + (iCount * 493));
+		int iRoll = GC.getGame().randRangeExclusive(0, 100, static_cast<uint>(GetID()) + (static_cast<uint>(defender.GetID()) / 2) + (static_cast<uint>(iCount) * 493));
 		iCount--;
 		if (iRoll > iPlagueChance)
 			return;
@@ -31306,7 +31306,7 @@ bool CvUnit::CheckWithdrawal(const CvUnit& attacker) const
 		return true;
 
 	//include damage so the result changes for each attack
-	int iRoll = GC.getGame().getSmallFakeRandNum(10, plot()->GetPlotIndex() + GetID() + getDamage()) * 10;
+	int iRoll = GC.getGame().randRangeExclusive(0, 10, plot()->GetPseudoRandomSeed() + static_cast<uint>(GetID()) + static_cast<uint>(getDamage())) * 10;
 	return iRoll < iWithdrawChance;
 }
 //	--------------------------------------------------------------------------------
@@ -31399,7 +31399,7 @@ bool CvUnit::DoFallBack(const CvUnit& attacker, bool bWithdraw)
 			// make a random selection from the remaining plots
 			multimap<int, CvPlot*>::iterator itChosenPlot = aNumFriendlies.begin();
 			if (aNumFriendlies.size() > 1)
-				advance(itChosenPlot, GC.getGame().getSmallFakeRandNum(aNumFriendlies.size(), plot()->GetPlotIndex() + GetID() + getDamage()));
+				advance(itChosenPlot, GC.getGame().urandLimitExclusive(aNumFriendlies.size(), plot()->GetPseudoRandomSeed() + static_cast<uint>(GetID()) + static_cast<uint>(getDamage())));
 			pDestPlot = itChosenPlot->second;
 		}
 	}
@@ -31538,7 +31538,7 @@ void CvUnit::AI_promote()
 
 			//add some randomness
 			if(iValue > 0)
-				iValue += GC.getGame().getSmallFakeRandNum(iValue, plot()->GetPlotIndex() + iI);
+				iValue += GC.getGame().randRangeExclusive(0, iValue, plot()->GetPseudoRandomSeed() + static_cast<uint>(iI));
 
 			if(iValue > iBestValue)
 			{

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -657,7 +657,7 @@ void CvUnit::initWithNameOffset(int iID, UnitTypes eUnit, int iNameOffset, UnitA
 	{
 		if(iNameOffset == -1)
 		{
-			iNameOffset = GC.getGame().randRangeExclusive(0, iNumNames, plot()->GetPseudoRandomSeed());
+			iNameOffset = GC.getGame().randRangeExclusive(0, iNumNames, CvSeeder(plot()->GetPseudoRandomSeed()));
 		}
 #if defined(MOD_BALANCE_CORE)
 		CvString strName = NULL;
@@ -676,7 +676,7 @@ void CvUnit::initWithNameOffset(int iID, UnitTypes eUnit, int iNameOffset, UnitA
 		}
 		if(vfPossibleUnits.size() > 0)
 		{
-			uint uRoll = GC.getGame().urandLimitExclusive(vfPossibleUnits.size(), static_cast<uint>(iID));
+			uint uRoll = GC.getGame().urandLimitExclusive(vfPossibleUnits.size(), CvSeeder(iID));
 			strName = getUnitInfo().GetUnitNames(vfPossibleUnits[uRoll]);
 			setName(strName);
 			SetGreatWork(getUnitInfo().GetGreatWorks(vfPossibleUnits[uRoll]));
@@ -705,7 +705,7 @@ void CvUnit::initWithNameOffset(int iID, UnitTypes eUnit, int iNameOffset, UnitA
 			}
 			if(vfPossibleUnits.size() > 0)
 			{
-				uint uRoll = GC.getGame().urandLimitExclusive(vfPossibleUnits.size(), static_cast<uint>(iID));
+				uint uRoll = GC.getGame().urandLimitExclusive(vfPossibleUnits.size(), CvSeeder(iID));
 				strName = getUnitInfo().GetUnitNames(vfPossibleUnits[uRoll]);
 				setName(strName);
 				SetGreatWork(getUnitInfo().GetGreatWorks(vfPossibleUnits[uRoll]));
@@ -1133,7 +1133,7 @@ void CvUnit::initWithNameOffset(int iID, UnitTypes eUnit, int iNameOffset, UnitA
 			CvCityReligions *pCityReligions = pPlotCity->GetCityReligions();
 
 			int totalFollowers = pPlotCity->getPopulation();
-			int randFollower = GC.getGame().randRangeInclusive(1, totalFollowers, GET_PLAYER(pPlotCity->getOwner()).GetPseudoRandomSeed());
+			int randFollower = GC.getGame().randRangeInclusive(1, totalFollowers, CvSeeder(GET_PLAYER(pPlotCity->getOwner()).GetPseudoRandomSeed()));
 
 			for (int i = RELIGION_PANTHEON; i < GC.getNumReligionInfos(); i++)
 			{
@@ -1163,7 +1163,7 @@ void CvUnit::initWithNameOffset(int iID, UnitTypes eUnit, int iNameOffset, UnitA
 			CvCityReligions *pCityReligions = pPlotCity->GetCityReligions();
 
 			int totalFollowers = pPlotCity->getPopulation();
-			int randFollower = GC.getGame().urandRangeInclusive(1, totalFollowers, GET_PLAYER(pPlotCity->getOwner()).GetPseudoRandomSeed());
+			int randFollower = GC.getGame().urandRangeInclusive(1, totalFollowers, CvSeeder(GET_PLAYER(pPlotCity->getOwner()).GetPseudoRandomSeed()));
 
 			for (int i = RELIGION_PANTHEON; i < GC.getNumReligionInfos(); i++)
 			{
@@ -5496,14 +5496,24 @@ int CvUnit::getCombatDamage(int iStrength, int iOpponentStrength, bool bIncludeR
 	{
 		iModifier += /*0*/ GD_INT_GET(ATTACKING_CITY_MELEE_DAMAGE_MOD) - 100;
 	}
+	
+	CvSeeder randomSeed;
+	if (bIncludeRand)
+	{
+		randomSeed
+			.mixAssign(plot()->GetPseudoRandomSeed())
+			.mixAssign(GetID())
+			.mixAssign(iStrength)
+			.mixAssign(iOpponentStrength);
+	}
 
-	uint uRandomSeed = bIncludeRand ? (static_cast<uint>(plot()->GetPlotIndex()) + static_cast<uint>(GetID()) + static_cast<uint>(iStrength) + static_cast<uint>(iOpponentStrength)) : 0;
 	return CvUnitCombat::DoDamageMath(
 		iStrength,
 		iOpponentStrength,
 		/*2400*/ GD_INT_GET(ATTACK_SAME_STRENGTH_MIN_DAMAGE), //ignore the min part, it's misleading
 		/*1200*/ GD_INT_GET(ATTACK_SAME_STRENGTH_POSSIBLE_EXTRA_DAMAGE),
-		uRandomSeed,
+		bIncludeRand,
+		randomSeed,
 		iModifier ) / 100;
 }
 
@@ -5790,7 +5800,7 @@ bool CvUnit::jumpToNearestValidPlotWithinRange(int iRange, CvPlot* pStartPlot)
 					if (pLoopPlot->getArea() != plot()->getArea())
 						iValue += 11;
 
-					if (iValue < iBestValue || (iValue == iBestValue && GC.getGame().randRangeExclusive(0, 3, pLoopPlot->GetPseudoRandomSeed()) < 2))
+					if (iValue < iBestValue || (iValue == iBestValue && GC.getGame().randRangeExclusive(0, 3, CvSeeder(pLoopPlot->GetPseudoRandomSeed())) < 2))
 					{
 						iBestValue = iValue;
 						pBestPlot = pLoopPlot;
@@ -8196,7 +8206,7 @@ void CvUnit::DoAttrition()
 
 		if (isEnemy(pPlot->getTeam(), pPlot) && getEnemyDamageChance() > 0 && getEnemyDamage() > 0)
 		{
-			if (GC.getGame().randRangeExclusive(0, 100, pPlot->GetPseudoRandomSeed()) < getEnemyDamageChance())
+			if (GC.getGame().randRangeExclusive(0, 100, CvSeeder(pPlot->GetPseudoRandomSeed())) < getEnemyDamageChance())
 			{
 				strAppendText =  GetLocalizedText("TXT_KEY_MISC_YOU_UNIT_WAS_DAMAGED_ATTRITION");
 				changeDamage(getEnemyDamage(), NO_PLAYER, 0.0, &strAppendText);
@@ -8204,7 +8214,7 @@ void CvUnit::DoAttrition()
 		}
 		else if (isEnemy(pPlot->getTeam(), pPlot) && getEnemyDamageChance() > 0 && getEnemyDamage() < 0)
 		{
-			if (GC.getGame().randRangeExclusive(0, 100, pPlot->GetPseudoRandomSeed()) <= getEnemyDamageChance())
+			if (GC.getGame().randRangeExclusive(0, 100, CvSeeder(pPlot->GetPseudoRandomSeed())) <= getEnemyDamageChance())
 			{
 				strAppendText =  GetLocalizedText("TXT_KEY_MISC_YOU_ENEMY_UNITS_DEFECT");
 				changeDamage(getEnemyDamage(), NO_PLAYER, 0.0, &strAppendText);
@@ -8212,7 +8222,7 @@ void CvUnit::DoAttrition()
 		}
 		else if (getNeutralDamageChance() > 0 && getNeutralDamage() > 0)
 		{
-			if (GC.getGame().randRangeExclusive(0, 100, pPlot->GetPseudoRandomSeed()) < getNeutralDamageChance())
+			if (GC.getGame().randRangeExclusive(0, 100, CvSeeder(pPlot->GetPseudoRandomSeed())) < getNeutralDamageChance())
 			{
 				strAppendText =  GetLocalizedText("TXT_KEY_MISC_YOU_UNIT_WAS_DAMAGED_ATTRITION");
 				changeDamage(getNeutralDamage(), NO_PLAYER, 0.0, &strAppendText);
@@ -9648,7 +9658,7 @@ bool CvUnit::createFreeLuxury()
 			{
 				if(GC.getMap().getNumResources(eResource) <= 0)
 				{
-					int iRandomFlavor = GC.getGame().randRangeExclusive(0, 100, static_cast<uint>(iResourceLoop));
+					int iRandomFlavor = GC.getGame().randRangeExclusive(0, 100, CvSeeder(iResourceLoop));
 					//If we've already got this resource, divide the value by the amount.
 					if(GET_PLAYER(getOwner()).getNumResourceTotal(eResource, false) > 0)
 					{
@@ -9670,7 +9680,7 @@ bool CvUnit::createFreeLuxury()
 				CvResourceInfo* pkResource = GC.getResourceInfo(eResource);
 				if (pkResource != NULL && pkResource->getResourceUsage() == RESOURCEUSAGE_LUXURY)
 				{
-					int iRandomFlavor = GC.getGame().randRangeExclusive(0, 100, static_cast<uint>(iResourceLoop));
+					int iRandomFlavor = GC.getGame().randRangeExclusive(0, 100, CvSeeder(iResourceLoop));
 					//If we've already got this resource, divide the value by the amount.
 					if(GET_PLAYER(getOwner()).getNumResourceTotal(eResource, false) > 0)
 					{
@@ -9692,7 +9702,7 @@ bool CvUnit::createFreeLuxury()
 				CvResourceInfo* pkResource = GC.getResourceInfo(eResource);
 				if (pkResource != NULL && pkResource->getResourceUsage() == RESOURCEUSAGE_LUXURY)
 				{
-					int iRandomFlavor = GC.getGame().randRangeExclusive(0, 100, static_cast<uint>(iResourceLoop));
+					int iRandomFlavor = GC.getGame().randRangeExclusive(0, 100, CvSeeder(iResourceLoop));
 					if(iRandomFlavor > iBestFlavor)
 					{
 						eResourceToGive = eResource;
@@ -10601,12 +10611,12 @@ bool CvUnit::pillage()
 					if (iEra <= 0)
 						iEra = 1;
 
-					iPillageGold += 3 + (pkImprovement->GetPillageGold() * iEra * (((75 + max(1, GC.getGame().randRangeExclusive(0, 50, plot()->GetPseudoRandomSeed()))) / 100)));
+					iPillageGold += 3 + (pkImprovement->GetPillageGold() * iEra * (((75 + max(1, GC.getGame().randRangeExclusive(0, 50, CvSeeder(plot()->GetPseudoRandomSeed())))) / 100)));
 					iPillageGold += (getPillageChange() * iPillageGold) / 100;
 				}
 				else
 				{
-					iPillageGold += GC.getGame().randRangeExclusive(0, pkImprovement->GetPillageGold(), plot()->GetPseudoRandomSeed());
+					iPillageGold += GC.getGame().randRangeExclusive(0, pkImprovement->GetPillageGold(), CvSeeder(plot()->GetPseudoRandomSeed()));
 					iPillageGold += (getPillageChange() * iPillageGold) / 100;
 				}
 #if defined(HH_MOD_BUILDINGS_FRUITLESS_PILLAGE)
@@ -17871,13 +17881,23 @@ int CvUnit::GetRangeCombatDamage(const CvUnit* pDefender, const CvCity* pCity, b
 		iDefenderStrength = GetBaseCombatStrength()*100;
 	}
 
-	uint uRandomSeed = bIncludeRand ? (static_cast<uint>(plot()->GetPlotIndex()) + static_cast<uint>(GetID()) + static_cast<uint>(iAttackerStrength) + static_cast<uint>(iDefenderStrength)) : 0;
+	CvSeeder randomSeed;
+	if (bIncludeRand)
+	{
+		randomSeed
+			.mixAssign(plot()->GetPseudoRandomSeed())
+			.mixAssign(GetID())
+			.mixAssign(iAttackerStrength)
+			.mixAssign(iDefenderStrength);
+	}
+
 	int iDamage = CvUnitCombat::DoDamageMath(
 		iAttackerStrength,
 		iDefenderStrength,
 		/*2400*/ GD_INT_GET(RANGE_ATTACK_SAME_STRENGTH_MIN_DAMAGE), //ignore the min part, it's misleading
 		/*1200*/ GD_INT_GET(RANGE_ATTACK_SAME_STRENGTH_POSSIBLE_EXTRA_DAMAGE),
-		uRandomSeed,
+		bIncludeRand,
+		randomSeed,
 		0 ) / 100;
 
 	//extra damage with special promotion
@@ -17933,7 +17953,7 @@ int CvUnit::GetAirStrikeDefenseDamage(const CvUnit* pAttacker, bool bIncludeRand
 		}
 
 		if (bIncludeRand)
-			return iBaseValue + GC.getGame().randRangeExclusive(0, iMaxRandom, plot()->GetPseudoRandomSeed());
+			return iBaseValue + GC.getGame().randRangeExclusive(0, iMaxRandom, CvSeeder(plot()->GetPseudoRandomSeed()));
 		else
 			return iBaseValue;
 	}
@@ -17947,7 +17967,7 @@ int CvUnit::GetAirStrikeDefenseDamage(const CvUnit* pAttacker, bool bIncludeRand
 		}
 
 		if (bIncludeRand)
-			return iVal + GC.getGame().randRangeExclusive(0, iVal / 2, plot()->GetPseudoRandomSeed());
+			return iVal + GC.getGame().randRangeExclusive(0, iVal / 2, CvSeeder(plot()->GetPseudoRandomSeed()));
 		else
 			return iVal+2;
 	}	
@@ -18004,14 +18024,23 @@ int CvUnit::GetInterceptionDamage(const CvUnit* pInterceptedAttacker, bool bIncl
 	// Mod to interceptor strength
 	iInterceptorStrength *= (100 + GetInterceptionCombatModifier());
 	iInterceptorStrength /= 100;
-
-	uint uRandomSeed = bIncludeRand ? (static_cast<uint>(pTargetPlot->GetPlotIndex()) + static_cast<uint>(GetID())+ static_cast<uint>(iInterceptorStrength) + static_cast<uint>(iInterceptedAttackerStrength)) : 0;
+	
+	CvSeeder randomSeed;
+	if (bIncludeRand)
+	{
+		randomSeed
+			.mixAssign(pTargetPlot->GetPseudoRandomSeed())
+			.mixAssign(GetID())
+			.mixAssign(iInterceptorStrength)
+			.mixAssign(iInterceptedAttackerStrength);
+	}
 	return CvUnitCombat::DoDamageMath(
 		iInterceptorStrength,
 		iInterceptedAttackerStrength,
 		/*2400*/ GD_INT_GET(INTERCEPTION_SAME_STRENGTH_MIN_DAMAGE), //ignore the min part, it's misleading
 		/*1200*/ GD_INT_GET(INTERCEPTION_SAME_STRENGTH_POSSIBLE_EXTRA_DAMAGE),
-		uRandomSeed,
+		bIncludeRand,
+		randomSeed,
 		pInterceptedAttacker->GetInterceptionDefenseDamageModifier() ) / 100;
 }
 
@@ -24717,7 +24746,7 @@ void CvUnit::DoConvertReligiousUnitsToMilitary(const CvPlot* pPlot)
 		if (getTeam() != GET_TEAM(kPlayer.getTeam()).GetID())
 		{
 			CvUnit* pConvertUnit = NULL;
-			if (GC.getGame().randRangeExclusive(0, 100, pPlot->GetPseudoRandomSeed()) <= iChanceToConvertReligiousUnit)
+			if (GC.getGame().randRangeExclusive(0, 100, CvSeeder(pPlot->GetPseudoRandomSeed())) <= iChanceToConvertReligiousUnit)
 			{
 				UnitTypes eBestLandUnit = NO_UNIT;
 				int iStrengthBestLandCombat = 0;
@@ -31152,7 +31181,7 @@ void CvUnit::DoPlagueTransfer(CvUnit& defender)
 		CvPromotionEntry* pkPlaguePromotionInfo = GC.getPromotionInfo(eInflictedPlague);
 
 		// Is the plague inflicted?
-		int iRoll = GC.getGame().randRangeExclusive(0, 100, static_cast<uint>(GetID()) + (static_cast<uint>(defender.GetID()) / 2) + (static_cast<uint>(iCount) * 493));
+		int iRoll = GC.getGame().randRangeExclusive(0, 100, CvSeeder(GetID()).mix(defender.GetID()).mix(iCount));
 		iCount--;
 		if (iRoll > iPlagueChance)
 			return;
@@ -31306,7 +31335,7 @@ bool CvUnit::CheckWithdrawal(const CvUnit& attacker) const
 		return true;
 
 	//include damage so the result changes for each attack
-	int iRoll = GC.getGame().randRangeExclusive(0, 10, plot()->GetPseudoRandomSeed() + static_cast<uint>(GetID()) + static_cast<uint>(getDamage())) * 10;
+	int iRoll = GC.getGame().randRangeExclusive(0, 10, CvSeeder(plot()->GetPseudoRandomSeed()).mix(GetID()).mix(getDamage())) * 10;
 	return iRoll < iWithdrawChance;
 }
 //	--------------------------------------------------------------------------------
@@ -31399,7 +31428,7 @@ bool CvUnit::DoFallBack(const CvUnit& attacker, bool bWithdraw)
 			// make a random selection from the remaining plots
 			multimap<int, CvPlot*>::iterator itChosenPlot = aNumFriendlies.begin();
 			if (aNumFriendlies.size() > 1)
-				advance(itChosenPlot, GC.getGame().urandLimitExclusive(aNumFriendlies.size(), plot()->GetPseudoRandomSeed() + static_cast<uint>(GetID()) + static_cast<uint>(getDamage())));
+				advance(itChosenPlot, GC.getGame().urandLimitExclusive(aNumFriendlies.size(), CvSeeder(plot()->GetPseudoRandomSeed()).mix(GetID()).mix(getDamage())));
 			pDestPlot = itChosenPlot->second;
 		}
 	}
@@ -31538,7 +31567,7 @@ void CvUnit::AI_promote()
 
 			//add some randomness
 			if(iValue > 0)
-				iValue += GC.getGame().randRangeExclusive(0, iValue, plot()->GetPseudoRandomSeed() + static_cast<uint>(iI));
+				iValue += GC.getGame().randRangeExclusive(0, iValue, CvSeeder(plot()->GetPseudoRandomSeed()).mix(iI));
 
 			if(iValue > iBestValue)
 			{

--- a/CvGameCoreDLL_Expansion2/CvUnitCombat.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnitCombat.cpp
@@ -354,7 +354,7 @@ void CvUnitCombat::GenerateMeleeCombatInfo(CvUnit& kAttacker, CvUnit* pkDefender
 		}
 		else if (iAttackerTotalDamageInflicted >= iDefenderMaxHP && kAttacker.IsCaptureDefeatedEnemy() && kAttacker.getDomainType()==pkDefender->getDomainType())
 		{
-			int iCaptureRoll = GC.getGame().randRangeExclusive(0, 100, static_cast<uint>(pkDefender->GetID()) + plot.GetPseudoRandomSeed());
+			int iCaptureRoll = GC.getGame().randRangeExclusive(0, 100, CvSeeder(pkDefender->GetID()).mix(plot.GetPseudoRandomSeed()));
 
 			if (iCaptureRoll < kAttacker.GetCaptureChance(pkDefender))
 			{
@@ -1079,7 +1079,7 @@ void CvUnitCombat::ResolveRangedUnitVsCombat(const CvCombatInfo& kCombatInfo, ui
 #if defined(MOD_BALANCE_CORE)
 						if (pkAttacker->GetMoraleBreakChance() > 0 && !pkDefender->isDelayedDeath() && pkDefender->GetNumFallBackPlotsAvailable(*pkAttacker) > 0)
 						{
-							int iRand = GC.getGame().randRangeExclusive(0, 100, static_cast<uint>(pkDefender->GetID()) + pkDefender->plot()->GetPseudoRandomSeed());
+							int iRand = GC.getGame().randRangeExclusive(0, 100, CvSeeder(pkDefender->GetID()).mix(pkDefender->plot()->GetPseudoRandomSeed()));
 							if(iRand <= pkAttacker->GetMoraleBreakChance())
 							{
 								pkDefender->DoFallBack(*pkAttacker);
@@ -1537,10 +1537,10 @@ void CvUnitCombat::GenerateAirCombatInfo(CvUnit& kAttacker, CvUnit* pkDefender, 
 	{
 		// Does the attacker evade?
 		int iInterceptionDamage = 0;
-		if(kAttacker.evasionProbability()==0 || GC.getGame().randRangeExclusive(0, 100, plot.GetPseudoRandomSeed() + static_cast<uint>(pInterceptor->GetID()) + static_cast<uint>(pInterceptor->getMadeInterceptionCount())) >= kAttacker.evasionProbability())
+		if(kAttacker.evasionProbability()==0 || GC.getGame().randRangeExclusive(0, 100, CvSeeder(plot.GetPseudoRandomSeed()).mix(pInterceptor->GetID()).mix(pInterceptor->getMadeInterceptionCount())) >= kAttacker.evasionProbability())
 		{
 			// Is the interception successful?
-			if (pInterceptor->interceptionProbability()>=100 || GC.getGame().randRangeExclusive(0, 100, plot.GetPseudoRandomSeed() + static_cast<uint>(kAttacker.GetID()) + static_cast<uint>(kAttacker.getDamage())) <= pInterceptor->interceptionProbability())
+			if (pInterceptor->interceptionProbability()>=100 || GC.getGame().randRangeExclusive(0, 100, CvSeeder(plot.GetPseudoRandomSeed()).mix(kAttacker.GetID()).mix(kAttacker.getDamage())) <= pInterceptor->interceptionProbability())
 			{
 				bool bIncludeRand = !GC.getGame().isGameMultiPlayer();
 				iInterceptionDamage = pInterceptor->GetInterceptionDamage(&kAttacker, bIncludeRand, &plot);
@@ -2530,7 +2530,7 @@ void CvUnitCombat::GenerateNuclearCombatInfo(CvUnit& kAttacker, CvPlot& plot, Cv
 			BATTLE_JOINED(plot.getPlotCity(), BATTLE_UNIT_DEFENDER, true);
 			pkCombatInfo->setCity(BATTLE_UNIT_DEFENDER, pInterceptionCity);
 
-			if (GC.getGame().randRangeExclusive(0, 100, plot.GetPseudoRandomSeed() + static_cast<uint>(kAttacker.GetID())) <= pInterceptionCity->getNukeInterceptionChance())
+			if (GC.getGame().randRangeExclusive(0, 100, CvSeeder(plot.GetPseudoRandomSeed()).mix(kAttacker.GetID())) <= pInterceptionCity->getNukeInterceptionChance())
 			{
 				bInterceptionSuccess = true;
 			}
@@ -2805,7 +2805,7 @@ uint CvUnitCombat::ApplyNuclearExplosionDamage(const CvCombatMemberEntry* pkDama
 							CvFeatureInfo* pkFeatureInfo = GC.getFeatureInfo(pLoopPlot->getFeatureType());
 							if(pkFeatureInfo && !pkFeatureInfo->isNukeImmune())
 							{
-								if (pLoopPlot == pkTargetPlot || GC.getGame().randRangeExclusive(0, 100, pLoopPlot->GetPseudoRandomSeed()) < /*50*/ GD_INT_GET(NUKE_FALLOUT_PROB))
+								if (pLoopPlot == pkTargetPlot || GC.getGame().randRangeExclusive(0, 100, CvSeeder(pLoopPlot->GetPseudoRandomSeed())) < /*50*/ GD_INT_GET(NUKE_FALLOUT_PROB))
 								{
 									if(pLoopPlot->getImprovementType() != NO_IMPROVEMENT)
 									{
@@ -2817,7 +2817,7 @@ uint CvUnitCombat::ApplyNuclearExplosionDamage(const CvCombatMemberEntry* pkDama
 						}
 						else
 						{
-							if(pLoopPlot == pkTargetPlot || GC.getGame().randRangeExclusive(0, 100, pLoopPlot->GetPseudoRandomSeed()) < /*50*/ GD_INT_GET(NUKE_FALLOUT_PROB))
+							if(pLoopPlot == pkTargetPlot || GC.getGame().randRangeExclusive(0, 100, CvSeeder(pLoopPlot->GetPseudoRandomSeed())) < /*50*/ GD_INT_GET(NUKE_FALLOUT_PROB))
 							{
 								if(pLoopPlot->getImprovementType() != NO_IMPROVEMENT)
 								{
@@ -2828,7 +2828,7 @@ uint CvUnitCombat::ApplyNuclearExplosionDamage(const CvCombatMemberEntry* pkDama
 						}
 #if defined(MOD_GLOBAL_NUKES_MELT_ICE)
 					} else if (MOD_GLOBAL_NUKES_MELT_ICE && pLoopPlot->getFeatureType() == FEATURE_ICE) {
-						if (pLoopPlot == pkTargetPlot || GC.getGame().randRangeExclusive(0, 100, pLoopPlot->GetPseudoRandomSeed()) < /*50*/ GD_INT_GET(NUKE_FALLOUT_PROB)) {
+						if (pLoopPlot == pkTargetPlot || GC.getGame().randRangeExclusive(0, 100, CvSeeder(pLoopPlot->GetPseudoRandomSeed())) < /*50*/ GD_INT_GET(NUKE_FALLOUT_PROB)) {
 							pLoopPlot->setFeatureType(NO_FEATURE);
 						}
 #endif
@@ -2880,14 +2880,14 @@ uint CvUnitCombat::ApplyNuclearExplosionDamage(const CvCombatMemberEntry* pkDama
 					if(iDamageLevel == 1)
 					{
 						iBaseDamage = /*30*/ GD_INT_GET(NUKE_LEVEL1_POPULATION_DEATH_BASE);
-						iRandDamage1 = GC.getGame().randRangeExclusive(0, /*20*/ GD_INT_GET(NUKE_LEVEL1_POPULATION_DEATH_RAND_1), static_cast<uint>(pkCity->getPopulation()) + static_cast<uint>(i));
-						iRandDamage2 = GC.getGame().randRangeExclusive(0, /*20*/ GD_INT_GET(NUKE_LEVEL1_POPULATION_DEATH_RAND_2), static_cast<uint>(pkCity->GetPower()) + static_cast<uint>(i));
+						iRandDamage1 = GC.getGame().randRangeExclusive(0, /*20*/ GD_INT_GET(NUKE_LEVEL1_POPULATION_DEATH_RAND_1), CvSeeder(pkCity->getPopulation()).mix(i));
+						iRandDamage2 = GC.getGame().randRangeExclusive(0, /*20*/ GD_INT_GET(NUKE_LEVEL1_POPULATION_DEATH_RAND_2), CvSeeder(pkCity->GetPower()).mix(i));
 					}
 					else
 					{
 						iBaseDamage = /*60*/ GD_INT_GET(NUKE_LEVEL2_POPULATION_DEATH_BASE);
-						iRandDamage1 = GC.getGame().randRangeExclusive(0, /*10*/ GD_INT_GET(NUKE_LEVEL2_POPULATION_DEATH_RAND_1), static_cast<uint>(pkCity->getPopulation()) + static_cast<uint>(i));
-						iRandDamage2 = GC.getGame().randRangeExclusive(0, /*10*/ GD_INT_GET(NUKE_LEVEL2_POPULATION_DEATH_RAND_2), static_cast<uint>(pkCity->GetPower()) + static_cast<uint>(i));
+						iRandDamage1 = GC.getGame().randRangeExclusive(0, /*10*/ GD_INT_GET(NUKE_LEVEL2_POPULATION_DEATH_RAND_1), CvSeeder(pkCity->getPopulation()).mix(i));
+						iRandDamage2 = GC.getGame().randRangeExclusive(0, /*10*/ GD_INT_GET(NUKE_LEVEL2_POPULATION_DEATH_RAND_2), CvSeeder(pkCity->GetPower()).mix(i));
 					}
 
 					int iNukedPopulation = pkCity->getPopulation() * (iBaseDamage + iRandDamage1 + iRandDamage2) / 100;
@@ -3045,7 +3045,7 @@ void CvUnitCombat::GenerateNuclearExplosionDamage(CvPlot* pkTargetPlot, int iDam
 								// How much destruction is unleashed on nearby Units?
 								if(iDamageLevel == 1 && pLoopPlot != pkTargetPlot)	// Nuke level 1, but NOT the plot that got hit directly (units there are killed)
 								{
-									iNukeDamage = (/*30*/ GD_INT_GET(NUKE_UNIT_DAMAGE_BASE) + /*40*/ GC.getGame().randRangeExclusive(0, GD_INT_GET(NUKE_UNIT_DAMAGE_RAND_1), pLoopPlot->GetPseudoRandomSeed()) + /*40*/ GC.getGame().randRangeExclusive(0, GD_INT_GET(NUKE_UNIT_DAMAGE_RAND_2), static_cast<uint>(pLoopUnit->GetID()) + static_cast<uint>(iDX) + static_cast<uint>(iDY)));
+									iNukeDamage = (/*30*/ GD_INT_GET(NUKE_UNIT_DAMAGE_BASE) + /*40*/ GC.getGame().randRangeExclusive(0, GD_INT_GET(NUKE_UNIT_DAMAGE_RAND_1), CvSeeder(pLoopPlot->GetPseudoRandomSeed())) + /*40*/ GC.getGame().randRangeExclusive(0, GD_INT_GET(NUKE_UNIT_DAMAGE_RAND_2), CvSeeder(pLoopUnit->GetID()).mix(iDX).mix(iDY)));
 								}
 								// Wipe everything out
 								else
@@ -3238,7 +3238,7 @@ bool CvUnitCombat::ParadropIntercept(CvUnit& paraUnit, CvPlot& dropPlot) {
 		int iInterceptionDamage = 0;
 
 		// Is the interception successful?
-		if(GC.getGame().randRangeExclusive(0, 100, dropPlot.GetPseudoRandomSeed() + static_cast<uint>(paraUnit.GetID()) + static_cast<uint>(paraUnit.getDamage())) < pInterceptor->interceptionProbability())
+		if(GC.getGame().randRangeExclusive(0, 100, CvSeeder(dropPlot.GetPseudoRandomSeed()).mix(paraUnit.GetID()).mix(paraUnit.getDamage())) < pInterceptor->interceptionProbability())
 		{
 			iInterceptionDamage = pInterceptor->GetInterceptionDamage(&paraUnit, true, &dropPlot);
 		}
@@ -3318,15 +3318,15 @@ bool CvUnitCombat::ParadropIntercept(CvUnit& paraUnit, CvPlot& dropPlot) {
 #endif
 
 //result is times 100
-int CvUnitCombat::DoDamageMath(int iAttackerStrength100, int iDefenderStrength100, int iDefaultDamage100, int iMaxRandomDamage100, uint uRandomSeed, int iModifierPercent)
+int CvUnitCombat::DoDamageMath(int iAttackerStrength100, int iDefenderStrength100, int iDefaultDamage100, int iMaxRandomDamage100, bool bIncludeRand, CvSeeder randomSeed, int iModifierPercent)
 {
 	// Base damage for two units of identical strength
 	int iDamage = iDefaultDamage100;
 
 	// Don't use rand when calculating projected combat results
-	if(uRandomSeed > 0)
+	if(bIncludeRand)
 	{
-		iDamage += GC.getGame().randRangeExclusive(0, iMaxRandomDamage100, uRandomSeed);
+		iDamage += GC.getGame().randRangeExclusive(0, iMaxRandomDamage100, randomSeed);
 	}
 	else
 	{

--- a/CvGameCoreDLL_Expansion2/CvUnitCombat.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnitCombat.cpp
@@ -354,7 +354,7 @@ void CvUnitCombat::GenerateMeleeCombatInfo(CvUnit& kAttacker, CvUnit* pkDefender
 		}
 		else if (iAttackerTotalDamageInflicted >= iDefenderMaxHP && kAttacker.IsCaptureDefeatedEnemy() && kAttacker.getDomainType()==pkDefender->getDomainType())
 		{
-			int iCaptureRoll = GC.getGame().getSmallFakeRandNum(100, pkDefender->GetID(), plot);
+			int iCaptureRoll = GC.getGame().randRangeExclusive(0, 100, static_cast<uint>(pkDefender->GetID()) + plot.GetPseudoRandomSeed());
 
 			if (iCaptureRoll < kAttacker.GetCaptureChance(pkDefender))
 			{
@@ -1079,7 +1079,7 @@ void CvUnitCombat::ResolveRangedUnitVsCombat(const CvCombatInfo& kCombatInfo, ui
 #if defined(MOD_BALANCE_CORE)
 						if (pkAttacker->GetMoraleBreakChance() > 0 && !pkDefender->isDelayedDeath() && pkDefender->GetNumFallBackPlotsAvailable(*pkAttacker) > 0)
 						{
-							int iRand = GC.getGame().getSmallFakeRandNum(100, pkDefender->GetID()+pkDefender->plot()->GetPlotIndex());
+							int iRand = GC.getGame().randRangeExclusive(0, 100, static_cast<uint>(pkDefender->GetID()) + pkDefender->plot()->GetPseudoRandomSeed());
 							if(iRand <= pkAttacker->GetMoraleBreakChance())
 							{
 								pkDefender->DoFallBack(*pkAttacker);
@@ -1537,10 +1537,10 @@ void CvUnitCombat::GenerateAirCombatInfo(CvUnit& kAttacker, CvUnit* pkDefender, 
 	{
 		// Does the attacker evade?
 		int iInterceptionDamage = 0;
-		if(kAttacker.evasionProbability()==0 || GC.getGame().getSmallFakeRandNum(100, plot.GetPlotIndex()+pInterceptor->GetID()+pInterceptor->getMadeInterceptionCount()) >= kAttacker.evasionProbability())
+		if(kAttacker.evasionProbability()==0 || GC.getGame().randRangeExclusive(0, 100, plot.GetPseudoRandomSeed() + static_cast<uint>(pInterceptor->GetID()) + static_cast<uint>(pInterceptor->getMadeInterceptionCount())) >= kAttacker.evasionProbability())
 		{
 			// Is the interception successful?
-			if (pInterceptor->interceptionProbability()>=100 || GC.getGame().getSmallFakeRandNum(100, plot.GetPlotIndex()+kAttacker.GetID()+kAttacker.getDamage()) <= pInterceptor->interceptionProbability())
+			if (pInterceptor->interceptionProbability()>=100 || GC.getGame().randRangeExclusive(0, 100, plot.GetPseudoRandomSeed() + static_cast<uint>(kAttacker.GetID()) + static_cast<uint>(kAttacker.getDamage())) <= pInterceptor->interceptionProbability())
 			{
 				bool bIncludeRand = !GC.getGame().isGameMultiPlayer();
 				iInterceptionDamage = pInterceptor->GetInterceptionDamage(&kAttacker, bIncludeRand, &plot);
@@ -2530,7 +2530,7 @@ void CvUnitCombat::GenerateNuclearCombatInfo(CvUnit& kAttacker, CvPlot& plot, Cv
 			BATTLE_JOINED(plot.getPlotCity(), BATTLE_UNIT_DEFENDER, true);
 			pkCombatInfo->setCity(BATTLE_UNIT_DEFENDER, pInterceptionCity);
 
-			if (GC.getGame().getSmallFakeRandNum(100, plot.GetPlotIndex() + kAttacker.GetID()) <= pInterceptionCity->getNukeInterceptionChance())
+			if (GC.getGame().randRangeExclusive(0, 100, plot.GetPseudoRandomSeed() + static_cast<uint>(kAttacker.GetID())) <= pInterceptionCity->getNukeInterceptionChance())
 			{
 				bInterceptionSuccess = true;
 			}
@@ -2805,7 +2805,7 @@ uint CvUnitCombat::ApplyNuclearExplosionDamage(const CvCombatMemberEntry* pkDama
 							CvFeatureInfo* pkFeatureInfo = GC.getFeatureInfo(pLoopPlot->getFeatureType());
 							if(pkFeatureInfo && !pkFeatureInfo->isNukeImmune())
 							{
-								if (pLoopPlot == pkTargetPlot || GC.getGame().getSmallFakeRandNum(100, *pLoopPlot) < /*50*/ GD_INT_GET(NUKE_FALLOUT_PROB))
+								if (pLoopPlot == pkTargetPlot || GC.getGame().randRangeExclusive(0, 100, pLoopPlot->GetPseudoRandomSeed()) < /*50*/ GD_INT_GET(NUKE_FALLOUT_PROB))
 								{
 									if(pLoopPlot->getImprovementType() != NO_IMPROVEMENT)
 									{
@@ -2817,7 +2817,7 @@ uint CvUnitCombat::ApplyNuclearExplosionDamage(const CvCombatMemberEntry* pkDama
 						}
 						else
 						{
-							if(pLoopPlot == pkTargetPlot || GC.getGame().getSmallFakeRandNum(100, *pLoopPlot) < /*50*/ GD_INT_GET(NUKE_FALLOUT_PROB))
+							if(pLoopPlot == pkTargetPlot || GC.getGame().randRangeExclusive(0, 100, pLoopPlot->GetPseudoRandomSeed()) < /*50*/ GD_INT_GET(NUKE_FALLOUT_PROB))
 							{
 								if(pLoopPlot->getImprovementType() != NO_IMPROVEMENT)
 								{
@@ -2828,7 +2828,7 @@ uint CvUnitCombat::ApplyNuclearExplosionDamage(const CvCombatMemberEntry* pkDama
 						}
 #if defined(MOD_GLOBAL_NUKES_MELT_ICE)
 					} else if (MOD_GLOBAL_NUKES_MELT_ICE && pLoopPlot->getFeatureType() == FEATURE_ICE) {
-						if (pLoopPlot == pkTargetPlot || GC.getGame().getSmallFakeRandNum(100, *pLoopPlot) < /*50*/ GD_INT_GET(NUKE_FALLOUT_PROB)) {
+						if (pLoopPlot == pkTargetPlot || GC.getGame().randRangeExclusive(0, 100, pLoopPlot->GetPseudoRandomSeed()) < /*50*/ GD_INT_GET(NUKE_FALLOUT_PROB)) {
 							pLoopPlot->setFeatureType(NO_FEATURE);
 						}
 #endif
@@ -2880,14 +2880,14 @@ uint CvUnitCombat::ApplyNuclearExplosionDamage(const CvCombatMemberEntry* pkDama
 					if(iDamageLevel == 1)
 					{
 						iBaseDamage = /*30*/ GD_INT_GET(NUKE_LEVEL1_POPULATION_DEATH_BASE);
-						iRandDamage1 = GC.getGame().getSmallFakeRandNum(/*20*/ GD_INT_GET(NUKE_LEVEL1_POPULATION_DEATH_RAND_1), pkCity->getPopulation() + i);
-						iRandDamage2 = GC.getGame().getSmallFakeRandNum(/*20*/ GD_INT_GET(NUKE_LEVEL1_POPULATION_DEATH_RAND_2), pkCity->GetPower() +i);
+						iRandDamage1 = GC.getGame().randRangeExclusive(0, /*20*/ GD_INT_GET(NUKE_LEVEL1_POPULATION_DEATH_RAND_1), static_cast<uint>(pkCity->getPopulation()) + static_cast<uint>(i));
+						iRandDamage2 = GC.getGame().randRangeExclusive(0, /*20*/ GD_INT_GET(NUKE_LEVEL1_POPULATION_DEATH_RAND_2), static_cast<uint>(pkCity->GetPower()) + static_cast<uint>(i));
 					}
 					else
 					{
 						iBaseDamage = /*60*/ GD_INT_GET(NUKE_LEVEL2_POPULATION_DEATH_BASE);
-						iRandDamage1 = GC.getGame().getSmallFakeRandNum(/*10*/ GD_INT_GET(NUKE_LEVEL2_POPULATION_DEATH_RAND_1), pkCity->getPopulation() + i);
-						iRandDamage2 = GC.getGame().getSmallFakeRandNum(/*10*/ GD_INT_GET(NUKE_LEVEL2_POPULATION_DEATH_RAND_2), pkCity->GetPower() + i);
+						iRandDamage1 = GC.getGame().randRangeExclusive(0, /*10*/ GD_INT_GET(NUKE_LEVEL2_POPULATION_DEATH_RAND_1), static_cast<uint>(pkCity->getPopulation()) + static_cast<uint>(i));
+						iRandDamage2 = GC.getGame().randRangeExclusive(0, /*10*/ GD_INT_GET(NUKE_LEVEL2_POPULATION_DEATH_RAND_2), static_cast<uint>(pkCity->GetPower()) + static_cast<uint>(i));
 					}
 
 					int iNukedPopulation = pkCity->getPopulation() * (iBaseDamage + iRandDamage1 + iRandDamage2) / 100;
@@ -3045,7 +3045,7 @@ void CvUnitCombat::GenerateNuclearExplosionDamage(CvPlot* pkTargetPlot, int iDam
 								// How much destruction is unleashed on nearby Units?
 								if(iDamageLevel == 1 && pLoopPlot != pkTargetPlot)	// Nuke level 1, but NOT the plot that got hit directly (units there are killed)
 								{
-									iNukeDamage = (/*30*/ GD_INT_GET(NUKE_UNIT_DAMAGE_BASE) + /*40*/ GC.getGame().getSmallFakeRandNum(GD_INT_GET(NUKE_UNIT_DAMAGE_RAND_1), *pLoopPlot) + /*40*/ GC.getGame().getSmallFakeRandNum(GD_INT_GET(NUKE_UNIT_DAMAGE_RAND_2), pLoopUnit->GetID() + iDX + iDY));
+									iNukeDamage = (/*30*/ GD_INT_GET(NUKE_UNIT_DAMAGE_BASE) + /*40*/ GC.getGame().randRangeExclusive(0, GD_INT_GET(NUKE_UNIT_DAMAGE_RAND_1), pLoopPlot->GetPseudoRandomSeed()) + /*40*/ GC.getGame().randRangeExclusive(0, GD_INT_GET(NUKE_UNIT_DAMAGE_RAND_2), static_cast<uint>(pLoopUnit->GetID()) + static_cast<uint>(iDX) + static_cast<uint>(iDY)));
 								}
 								// Wipe everything out
 								else
@@ -3238,7 +3238,7 @@ bool CvUnitCombat::ParadropIntercept(CvUnit& paraUnit, CvPlot& dropPlot) {
 		int iInterceptionDamage = 0;
 
 		// Is the interception successful?
-		if(GC.getGame().getSmallFakeRandNum(100, dropPlot.GetPlotIndex()+paraUnit.GetID()+paraUnit.getDamage()) < pInterceptor->interceptionProbability())
+		if(GC.getGame().randRangeExclusive(0, 100, dropPlot.GetPseudoRandomSeed() + static_cast<uint>(paraUnit.GetID()) + static_cast<uint>(paraUnit.getDamage())) < pInterceptor->interceptionProbability())
 		{
 			iInterceptionDamage = pInterceptor->GetInterceptionDamage(&paraUnit, true, &dropPlot);
 		}
@@ -3318,15 +3318,15 @@ bool CvUnitCombat::ParadropIntercept(CvUnit& paraUnit, CvPlot& dropPlot) {
 #endif
 
 //result is times 100
-int CvUnitCombat::DoDamageMath(int iAttackerStrength100, int iDefenderStrength100, int iDefaultDamage100, int iMaxRandomDamage100, int iRandomSeed, int iModifierPercent)
+int CvUnitCombat::DoDamageMath(int iAttackerStrength100, int iDefenderStrength100, int iDefaultDamage100, int iMaxRandomDamage100, uint uRandomSeed, int iModifierPercent)
 {
 	// Base damage for two units of identical strength
 	int iDamage = iDefaultDamage100;
 
 	// Don't use rand when calculating projected combat results
-	if(iRandomSeed>0)
+	if(uRandomSeed > 0)
 	{
-		iDamage += GC.getGame().getSmallFakeRandNum(iMaxRandomDamage100, iRandomSeed);
+		iDamage += GC.getGame().randRangeExclusive(0, iMaxRandomDamage100, uRandomSeed);
 	}
 	else
 	{

--- a/CvGameCoreDLL_Expansion2/CvUnitCombat.h
+++ b/CvGameCoreDLL_Expansion2/CvUnitCombat.h
@@ -43,7 +43,7 @@ public:
 #endif
 
 	//returns damage times 100
-	static int DoDamageMath(int iAttackerStrength100, int iDefenderStrength100, int iDefaultDamage100, int iMaxRandomDamage100, uint uRandomSeed, int iModifierPercent);
+	static int DoDamageMath(int iAttackerStrength100, int iDefenderStrength100, int iDefaultDamage100, int iMaxRandomDamage100, bool bIncludeRand, CvSeeder randomSeed, int iModifierPercent);
 	static void ResolveCombat(const CvCombatInfo& kInfo, uint uiParentEventID = 0);
 
 	static ATTACK_RESULT Attack(CvUnit& kAttacker, CvPlot& targetPlot, ATTACK_OPTION eOption);

--- a/CvGameCoreDLL_Expansion2/CvUnitCombat.h
+++ b/CvGameCoreDLL_Expansion2/CvUnitCombat.h
@@ -43,7 +43,7 @@ public:
 #endif
 
 	//returns damage times 100
-	static int DoDamageMath(int iAttackerStrength100, int iDefenderStrength100, int iDefaultDamage100, int iMaxRandomDamage100, int iRandomSeed, int iModifierPercent);
+	static int DoDamageMath(int iAttackerStrength100, int iDefenderStrength100, int iDefaultDamage100, int iMaxRandomDamage100, uint uRandomSeed, int iModifierPercent);
 	static void ResolveCombat(const CvCombatInfo& kInfo, uint uiParentEventID = 0);
 
 	static ATTACK_RESULT Attack(CvUnit& kAttacker, CvPlot& targetPlot, ATTACK_OPTION eOption);

--- a/CvGameCoreDLL_Expansion2/CvVotingClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvVotingClasses.cpp
@@ -8961,7 +8961,7 @@ void CvLeague::DoProjectReward(PlayerTypes ePlayer, LeagueProjectTypes eLeaguePr
 void CvLeague::UpdateName()
 {
 	// Roll for a new name type
-	int iRoll = GC.getGame().getSmallFakeRandNum(GC.getNumLeagueNameInfos(), GC.getNumLeagueNameInfos());
+	int iRoll = GC.getGame().randRangeExclusive(0, GC.getNumLeagueNameInfos(), static_cast<uint>(GC.getNumLeagueNameInfos()));
 	CvLeagueNameEntry* pInfo = GC.getLeagueNameInfo((LeagueNameTypes)iRoll);
 	if (pInfo)
 	{

--- a/CvGameCoreDLL_Expansion2/CvVotingClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvVotingClasses.cpp
@@ -8961,7 +8961,7 @@ void CvLeague::DoProjectReward(PlayerTypes ePlayer, LeagueProjectTypes eLeaguePr
 void CvLeague::UpdateName()
 {
 	// Roll for a new name type
-	int iRoll = GC.getGame().randRangeExclusive(0, GC.getNumLeagueNameInfos(), static_cast<uint>(GC.getNumLeagueNameInfos()));
+	int iRoll = GC.getGame().randRangeExclusive(0, GC.getNumLeagueNameInfos(), CvSeeder(GC.getNumLeagueNameInfos()));
 	CvLeagueNameEntry* pInfo = GC.getLeagueNameInfo((LeagueNameTypes)iRoll);
 	if (pInfo)
 	{


### PR DESCRIPTION
This makes a number of changes to the random number generation functions inside `CvGame` with the intention of reducing the likelihood that programmers make errors while writing RNG related code.

Making these changes required a great deal of code to be touched, the impact of this is that some random number generation may have had its behavior changed in unintentional or unexpected ways. Because of this, the impacted locations should be reviewed carefully.

Additionally, there are several locations where `randRangeExclusive()` is used where it seems likely that the programmer intended `randRangeInclusive()`'s behavior; However the only locations where I made changes to use `randRangeInclusive()` instead were those that would otherwise lead to crashes with the newer strict behavior present (see `randRangeExclusive()`'s documentation). This preserves most of the existing random number generation behavior, but it also suggests that all calls too `randRangeExclusive()` be reviewed to ensure that they _actually_ satisfy the original author's intended behavior.

## Changes Summary
- Removed `CvGame::getSmallFakeRandNum()`. This was done because it was easy to use incorrectly.
- Added `CvGame::randCore()`. This is the core entry point from which random numbers are generated for all the new functions.
- Added several new functions to replace `CvGame::getSmallFakeRandNum()`. See the comments above each declaration within `CvGame.h` for their exact behaviors.
  - `CvGame::urandLimitExclusive()`
  - `CvGame::urandLimitInclusive()`
  - `CvGame::urandRangeExclusive()`
  - `CvGame::urandRangeInclusive()`
  - `CvGame::randRangeExclusive()`
  - `CvGame::randRangeInclusive()`
- Added the `CvSeeder` type. It is a wrapper around an unsigned integer that is intended to be used as a seed and provides convenience functions for mixing values into a composite seed. Any value statically convertible too a `uint` may be used to construct the type and mix values.