### PR TITLE
Minor RNG changes

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvGame.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGame.cpp
@@ -10777,7 +10777,7 @@ unsigned long hash32(unsigned long x)
 uint CvGame::randCore(CvSeeder extraSeed) const
 {
 	const CvSeeder mapSeed = CvSeeder::fromRaw(CvPreGame::mapRandomSeed());
-	const CvSeeder gameSeed = CvSeeder(static_cast<uint>(getGameTurn()) * 11);
+	const CvSeeder gameSeed = CvSeeder(static_cast<uint>(getGameTurn()));
 	return mapSeed.mix(gameSeed).mix(extraSeed);
 }
 

--- a/CvGameCoreDLL_Expansion2/CvGame.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGame.cpp
@@ -10777,7 +10777,7 @@ unsigned long hash32(unsigned long x)
 uint CvGame::randCore(CvSeeder extraSeed) const
 {
 	const CvSeeder mapSeed = CvSeeder::fromRaw(CvPreGame::mapRandomSeed());
-	const CvSeeder gameSeed = CvSeeder(static_cast<uint>(getGameTurn()));
+	const CvSeeder gameSeed = CvSeeder(getGameTurn());
 	return mapSeed.mix(gameSeed).mix(extraSeed);
 }
 

--- a/CvGameCoreDLL_Expansion2/CvGame.h
+++ b/CvGameCoreDLL_Expansion2/CvGame.h
@@ -88,7 +88,7 @@ struct NODISCARD CvSeeder {
 		return newSeed;
 	}
 
-	inline operator uint()
+	inline operator uint() const
 	{
 		return value;
 	}

--- a/CvGameCoreDLL_Expansion2/CvGame.h
+++ b/CvGameCoreDLL_Expansion2/CvGame.h
@@ -560,42 +560,83 @@ public:
 	int getJonRandNumVA(int iNum, const char* pszLog, ...);
 	int getAsyncRandNum(int iNum, const char* pszLog);
 
-	/// Generates a pseudo-random 32-bit number using the game's current state and an extra seed value.
+	/// Generates a pseudo-random 32-bit number using the game's current state and an extra seed.
 	///
-	/// Understand that the number returned by this function is pseudo-random, but consistent given the inputs.
+	/// The number returned by this function is derived from the following parameters and consistent for any unique set:
+	/// - The game's map seed.
+	/// - The game's current turn.
+	/// - The provided extra seed.
+	/// 
+	/// Given that the returned number is consistent for any unique set of the above parameters, the user should make an effort to
+	/// ensure that the provided extra seed is different for any number of consecutive calls that occur on a single turn.
+	/// Failure to do so will lead to the same number being returned for each consecutive call on any given turn.
+	/// 
+	/// If this function is used to generate a number that is subsequently used to change the game state in manner that all peers
+	/// of a multiplayer session must replicate to retain synchronization, then the extra seed must be guaranteed to be identical 
+	/// for all peers of that multiplayer session. If this requirement is not met, then the multiplayer session will desynchronize.
 	uint randCore(CvSeeder extraSeed) const;
 
-	/// Generates a pseudo-random unsigned integer using `randCore` and bounds it within an exclusive range of `0` and `limit`.
+	/// Generates a psuedo-random number using `randCore` and remaps the output into an exclusive range within `0` and `limit`.
+	/// Specifically, if `x` is the returned unsigned integer, then `x` is guaranteed to satisfy the following:
+	/// - `x >= 0`
+	/// - `x < limit`
 	///
-	/// The following invariants must be satisfied for the function to operate correctly:
-	/// - `limit != 0`.
+	/// The following invariants must be satisfied for function to operate correctly:
+	/// - `limit != 0`
+	/// 
+	/// All advisories documented on `randCore` apply to this function.
 	uint urandLimitExclusive(uint limit, CvSeeder extraSeed) const;
 
-	/// Generates a pseudo-random unsigned integer using `randCore` and bounds it within an inclusive range of `0` and `limit`.
+	/// Generates a psuedo-random number using `randCore` and remaps the output into an inclusive range within `0` and `limit`.
+	/// Specifically, if `x` is the returned unsigned integer, then `x` is guaranteed to satisfy the following:
+	/// - `x >= 0`
+	/// - `x <= limit`
+	/// 
+	/// All advisories documented on `randCore` apply to this function.
 	uint urandLimitInclusive(uint limit, CvSeeder extraSeed) const;
 
-	/// Generates a pseudo-random unsigned integer using `randCore` and bounds it within an exclusive range of `min` and `max`.
-	///
+	/// Generates a psuedo-random number using `randCore` and remaps the output into an exclusive range within `min` and `max`.
+	/// Specifically, if `x` is the returned unsigned integer, then `x` is guaranteed to satisfy the following:
+	/// - `x >= min`
+	/// - `x < max`
+	/// 
 	/// The following invariants must be satisfied for the function to operate correctly:
-	/// - `min < max`.
+	/// - `min < max`
+	/// 
+	/// All advisories documented on `randCore` apply to this function.
 	uint urandRangeExclusive(uint min, uint max, CvSeeder extraSeed) const;
 
-	/// Generates a pseudo-random unsigned integer using `randCore` and bounds it within an inclusive range of `min` and `max`.
+	/// Generates a psuedo-random number using `randCore` and remaps the output into an inclusive range within `min` and `max`.
+	/// Specifically, if `x` is the returned unsigned integer, then `x` is guaranteed to satisfy the following:
+	/// - `x >= min`
+	/// - `x <= max`
 	///
 	/// The following invariants must be satisfied for the function to operate correctly:
-	/// - `min <= max`.
+	/// - `min <= max`
+	/// 
+	/// All advisories documented on `randCore` apply to this function.
 	uint urandRangeInclusive(uint min, uint max, CvSeeder extraSeed) const;
 
