### PR TITLE
Bunch of trade path cache fixes

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvBarbarians.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBarbarians.cpp
@@ -966,6 +966,9 @@ void CvBarbarians::DoCamps()
 
 	if (bUpdateMapFog)
 		GC.getMap().updateDeferredFog();
+
+	// new barbarian camps can affect trade route paths cache
+	GC.getGame().GetGameTrade()->InvalidateTradePathCache();
 }
 
 //	--------------------------------------------------------------------------------

--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -651,10 +651,7 @@ void CvCity::init(int iID, PlayerTypes eOwner, int iX, int iY, bool bBumpUnits, 
 	pPlot->updateCityRoute();
 
 	//force recalculation of trade routes
-	for (int iPlayer = 0; iPlayer < MAX_PLAYERS; ++iPlayer)
-	{
-		GC.getGame().GetGameTrade()->InvalidateTradePathCache((PlayerTypes) iPlayer);
-	}
+	GC.getGame().GetGameTrade()->InvalidateTradePathCache();
 
 	for (iI = 0; iI < MAX_TEAMS; iI++)
 	{

--- a/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
@@ -2242,6 +2242,9 @@ void CvMinorCivQuest::DoStartQuest(int iStartTurn, PlayerTypes pCallingPlayer)
 		pPlot->setRevealed(pAssignedPlayer->getTeam(), true);
 		pPlot->setRevealedImprovementType(pAssignedPlayer->getTeam(), pPlot->getImprovementType());
 
+		// revealed barbarian camps can affect trade route paths cache
+		GC.getGame().GetGameTrade()->InvalidateTradePathCache(pAssignedPlayer->GetID());
+
 		strMessage = Localization::Lookup("TXT_KEY_NOTIFICATION_QUEST_KILL_CAMP");
 		strSummary = Localization::Lookup("TXT_KEY_NOTIFICATION_SUMMARY_QUEST_KILL_CAMP");
 		iNotificationX = pPlot->getX();
@@ -2957,6 +2960,9 @@ void CvMinorCivQuest::DoStartQuestUsingExistingData(CvMinorCivQuest* pExistingQu
 
 		pPlot->setRevealed(pAssignedPlayer->getTeam(), true);
 		pPlot->setRevealedImprovementType(pAssignedPlayer->getTeam(), pPlot->getImprovementType());
+
+		// revealed barbarian camps can affect trade route paths cache
+		GC.getGame().GetGameTrade()->InvalidateTradePathCache(pAssignedPlayer->GetID());
 
 		strMessage = Localization::Lookup("TXT_KEY_NOTIFICATION_QUEST_KILL_CAMP");
 		strSummary = Localization::Lookup("TXT_KEY_NOTIFICATION_SUMMARY_QUEST_KILL_CAMP");

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -13842,6 +13842,7 @@ void CvPlayer::receiveGoody(CvPlot* pPlot, GoodyTypes eGoody, CvUnit* pUnit)
 				}
 			}
 		}
+		GC.getGame().GetGameTrade()->InvalidateTradePathTeamCache(getTeam());
 	}
 
 	// Map
@@ -13932,6 +13933,11 @@ void CvPlayer::receiveGoody(CvPlot* pPlot, GoodyTypes eGoody, CvUnit* pUnit)
 				}
 			}
 		}
