### PR TITLE
readability-string-compare

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvVotingClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvVotingClasses.cpp
@@ -2251,7 +2251,7 @@ Localization::String CvLeague::GetName()
 
 				sName = Localization::Lookup(pInfo->GetNameKey());
 				//antonjs: temp: Did our lookup return the same thing (ie. we don't have that text key)?
-				if (sOrdinalKey.compare(sOrdinal.toUTF8()) == 0)
+				if (sOrdinalKey == sOrdinal.toUTF8())
 				{
 					sName << "" << pCapital->getNameKey();
 				}


### PR DESCRIPTION
clang-tidy [readability-string-compare](https://clang.llvm.org/extra/clang-tidy/checks/readability/string-compare.html). v90 build works.
```
C:\Users\user\Documents\GitHub\Community-Patch-DLL\CvGameCoreDLL_Expansion2\CvVotingClasses.cpp:2254:9: warning: do not use 'compare' to test equality of strings; use the string equality operator instead [readability-string-compare]
 2254 |                                 if (sOrdinalKey.compare(sOrdinal.toUTF8()) == 0)
      |                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~    ~
      |                                     sOrdinalKey                               sOrdinal.toUTF8()
```