### PR TITLE
Turn speed small improvements

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvBuildingClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvBuildingClasses.h
@@ -1117,6 +1117,9 @@ public:
 	void Read(FDataStream& kStream);
 	void Write(FDataStream& kStream) const;
 
+	void SetBuildingTypeByClassDirty(bool dirty) const;
+	void CacheBuildingTypeByClass() const;
+
 	// Accessor functions
 	CvBuildingXMLEntries* GetPossibleBuildings() const;
 
@@ -1262,6 +1265,9 @@ private:
 
 #if defined(MOD_BALANCE_CORE)
 	std::vector<BuildingTypes> m_buildingsThatExistAtLeastOnce;
+
+	mutable bool b_existBuildingsAreDirty;
+	mutable std::map<BuildingClassTypes, BuildingTypes> m_buildingTypeByClass;
 #endif
 
 	std::vector<BuildingYieldChange> m_aBuildingYieldChange;

--- a/CvGameCoreDLL_Expansion2/CvGlobals.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGlobals.cpp
@@ -3814,7 +3814,7 @@ CvBuildingClassInfo* CvGlobals::getBuildingClassInfo(BuildingClassTypes eBuildin
 		return NULL;
 }
 
-int CvGlobals::getNumBuildingInfos()
+inline int CvGlobals::getNumBuildingInfos()
 {
 	return m_pBuildings->GetNumBuildings();
 }
@@ -3824,7 +3824,7 @@ std::vector<CvBuildingEntry*>& CvGlobals::getBuildingInfo()
 	return m_pBuildings->GetBuildingEntries();
 }
 
-CvBuildingEntry* CvGlobals::getBuildingInfo(BuildingTypes eBuildingNum)
+inline CvBuildingEntry* CvGlobals::getBuildingInfo(BuildingTypes eBuildingNum)
 {
 	CvAssert(eBuildingNum > -1);
 	CvAssert(eBuildingNum < GC.getNumBuildingInfos());

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -10827,7 +10827,7 @@ void CvPlayer::SetDangerPlotsDirty()
 }
 
 //	--------------------------------------------------------------------------------
-bool CvPlayer::isHuman() const
+inline bool CvPlayer::isHuman() const
 {
 	if(GetID() == NO_PLAYER)
 	{

--- a/CvGameCoreDLL_Expansion2/CvPlayerAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayerAI.cpp
@@ -48,7 +48,7 @@
 
 static CvEnumMap<PlayerTypes, CvPlayerAI> s_players;
 
-CvPlayerAI& CvPlayerAI::getPlayer(PlayerTypes ePlayer)
+inline CvPlayerAI& CvPlayerAI::getPlayer(PlayerTypes ePlayer)
 {
 	CvAssertMsg(ePlayer != NO_PLAYER, "Player is not assigned a valid value");
 	CvAssertMsg(ePlayer < MAX_PLAYERS, "Player is not assigned a valid value");

--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -13570,7 +13570,7 @@ int CvPlot::countNumAirUnits(TeamTypes eTeam, bool bNoSuicide) const
 }
 
 //	--------------------------------------------------------------------------------
-int CvPlot::GetPlotIndex() const
+inline int CvPlot::GetPlotIndex() const
 {
 	return m_iPlotIndex;
 }

--- a/CvGameCoreDLL_Expansion2/CvPlot.h
+++ b/CvGameCoreDLL_Expansion2/CvPlot.h
@@ -408,7 +408,7 @@ public:
 	{
 		return (PlotTypes)m_ePlotType;
 	}
-	bool isWater()          const
+	inline bool isWater()          const
 	{
 		return (PlotTypes)m_ePlotType == PLOT_OCEAN;
 	};

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -18629,12 +18629,12 @@ void CvUnit::ChangeIsConvertUnit(int iValue)
 	VALIDATE_OBJECT
 	m_iConvertUnit += iValue;
 }
-int CvUnit::getIsConvertUnit() const
+inline int CvUnit::getIsConvertUnit() const
 {
 	VALIDATE_OBJECT
 	return	m_iConvertUnit;
 }
-bool CvUnit::isConvertUnit() const
+inline bool CvUnit::isConvertUnit() const
 {
 	VALIDATE_OBJECT
 	return getIsConvertUnit() > 0;


### PR DESCRIPTION
- Implementing `CvCityBuildings::CacheBuildingTypeByClass`, so `CvCityBuildings::GetBuildingTypeFromClass` works faster.

Here is how much time does it take before the fix (`CvEconomicAI` is at top usage inside `doPostTurnDiplomacy`):

![image](https://github.com/LoneGazebo/Community-Patch-DLL/assets/3791221/66c24faf-2966-476d-ba02-6c88017148cf)

After the fix `CvEconomicAI` now is at third position and takes much less time to calculate (4k vs 1k samples, overall turn update was 27k samples):

![image](https://github.com/LoneGazebo/Community-Patch-DLL/assets/3791221/0417d297-57a5-4953-9908-8949777a3d5e)

- `CvUnitMovement::GetCostsForMove` minor tweaks. This method is called too often during path building, so trying to optimize it as much as possible.
- Also some small improvements like `inline` on frequently called methods.