### PR TITLE
readability-isolate-declaration

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvAIOperation.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAIOperation.cpp
@@ -746,7 +746,8 @@ bool CvAIOperation::Move()
 		return false;
 	}
 
-	float fOldVarX,fOldVarY;
+	float fOldVarX;
+	float fOldVarY;
 	CvPlot* pOldCOM = pThisArmy->GetCenterOfMass(false,&fOldVarX,&fOldVarY);
 
 	//todo: move the relevant code from tactical AI to operations
@@ -768,7 +769,8 @@ bool CvAIOperation::Move()
 	//exclude rapid response ops etc
 	if (pThisArmy->GetNumSlotsFilled()>3)
 	{
-		float fNewVarX, fNewVarY;
+		float fNewVarX;
+		float fNewVarY;
 		//center of mass should be moving
 		CvPlot* pNewCOM = pThisArmy->GetCenterOfMass(false, &fNewVarX, &fNewVarY);
 		if (pNewCOM == pOldCOM && fNewVarX >= max(5.f, fOldVarX) && fNewVarY >= max(5.f, fOldVarY))
@@ -1010,7 +1012,10 @@ FDataStream& operator<<(FDataStream& stream, const CvAIOperation& aiOperation)
 #if defined(MOD_BALANCE_CORE)
 const char* CvAIOperation::GetInfoString()
 {
-	CvString strTemp0, strTemp1, strTemp2, strTemp3;
+	CvString strTemp0;
+	CvString strTemp1;
+	CvString strTemp2;
+	CvString strTemp3;
 	strTemp0 = GetOperationName();
 	strTemp1.Format(" (%d) / Target at %d,%d / Muster at %d,%d / ", m_iID, m_iTargetX, m_iTargetY, m_iMusterX, m_iMusterY );
 
@@ -1117,7 +1122,9 @@ void CvAIOperation::LogOperationStatus(bool bPreTurn) const
 	{
 		CvString strOutBuf;
 		CvString strBaseString;
-		CvString strTemp, szTemp2, szTemp3;
+		CvString strTemp;
+		CvString szTemp2;
+		CvString szTemp3;
 		CvString strPlayerName;
 		FILogFile* pLog = NULL;
 
@@ -1175,7 +1182,8 @@ void CvAIOperation::LogOperationStatus(bool bPreTurn) const
 			{
 				CvArmyAI* pThisArmy = GetArmy(uiI);
 				//we don't really need the center of mass but the variance
-				float varX=-1,varY=-1;
+				float varX=-1;
+				float varY=-1;
 				CvPlot* pCoM = pThisArmy->GetCenterOfMass(true,&varX,&varY);
 				szTemp2.Format("Gathering Forces for army %d; center (%d:%d); variance (%.2f:%.2f); free slots %d", 
 					pThisArmy->GetID(), pCoM->getX(), pCoM->getY(), varX, varY, pThisArmy->GetNumFormationEntries() - pThisArmy->GetNumSlotsFilled());
@@ -1541,7 +1549,8 @@ bool CvAIOperationMilitary::CheckTransitionToNextStage()
 
 			//if we have an initial cluster of units, everyone should go there
 			int iGatherTolerance = GetGatherTolerance(pThisArmy, GetMusterPlot());
-			float fX = 0, fY = 0;
+			float fX = 0;
+			float fY = 0;
 			CvPlot* pCoM = pThisArmy->GetCenterOfMass(true,&fX,&fY);
 			if (pCoM && fX < iGatherTolerance && fY < iGatherTolerance && GetMusterPlot() && GetTargetPlot())
 			{
@@ -1559,7 +1568,8 @@ bool CvAIOperationMilitary::CheckTransitionToNextStage()
 	case ARMYAISTATE_WAITING_FOR_UNITS_TO_CATCH_UP:
 		{
 			int iGatherTolerance = GetGatherTolerance(pThisArmy, GetMusterPlot());
-			float fX = 0, fY = 0;
+			float fX = 0;
+			float fY = 0;
 			CvPlot* pCoM = pThisArmy->GetCenterOfMass(true,&fX,&fY);
 			if (fX < iGatherTolerance && fY < iGatherTolerance)
 			{
@@ -3356,7 +3366,8 @@ pair<CvCity*,CvCity*> OperationalAIHelpers::GetClosestCoastalCityPair(PlayerType
 		return result;
 
 	int iBestDistance = MAX_INT;
-	int iLoopA = 0, iLoopB = 0;
+	int iLoopA = 0;
+	int iLoopB = 0;
 	for(CvCity* pLoopCityA = GET_PLAYER(ePlayerA).firstCity(&iLoopA); pLoopCityA != NULL; pLoopCityA = GET_PLAYER(ePlayerA).nextCity(&iLoopA))
 	{
 		if(pLoopCityA->isCoastal())

--- a/CvGameCoreDLL_Expansion2/CvAStar.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAStar.cpp
@@ -519,7 +519,8 @@ CvAStarNode* CvAStar::GetBest()
 void CvAStar::PrecalcNeighbors(CvAStarNode* node)
 {
 	int range = 6;
-	int x = 0, y = 0;
+	int x = 0;
+	int y = 0;
 	static int s_CvAStarChildHexX[6] = { 0, 1,  1,  0, -1, -1, };
 	static int s_CvAStarChildHexY[6] = { 1, 0, -1, -1,  0,  1, };
 

--- a/CvGameCoreDLL_Expansion2/CvArea.cpp
+++ b/CvGameCoreDLL_Expansion2/CvArea.cpp
@@ -792,7 +792,8 @@ void CvArea::GetTopAndBottomLatitudes(int& iTopLatitude, int& iBottomLatitude) c
 /// What is the largest latitude value of this Area?
 int CvArea::GetAreaMaxLatitude()
 {
-	int iTopLatitude, iBottomLatitude;
+	int iTopLatitude;
+	int iBottomLatitude;
 	GetTopAndBottomLatitudes(iTopLatitude, iBottomLatitude);
 
 	return max(iTopLatitude, iBottomLatitude);
@@ -802,7 +803,8 @@ int CvArea::GetAreaMaxLatitude()
 /// What is the smallest latitude value of this Area?
 int CvArea::GetAreaMinLatitude()
 {
-	int iTopLatitude, iBottomLatitude;
+	int iTopLatitude;
+	int iBottomLatitude;
 	GetTopAndBottomLatitudes(iTopLatitude, iBottomLatitude);
 
 	return min(iTopLatitude, iBottomLatitude);

--- a/CvGameCoreDLL_Expansion2/CvBarbarians.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBarbarians.cpp
@@ -604,7 +604,9 @@ void CvBarbarians::DoCamps()
 	}
 
 	CvMap& theMap = GC.getMap();
-	int iNumCampsInExistence = 0, iNumCoastalCamps = 0, iNumWorldPlots = theMap.numPlots();
+	int iNumCampsInExistence = 0;
+	int iNumCoastalCamps = 0;
+	int iNumWorldPlots = theMap.numPlots();
 	int iMajorCapitalMinDistance = /*4*/ GD_INT_GET(BARBARIAN_CAMP_MINIMUM_DISTANCE_CAPITAL);
 	int iBarbCampMinDistance = /*4*/ GD_INT_GET(BARBARIAN_CAMP_MINIMUM_DISTANCE_ANOTHER_CAMP);
 	int iRecentlyClearedCampMinDistance = /*2*/ GD_INT_GET(BARBARIAN_CAMP_MINIMUM_DISTANCE_RECENTLY_CLEARED_CAMP);
@@ -791,13 +793,15 @@ void CvBarbarians::DoCamps()
 	for (unsigned int iI = 0; iI < vPotentialPlots.size(); iI++)
 	{
 		CvPlot* pLoopPlot = vPotentialPlots[iI];
-		int iX = pLoopPlot->getX(), iY = pLoopPlot->getY();
+		int iX = pLoopPlot->getX();
+		int iY = pLoopPlot->getY();
 		bool bTooClose = false;
 
 		for (std::vector<int>::iterator it = MajorCapitals.begin(); it != MajorCapitals.end(); it++)
 		{
 			CvPlot* pInvalidAreaPlot = theMap.plotByIndex(*it);
-			int iCapitalX = pInvalidAreaPlot->getX(), iCapitalY = pInvalidAreaPlot->getY();
+			int iCapitalX = pInvalidAreaPlot->getX();
+			int iCapitalY = pInvalidAreaPlot->getY();
 			int iDistance = plotDistance(iX, iY, iCapitalX, iCapitalY);
 			if (iDistance <= iMajorCapitalMinDistance)
 			{
@@ -941,7 +945,8 @@ void CvBarbarians::DoCamps()
 		vValidPlots.clear();
 		vValidCoastalPlots.clear();
 
-		int iNewCampX = pPlot->getX(), iNewCampY = pPlot->getY();
+		int iNewCampX = pPlot->getX();
+		int iNewCampY = pPlot->getY();
 		for (unsigned int iI = 0; iI < vPotentialPlots.size(); iI++)
 		{
 			CvPlot* pLoopPlot = vValidPlots[iI];
@@ -991,7 +996,10 @@ void CvBarbarians::SpawnBarbarianUnits(CvPlot* pPlot, int iNumUnits, BarbSpawnRe
 	// Boats can only be spawned from encampments or captured cities on turn 30 or later.
 	// ----------------------------------- //
 
-	int iMaxBarbarians = INT_MAX, iMaxBarbarianRange = 0, iMinSpawnRadius = 1, iMaxSpawnRadius = 1;
+	int iMaxBarbarians = INT_MAX;
+	int iMaxBarbarianRange = 0;
+	int iMinSpawnRadius = 1;
+	int iMaxSpawnRadius = 1;
 	bool bNotBasePlot = false;
 
 	switch (eReason)
@@ -1021,7 +1029,10 @@ void CvBarbarians::SpawnBarbarianUnits(CvPlot* pPlot, int iNumUnits, BarbSpawnRe
 	}
 
 	// Are there too many Barbarian units nearby?
-	int iCount = 0, iUnitLoop = 0, iX = pPlot->getX(), iY = pPlot->getY();
+	int iCount = 0;
+	int iUnitLoop = 0;
+	int iX = pPlot->getX();
+	int iY = pPlot->getY();
 	bool bSpawnOnPlot = !bNotBasePlot;
 	for (CvUnit* pLoopUnit = GET_PLAYER(BARBARIAN_PLAYER).firstUnit(&iUnitLoop); pLoopUnit != NULL; pLoopUnit = GET_PLAYER(BARBARIAN_PLAYER).nextUnit(&iUnitLoop))
 	{
@@ -1381,7 +1392,8 @@ UnitTypes CvBarbarians::GetRandomBarbarianUnitType(CvPlot* pPlot, UnitAITypes eP
 		}
 
 		// Must have prereq tech(s) and must NOT have obsolete tech
-		TechTypes ePrereqTech = (TechTypes)pkUnitInfo->GetPrereqAndTech(), eObsoleteTech = (TechTypes)pkUnitInfo->GetObsoleteTech();
+		TechTypes ePrereqTech = (TechTypes)pkUnitInfo->GetPrereqAndTech();
+		TechTypes eObsoleteTech = (TechTypes)pkUnitInfo->GetObsoleteTech();
 		if (ePrereqTech != NO_TECH && !GET_TEAM(BARBARIAN_TEAM).GetTeamTechs()->HasTech(ePrereqTech))
 			continue;
 

--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
@@ -2956,7 +2956,8 @@ void CvBuilderTaskingAI::LogInfo(const CvString& strNewLogStr, CvPlayer* pPlayer
 	FILogFile* pLog;
 	pLog = LOGFILEMGR.GetLog(strFileName, FILogFile::kDontTimeStamp);
 
-	CvString strLog, strTemp;
+	CvString strLog;
+	CvString strTemp;
 
 	CvString strPlayerName;
 	strPlayerName = pPlayer->getCivilizationShortDescription();
@@ -2982,7 +2983,8 @@ void CvBuilderTaskingAI::LogYieldInfo(const CvString& strNewLogStr, CvPlayer* pP
 	FILogFile* pLog;
 	pLog = LOGFILEMGR.GetLog(strFileName, FILogFile::kDontTimeStamp);
 
-	CvString strLog, strTemp;
+	CvString strLog;
+	CvString strTemp;
 
 	CvString strPlayerName;
 	strPlayerName = pPlayer->getCivilizationShortDescription();

--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -15831,7 +15831,8 @@ void CvCity::processBuilding(BuildingTypes eBuilding, int iChange, bool bFirst, 
 #endif
 
 		// Resource loop
-		int iCulture = 0, iFaith = 0;
+		int iCulture = 0;
+		int iFaith = 0;
 		ResourceTypes eResource;
 		for (int iResourceLoop = 0; iResourceLoop < GC.getNumResourceInfos(); iResourceLoop++)
 		{
@@ -22749,7 +22750,8 @@ int CvCity::GetEmpireSizeModifier() const
 		iNumCitiesMod = 0;
 
 	// x% per empire pop, excluding puppets
-	int iLoop = 0, iPopMod = 0;
+	int iLoop = 0;
+	int iPopMod = 0;
 	for (CvCity* pLoopCity = GET_PLAYER(getOwner()).firstCity(&iLoop); pLoopCity != NULL; pLoopCity = GET_PLAYER(getOwner()).nextCity(&iLoop))
 	{
 		if (pLoopCity->IsPuppet())
@@ -23115,7 +23117,10 @@ CvString CvCity::GetCityUnhappinessBreakdown(bool bIncludeMedian, bool bCityBann
 		int iReduction = GetDistressFlatReduction() + kPlayer.GetDistressFlatReductionGlobal();
 
 		// Total Deficit
-		float fAmountNeeded = 0.00f, fAmountHave = 0.00f, fDeficit = 0.00f, fAmountForNextReduction = 0.00f;
+		float fAmountNeeded = 0.00f;
+		float fAmountHave = 0.00f;
+		float fDeficit = 0.00f;
+		float fAmountForNextReduction = 0.00f;
 		fAmountNeeded += fBasicNeedsMedian * iPopulation;
 		fAmountHave += ((float)getYieldRateTimes100(YIELD_FOOD, false, false) + (float)getYieldRateTimes100(YIELD_PRODUCTION, false, false)) / 100;
 		fDeficit += fAmountNeeded - fAmountHave;
@@ -23128,7 +23133,8 @@ CvString CvCity::GetCityUnhappinessBreakdown(bool bIncludeMedian, bool bCityBann
 	// Above Basic Needs requirement
 	else
 	{
-		float fAmountNeeded = 0.00f, fSurplus = 0.00f;
+		float fAmountNeeded = 0.00f;
+		float fSurplus = 0.00f;
 		fAmountNeeded += fBasicNeedsMedian * iPopulation;
 		fSurplus += (((float)getYieldRateTimes100(YIELD_FOOD, false, false) + (float)getYieldRateTimes100(YIELD_PRODUCTION, false, false)) / 100) - fAmountNeeded;
 
@@ -23147,7 +23153,10 @@ CvString CvCity::GetCityUnhappinessBreakdown(bool bIncludeMedian, bool bCityBann
 		int iReduction = GetPovertyFlatReduction() + kPlayer.GetPovertyFlatReductionGlobal();
 
 		// Total Deficit
-		float fAmountNeeded = 0.00f, fAmountHave = 0.00f, fDeficit = 0.00f, fAmountForNextReduction = 0.00f;
+		float fAmountNeeded = 0.00f;
+		float fAmountHave = 0.00f;
+		float fDeficit = 0.00f;
+		float fAmountForNextReduction = 0.00f;
 		fAmountNeeded += fGoldMedian * iPopulation;
 		fAmountHave += (float)getYieldRateTimes100(YIELD_GOLD, false, false) / 100;
 		fDeficit += fAmountNeeded - fAmountHave;
@@ -23160,7 +23169,8 @@ CvString CvCity::GetCityUnhappinessBreakdown(bool bIncludeMedian, bool bCityBann
 	// Above Gold requirement
 	else
 	{
-		float fAmountNeeded = 0.00f, fSurplus = 0.00f;
+		float fAmountNeeded = 0.00f;
+		float fSurplus = 0.00f;
 		fAmountNeeded += fGoldMedian * iPopulation;
 		fSurplus += ((float)getYieldRateTimes100(YIELD_GOLD, false, false) / 100) - fAmountNeeded;
 
@@ -23179,7 +23189,10 @@ CvString CvCity::GetCityUnhappinessBreakdown(bool bIncludeMedian, bool bCityBann
 		int iReduction = GetIlliteracyFlatReduction() + kPlayer.GetIlliteracyFlatReductionGlobal();
 
 		// Total Deficit
-		float fAmountNeeded = 0.00f, fAmountHave = 0.00f, fDeficit = 0.00f, fAmountForNextReduction = 0.00f;
+		float fAmountNeeded = 0.00f;
+		float fAmountHave = 0.00f;
+		float fDeficit = 0.00f;
+		float fAmountForNextReduction = 0.00f;
 		fAmountNeeded += fScienceMedian * iPopulation;
 		fAmountHave += (float)getYieldRateTimes100(YIELD_SCIENCE, false, false) / 100;
 		fDeficit += fAmountNeeded - fAmountHave;
@@ -23192,7 +23205,8 @@ CvString CvCity::GetCityUnhappinessBreakdown(bool bIncludeMedian, bool bCityBann
 	// Above Science requirement
 	else
 	{
-		float fAmountNeeded = 0.00f, fSurplus = 0.00f;
+		float fAmountNeeded = 0.00f;
+		float fSurplus = 0.00f;
 		fAmountNeeded += fScienceMedian * iPopulation;
 		fSurplus += ((float)getYieldRateTimes100(YIELD_SCIENCE, false, false) / 100) - fAmountNeeded;
 
@@ -23211,7 +23225,10 @@ CvString CvCity::GetCityUnhappinessBreakdown(bool bIncludeMedian, bool bCityBann
 		int iReduction = GetBoredomFlatReduction() + kPlayer.GetBoredomFlatReductionGlobal();
 
 		// Total Deficit
-		float fAmountNeeded = 0.00f, fAmountHave = 0.00f, fDeficit = 0.00f, fAmountForNextReduction = 0.00f;
+		float fAmountNeeded = 0.00f;
+		float fAmountHave = 0.00f;
+		float fDeficit = 0.00f;
+		float fAmountForNextReduction = 0.00f;
 		fAmountNeeded += fCultureMedian * iPopulation;
 		fAmountHave += (float)getJONSCulturePerTurn(false);
 		fDeficit += fAmountNeeded - fAmountHave;
@@ -23224,7 +23241,8 @@ CvString CvCity::GetCityUnhappinessBreakdown(bool bIncludeMedian, bool bCityBann
 	// Above Culture requirement
 	else
 	{
-		float fAmountNeeded = 0.00f, fSurplus = 0.00f;
+		float fAmountNeeded = 0.00f;
+		float fSurplus = 0.00f;
 		fAmountNeeded += fCultureMedian * iPopulation;
 		fSurplus += (float)getJONSCulturePerTurn(false) - fAmountNeeded;
 
@@ -23345,7 +23363,11 @@ CvString CvCity::GetCityUnhappinessBreakdown(bool bIncludeMedian, bool bCityBann
 		int iTotalMod = iCapitalMod + iTechMod + iCitySize + iEmpireSize + iDifficultyMod + iCarnivalMod + iAirUnitsMod;
 
 		// Process Modifiers
-		int iFarmingModifier = 0, iWealthModifier = 0, iResearchModifier = 0, iArtsModifier = 0, iPrayerModifier = 0;
+		int iFarmingModifier = 0;
+		int iWealthModifier = 0;
+		int iResearchModifier = 0;
+		int iArtsModifier = 0;
+		int iPrayerModifier = 0;
 		if (getProductionProcess() != NO_PROCESS)
 		{
 			CvProcessInfo* pkProcessInfo = GC.getProcessInfo(getProductionProcess());

--- a/CvGameCoreDLL_Expansion2/CvCityConnections.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCityConnections.cpp
@@ -278,7 +278,9 @@ void CvCityConnections::UpdateRouteInfo(void)
 			pStartCity->SetIndustrialRouteToCapitalConnected(false);
 		}
 
-		ReachablePlots roadPlots, railroadPlots, waterPlots;
+		ReachablePlots roadPlots;
+		ReachablePlots railroadPlots;
+		ReachablePlots waterPlots;
 		SPathFinderUserData data(m_pPlayer->GetID(),PT_CITY_CONNECTION_LAND, ROUTE_ROAD);
 		if (!pStartCity->IsBlockaded(DOMAIN_LAND))
 		{
@@ -374,7 +376,8 @@ void CvCityConnections::UpdateRouteInfo(void)
 	}
 
 	//for any cities which are not linked now, check what lua says
-	int iCityLoopA = 0, iCityLoopB = 0;
+	int iCityLoopA = 0;
+	int iCityLoopB = 0;
 	for(CvCity* pCityA = m_pPlayer->firstCity(&iCityLoopA); pCityA != NULL; pCityA = m_pPlayer->nextCity(&iCityLoopA))
 	{
 		for(CvCity* pCityB = m_pPlayer->firstCity(&iCityLoopB); pCityB != NULL; pCityB = m_pPlayer->nextCity(&iCityLoopB))

--- a/CvGameCoreDLL_Expansion2/CvCityStrategyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCityStrategyAI.cpp
@@ -1173,7 +1173,9 @@ void CvCityStrategyAI::ChooseProduction(BuildingTypes eIgnoreBldg, UnitTypes eIg
 /// Pick the next build for a city (unit, building)
 CvCityBuildable CvCityStrategyAI::ChooseHurry(bool bUnitOnly, bool bFaithPurchase)
 {
-	int iBldgLoop = 0, iUnitLoop = 0, iTempWeight = 0;
+	int iBldgLoop = 0;
+	int iUnitLoop = 0;
+	int iTempWeight = 0;
 	CvCityBuildable buildable;
 	CvCityBuildable selection;
 	UnitTypes eUnitForOperation;
@@ -2000,7 +2002,8 @@ void CvCityStrategyAI::LogHurryMessage(CvString& strMsg)
 	{
 		CvString strOutBuf;
 		CvString strBaseString;
-		CvString strTemp, szTemp2;
+		CvString strTemp;
+		CvString szTemp2;
 		CvString playerName;
 		CvString cityName;
 

--- a/CvGameCoreDLL_Expansion2/CvCorporationClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCorporationClasses.cpp
@@ -1169,7 +1169,8 @@ void CvPlayerCorporations::LogCorporationMessage(const CvString& strMsg)
 	{
 		CvString strOutBuf;
 		CvString strBaseString;
-		CvString strTemp, szTemp2;
+		CvString strTemp;
+		CvString szTemp2;
 		CvString strPlayerName;
 		FILogFile* pLog = NULL;
 

--- a/CvGameCoreDLL_Expansion2/CvCultureClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCultureClasses.cpp
@@ -5854,7 +5854,8 @@ void CvPlayerCulture::DoPublicOpinion()
 			locText = Localization::Lookup("TXT_KEY_CO_OPINION_TT_UNHAPPINESS_LINE2");
 			m_strOpinionUnhappinessTooltip += locText.toUTF8();
 
-			int iPerCityUnhappy = 0, iUnhappyPerXPop = 0;
+			int iPerCityUnhappy = 0;
+			int iUnhappyPerXPop = 0;
 			if (iDissatisfaction < 3)
 			{
 				iPerCityUnhappy = 1;
@@ -6089,7 +6090,8 @@ int CvPlayerCulture::ComputePublicOpinionUnhappiness(int iDissatisfaction)
 
 	if (!MOD_BALANCE_CORE_POLICIES)
 	{
-		int iPerCityUnhappy = 0, iUnhappyPerXPop = 0;
+		int iPerCityUnhappy = 0;
+		int iUnhappyPerXPop = 0;
 
 		if (iDissatisfaction < 3)
 		{
@@ -7690,7 +7692,9 @@ CvString CvCityCulture::GetFilledSlotsTooltip()
 CvString CvCityCulture::GetTotalSlotsTooltip()
 {
 	CvString szRtnValue = "";
-	CvString szTemp1, szTemp2, szTemp3;
+	CvString szTemp1;
+	CvString szTemp2;
+	CvString szTemp3;
 	
 	GreatWorkSlotType eLiteratureSlot = CvTypes::getGREAT_WORK_SLOT_LITERATURE();
 	int iFilledWriting = m_pCity->GetCityBuildings()->GetNumGreatWorks(eLiteratureSlot);

--- a/CvGameCoreDLL_Expansion2/CvDealAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDealAI.cpp
@@ -1571,7 +1571,9 @@ int CvDealAI::GetLuxuryResourceValue(ResourceTypes eResource, int iNumTurns, boo
 						if (pLoopCity->IsRazing())
 							continue;
 
-						int iX = pLoopCity->getX(), iY = pLoopCity->getY(), iNumWorkablePlots = pLoopCity->GetNumWorkablePlots();
+						int iX = pLoopCity->getX();
+						int iY = pLoopCity->getY();
+						int iNumWorkablePlots = pLoopCity->GetNumWorkablePlots();
 						for (int iPlotLoop = 0; iPlotLoop < iNumWorkablePlots; iPlotLoop++)
 						{
 							CvPlot* pLoopPlot = iterateRingPlots(iX, iY, iPlotLoop);
@@ -6780,7 +6782,11 @@ DemandResponseTypes CvDealAI::GetRequestForHelpResponse(CvDeal* pDeal)
 	// Possibility exists the AI will accept
 	if(eResponse == NO_DEMAND_RESPONSE_TYPE)
 	{
-		int iGoldRequested = 0, iGPTRequested = 0, iLuxuriesRequested = 0, iStrategicsRequested = 0, iTechsRequested = 0;
+		int iGoldRequested = 0;
+		int iGPTRequested = 0;
+		int iLuxuriesRequested = 0;
+		int iStrategicsRequested = 0;
+		int iTechsRequested = 0;
 		int iTempGold = 0;
 
 		TradedItemList::iterator it;
@@ -7064,7 +7070,8 @@ int CvDealAI::GetTechValue(TechTypes eTech, bool bFromMe, PlayerTypes eOtherPlay
 		iTurnsLeft = GetPlayer()->GetPlayerTechs()->GetResearchTurnsLeft(eTech, true, m_vResearchRates[GetPlayer()->GetID()].second);
 	}
 
-	int iI = 0, iTechMod = 0;
+	int iI = 0;
+	int iTechMod = 0;
 
 	for(iI = 0; iI < GC.getNumUnitInfos(); iI++)
 	{

--- a/CvGameCoreDLL_Expansion2/CvDealClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDealClasses.cpp
@@ -572,7 +572,8 @@ bool CvDeal::IsPossibleToTradeItem(PlayerTypes ePlayer, PlayerTypes eToPlayer, T
 					return false;
 
 				// How much of this resource do we and the other guy have? Don't call getNumResourceAvailable() for the other player for strategic resources since that's not relevant.
-				int iNumAvailableToUs = pFromPlayer->getNumResourceAvailable(eResource, /*bIncludeImport*/ false), iNumAvailableToOther = eUsage == RESOURCEUSAGE_LUXURY ? pToPlayer->getNumResourceAvailable(eResource, /*bIncludeImport*/ true) : 0;
+				int iNumAvailableToUs = pFromPlayer->getNumResourceAvailable(eResource, /*bIncludeImport*/ false);
+				int iNumAvailableToOther = eUsage == RESOURCEUSAGE_LUXURY ? pToPlayer->getNumResourceAvailable(eResource, /*bIncludeImport*/ true) : 0;
 
 				// If a renewal deal, add/subtract the resources already included in the renewal.
 				if (pRenewDeals.size() > 0)
@@ -789,10 +790,12 @@ bool CvDeal::IsPossibleToTradeItem(PlayerTypes ePlayer, PlayerTypes eToPlayer, T
 			}
 
 			bool bAITradingWithHuman = !bHumanToHuman && pToPlayer->isHuman();
-			int iMyLimit = pFromPlayer->CalculateDefensivePactLimit(bAITradingWithHuman), iMyDefensePacts = pFromPlayer->GetDiplomacyAI()->GetNumDefensePacts();
+			int iMyLimit = pFromPlayer->CalculateDefensivePactLimit(bAITradingWithHuman);
+			int iMyDefensePacts = pFromPlayer->GetDiplomacyAI()->GetNumDefensePacts();
 
 			bAITradingWithHuman = !bHumanToHuman && pFromPlayer->isHuman();
-			int iTheirLimit = pToPlayer->CalculateDefensivePactLimit(bAITradingWithHuman), iTheirDefensePacts = pToPlayer->GetDiplomacyAI()->GetNumDefensePacts();
+			int iTheirLimit = pToPlayer->CalculateDefensivePactLimit(bAITradingWithHuman);
+			int iTheirDefensePacts = pToPlayer->GetDiplomacyAI()->GetNumDefensePacts();
 
 			if (bIgnoreExistingDP)
 			{
@@ -1340,7 +1343,8 @@ bool CvDeal::BlockTemporaryForPermanentTrade(TradeableItems eItemType, PlayerTyp
 	if (eItemType == TRADE_ITEM_THIRD_PARTY_PEACE && GET_PLAYER(eFromPlayer).IsAtWarWith(eToPlayer))
 		return false;
 
-	bool bFromHuman = GET_PLAYER(eFromPlayer).isHuman(), bToHuman = GET_PLAYER(eToPlayer).isHuman();
+	bool bFromHuman = GET_PLAYER(eFromPlayer).isHuman();
+	bool bToHuman = GET_PLAYER(eToPlayer).isHuman();
 	bool bNoHumans = !bFromHuman && !bToHuman;
 
 	// Humans can handle their own dealmaking
@@ -1433,7 +1437,11 @@ bool CvDeal::BlockTemporaryForPermanentTrade(TradeableItems eItemType, PlayerTyp
 /// The Data parameters can be -1, which means we don't care about whatever data is stored there (e.g. -1 for Gold means can we trade ANY amount of Gold?)
 CvString CvDeal::GetReasonsItemUntradeable(PlayerTypes ePlayer, PlayerTypes eToPlayer, TradeableItems eItem, int iData1, int iData2, int iData3, bool bFlag1)
 {
-	CvString strTooltip = "", strReason = "", strDivider = "[NEWLINE][NEWLINE]", strStartColor = "[COLOR_NEGATIVE_TEXT]", strEndColor = "[ENDCOLOR]";
+	CvString strTooltip = "";
+	CvString strReason = "";
+	CvString strDivider = "[NEWLINE][NEWLINE]";
+	CvString strStartColor = "[COLOR_NEGATIVE_TEXT]";
+	CvString strEndColor = "[ENDCOLOR]";
 	CvString strError = ""; // There shouldn't be a tooltip for this reason (because either the situation should not ever occur ingame, or the item is hidden by the UI)
 
 	if (eItem <= TRADE_ITEM_NONE || eItem >= NUM_TRADEABLE_ITEMS)
@@ -1762,8 +1770,10 @@ CvString CvDeal::GetReasonsItemUntradeable(PlayerTypes ePlayer, PlayerTypes eToP
 				return strTooltip;
 			}
 
-			int iMyLimit = pFromPlayer->CalculateDefensivePactLimit(bToHuman), iMyDefensePacts = pFromPlayer->GetDiplomacyAI()->GetNumDefensePacts();
-			int iTheirLimit = pToPlayer->CalculateDefensivePactLimit(bFromHuman), iTheirDefensePacts = pToPlayer->GetDiplomacyAI()->GetNumDefensePacts();
+			int iMyLimit = pFromPlayer->CalculateDefensivePactLimit(bToHuman);
+			int iMyDefensePacts = pFromPlayer->GetDiplomacyAI()->GetNumDefensePacts();
+			int iTheirLimit = pToPlayer->CalculateDefensivePactLimit(bFromHuman);
+			int iTheirDefensePacts = pToPlayer->GetDiplomacyAI()->GetNumDefensePacts();
 
 			if (bIgnoreExistingDP)
 			{
@@ -4438,7 +4448,8 @@ void CvGameDeals::ActivateDeal(PlayerTypes eFromPlayer, PlayerTypes eToPlayer, C
 	bool bIsPeaceDeal = kDeal.IsPeaceTreatyTrade(eFromPlayer) || kDeal.IsPeaceTreatyTrade(eToPlayer);
 	bool bHumanToHuman = GET_PLAYER(eFromPlayer).isHuman() && GET_PLAYER(eToPlayer).isHuman();
 	bool bShouldSetHumanSurrender = bHumanToHuman && bIsPeaceDeal;
-	bool bFromPlayerItem = false, bToPlayerItem = false;
+	bool bFromPlayerItem = false;
+	bool bToPlayerItem = false;
 
 	for (TradedItemList::iterator it = kDeal.m_TradedItems.begin(); it != kDeal.m_TradedItems.end(); it++)
 	{
@@ -4501,7 +4512,9 @@ void CvGameDeals::ActivateDeal(PlayerTypes eFromPlayer, PlayerTypes eToPlayer, C
 	m_CurrentDeals.push_back(kDeal);
 
 	// Set one-time values here
-	bool bDoDefensivePactNotification = true, bDoResearchAgreementNotification = true, bDoWarVictoryBonuses = true;
+	bool bDoDefensivePactNotification = true;
+	bool bDoResearchAgreementNotification = true;
+	bool bDoWarVictoryBonuses = true;
 
 	// Process each item in the deal!
 	for (TradedItemList::iterator it = kDeal.m_TradedItems.begin(); it != kDeal.m_TradedItems.end(); it++)
@@ -5558,8 +5571,10 @@ void CvGameDeals::DoCancelDealsBetweenTeams(TeamTypes eTeam1, TeamTypes eTeam2)
 {
 	if(m_CurrentDeals.size() > 0)
 	{
-		PlayerTypes eFromPlayer, eToPlayer;
-		int iPlayerLoop1 = 0, iPlayerLoop2 = 0;
+		PlayerTypes eFromPlayer;
+		PlayerTypes eToPlayer;
+		int iPlayerLoop1 = 0;
+		int iPlayerLoop2 = 0;
 
 		// Loop through first set of players
 		for(iPlayerLoop1 = 0; iPlayerLoop1 < MAX_MAJOR_CIVS; iPlayerLoop1++)

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
@@ -2057,7 +2057,8 @@ void CvDiplomacyAI::SelectDefaultVictoryPursuits()
 	}
 
 	// Civs are given AI victory pursuit hints/biases in the Leaders table, so retrieve those now
-	VictoryPursuitTypes ePrimaryVictory = NO_VICTORY_PURSUIT, eSecondaryVictory = NO_VICTORY_PURSUIT;
+	VictoryPursuitTypes ePrimaryVictory = NO_VICTORY_PURSUIT;
+	VictoryPursuitTypes eSecondaryVictory = NO_VICTORY_PURSUIT;
 	LeaderHeadTypes leader = iNumValidOptions > 2 ? GetPlayer()->getPersonalityType() : GetPlayer()->getLeaderType(); // ignore Random Personalities when retrieving victory pursuit hints for highly specialized scenarios
 	if (leader != NO_LEADER)
 	{
@@ -2072,7 +2073,8 @@ void CvDiplomacyAI::SelectDefaultVictoryPursuits()
 	// If only TWO options are valid, we have only two choices...though at least we can use the pursuit hints to prioritize this time.
 	if (iNumValidOptions == 2)
 	{
-		VictoryPursuitTypes eOptionOne = NO_VICTORY_PURSUIT, eOptionTwo = NO_VICTORY_PURSUIT;
+		VictoryPursuitTypes eOptionOne = NO_VICTORY_PURSUIT;
+		VictoryPursuitTypes eOptionTwo = NO_VICTORY_PURSUIT;
 
 		if (bCanUnlockTechs)
 		{
@@ -2555,7 +2557,9 @@ void CvDiplomacyAI::SelectDefaultVictoryPursuits()
 	}
 
 	SortedVictoryScores.StableSortItems();
-	VictoryPursuitTypes eHighestScore = SortedVictoryScores.GetElement(0), eRunnerUp = SortedVictoryScores.GetElement(1), eChosenPrimary = NO_VICTORY_PURSUIT;
+	VictoryPursuitTypes eHighestScore = SortedVictoryScores.GetElement(0);
+	VictoryPursuitTypes eRunnerUp = SortedVictoryScores.GetElement(1);
+	VictoryPursuitTypes eChosenPrimary = NO_VICTORY_PURSUIT;
 
 	if (SortedVictoryScores.GetWeight(0) > SortedVictoryScores.GetWeight(1))
 	{
@@ -3329,7 +3333,9 @@ int CvDiplomacyAI::GetScoreVictoryProgress() const
 		return 0;
 	}
 
-	int iProgress = 0, iOurScore = 0, iHighestScore = 0;
+	int iProgress = 0;
+	int iOurScore = 0;
+	int iHighestScore = 0;
 	for (int iPlayerLoop = 0; iPlayerLoop < MAX_MAJOR_CIVS; iPlayerLoop++)
 	{
 		PlayerTypes eLoopPlayer = (PlayerTypes)iPlayerLoop;
@@ -3363,7 +3369,10 @@ int CvDiplomacyAI::GetDominationVictoryProgress() const
 		return 0;
 	}
 
-	int iCapitalsProgress = 0, iTotalCapitals = 0, iOurMight = 0, iTotalMight = 0;
+	int iCapitalsProgress = 0;
+	int iTotalCapitals = 0;
+	int iOurMight = 0;
+	int iTotalMight = 0;
 	for (int iPlayerLoop = 0; iPlayerLoop < MAX_MAJOR_CIVS; iPlayerLoop++)
 	{
 		PlayerTypes ePlayer = (PlayerTypes) iPlayerLoop;
@@ -3451,7 +3460,8 @@ int CvDiplomacyAI::GetScienceVictoryProgress() const
 		return 0;
 	}
 
-	int iProjectsRequired = 0, iProjectsCompleted = 0;
+	int iProjectsRequired = 0;
+	int iProjectsCompleted = 0;
 	for (int iK = 0; iK < GC.getNumProjectInfos(); iK++)
 	{
 		const ProjectTypes eProject = static_cast<ProjectTypes>(iK);
@@ -10658,8 +10668,14 @@ void CvDiplomacyAI::DoUpdateWarStates()
 			ReligionTypes eTheirReligion = GET_PLAYER(eLoopPlayer).isMinorCiv() ? NO_RELIGION : GET_PLAYER(eLoopPlayer).GetReligions()->GetOwnedReligion();
 
 			// Evaluate our danger and their danger from this war
-			int iNumOurCities = 0, iNumOurCitiesInDanger = 0, iNumTheirCities = 0, iNumTheirCitiesInDanger = 0, iOurDanger = 0, iTheirDanger = 0;
-			bool bSeriousDangerUs = false, bSeriousDangerThem = false;
+			int iNumOurCities = 0;
+			int iNumOurCitiesInDanger = 0;
+			int iNumTheirCities = 0;
+			int iNumTheirCitiesInDanger = 0;
+			int iOurDanger = 0;
+			int iTheirDanger = 0;
+			bool bSeriousDangerUs = false;
+			bool bSeriousDangerThem = false;
 			vector<PlayerTypes> vOurWarAllies = GetOffensiveWarAllies(eLoopPlayer, /*bIncludeMinors*/ true, /*bReverseMode*/ false);
 			vector<PlayerTypes> vTheirWarAllies = GetOffensiveWarAllies(eLoopPlayer, /*bIncludeMinors*/ true, /*bReverseMode*/ true);
 			vOurWarAllies.push_back(GetID());
@@ -12653,7 +12669,8 @@ void CvDiplomacyAI::DoExpansionBickering()
 	if (GetPlayer()->isHuman())
 		return;
 
-	int iLoop = 0, iLoop2 = 0;
+	int iLoop = 0;
+	int iLoop2 = 0;
 	int iGameTurn = GC.getGame().getGameTurn();
 	int iExpansionBickerRange = GetExpansionBickerRange();
 
@@ -13875,7 +13892,11 @@ bool CvDiplomacyAI::DoTestOnePlayerUntrustworthyFriend(PlayerTypes ePlayer)
 			bool bResurrected = WasResurrectedBy(ePlayer);
 
 			// If multiple players on ePlayer's team backstab the same player in the same way, it still only counts as one betrayal
-			bool bFriendDenouncedUs = false, bFriendAttackedUs = false, bBrokeMilitaryPromise = false, bBrokeAttackCityStatePromise = false, bBrokeVassalAgreement = false;
+			bool bFriendDenouncedUs = false;
+			bool bFriendAttackedUs = false;
+			bool bBrokeMilitaryPromise = false;
+			bool bBrokeAttackCityStatePromise = false;
+			bool bBrokeVassalAgreement = false;
 
 			for (size_t i=0; i<vTheirTeam.size(); i++)
 			{
@@ -15815,7 +15836,8 @@ void CvDiplomacyAI::SelectBestApproachTowardsMajorCiv(PlayerTypes ePlayer, bool 
 
 	// Initialize some variables that are called repeatedly here, just for convenience
 	PlayerTypes eMyPlayer = GetID();
-	TeamTypes eMyTeam = GetTeam(), eTeam = GET_PLAYER(ePlayer).getTeam();
+	TeamTypes eMyTeam = GetTeam();
+	TeamTypes eTeam = GET_PLAYER(ePlayer).getTeam();
 	PlayerProximityTypes eOurProximity = GetPlayer()->GetProximityToPlayer(ePlayer);
 	PlayerProximityTypes eTheirProximity = GET_PLAYER(ePlayer).GetProximityToPlayer(eMyPlayer);
 	PlayerProximityTypes eClosestProximity = (PlayerProximityTypes)(max((int)eOurProximity, (int)eTheirProximity));
@@ -15824,31 +15846,51 @@ void CvDiplomacyAI::SelectBestApproachTowardsMajorCiv(PlayerTypes ePlayer, bool 
 	CvDiplomacyAI* pTheirDiplo = GET_PLAYER(ePlayer).GetDiplomacyAI();
 
 	// Turn/Era
-	int iMyEra = GetPlayer()->GetCurrentEra(), iTheirEra = GET_PLAYER(ePlayer).GetCurrentEra(), iGameEra = GC.getGame().getCurrentEra(), iGameTurn = GC.getGame().getGameTurn();
+	int iMyEra = GetPlayer()->GetCurrentEra();
+	int iTheirEra = GET_PLAYER(ePlayer).GetCurrentEra();
+	int iGameEra = GC.getGame().getCurrentEra();
+	int iGameTurn = GC.getGame().getGameTurn();
 
 	bool bWeHaveUUTech = GetPlayer()->HasUUPeriod() && GetPlayer()->GetPlayerTechs()->HasUUTech();
 	bool bWeHaveUUActive = bWeHaveUUTech && GetPlayer()->HasUUActive();
 
 	// Player traits
 	CvPlayerTraits* pTraits = GetPlayer()->GetPlayerTraits();
-	bool bConquerorTraits = pTraits->IsWarmonger(), bDiplomatTraits = pTraits->IsDiplomat(), bCulturalTraits = pTraits->IsTourism(), bScientistTraits = pTraits->IsNerd();
+	bool bConquerorTraits = pTraits->IsWarmonger();
+	bool bDiplomatTraits = pTraits->IsDiplomat();
+	bool bCulturalTraits = pTraits->IsTourism();
+	bool bScientistTraits = pTraits->IsNerd();
 
 	// Victory stuff
-	bool bCloseToWorldConquest = IsCloseToWorldConquest(), bCloseToDiploVictory = IsCloseToDiploVictory(), bCloseToScienceVictory = IsCloseToSpaceshipVictory(), bCloseToCultureVictory = IsCloseToCultureVictory();
+	bool bCloseToWorldConquest = IsCloseToWorldConquest();
+	bool bCloseToDiploVictory = IsCloseToDiploVictory();
+	bool bCloseToScienceVictory = IsCloseToSpaceshipVictory();
+	bool bCloseToCultureVictory = IsCloseToCultureVictory();
 	bool bCloseToAnyVictory = bCloseToWorldConquest || bCloseToDiploVictory || bCloseToScienceVictory || bCloseToCultureVictory;
-	bool bTheyAreCloseToWorldConquest = pTheirDiplo->IsCloseToWorldConquest(), bTheyAreCloseToDiploVictory = pTheirDiplo->IsCloseToDiploVictory(), bTheyAreCloseToScienceVictory = pTheirDiplo->IsCloseToSpaceshipVictory(), bTheyAreCloseToCultureVictory = pTheirDiplo->IsCloseToCultureVictory();
+	bool bTheyAreCloseToWorldConquest = pTheirDiplo->IsCloseToWorldConquest();
+	bool bTheyAreCloseToDiploVictory = pTheirDiplo->IsCloseToDiploVictory();
+	bool bTheyAreCloseToScienceVictory = pTheirDiplo->IsCloseToSpaceshipVictory();
+	bool bTheyAreCloseToCultureVictory = pTheirDiplo->IsCloseToCultureVictory();
 
 	// Possessions
-	int iNumOurTechs = GET_TEAM(GetTeam()).GetTeamTechs()->GetNumTechsKnown(), iNumTheirTechs = GET_TEAM(eTeam).GetTeamTechs()->GetNumTechsKnown();
-	bool bWeLostCapital = GetPlayer()->IsHasLostCapital(), bTheyLostCapital = GET_PLAYER(ePlayer).IsHasLostCapital();
-	bool bCapturedOurCapital = IsCapitalCapturedBy(ePlayer, true, false), bCapturedOurHolyCity = IsHolyCityCapturedBy(ePlayer, true, false);
-	bool bCapturedTheirCapital = pTheirDiplo->IsCapitalCapturedBy(eMyPlayer, true, false), bCapturedTheirHolyCity = pTheirDiplo->IsHolyCityCapturedBy(eMyPlayer, true, false);
+	int iNumOurTechs = GET_TEAM(GetTeam()).GetTeamTechs()->GetNumTechsKnown();
+	int iNumTheirTechs = GET_TEAM(eTeam).GetTeamTechs()->GetNumTechsKnown();
+	bool bWeLostCapital = GetPlayer()->IsHasLostCapital();
+	bool bTheyLostCapital = GET_PLAYER(ePlayer).IsHasLostCapital();
+	bool bCapturedOurCapital = IsCapitalCapturedBy(ePlayer, true, false);
+	bool bCapturedOurHolyCity = IsHolyCityCapturedBy(ePlayer, true, false);
+	bool bCapturedTheirCapital = pTheirDiplo->IsCapitalCapturedBy(eMyPlayer, true, false);
+	bool bCapturedTheirHolyCity = pTheirDiplo->IsHolyCityCapturedBy(eMyPlayer, true, false);
 	bool bEverCapturedKeyCity = IsCapitalCapturedBy(ePlayer) || IsHolyCityCapturedBy(ePlayer); // this also checks teammates
 	int iNumOurCitiesTheyOwn = GetPlayer()->GetNumOurCitiesOwnedBy(ePlayer);
 
 	// Evaluations
-	StrengthTypes eMilitaryStrength = GetMilitaryStrengthComparedToUs(ePlayer), eEconomicStrength = GetEconomicStrengthComparedToUs(ePlayer);
-	bool bUntrustworthy = IsUntrustworthy(ePlayer), bEarlyGameCompetitor = IsEarlyGameCompetitor(ePlayer), bEasyTarget = IsEasyTarget(ePlayer), bGoodAttackTarget = GetPlayer()->GetMilitaryAI()->HavePreferredAttackTarget(ePlayer);
+	StrengthTypes eMilitaryStrength = GetMilitaryStrengthComparedToUs(ePlayer);
+	StrengthTypes eEconomicStrength = GetEconomicStrengthComparedToUs(ePlayer);
+	bool bUntrustworthy = IsUntrustworthy(ePlayer);
+	bool bEarlyGameCompetitor = IsEarlyGameCompetitor(ePlayer);
+	bool bEasyTarget = IsEasyTarget(ePlayer);
+	bool bGoodAttackTarget = GetPlayer()->GetMilitaryAI()->HavePreferredAttackTarget(ePlayer);
 
 	// They're only an easy target if we're not already at war with somebody else.
 	// ...however, if we're already at war with them, let's keep this weight.
@@ -25834,7 +25876,8 @@ void CvDiplomacyAI::DoUpdatePeaceTreatyWillingness(bool bMyTurn)
 
 	// STEP 3: Determine whether we're willing to make peace with any majors
 	vector<PlayerTypes> vMakePeacePlayers;
-	bool bInTerribleShape = false, bUABonusesFromCityConquest = false;
+	bool bInTerribleShape = false;
+	bool bUABonusesFromCityConquest = false;
 	if (!bCriticalState)
 	{
 		bInTerribleShape = GetPlayer()->IsInTerribleShapeForWar();
@@ -27073,7 +27116,8 @@ int CvDiplomacyAI::CountUnitsAroundEnemyCities(PlayerTypes ePlayer, int iTurnRan
 	if (ePlayer == NO_PLAYER)
 		return 0;
 
-	int iCount = 0, iUnitLoop = 0;
+	int iCount = 0;
+	int iUnitLoop = 0;
 	for (CvUnit* pLoopUnit = m_pPlayer->firstUnit(&iUnitLoop); pLoopUnit != NULL; pLoopUnit = m_pPlayer->nextUnit(&iUnitLoop))
 	{
 		if (!pLoopUnit->IsCanAttack() || pLoopUnit->isDelayedDeath() || pLoopUnit->isProjectedToDieNextTurn())
@@ -27099,7 +27143,10 @@ void CvDiplomacyAI::DetermineVassalTaxRates()
 		return;
 
 	vector<PlayerTypes> vMyTeam = GET_TEAM(GetTeam()).getPlayers();
-	int iMyCurrentGPT = 0, iAverageMeanness = 0, iAverageDoFWillingness = 0, iNumTeamMembers = 0;
+	int iMyCurrentGPT = 0;
+	int iAverageMeanness = 0;
+	int iAverageDoFWillingness = 0;
+	int iNumTeamMembers = 0;
 	bool bNotLowestEconomicMight = false;
 	bool bAnyoneInDireStraits = false;
 	int iMinTaxRate = /*0*/ GD_INT_GET(VASSALAGE_VASSAL_TAX_PERCENT_MINIMUM);
@@ -27165,7 +27212,10 @@ void CvDiplomacyAI::DetermineVassalTaxRates()
 		}
 
 		bool bTheyAreInDireStraits = GET_PLAYER(ePlayer).GetDiplomacyAI()->GetStateAllWars() == STATE_ALL_WARS_LOSING || GET_PLAYER(ePlayer).IsEmpireVeryUnhappy();
-		int iVassalCurrentGPT = GET_PLAYER(ePlayer).getAvgGoldRate(), iVassalCurrentGross = GET_PLAYER(ePlayer).GetTreasury()->CalculateGrossGoldTimes100(), iAverageOpinionScore = 0, iNumOpinions = 0;
+		int iVassalCurrentGPT = GET_PLAYER(ePlayer).getAvgGoldRate();
+		int iVassalCurrentGross = GET_PLAYER(ePlayer).GetTreasury()->CalculateGrossGoldTimes100();
+		int iAverageOpinionScore = 0;
+		int iNumOpinions = 0;
 		for (size_t i=0; i<vTheirTeam.size(); i++)
 		{
 			if (!GET_PLAYER(vTheirTeam[i]).isAlive() || !GET_PLAYER(vTheirTeam[i]).isMajorCiv() || GET_PLAYER(vTheirTeam[i]).getNumCities() <= 0)

--- a/CvGameCoreDLL_Expansion2/CvEconomicAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvEconomicAI.cpp
@@ -475,7 +475,8 @@ void CvEconomicAI::LogEconomyMessage(const CvString& strMsg)
 	{
 		CvString strOutBuf;
 		CvString strBaseString;
-		CvString strTemp, szTemp2;
+		CvString strTemp;
+		CvString szTemp2;
 		CvString strPlayerName;
 		FILogFile* pLog = NULL;
 
@@ -1978,7 +1979,8 @@ void CvEconomicAI::DoPlotPurchases()
 		{
 			if(pLoopCity->CanBuyAnyPlot())
 			{
-				int iTempX = 0, iTempY = 0;
+				int iTempX = 0;
+				int iTempY = 0;
 				int iScore = pLoopCity->GetBuyPlotScore(iTempX, iTempY);
 				if (iScore == -1)
 					continue;

--- a/CvGameCoreDLL_Expansion2/CvFractal.cpp
+++ b/CvGameCoreDLL_Expansion2/CvFractal.cpp
@@ -79,7 +79,8 @@ void CvFractal::fracInitInternal(int iNewXs, int iNewYs, int iGrain, CvRandom& r
 	int iScreen = 0;  // This screens out already marked spots in m_aaiFrac[][];
 	int iPass = 0;
 	int iSum = 0;
-	int iX = 0, iY = 0;
+	int iX = 0;
+	int iY = 0;
 	int iI = 0;
 
 	reset();
@@ -339,7 +340,8 @@ int CvFractal::getHeightFromPercent(int iPercent)
 	int iLowerBound = 0;
 	int iUpperBound = 0;
 	int iSum = 0;
-	int iX = 0, iY = 0;
+	int iX = 0;
+	int iY = 0;
 
 	iLowerBound = 0;
 	iUpperBound = 255;

--- a/CvGameCoreDLL_Expansion2/CvGame.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGame.cpp
@@ -603,7 +603,10 @@ void CvGame::InitPlayers()
 {
 	PlayerColorTypes aePlayerColors[REALLY_MAX_PLAYERS];
 	bool bValid = false;
-	int iI = 0, iJ = 0, iK = 0, iL = 0;
+	int iI = 0;
+	int iJ = 0;
+	int iK = 0;
+	int iL = 0;
 
 	for(iI = 0; iI < MAX_TEAMS; iI++)
 	{
@@ -1779,7 +1782,9 @@ void CvGame::updateScore(bool bForce)
 	int iBestScore = 0;
 	PlayerTypes eBestPlayer;
 	TeamTypes eBestTeam;
-	int iI = 0, iJ = 0, iK = 0;
+	int iI = 0;
+	int iJ = 0;
+	int iK = 0;
 
 	for(iI = 0; iI < MAX_CIV_PLAYERS; iI++)
 	{
@@ -9511,7 +9516,8 @@ UnitTypes CvGame::GetRandomUniqueUnitType(bool bIncludeCivsInGame, bool bInclude
 //	--------------------------------------------------------------------------------
 void CvGame::updateWar() const
 {
-	int iI = 0, iJ = 0;
+	int iI = 0;
+	int iJ = 0;
 
 	if(isOption(GAMEOPTION_ALWAYS_WAR))
 	{
@@ -10833,7 +10839,8 @@ int CvGame::calculateSyncChecksum()
 	unsigned int iMultiplier = 0;
 	unsigned long long iValue = 0;
 	int iLoop = 0;
-	int iI = 0, iJ = 0;
+	int iI = 0;
+	int iJ = 0;
 
 	iValue = 0;
 
@@ -10998,7 +11005,8 @@ void CvGame::debugSyncChecksum()
 int CvGame::calculateOptionsChecksum()
 {
 	int iValue = 0;
-	int iI = 0, iJ = 0;
+	int iI = 0;
+	int iJ = 0;
 
 	iValue = 0;
 

--- a/CvGameCoreDLL_Expansion2/CvGoodyHuts.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGoodyHuts.cpp
@@ -69,7 +69,8 @@ bool CvGoodyHuts::IsHasPlayerReceivedGoodyLately(PlayerTypes ePlayer, GoodyTypes
 /// Reset
 void CvGoodyHuts::Reset()
 {
-	int iI = 0, iJ = 0;
+	int iI = 0;
+	int iJ = 0;
 
 	// Allocate memory
 	if (m_aaiPlayerGoodyHutResults == NULL)

--- a/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
@@ -1222,7 +1222,8 @@ void CvHomelandAI::ExecuteUnitGift()
 		// Do we have units to spare?
 		bool bCanSendLandUnit = GET_PLAYER(ePlayer).GetMilitaryAI()->GetLandDefenseState() == DEFENSE_STATE_ENOUGH || GET_PLAYER(ePlayer).GetMilitaryAI()->GetLandDefenseState() == DEFENSE_STATE_NEUTRAL;
 		bool bCanSendNavalUnit = GET_PLAYER(ePlayer).GetMilitaryAI()->GetNavalDefenseState() == DEFENSE_STATE_ENOUGH || GET_PLAYER(ePlayer).GetMilitaryAI()->GetNavalDefenseState() == DEFENSE_STATE_NEUTRAL;
-		bool bPrioritizeLand = false, bPrioritizeNaval = false;
+		bool bPrioritizeLand = false;
+		bool bPrioritizeNaval = false;
 
 		if (bCanSendLandUnit && bCanSendNavalUnit)
 		{
@@ -1379,7 +1380,8 @@ void CvHomelandAI::PlotPatrolMoves()
 void CvHomelandAI::ExecutePatrolMoves()
 {
 	//check what kind of units we have
-	int iUnitsSea = 0, iUnitsLand = 0;
+	int iUnitsSea = 0;
+	int iUnitsLand = 0;
 	for(CHomelandUnitArray::iterator itUnit = m_CurrentMoveUnits.begin(); itUnit != m_CurrentMoveUnits.end(); ++itUnit)
 	{
 		CvUnit* pUnit = m_pPlayer->getUnit(itUnit->GetID());
@@ -5374,7 +5376,8 @@ void CvHomelandAI::LogHomelandMessage(const CvString& strMsg)
 	{
 		CvString strOutBuf;
 		CvString strBaseString;
-		CvString strTemp, szTemp2;
+		CvString strTemp;
+		CvString szTemp2;
 		CvString strPlayerName;
 		FILogFile* pLog = NULL;
 

--- a/CvGameCoreDLL_Expansion2/CvMap.cpp
+++ b/CvGameCoreDLL_Expansion2/CvMap.cpp
@@ -509,7 +509,10 @@ void CvMap::PrecalcNeighbors()
 	if (!pNeighbors)
 		return;
 
-	int iNX = 0, iNY = 0, iHX = 0, iHY = 0;
+	int iNX = 0;
+	int iNY = 0;
+	int iHX = 0;
+	int iHY = 0;
 
 	for(int iY = 0; iY < iH; iY++)
 	{
@@ -859,7 +862,8 @@ CvPlot* CvMap::syncRandPlot(int iFlags, int iArea, int iMinUnitDistance, int iTi
 	CvPlot* pLoopPlot = NULL;
 	bool bValid = false;
 	int iCount = 0;
-	int iDX = 0, iDY = 0;
+	int iDX = 0;
+	int iDY = 0;
 
 	pPlot = NULL;
 
@@ -1165,7 +1169,8 @@ int CvMap::getMapFractalFlags()
 bool CvMap::findWater(CvPlot* pPlot, int iRange, bool bFreshWater)
 {
 	CvPlot* pLoopPlot = NULL;
-	int iDX = 0, iDY = 0;
+	int iDX = 0;
+	int iDY = 0;
 	int iPlotX = pPlot->getX();
 	int iPlotY = pPlot->getY();
 

--- a/CvGameCoreDLL_Expansion2/CvMilitaryAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvMilitaryAI.cpp
@@ -1031,8 +1031,10 @@ int CvMilitaryAI::ScoreAttackTarget(const CvAttackTarget& target)
 	if(target.m_armyType==ARMY_TYPE_LAND)
 	{
 		// interpolate linearly between a low and a high distance
-		float fDistanceLow = 8, fWeightLow = 10;
-		float fDistanceHigh = 24, fWeightHigh = 1;
+		float fDistanceLow = 8;
+		float fWeightLow = 10;
+		float fDistanceHigh = 24;
+		float fWeightHigh = 1;
 
 		float fSlope = (fWeightHigh-fWeightLow) / (fDistanceHigh-fDistanceLow);
 		fDistWeightInterpolated = (target.GetPathLength()-fDistanceLow) * fSlope + fWeightLow;
@@ -1041,8 +1043,10 @@ int CvMilitaryAI::ScoreAttackTarget(const CvAttackTarget& target)
 	else
 	{
 		// interpolate linearly between a low and a high distance
-		float fDistanceLow = 8, fWeightLow = 6;
-		float fDistanceHigh = 36, fWeightHigh = 1;
+		float fDistanceLow = 8;
+		float fWeightLow = 6;
+		float fDistanceHigh = 36;
+		float fWeightHigh = 1;
 
 		float fSlope = (fWeightHigh-fWeightLow) / (fDistanceHigh-fDistanceLow);
 		fDistWeightInterpolated = (target.GetPathLength()-fDistanceLow) * fSlope + fWeightLow;

--- a/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
@@ -1558,7 +1558,8 @@ bool CvMinorCivQuest::IsComplete()
 	}
 	case MINOR_CIV_QUEST_ACQUIRE_CITY:
 	{
-		int iX = m_iData1, iY = m_iData2;
+		int iX = m_iData1;
+		int iY = m_iData2;
 		CvPlot* pPlot = GC.getMap().plot(iX, iY);
 
 		// Conquered or destroyed this city? NOTE: If the player liberated the city, it should still have the "previous owner" flag set
@@ -2243,8 +2244,10 @@ void CvMinorCivQuest::DoStartQuest(int iStartTurn, PlayerTypes pCallingPlayer)
 	CvPlayer* pMinor = &GET_PLAYER(m_eMinor);
 	CvPlayer* pAssignedPlayer = &GET_PLAYER(m_eAssignedPlayer);
 
-	Localization::String strMessage, strSummary;
-	int iNotificationX = -1, iNotificationY = -1;
+	Localization::String strMessage;
+	Localization::String strSummary;
+	int iNotificationX = -1;
+	int iNotificationY = -1;
 
 	// Calculate rewards based on quest type
 	CalculateRewards(m_eAssignedPlayer);
@@ -9313,7 +9316,8 @@ CvPlot* CvMinorCivAI::GetBestNearbyCampToKill()
 	int iNumWorldPlots = theMap.numPlots();
 	int iRange = /*12*/ max(GD_INT_GET(MINOR_CIV_QUEST_KILL_CAMP_RANGE), 2);
 	ImprovementTypes eCamp = (ImprovementTypes)GD_INT_GET(BARBARIAN_CAMP_IMPROVEMENT);
-	int iCapitalX = GetPlayer()->getCapitalCity()->getX(), iCapitalY = GetPlayer()->getCapitalCity()->getY();
+	int iCapitalX = GetPlayer()->getCapitalCity()->getX();
+	int iCapitalY = GetPlayer()->getCapitalCity()->getY();
 
 	for (int iI = 0; iI < iNumWorldPlots; iI++)
 	{
@@ -9352,7 +9356,8 @@ CvPlot* CvMinorCivAI::GetBestNearbyDig()
 	int iNumWorldPlots = theMap.numPlots();
 	int iRange = /*12*/ max(GD_INT_GET(MINOR_CIV_QUEST_ARCHAEOLOGY_RANGE), 2);
 	ResourceTypes eAntiquitySite = (ResourceTypes)GD_INT_GET(ARTIFACT_RESOURCE);
-	int iCapitalX = GetPlayer()->getCapitalCity()->getX(), iCapitalY = GetPlayer()->getCapitalCity()->getY();
+	int iCapitalX = GetPlayer()->getCapitalCity()->getX();
+	int iCapitalY = GetPlayer()->getCapitalCity()->getY();
 
 	for (int iI = 0; iI < iNumWorldPlots; iI++)
 	{
@@ -13008,7 +13013,8 @@ void CvMinorCivAI::TestChangeProtectionFromMajor(PlayerTypes eMajor)
 	if (!IsProtectedByMajor(eMajor))
 		return;
 
-	Localization::String strMessage, strSummary;
+	Localization::String strMessage;
+	Localization::String strSummary;
 
 	if (CanMajorProtect(eMajor, false))
 	{
@@ -13049,7 +13055,8 @@ void CvMinorCivAI::TestChangeProtectionFromMajor(PlayerTypes eMajor)
 	iMaxWarningTurns *= GC.getGame().getGameSpeedInfo().getTrainPercent();
 	iMaxWarningTurns /= 100;
 
-	bool bBadMilitary = false, bDistance = true;
+	bool bBadMilitary = false;
+	bool bDistance = true;
 	int iMajorStrength = 1; // to avoid division by zero issues
 	std::vector<int> viMilitaryStrengths;
 
@@ -13505,7 +13512,8 @@ bool CvMinorCivAI::DoMajorCivEraChange(PlayerTypes ePlayer, EraTypes eNewEra)
 		// Friends
 		if(IsFriends(ePlayer))
 		{
-			int iOldFood = 0, iNewFood = 0;
+			int iOldFood = 0;
+			int iNewFood = 0;
 
 			// Capital
 			iOldFood = GetFriendsCapitalFoodBonus(ePlayer);
@@ -13531,7 +13539,8 @@ bool CvMinorCivAI::DoMajorCivEraChange(PlayerTypes ePlayer, EraTypes eNewEra)
 		// Allies
 		if(IsAllies(ePlayer))
 		{
-			int iOldFood = 0, iNewFood = 0;
+			int iOldFood = 0;
+			int iNewFood = 0;
 
 			// Capital
 			iOldFood = GetAlliesCapitalFoodBonus(ePlayer);
@@ -13589,7 +13598,8 @@ bool CvMinorCivAI::DoMajorCivEraChange(PlayerTypes ePlayer, EraTypes eNewEra)
 		// Friends
 		if(IsFriends(ePlayer))
 		{
-			int iOldHappiness = 0, iNewHappiness = 0;
+			int iOldHappiness = 0;
+			int iNewHappiness = 0;
 
 			iOldHappiness = GetHappinessFlatFriendshipBonus(ePlayer) + GetHappinessPerLuxuryFriendshipBonus(ePlayer);
 			iNewHappiness = GetHappinessFlatFriendshipBonus(ePlayer, eNewEra) + GetHappinessPerLuxuryFriendshipBonus(ePlayer, eNewEra);
@@ -13604,7 +13614,8 @@ bool CvMinorCivAI::DoMajorCivEraChange(PlayerTypes ePlayer, EraTypes eNewEra)
 		// Allies
 		if(IsAllies(ePlayer))
 		{
-			int iOldHappiness = 0, iNewHappiness = 0;
+			int iOldHappiness = 0;
+			int iNewHappiness = 0;
 
 			iOldHappiness = GetHappinessFlatAlliesBonus(ePlayer) + GetHappinessPerLuxuryAlliesBonus(ePlayer);
 			iNewHappiness = GetHappinessFlatAlliesBonus(ePlayer, eNewEra) + GetHappinessPerLuxuryAlliesBonus(ePlayer, eNewEra);
@@ -18242,7 +18253,8 @@ TechTypes CvMinorCivAI::GetGoodTechPlayerDoesntHave(PlayerTypes ePlayer, int iRo
 	CvAssertMsg(ePlayer < MAX_MAJOR_CIVS, "ePlayer is expected to be within maximum bounds (invalid Index)");
 
 	CvWeightedVector<int> TechVector;
-	int iValue = 0, iProgress = 0;
+	int iValue = 0;
+	int iProgress = 0;
 
 
 	CvPlayerAI& kPlayer = GET_PLAYER(ePlayer);

--- a/CvGameCoreDLL_Expansion2/CvNotifications.cpp
+++ b/CvGameCoreDLL_Expansion2/CvNotifications.cpp
@@ -1387,7 +1387,8 @@ bool CvNotifications::IsNotificationRedundant(Notification& notification)
 		if(eOurPlayer1 == -1 || eOurPlayer2 == -1)
 			return false;
 
-		PlayerTypes eCheckingPlayer1, eCheckingPlayer2;
+		PlayerTypes eCheckingPlayer1;
+		PlayerTypes eCheckingPlayer2;
 
 		int iIndex = m_iNotificationsBeginIndex;
 		while(iIndex != m_iNotificationsEndIndex)

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -879,7 +879,8 @@ void CvPlayer::init(PlayerTypes eID)
 	LeaderHeadTypes eBestPersonality;
 	int iValue = 0;
 	int iBestValue = 0;
-	int iI = 0, iJ = 0;
+	int iI = 0;
+	int iJ = 0;
 
 	// only allocate notifications for civs that players can play as
 	if(eID < MAX_MAJOR_CIVS)
@@ -2819,7 +2820,8 @@ CvPlot* CvPlayer::addFreeUnit(UnitTypes eUnit, bool bGameStart, UnitAITypes eUni
 		return NULL;
 
 	CvPlot* pBestPlot = NULL;
-	int iX = pStartingPlot->getX(), iY = pStartingPlot->getY();
+	int iX = pStartingPlot->getX();
+	int iY = pStartingPlot->getY();
 
 	// If this is a civilian or air unit, spawn it on the starting plot
 	bool bCombat = pkUnitInfo->GetCombat() > 0 || pkUnitInfo->GetRangedCombat() > 0 || pkUnitInfo->GetNukeDamageLevel() != -1;
@@ -3005,8 +3007,13 @@ CvCity* CvPlayer::acquireCity(CvCity* pCity, bool bConquest, bool bGift)
 	if (!pCityPlot)
 		return NULL;
 
-	PlayerTypes eOldOwner = pCity->getOwner(), ePreviousOwner = pCity->getPreviousOwner(), eOriginalOwner = pCity->getOriginalOwner();
-	int iCityX = pCity->getX(), iCityY = pCity->getY(), iPopulation = pCity->getPopulation(), iNumCities = getNumCities();
+	PlayerTypes eOldOwner = pCity->getOwner();
+	PlayerTypes ePreviousOwner = pCity->getPreviousOwner();
+	PlayerTypes eOriginalOwner = pCity->getOriginalOwner();
+	int iCityX = pCity->getX();
+	int iCityY = pCity->getY();
+	int iPopulation = pCity->getPopulation();
+	int iNumCities = getNumCities();
 	const CvCivilizationInfo& playerCivilizationInfo = getCivilizationInfo();
 
 	// Can't acquire a city from yourself
@@ -3098,7 +3105,8 @@ CvCity* CvPlayer::acquireCity(CvCity* pCity, bool bConquest, bool bGift)
 		}
 	}
 
-	int iCaptureGold = 0, iCaptureCulture = 0;
+	int iCaptureGold = 0;
+	int iCaptureCulture = 0;
 	bool bSlaughter = bConquest && !bGift;
 	bool bFirstConquest = false;
 
@@ -3202,7 +3210,8 @@ CvCity* CvPlayer::acquireCity(CvCity* pCity, bool bConquest, bool bGift)
 			int iCityValue = /*175*/ GD_INT_GET(WAR_DAMAGE_LEVEL_CITY_WEIGHT);
 			iCityValue += (iPopulation * /*150*/ GD_INT_GET(WAR_DAMAGE_LEVEL_INVOLVED_CITY_POP_MULTIPLIER));
 			iCityValue += (pCity->getNumWorldWonders() * /*200*/ GD_INT_GET(WAR_DAMAGE_LEVEL_WORLD_WONDER_MULTIPLIER));
-			int iWinnerProgressValue = /*100*/ GD_INT_GET(WAR_PROGRESS_CAPTURED_CITY), iLoserProgressValue = /*-50*/ GD_INT_GET(WAR_PROGRESS_LOST_CITY);
+			int iWinnerProgressValue = /*100*/ GD_INT_GET(WAR_PROGRESS_CAPTURED_CITY);
+			int iLoserProgressValue = /*-50*/ GD_INT_GET(WAR_PROGRESS_LOST_CITY);
 
 			// Multipliers
 			// Their original capital!
@@ -4775,7 +4784,8 @@ CvCity* CvPlayer::acquireCity(CvCity* pCity, bool bConquest, bool bGift)
 	if (pNewCity && isBarbarian())
 	{
 		// Extra units?
-		int iNumExtraUnits = /*0*/ GD_INT_GET(BARBARIAN_NUM_UNITS_CITY_CAPTURE_SPAWN), iEra = GC.getGame().getCurrentEra();
+		int iNumExtraUnits = /*0*/ GD_INT_GET(BARBARIAN_NUM_UNITS_CITY_CAPTURE_SPAWN);
+		int iEra = GC.getGame().getCurrentEra();
 		iNumExtraUnits += GC.getGame().isOption(GAMEOPTION_CHILL_BARBARIANS) ? /*0*/ GD_INT_GET(BARBARIAN_NUM_UNITS_CITY_CAPTURE_SPAWN_CHILL) : 0;
 		iNumExtraUnits += GC.getGame().isOption(GAMEOPTION_RAGING_BARBARIANS) ? /*0*/ GD_INT_GET(BARBARIAN_NUM_UNITS_CITY_CAPTURE_SPAWN_RAGING) : 0;
 		if (iEra > 0)
@@ -13130,7 +13140,8 @@ bool CvPlayer::canReceiveGoody(CvPlot* pPlot, GoodyTypes eGoody, CvUnit* pUnit)
 
 		bool bGood = false;
 		int iOffset = kGoodyInfo.getMapOffset();
-		int iDX = 0, iDY = 0;
+		int iDX = 0;
+		int iDY = 0;
 		for(iDX = -(iOffset); iDX <= iOffset; iDX++)
 		{
 			for(iDY = -(iOffset); iDY <= iOffset; iDY++)
@@ -13159,7 +13170,8 @@ bool CvPlayer::canReceiveGoody(CvPlot* pPlot, GoodyTypes eGoody, CvUnit* pUnit)
 	// Reveal Nearby Barbs
 	if(kGoodyInfo.getRevealNearbyBarbariansRange() > 0)
 	{
-		int iDX = 0, iDY = 0;
+		int iDX = 0;
+		int iDY = 0;
 		int iBarbCampDistance = kGoodyInfo.getRevealNearbyBarbariansRange();
 		CvPlot* pNearbyPlot = NULL;
 
@@ -13466,7 +13478,8 @@ void CvPlayer::receiveGoody(CvPlot* pPlot, GoodyTypes eGoody, CvUnit* pUnit)
 	int iValue = 0;
 	int iBestValue = 0;
 	int iPass = 0;
-	int iDX = 0, iDY = 0;
+	int iDX = 0;
+	int iDY = 0;
 	int iI = 0;
 
 	CvAssertMsg(canReceiveGoody(pPlot, eGoody, pUnit), "Instance is expected to be able to receive goody");
@@ -16855,7 +16868,8 @@ void CvPlayer::removeBuildingClass(BuildingClassTypes eBuildingClass)
 // What is the effect of a building on the player?
 void CvPlayer::processBuilding(BuildingTypes eBuilding, int iChange, bool bFirst, CvArea* pArea)
 {
-	int iI = 0, iJ = 0;
+	int iI = 0;
+	int iJ = 0;
 
 	CvBuildingEntry* pBuildingInfo = GC.getBuildingInfo(eBuilding);
 	if(pBuildingInfo == NULL)
@@ -19881,7 +19895,8 @@ void CvPlayer::DoDifficultyBonus(HistoricEventTypes eHistoricEvent)
 
 		if (iYieldHandicap > 0)
 		{
-			CvString strLogString, strTemp;
+			CvString strLogString;
+			CvString strTemp;
 			strLogString.Format("VP ");
 			if (isHuman())
 			{
@@ -20491,7 +20506,8 @@ void CvPlayer::DoDifficultyBonus(HistoricEventTypes eHistoricEvent)
 
 		if (iYieldHandicap > 0)
 		{
-			CvString strLogString, strTemp;
+			CvString strLogString;
+			CvString strTemp;
 			strLogString.Format("VP AI DIFFICULTY BONUS FROM ");
 
 			switch (eHistoricEvent)
@@ -31492,7 +31508,8 @@ int CvPlayer::GetHappinessFromMilitaryUnits() const
 	if (iHappyPerXUnits <= 0)
 		return 0;
 
-	int iLoop = 0, iCount = 0;
+	int iLoop = 0;
+	int iCount = 0;
 	for (const CvUnit* pLoopUnit = firstUnit(&iLoop); pLoopUnit != NULL; pLoopUnit = nextUnit(&iLoop))
 	{
 		if (pLoopUnit->IsCivilianUnit() || pLoopUnit->isDelayedDeath())
@@ -31510,7 +31527,8 @@ int CvPlayer::GetYieldFromMilitaryUnits(YieldTypes eIndex) const
 	if (iYieldPerXUnits <= 0)
 		return 0;
 
-	int iLoop = 0, iCount = 0;
+	int iLoop = 0;
+	int iCount = 0;
 	for (const CvUnit* pLoopUnit = firstUnit(&iLoop); pLoopUnit != NULL; pLoopUnit = nextUnit(&iLoop))
 	{
 		if (pLoopUnit->IsCivilianUnit() || pLoopUnit->isDelayedDeath())
@@ -38270,7 +38288,8 @@ void CvPlayer::SetProximityToPlayer(PlayerTypes ePlayer, PlayerProximityTypes eP
 			CvString strFileName = "PlayerProximityLog.csv";
 			FILogFile* pLog = NULL;
 			pLog = LOGFILEMGR.GetLog(strFileName, FILogFile::kDontTimeStamp);
-			CvString strLog, strTemp;
+			CvString strLog;
+			CvString strTemp;
 
 			CvString strPlayerName;
 			strPlayerName = getCivilizationShortDescription();
@@ -45353,7 +45372,8 @@ void CvPlayer::doWarnings()
 //	--------------------------------------------------------------------------------
 void CvPlayer::processPolicies(PolicyTypes ePolicy, int iChange)
 {
-	int iI = 0, iJ = 0;
+	int iI = 0;
+	int iJ = 0;
 
 	CvPolicyEntry* pPolicy = GC.getPolicyInfo(ePolicy);
 	if(pPolicy == NULL)
@@ -47211,7 +47231,8 @@ void CvPlayer::processCorporations(CorporationTypes eCorporation, int iChange)
 	if(pkCorporationEntry == NULL)
 		return;
 
-	int iI = 0, jJ = 0;
+	int iI = 0;
+	int jJ = 0;
 
 	for (iI = 0; iI < GC.getNUM_YIELD_TYPES(); iI++)
 	{
@@ -49790,7 +49811,8 @@ void CvPlayer::UpdateMilitaryStats()
 		m_iFractionOriginalCapitalsUnderControl = iOCCount * 100 / max(1, (iCivCount-1));
 	}
 
-	int iExpCount = 0, iExpSum = 0;
+	int iExpCount = 0;
+	int iExpSum = 0;
 	for (CvUnit* pLoopUnit = firstUnit(&iLoop); pLoopUnit != NULL; pLoopUnit = nextUnit(&iLoop))
 	{
 		if (pLoopUnit->IsCombatUnit() && pLoopUnit->AI_getUnitAIType() != UNITAI_EXPLORE)

--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -1963,7 +1963,8 @@ void CvPlot::updateSight(bool bIncrement)
 void CvPlot::updateSeeFromSight(bool bIncrement, bool bRecalculate)
 {
 	CvPlot* pLoopPlot = NULL;
-	int iDX = 0, iDY = 0;
+	int iDX = 0;
+	int iDY = 0;
 
 	int iRange = 1 + /*1*/ GD_INT_GET(UNIT_VISIBILITY_RANGE);
 #if defined(MOD_PROMOTIONS_VARIABLE_RECON)
@@ -12706,7 +12707,8 @@ void CvPlot::showPopupText(PlayerTypes ePlayer, const char* szMessage)
 void CvPlot::processArea(CvArea* pArea, int iChange)
 {
 	CvCity* pCity = NULL;
-	int iI = 0, iJ = 0;
+	int iI = 0;
+	int iJ = 0;
 
 	pArea->changeNumTiles(iChange);
 

--- a/CvGameCoreDLL_Expansion2/CvSiteEvaluationClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvSiteEvaluationClasses.cpp
@@ -357,7 +357,10 @@ int CvSiteEvaluatorForSettler::PlotFoundValue(CvPlot* pPlot, const CvPlayer* pPl
 	std::vector<SPlotWithScore> workablePlots;
 	workablePlots.reserve(49);
 
-	int nFoodPlots = 0, nHammerPlots = 0, nWaterPlots = 0, nGoodPlots = 0;
+	int nFoodPlots = 0;
+	int nHammerPlots = 0;
+	int nWaterPlots = 0;
+	int nGoodPlots = 0;
 	int iRange = pPlayer ? max(2,min(5,pPlayer->getWorkPlotDistance())) : 3;
 	for (int iI=0; iI<RING_PLOTS[iRange]; iI++)
 	{

--- a/CvGameCoreDLL_Expansion2/CvStartPositioner.cpp
+++ b/CvGameCoreDLL_Expansion2/CvStartPositioner.cpp
@@ -102,7 +102,8 @@ void CvStartPositioner::ComputeFoundValues()
 	CUSTOMLOG("CvStartPositioner::ComputeFoundValues()");
 
 	// Progress through entire map
-	unsigned int iSum = 0, iValidPlots = 0;
+	unsigned int iSum = 0;
+	unsigned int iValidPlots = 0;
 	for(int iI = 0; iI < GC.getMap().numPlots(); iI++)
 	{
 		// Store found value in player 1 slot for now
@@ -798,7 +799,8 @@ bool PlotMeetsFoodRequirement(CvPlot* pPlot, PlayerTypes ePlayer, int iFoodRequi
 int CvStartPositioner::StartingPlotRange() const
 {
 	int iRange = 0;
-	int iNumMinors = 0, iNumMajors = 0;
+	int iNumMinors = 0;
+	int iNumMajors = 0;
 	int iExpectedCities = 0;
 
 	// Start with the range as a percentage of the maximum path length across the map

--- a/CvGameCoreDLL_Expansion2/CvTeam.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTeam.cpp
@@ -424,7 +424,8 @@ void CvTeam::addTeam(TeamTypes eTeam)
 {
 	CvPlot* pLoopPlot = NULL;
 	CvString strBuffer;
-	int iI = 0, iJ = 0;
+	int iI = 0;
+	int iJ = 0;
 
 	CvAssert(eTeam != NO_TEAM);
 	CvAssert(eTeam != GetID());
@@ -625,7 +626,9 @@ void CvTeam::shareItems(TeamTypes eTeam)
 {
 	CvCity* pLoopCity = NULL;
 	int iLoop = 0;
-	int iI = 0, iJ = 0, iK = 0;
+	int iI = 0;
+	int iJ = 0;
+	int iK = 0;
 
 	CvAssert(eTeam != NO_TEAM);
 	CvAssert(eTeam != GetID());
@@ -4197,7 +4200,9 @@ void CvTeam::makeHasMet(TeamTypes eIndex, bool bSuppressMessages)
 
 	if (GET_TEAM(eIndex).isMinorCiv())
 	{
-		int iCapitalX = -1, iCapitalY = -1, iCapitalID = -1;
+		int iCapitalX = -1;
+		int iCapitalY = -1;
+		int iCapitalID = -1;
 
 		// Minor reveals his capital to the player so that he can click on the City to contact
 		CvCity* pCap = GET_PLAYER(GET_TEAM(eIndex).getLeaderID()).getCapitalCity();
@@ -5221,7 +5226,8 @@ void CvTeam::changeProjectCount(ProjectTypes eIndex, int iChange)
 {
 	bool bChangeProduction = false;
 	int iOldProjectCount = 0;
-	int iI = 0, iJ = 0;
+	int iI = 0;
+	int iJ = 0;
 
 	CvAssertMsg(eIndex >= 0, "eIndex is expected to be non-negative (invalid Index)");
 	CvAssertMsg(eIndex < GC.getNumProjectInfos(), "eIndex is expected to be within maximum bounds (invalid Index)");
@@ -5939,7 +5945,8 @@ void CvTeam::DoTestSmallAwards()
 
 	bool bShouldShowNotification = false;
 	int iNotificationData = 0;
-	int iNotificationX = 0, iNotificationY = 0;
+	int iNotificationX = 0;
+	int iNotificationY = 0;
 
 	for(int iSmallAwardLoop = 0; iSmallAwardLoop < GC.getNumSmallAwardInfos(); iSmallAwardLoop++)
 	{
@@ -7503,7 +7510,8 @@ void CvTeam::testCircumnavigated()
 	CvPlot* pPlot = NULL;
 	CvString strBuffer;
 	bool bFoundVisible = false;
-	int iX = 0, iY = 0;
+	int iX = 0;
+	int iY = 0;
 
 	if(isBarbarian())
 	{
@@ -7654,7 +7662,8 @@ void CvTeam::processTech(TechTypes eTech, int iChange)
 	CvCity* pCity = NULL;
 	CvPlot* pLoopPlot = NULL;
 	ResourceTypes eResource;
-	int iI = 0, iJ = 0;
+	int iI = 0;
+	int iJ = 0;
 
 	CvTechEntry* pTech = GC.getTechInfo(eTech);
 
@@ -9524,7 +9533,8 @@ void CvTeam::DoEndVassal(TeamTypes eTeam, bool bPeaceful, bool bSuppressNotifica
 	if (bSuppressNotification)
 		return;
 
-	Localization::String locString, summaryString;
+	Localization::String locString;
+	Localization::String summaryString;
 
 	for (int iI = 0; iI < MAX_PLAYERS; iI++)
 	{
@@ -9792,7 +9802,8 @@ bool CvTeam::CanMakeVassal(TeamTypes eTeam, bool bIgnoreAlreadyVassal) const
 // We become the new Vassal of eTeam
 void CvTeam::DoBecomeVassal(TeamTypes eTeam, bool bVoluntary, PlayerTypes eOriginatingMaster)
 {
-	Localization::String locString, summaryString;
+	Localization::String locString;
+	Localization::String summaryString;
 
 	CvAssertMsg(eTeam != NO_TEAM, "eTeam is not assigned a valid value");
 	CvAssertMsg(eTeam != GetID(), "eTeam is not expected to be equal with GetID()");
@@ -10175,7 +10186,8 @@ void CvTeam::DoApplyVassalTax(PlayerTypes ePlayer, int iPercent)
 		GET_PLAYER(ePlayer).GetDiplomacyAI()->DoVassalTaxChanged(GetID(), (iPercent < iCurrentTaxRate));	
 
 		// send a notification if there was some change
-		Localization::String locString, summaryString;
+		Localization::String locString;
+		Localization::String summaryString;
 		if(iPercent > iCurrentTaxRate)
 		{
 			locString = Localization::Lookup("TXT_KEY_MISC_VASSAL_TAX_INCREASED");

--- a/CvGameCoreDLL_Expansion2/CvTradeClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTradeClasses.cpp
@@ -2106,7 +2106,8 @@ CvUnit* CvGameTrade::GetTradeUnitForRoute(int iIndex)
 //	----------------------------------------------------------------------------
 void CvGameTrade::DisplayTemporaryPopupTradeRoute(int iDestX, int iDestY, TradeConnectionType type, DomainTypes eDomain)
 {
-	int iOriginX = 0,iOriginY = 0;
+	int iOriginX = 0;
+	int iOriginY = 0;
 	PlayerTypes eOriginPlayer;
 
 	CvInterfacePtr<ICvUnit1> pSelectedUnit(GC.GetEngineUserInterface()->GetHeadSelectedUnit());
@@ -2135,7 +2136,8 @@ void CvGameTrade::DisplayTemporaryPopupTradeRoute(int iDestX, int iDestY, TradeC
 			size_t n = path.vPlots.size();
 			if (n>0 && n<=MAX_PLOTS_TO_DISPLAY)
 			{
-				int plotsX[MAX_PLOTS_TO_DISPLAY], plotsY[MAX_PLOTS_TO_DISPLAY];
+				int plotsX[MAX_PLOTS_TO_DISPLAY];
+				int plotsY[MAX_PLOTS_TO_DISPLAY];
 				for (size_t i=0;i<n;++i)
 				{
 					plotsX[i] = path.vPlots[i].x;
@@ -2769,7 +2771,8 @@ int CvPlayerTrade::GetTradeConnectionGPTValueTimes100(const TradeConnection& kTr
 		{
 			if (eYield == YIELD_GOLD)
 			{
-				int iX = 0, iY = 0;
+				int iX = 0;
+				int iY = 0;
 				if (bOriginCity)
 				{
 					iX = kTradeConnection.m_iOriginX;
@@ -4357,7 +4360,8 @@ bool CvPlayerTrade::CanCreateTradeRoute(DomainTypes eDomain) const
 //	--------------------------------------------------------------------------------
 bool CvPlayerTrade::CreateTradeRoute(CvCity* pOriginCity, CvCity* pDestCity, DomainTypes eDomain, TradeConnectionType eConnectionType) const
 {
-	int plotsX[MAX_PLOTS_TO_DISPLAY], plotsY[MAX_PLOTS_TO_DISPLAY];
+	int plotsX[MAX_PLOTS_TO_DISPLAY];
+	int plotsY[MAX_PLOTS_TO_DISPLAY];
 
 	CvGameTrade* pTrade = GC.getGame().GetGameTrade();
 	int iRouteID = -1;
@@ -4984,7 +4988,8 @@ bool CvPlayerTrade::PlunderTradeRoute(int iTradeConnectionID, CvUnit* pUnit)
 	// barbarians get a bonus unit out of the deal!
 	if (pUnit->isBarbarian())
 	{
-		int iNumExtraUnits = /*1*/ GD_INT_GET(BARBARIAN_NUM_UNITS_PLUNDER_TRADE_ROUTE_SPAWN), iGameEra = GC.getGame().getCurrentEra();
+		int iNumExtraUnits = /*1*/ GD_INT_GET(BARBARIAN_NUM_UNITS_PLUNDER_TRADE_ROUTE_SPAWN);
+		int iGameEra = GC.getGame().getCurrentEra();
 		iNumExtraUnits += GC.getGame().isOption(GAMEOPTION_CHILL_BARBARIANS) ? /*0*/ GD_INT_GET(BARBARIAN_NUM_UNITS_PLUNDER_TRADE_ROUTE_SPAWN_CHILL) : 0;
 		iNumExtraUnits += GC.getGame().isOption(GAMEOPTION_RAGING_BARBARIANS) ? /*0*/ GD_INT_GET(BARBARIAN_NUM_UNITS_PLUNDER_TRADE_ROUTE_SPAWN_RAGING) : 0;
 		if (iGameEra > 0)

--- a/CvGameCoreDLL_Expansion2/CvTreasury.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTreasury.cpp
@@ -987,7 +987,8 @@ int CvTreasury::GetVassalGoldMaintenance() const
 			&& !GET_PLAYER((PlayerTypes)iI).isBarbarian()
 			&& GET_PLAYER((PlayerTypes)iI).isAlive())
 		{
-			int iLoop = 0, iCityPop = 0;
+			int iLoop = 0;
+			int iCityPop = 0;
 			// This player is our vassal
 			if(GET_TEAM(GET_PLAYER((PlayerTypes)iI).getTeam()).IsVassal(m_pPlayer->getTeam()))
 			{

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -8646,7 +8646,8 @@ bool CvUnit::isNukeVictim(const CvPlot* pPlot, TeamTypes eTeam) const
 {
 	VALIDATE_OBJECT
 	CvPlot* pLoopPlot = NULL;
-	int iDX = 0, iDY = 0;
+	int iDX = 0;
+	int iDY = 0;
 
 	if(!(GET_TEAM(eTeam).isAlive()))
 	{

--- a/CvGameCoreDLL_Expansion2/CvUnitCombat.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnitCombat.cpp
@@ -2520,7 +2520,8 @@ void CvUnitCombat::GenerateNuclearCombatInfo(CvUnit& kAttacker, CvPlot& plot, Cv
 
 	// Any interception to be done?
 	CvCity* pInterceptionCity = plot.GetNukeInterceptor(kAttacker.getOwner());
-	bool bInterceptionSuccess = false, bPartialInterception = false;
+	bool bInterceptionSuccess = false;
+	bool bPartialInterception = false;
 	CvPlot* pInterceptionCityPlot = NULL;
 
 	if (pInterceptionCity != NULL)
@@ -2876,7 +2877,9 @@ uint CvUnitCombat::ApplyNuclearExplosionDamage(const CvCombatMemberEntry* pkDama
 					// Unlike the city hit points, the population damage is calculated when the pre-calculated damage is applied.
 					// This is simply to save space in the damage array, since the combat visualization does not need it.
 					// It can be moved into the pre-calculated damage array if needed.
-					int iBaseDamage = 0, iRandDamage1 = 0, iRandDamage2 = 0;
+					int iBaseDamage = 0;
+					int iRandDamage1 = 0;
+					int iRandDamage2 = 0;
 					// How much destruction is unleashed on nearby Cities?
 					if(iDamageLevel == 1)
 					{

--- a/CvGameCoreDLL_Expansion2/CvVotingClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvVotingClasses.cpp
@@ -4111,7 +4111,9 @@ int CvLeague::CalculateStartingVotesForMember(PlayerTypes ePlayer, bool bFakeUN,
 	int iHostVotes = IsHostMember(ePlayer) ? pInfo->GetHostDelegates() : 0;
 
 	// Base votes from City-State allies
-	int iCityStateVotes = 0, iNumAllies = 0, iNumMinorsFollowingReligion = 0;
+	int iCityStateVotes = 0;
+	int iNumAllies = 0;
+	int iNumMinorsFollowingReligion = 0;
 	for (int iMinorLoop = MAX_MAJOR_CIVS; iMinorLoop < MAX_CIV_PLAYERS; iMinorLoop++)
 	{
 		PlayerTypes eMinor = (PlayerTypes) iMinorLoop;
@@ -4219,7 +4221,8 @@ int CvLeague::CalculateStartingVotesForMember(PlayerTypes ePlayer, bool bFakeUN,
 		iVotes += iPolicyVotes;
 	}
 
-	int iTraitVotes = 0, iTraitPotential = 0;
+	int iTraitVotes = 0;
+	int iTraitPotential = 0;
 
 	if (iNumAllies != 0)
 	{
@@ -4241,7 +4244,8 @@ int CvLeague::CalculateStartingVotesForMember(PlayerTypes ePlayer, bool bFakeUN,
 	iVotes += iTraitVotes;
 
 	//Votes from GPT
-	int iVotesPerGPT = GET_PLAYER(ePlayer).GetVotesPerGPT(), iGPTVotes = 0;
+	int iVotesPerGPT = GET_PLAYER(ePlayer).GetVotesPerGPT();
+	int iGPTVotes = 0;
 	if (iVotesPerGPT > 0)
 	{
 		int iGPT = GET_PLAYER(ePlayer).GetTreasury()->CalculateGrossGold();


### PR DESCRIPTION
Delayed follow up to https://github.com/LoneGazebo/Community-Patch-DLL/pull/9853, clang-tidy [readability-isolate-declaration](https://clang.llvm.org/extra/clang-tidy/checks/readability/isolate-declaration.html) actioned before attempting [misc-const-correctness](https://clang.llvm.org/extra/clang-tidy/checks/misc/const-correctness.html) again. v90 build works.