+
+		if (iNumPlotsRevealed > 0) {
+			GC.getGame().GetGameTrade()->InvalidateTradePathTeamCache(getTeam());
+		}
+
 		if (pUnit != NULL && pUnit->IsGainsXPFromScouting())
 		{
 			pUnit->changeExperienceTimes100(iNumPlotsRevealed * 100);

--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -11035,6 +11035,9 @@ PlotVisibilityChangeResult CvPlot::changeVisibilityCount(TeamTypes eTeam, int iC
 			{
 				GET_TEAM(eTeam).meet(getTeam(), false);	// If there's a City here, we can assume its owner is the same as the plot owner
 			}
+
+			GC.getGame().GetGameTrade()->InvalidateTradePathTeamCache(getTeam());
+			GC.getGame().GetGameTrade()->InvalidateTradePathTeamCache(eTeam);
 		}
 
 		if (eTeam == GC.getGame().getActiveTeam())

--- a/CvGameCoreDLL_Expansion2/CvSerialize.h
+++ b/CvGameCoreDLL_Expansion2/CvSerialize.h
@@ -277,8 +277,8 @@ public:
 		const bool result = other == currentValue();
 
 		if (!result) {
-			// std::string desyncValues = std::string("Desync values, current ") + FSerialization::toString(currentValue()) + "; other " + FSerialization::toString(other) + std::string("\n");
-			// gGlobals.getDLLIFace()->netMessageDebugLog(desyncValues);
+			std::string desyncValues = std::string("Desync values, current ") + FSerialization::toString(currentValue()) + "; other " + FSerialization::toString(other) + std::string("\n");
+			gGlobals.getDLLIFace()->netMessageDebugLog(desyncValues);
 		}
 
 		return result; // Place a conditional breakpoint here to help debug sync errors.

--- a/CvGameCoreDLL_Expansion2/CvTacticalAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTacticalAI.cpp
@@ -10499,9 +10499,9 @@ vector<STacticalAssignment> TacticalAIHelpers::FindBestUnitAssignments(
 			result.empty() ? "failed" : "success",
 			pTarget->getX(), pTarget->getY(), ourUnits.size(), eAggLvl, GET_PLAYER(ePlayer).GetDangerPlotAge(), 
 			iUsedPositions, completedPositions.size(), openPositionsHeap.size(), timer.GetDeltaInSeconds()*1000.f );*/
-		strMsg.Format("tactsim %s, target %d:%d with %d units (agglvl %d). last dangerplots update at %d. tested %d, completed %d, open %d.", 
+		strMsg.Format("tactsim %s, target %d:%d with %d units (agglvl %d). tested %d, completed %d, open %d.", 
 			result.empty() ? "failed" : "success",
-			pTarget->getX(), pTarget->getY(), ourUnits.size(), eAggLvl, GET_PLAYER(ePlayer).GetDangerPlotAge(), 
+			pTarget->getX(), pTarget->getY(), ourUnits.size(), eAggLvl, 
 			iUsedPositions, completedPositions.size(), openPositionsHeap.size());
 		GET_PLAYER(ePlayer).GetTacticalAI()->LogTacticalMessage(strMsg);
 

--- a/CvGameCoreDLL_Expansion2/CvTeam.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTeam.cpp
@@ -4229,6 +4229,10 @@ void CvTeam::makeHasMet(TeamTypes eIndex, bool bSuppressMessages)
 		}
 	}
 
+	// new contacts affects trade route paths cache
+	GC.getGame().GetGameTrade()->InvalidateTradePathTeamCache(GetID());
+	GC.getGame().GetGameTrade()->InvalidateTradePathTeamCache(eIndex);
+
 	// Report event
 	gDLL->GameplayMetTeam(GetID(), eIndex);
 }
@@ -4645,6 +4649,7 @@ void CvTeam::SetHasEmbassyAtTeam(TeamTypes eIndex, bool bNewValue)
 		if(bRevealPlots)
 		{
 			GC.getMap().updateDeferredFog();
+			GC.getGame().GetGameTrade()->InvalidateTradePathTeamCache(GetID());
 		}
 
 		GC.getMap().verifyUnitValidPlot();

--- a/CvGameCoreDLL_Expansion2/CvTradeClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTradeClasses.cpp
@@ -161,6 +161,24 @@ bool CvGameTrade::HavePotentialTradePath(bool bWater, CvCity* pOriginCity, CvCit
 	return false;
 }
 
