### PR TITLE
fix for issue #10172

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -16414,7 +16414,7 @@ void CvCity::processBuilding(BuildingTypes eBuilding, int iChange, bool bFirst, 
 			{
 				if (pBuildingInfo->IsTeamShare() || (iI == getOwner()))
 				{
-					GET_PLAYER((PlayerTypes)iI).processBuilding(eBuilding, iChange, bFirst, plot()->area());
+					GET_PLAYER((PlayerTypes)iI).processBuilding(eBuilding, iChange, bFirst, this);
 				}
 			}
 		}

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -16913,10 +16913,12 @@ void CvPlayer::removeBuildingClass(BuildingClassTypes eBuildingClass)
 
 //	--------------------------------------------------------------------------------
 // What is the effect of a building on the player?
-void CvPlayer::processBuilding(BuildingTypes eBuilding, int iChange, bool bFirst, CvArea* pArea)
+void CvPlayer::processBuilding(BuildingTypes eBuilding, int iChange, bool bFirst, CvCity* pSourceCity)
 {
 	int iI = 0;
 	int iJ = 0;
+	
+	CvArea* pArea = pSourceCity->plot()->area();
 
 	CvBuildingEntry* pBuildingInfo = GC.getBuildingInfo(eBuilding);
 	if(pBuildingInfo == NULL)
@@ -17339,7 +17341,7 @@ void CvPlayer::processBuilding(BuildingTypes eBuilding, int iChange, bool bFirst
 				if(pkBuilding && pkBuildingClassInfo)
 				{
 					iBuildingCount = pLoopCityBuildings->GetNumBuilding(eTestBuilding);
-					if(iBuildingCount > 0) // FIXME: This code will not be run when removing a building that buffs its own building class.
+					if(iBuildingCount > 0 || pLoopCity == pSourceCity)
 					{
 						// Building Class Yield Stuff
 						for(iJ = 0; iJ < NUM_YIELD_TYPES; iJ++)

--- a/CvGameCoreDLL_Expansion2/CvPlayer.h
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.h
@@ -366,7 +366,7 @@ public:
 
 	int getBuildingClassPrereqBuilding(BuildingTypes eBuilding, BuildingClassTypes ePrereqBuildingClass, int iExtra = 0) const;
 	void removeBuildingClass(BuildingClassTypes eBuildingClass);
-	void processBuilding(BuildingTypes eBuilding, int iChange, bool bFirst, CvArea* pArea);
+	void processBuilding(BuildingTypes eBuilding, int iChange, bool bFirst, CvCity* pSourceCity);
 	int GetBuildingClassYieldChange(BuildingClassTypes eBuildingClass, YieldTypes eYieldType);
 	int GetBuildingClassYieldModifier(BuildingClassTypes eBuildingClass, YieldTypes eYieldType);
 	int GetBuildingClassYieldChange(BuildingClassTypes eBuildingClass, YieldTypes eYieldType, const vector<int>& preexistingBuildingsCount);

--- a/CvGameCoreDLL_Expansion2/CvTeam.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTeam.cpp
@@ -676,8 +676,7 @@ void CvTeam::shareItems(TeamTypes eTeam)
 											CvPlayerAI& kOtherPlayer = GET_PLAYER(static_cast<PlayerTypes>(iK));
 											if(kOtherPlayer.isAlive() && kOtherPlayer.getTeam() == m_eID)
 											{
-												CvArea* pArea = pLoopCity->plot()->area();
-												kOtherPlayer.processBuilding(eBuilding, pLoopCity->GetCityBuildings()->GetNumBuilding(eBuilding), /*bFirst*/ false, pArea);
+												kOtherPlayer.processBuilding(eBuilding, pLoopCity->GetCityBuildings()->GetNumBuilding(eBuilding), /*bFirst*/ false, pLoopCity);
 											}
 										}
 									}


### PR DESCRIPTION
A simple way of dealing with trying to remove global yields from a city whose building has just been removed, while iterating through all cities, is to check if the current loop city is the city that has just removed the building.