### PR TITLE
DangerPlots and TacticalAI cache invalidation

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -35267,8 +35267,13 @@ void CvPlayer::setTurnActive(bool bNewValue, bool bDoTurn) // R: bDoTurn default
 				GetTreasury()->DoUpdateCityConnectionGold();
 
 				//no tactical AI for human, only make sure we have current postures in case we want the AI to take over (debugging)
-				if (isHuman())
+				if (isHuman() || /* if MP, invalidate for AI too */ kGame.isNetworkMultiPlayer()) {
 					GetTacticalAI()->GetTacticalAnalysisMap()->Invalidate();
+				}
+
+				// update danger plots before the turn
+				// causes MP desyncs otherwise (see #10147), affects SP just a little
+				UpdateDangerPlots(false);
 
 				if(kGame.isFinalInitialized())
 				{

--- a/CvGameCoreDLL_Expansion2/CvTacticalAnalysisMap.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTacticalAnalysisMap.cpp
@@ -561,12 +561,17 @@ bool CvTacticalAnalysisMap::IsUpToDate()
 	if (m_iLastUpdate == -1)
 		return false;
 
-	//otherwise consider it up to date if it's not our turn
-	if (m_ePlayer != GC.getGame().getActivePlayer())
-		return true;
+	if (GC.getGame().isNetworkMultiPlayer()) {
+		return (m_iLastUpdate == GC.getGame().getGameTurn());
+	}
+	else {
+		//otherwise consider it up to date if it's not our turn
+		if (m_ePlayer != GC.getGame().getActivePlayer())
+			return true;
 
-	//default check for age
-	return (m_iLastUpdate == GC.getGame().getGameTurn());
+		//default check for age
+		return (m_iLastUpdate == GC.getGame().getGameTurn());
+	}
 }
 
 void CvTacticalAnalysisMap::Invalidate()


### PR DESCRIPTION
Fixes #10147

Some details are [here](https://github.com/LoneGazebo/Community-Patch-DLL/issues/10147#issuecomment-1704318522) too.

This desync works like so:
- Turn begins, some core logic, ..., Player A starts the turn
- In this case all danger plots caches are invalidated because someone made a peace treaty (`CvPlayerManager::Refresh`, invalidates all caches)
- Player A moves some units
- Player A clicks some UI button, it recalculates danger plots cache for AI
![image](https://github.com/LoneGazebo/Community-Patch-DLL/assets/3791221/e85a21b3-e74b-44a3-bd58-d8d7a770c1fb)
- All players end the turn, next turn begins
- On the Player's A end, AI has the updated danger plots cache (because some UI button was clicked) and it works correctly
- Player B didn't click the mentioned UI button, so all danger plots are outdated initially. So, getting the different results for AI logic.

The situation is very similar to trade path cache: using the same cache for UI and for core logic. Possibly we should just invalidate trade path cache here too. Also possibly we should generalize and refactor all the caches to get rid of such desyncs forever, because looks like the logic which exists right now works wrong fundamentally.

P.S. Also made some changes to tactical AI cache, I'm not sure if it fixes something, but still let it be so. 