-	/// Generates a pseudo-random signed integer using `randCore` and bounds it within an exclusive range of `min` and `max`.
-	///
+	/// Generates a psuedo-random number using `randCore` and remaps the output into an exclusive range within `min` and `max`.
+	/// Specifically, if `x` is the returned signed integer, then `x` is guaranteed to satisfy the following:
+	/// - `x >= min`
+	/// - `x < max`
+	/// 
 	/// The following invariants must be satisfied for the function to operate correctly:
-	/// - `min < max`.
+	/// - `min < max`
+	/// 
+	/// All advisories documented on `randCore` apply to this function.
 	int randRangeExclusive(int min, int max, CvSeeder extraSeed) const;
 
-	/// Generates a pseudo-random signed integer using `randCore` and bounds it within an inclusive range of `min` and `max`.
-	///
+	/// Generates a psuedo-random number using `randCore` and remaps the output into an inclusive range within `min` and `max`.
+	/// Specifically, if `x` is the returned signed integer, then `x` is guaranteed to satisfy the following:
+	/// - `x >= min`
+	/// - `x <= max`
+	/// 
 	/// The following invariants must be satisfied for the function to operate correctly:
-	/// - `min <= max`.
+	/// - `min <= max`
+	/// 
+	/// All advisories documented on `randCore` apply to this function.
 	int randRangeInclusive(int min, int max, CvSeeder extraSeed) const;
 
 	int calculateSyncChecksum();

--- a/CvGameCoreDLL_Expansion2/CvGame.h
+++ b/CvGameCoreDLL_Expansion2/CvGame.h
@@ -576,7 +576,7 @@ public:
 	/// for all peers of that multiplayer session. If this requirement is not met, then the multiplayer session will desynchronize.
 	uint randCore(CvSeeder extraSeed) const;
 
-	/// Generates a psuedo-random number using `randCore` and remaps the output into an exclusive range within `0` and `limit`.
+	/// Generates a pseudo-random number using `randCore` and remaps the output into an exclusive range within `0` and `limit`.
 	/// Specifically, if `x` is the returned unsigned integer, then `x` is guaranteed to satisfy the following:
 	/// - `x >= 0`
 	/// - `x < limit`
@@ -587,7 +587,7 @@ public:
 	/// All advisories documented on `randCore` apply to this function.
 	uint urandLimitExclusive(uint limit, CvSeeder extraSeed) const;
 
-	/// Generates a psuedo-random number using `randCore` and remaps the output into an inclusive range within `0` and `limit`.
+	/// Generates a pseudo-random number using `randCore` and remaps the output into an inclusive range within `0` and `limit`.
 	/// Specifically, if `x` is the returned unsigned integer, then `x` is guaranteed to satisfy the following:
 	/// - `x >= 0`
 	/// - `x <= limit`
@@ -595,7 +595,7 @@ public:
 	/// All advisories documented on `randCore` apply to this function.
 	uint urandLimitInclusive(uint limit, CvSeeder extraSeed) const;
 
-	/// Generates a psuedo-random number using `randCore` and remaps the output into an exclusive range within `min` and `max`.
+	/// Generates a pseudo-random number using `randCore` and remaps the output into an exclusive range within `min` and `max`.
 	/// Specifically, if `x` is the returned unsigned integer, then `x` is guaranteed to satisfy the following:
 	/// - `x >= min`
 	/// - `x < max`
@@ -606,7 +606,7 @@ public:
 	/// All advisories documented on `randCore` apply to this function.
 	uint urandRangeExclusive(uint min, uint max, CvSeeder extraSeed) const;
 
-	/// Generates a psuedo-random number using `randCore` and remaps the output into an inclusive range within `min` and `max`.
+	/// Generates a pseudo-random number using `randCore` and remaps the output into an inclusive range within `min` and `max`.
 	/// Specifically, if `x` is the returned unsigned integer, then `x` is guaranteed to satisfy the following:
 	/// - `x >= min`
 	/// - `x <= max`
@@ -617,7 +617,7 @@ public:
 	/// All advisories documented on `randCore` apply to this function.
 	uint urandRangeInclusive(uint min, uint max, CvSeeder extraSeed) const;
 
-	/// Generates a psuedo-random number using `randCore` and remaps the output into an exclusive range within `min` and `max`.
+	/// Generates a pseudo-random number using `randCore` and remaps the output into an exclusive range within `min` and `max`.
 	/// Specifically, if `x` is the returned signed integer, then `x` is guaranteed to satisfy the following:
 	/// - `x >= min`
 	/// - `x < max`
@@ -628,7 +628,7 @@ public:
 	/// All advisories documented on `randCore` apply to this function.
 	int randRangeExclusive(int min, int max, CvSeeder extraSeed) const;
 
-	/// Generates a psuedo-random number using `randCore` and remaps the output into an inclusive range within `min` and `max`.
+	/// Generates a pseudo-random number using `randCore` and remaps the output into an inclusive range within `min` and `max`.
 	/// Specifically, if `x` is the returned signed integer, then `x` is guaranteed to satisfy the following:
 	/// - `x >= min`
 	/// - `x <= max`


### PR DESCRIPTION
# Changes Summary
- Do not multiply the current game turn by `11` in `CvGame::randCore()`.
  - This was done because multiplying by `11` would only change how the number is remapped by `hash32()`, but `hash32()` on its own is enough to produce a good seed for mixing, thus multiplying by `11` would serve little purpose.
- Provide more explicit and generally better documentation for the RNG functions within `CvGame`.
- Change `CvSeeder::operator uint()` to `CvSeeder::operator uint() const`.
  - This should have no impact on optimized builds but is the more correct signature given that the function does not (and should not) modify `this`.