### PR TITLE
Fix CTD when liberating a city

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
@@ -54799,27 +54799,29 @@ int CvDiplomacyAIHelpers::GetCityLiberationValue(CvCity* pCity, PlayerTypes eLib
 
 	if (!bHisGainIsOurOwn)
 	{
-		// DECREASE if opponent is big and nasty.
-		switch (pDiplo->GetMilitaryStrengthComparedToUs(eNewOwner))
+		if (GET_PLAYER(eNewOwner).isAlive())
 		{
-		case NO_STRENGTH_VALUE:
-			UNREACHABLE(); // Strengths are supposed to have been evaluated by this point.
-		case STRENGTH_IMMENSE:
-			iWarmongerStrengthModifier += /*-75*/ GD_INT_GET(WARMONGER_THREAT_DEFENDER_STRENGTH_IMMENSE);
-			break;
-		case STRENGTH_POWERFUL:
-			iWarmongerStrengthModifier += /*-50*/ GD_INT_GET(WARMONGER_THREAT_DEFENDER_STRENGTH_POWERFUL);
-			break;
-		case STRENGTH_STRONG:
-			iWarmongerStrengthModifier += /*-25*/ GD_INT_GET(WARMONGER_THREAT_DEFENDER_STRENGTH_STRONG);
-			break;
-		case STRENGTH_AVERAGE:
-			iWarmongerStrengthModifier += /*0*/ GD_INT_GET(WARMONGER_THREAT_DEFENDER_STRENGTH_AVERAGE);
-			break;
-		case STRENGTH_POOR:
-		case STRENGTH_WEAK:
-		case STRENGTH_PATHETIC:
-			break; // Not applicable.
+			switch (pDiplo->GetMilitaryStrengthComparedToUs(eNewOwner))
+			{
+			case NO_STRENGTH_VALUE:
+				UNREACHABLE(); // Strengths are supposed to have been evaluated by this point.
+			case STRENGTH_IMMENSE:
+				iWarmongerStrengthModifier += /*-75*/ GD_INT_GET(WARMONGER_THREAT_DEFENDER_STRENGTH_IMMENSE);
+				break;
+			case STRENGTH_POWERFUL:
+				iWarmongerStrengthModifier += /*-50*/ GD_INT_GET(WARMONGER_THREAT_DEFENDER_STRENGTH_POWERFUL);
+				break;
+			case STRENGTH_STRONG:
+				iWarmongerStrengthModifier += /*-25*/ GD_INT_GET(WARMONGER_THREAT_DEFENDER_STRENGTH_STRONG);
+				break;
+			case STRENGTH_AVERAGE:
+				iWarmongerStrengthModifier += /*0*/ GD_INT_GET(WARMONGER_THREAT_DEFENDER_STRENGTH_AVERAGE);
+				break;
+			case STRENGTH_POOR:
+			case STRENGTH_WEAK:
+			case STRENGTH_PATHETIC:
+				break; // Not applicable.
+			}
 		}
 	}
 


### PR DESCRIPTION
Fix #9772 

The relative strength value between Rome and to-be-liberated Jerusalem was NO_STRENGTH_VALUE, causing a crash. Usually strength values are updated when two players meet for the first time, and Rome had met Jerusalem according to the game data. I can't figure out from the save game where the error happened (I assume Rome didn't actually meet Jerusalem, as Jerusalem was probably annexed by Venice early in the game). Anyway, restricting the strength check to players that are alive prevents such crashes, and it also prevents using outdated strength valuations which might happen otherwise.