+void CvGameTrade::InvalidateTradePathCache()
+{
+	for (uint uiPlayer1 = 0; uiPlayer1 < MAX_PLAYERS; uiPlayer1++)
+	{
+		PlayerTypes ePlayer1 = (PlayerTypes)uiPlayer1;
+		InvalidateTradePathCache(ePlayer1);
+	}
+}
+
+void CvGameTrade::InvalidateTradePathTeamCache(TeamTypes eTeam)
+{
+	vector<PlayerTypes> vFromTeam = GET_TEAM(eTeam).getPlayers();
+	for (size_t j = 0; j < vFromTeam.size(); j++)
+	{
+		GC.getGame().GetGameTrade()->InvalidateTradePathCache(vFromTeam[j]);
+	}
+}
+
 void CvGameTrade::InvalidateTradePathCache(PlayerTypes ePlayer)
 {
 	m_lastTradePathUpdate[ePlayer] = -1;
@@ -169,7 +187,7 @@ void CvGameTrade::InvalidateTradePathCache(PlayerTypes ePlayer)
 void CvGameTrade::UpdateTradePathCache(PlayerTypes ePlayer1)
 {
 	CvPlayer& kPlayer1 = GET_PLAYER(ePlayer1);
-	if (!kPlayer1.isAlive() || kPlayer1.isBarbarian())
+	if (!kPlayer1.isAlive() || kPlayer1.isBarbarian() || kPlayer1.isMinorCiv())
 		return;
 
 	//check if we have anything to do
@@ -5159,6 +5177,11 @@ bool CvPlayerTrade::PlunderTradeRoute(int iTradeConnectionID, CvUnit* pUnit)
 }
 void CvPlayerTrade::UpdateFurthestPossibleTradeRoute(DomainTypes eDomain, CvCity* pOriginCity, int iMaxRange)
 {
+	// don't calculate trade routes for minors
+	if (m_pPlayer->isMinorCiv()) {
+		return;
+	}
+
 	int iLongestRoute = 0;
 	
 	CvString strMsg;

--- a/CvGameCoreDLL_Expansion2/CvTradeClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvTradeClasses.h
@@ -213,7 +213,9 @@ public:
 	const std::map<int, SPath>& GetAllPotentialTradeRoutesFromCity(CvCity* pOrigin, bool bWater);
 	bool HavePotentialTradePath(bool bWater, CvCity* pOriginCity, CvCity* pDestCity, SPath* pPathOut=NULL);
 	void UpdateTradePathCache(PlayerTypes iOriginPlayer);
+	void InvalidateTradePathCache();
 	void InvalidateTradePathCache(PlayerTypes iPlayer);
+	void InvalidateTradePathTeamCache(TeamTypes eTeam);
 
 protected:
 

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -14144,6 +14144,8 @@ bool CvUnit::build(BuildTypes eBuild)
 				}
 			}
 #endif
+			// invalidate trade paths because plot was changed and it can affect trade route length
+			GC.getGame().GetGameTrade()->InvalidateTradePathCache();
 #if defined(MOD_BALANCE_CORE)
 			if (eImprovement != NO_IMPROVEMENT)
 			{


### PR DESCRIPTION
(possibly) fixes #10126

1. Don't calculate trade path cache for CS (correct me if we really need this)
2. Reset trade path cache when some improvement built (new roads, forest/jungle removal (something else?) affects trade path cache)
3. Reset cache when new civ met, when revealing barbarian camp, when revealing new city

Quite possible still some cases are missing. Maybe we should rethink how everything work because it is really hard to make this cache up-to-date.

Such bugs affect SP too, but they are not so fatal there, just outdated data beign used. 

For MP it causes desyncs because the same cache is used for UI displaying and for core calculations. For example, the following situation is possible:
- Player A starts the turn, some UI LUA function got called, they initialized the trade path cache.
- These UI LUA functions were not triggered on the Player B end, as a result Player B has empty trade path cache.
- Core logic got executed, trade paths got changed, but cache for the Player A was already initialized and now it remains unchanged even after core logic execution, while for Player B it was calculated by core logic from scratch.
- Now Player A and Player B has different trade path caches and both of them make different game decisions.

Still hard to find out whether or not this desync affects too much. Anyway, let's fix it.