### PR TITLE
clang-tidy

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvArea.cpp
+++ b/CvGameCoreDLL_Expansion2/CvArea.cpp
@@ -792,8 +792,8 @@ void CvArea::GetTopAndBottomLatitudes(int& iTopLatitude, int& iBottomLatitude) c
 /// What is the largest latitude value of this Area?
 int CvArea::GetAreaMaxLatitude()
 {
-	int iTopLatitude;
-	int iBottomLatitude;
+	int iTopLatitude = 0;
+	int iBottomLatitude = 0;
 	GetTopAndBottomLatitudes(iTopLatitude, iBottomLatitude);
 
 	return max(iTopLatitude, iBottomLatitude);
@@ -803,8 +803,8 @@ int CvArea::GetAreaMaxLatitude()
 /// What is the smallest latitude value of this Area?
 int CvArea::GetAreaMinLatitude()
 {
-	int iTopLatitude;
-	int iBottomLatitude;
+	int iTopLatitude = 0;
+	int iBottomLatitude = 0;
 	GetTopAndBottomLatitudes(iTopLatitude, iBottomLatitude);
 
 	return min(iTopLatitude, iBottomLatitude);

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -4472,7 +4472,7 @@ CvCity* CvPlayer::acquireCity(CvCity* pCity, bool bConquest, bool bGift)
 		else
 		{
 			BuildingClassTypes eGWBuildingClass; // Passed by reference below
-			int iGWSlot; // Passed by reference below
+			int iGWSlot = 0; // Passed by reference below
 			CvCity* pClosestValidCity = GetCulture()->GetClosestAvailableGreatWorkSlot(iCityX, iCityY, eGreatWorkSlot, &eGWBuildingClass, &iGWSlot);
 			if (pClosestValidCity)
 			{
@@ -19764,9 +19764,9 @@ void CvPlayer::DoFreeGreatWorkOnConquest(PlayerTypes ePlayer, CvCity* pCity)
 					{
 						break;
 					}
-					int iCityLoop;
+					int iCityLoop = 0;
 					CvCity* pPlayerCity = NULL;
-					int iGreatWorkIndex;
+					int iGreatWorkIndex = 0;
 					for (pPlayerCity = GET_PLAYER(ePlayer).firstCity(&iCityLoop); pPlayerCity != NULL; pPlayerCity = GET_PLAYER(ePlayer).nextCity(&iCityLoop))
 					{
 						if (iStuffStolen >= iPlunder)
@@ -19813,7 +19813,7 @@ void CvPlayer::DoFreeGreatWorkOnConquest(PlayerTypes ePlayer, CvCity* pCity)
 														iNotificationArtwork = iGreatWorkIndex;
 														// and create great work at home
 														BuildingClassTypes eGWBuildingClass;
-														int iGWSlot;
+														int iGWSlot = 0;
 														CvCity *pArtCity = GetCulture()->GetClosestAvailableGreatWorkSlot(pPlayerCity->getX(), pPlayerCity->getY(), pkBuilding->GetGreatWorkSlotType(), &eGWBuildingClass, &iGWSlot);
 														if (pArtCity)
 														{
@@ -50681,7 +50681,7 @@ void CvPlayer::ChangeNumGreatPeople(int iValue)
 std::vector<int> CvPlayer::GetTotalBuildingCount(bool bIncludePuppets) const
 {
 	std::vector<int> vTotalBuildingCount(GC.getNumBuildingInfos(), 0);
-	int iLoop;
+	int iLoop = 0;
 	for (const CvCity* pLoopCity = firstCity(&iLoop); pLoopCity != NULL; pLoopCity = nextCity(&iLoop))
 	{
 		if (bIncludePuppets || !CityStrategyAIHelpers::IsTestCityStrategy_IsPuppetAndAnnexable(pLoopCity))

--- a/CvGameCoreDLL_Expansion2/CvTacticalAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTacticalAI.cpp
@@ -1150,7 +1150,9 @@ void CvTacticalAI::ExecuteDestroyUnitMoves(AITacticalTargetType targetType, bool
 				// If so, execute enough moves to destroy it
 				if(GC.getLogging() && GC.getAILogging())
 				{
-					CvString strLogString, strTemp, strPlayerName;
+					CvString strLogString;
+					CvString strTemp;
+					CvString strPlayerName;
 					strPlayerName = GET_PLAYER(pDefender->getOwner()).getCivilizationShortDescription();
 					strTemp = GC.getUnitInfo(pDefender->getUnitType())->GetDescription();
 					switch(targetType)
@@ -2713,7 +2715,8 @@ bool CvTacticalAI::CheckForEnemiesNearArmy(CvArmyAI* pArmy)
 		return false;
 
 	//now that we have a set of units find the center of mass
-	int x = 0, y = 0;
+	int x = 0;
+	int y = 0;
 	set<CvPlot*, PrSortByPlotIndex> allEnemyPlots;
 	for (set<CvUnit*, PrSortByUnitId>::iterator it = ourUnitsInitial.begin(); it != ourUnitsInitial.end(); ++it)
 	{
@@ -4445,7 +4448,8 @@ bool CvTacticalAI::ExecuteMoveOfBlockingUnit(CvUnit* pBlockingUnit, CvPlot* pPre
 			ExecuteMoveToPlot(pBlockingUnit, pPlot);
 			if(GC.getLogging() && GC.getAILogging())
 			{
-				CvString strTemp, strLogString;
+				CvString strTemp;
+				CvString strLogString;
 				strTemp = pBlockingUnit->getUnitInfo().GetDescription();
 				strLogString.Format("Moving blocking %s out of way, Leaving X: %d, Y: %d, Now At X: %d, Y: %d", strTemp.GetCString(), pOldPlot->getX(), pOldPlot->getY(), pBlockingUnit->getX(), pBlockingUnit->getY());
 				LogTacticalMessage(strLogString);
@@ -6067,7 +6071,8 @@ bool TacticalAIHelpers::IsAttackNetPositive(CvUnit* pUnit, const CvPlot* pTarget
 	//no visibility check, when we call this we already know there is an enemy unit ...
 	CvUnit* pTargetUnit = pTargetPlot->getBestDefender( NO_PLAYER, pUnit->getOwner(), pUnit, false, true);
 
-	int iDamageDealt = 0, iDamageReceived = 1;
+	int iDamageDealt = 0;
+	int iDamageReceived = 1;
 	if (pTargetCity)
 	{
 		//+2 to make sure it's positive if city has zero hitpoints left
@@ -6754,7 +6759,8 @@ bool TacticalAIHelpers::KillLoneEnemyIfPossible(CvUnit* pOurUnit, CvUnit* pEnemy
 		return false;
 
 	//see how the attack would go
-	int iDamageDealt = 0, iDamageReceived = 0;
+	int iDamageDealt = 0;
+	int iDamageReceived = 0;
 	iDamageDealt = TacticalAIHelpers::GetSimulatedDamageFromAttackOnUnit(pEnemyUnit, pOurUnit, pEnemyUnit->plot(), pOurUnit->plot(), iDamageReceived);
 
 	//is it worth it? (take into account some randomness ...)
@@ -6803,7 +6809,8 @@ bool TacticalAIHelpers::IsSuicideMeleeAttack(const CvUnit * pAttacker, CvPlot * 
 	if (!pAttacker || !pTarget || pAttacker->IsCanAttackRanged() || pAttacker->getDomainType()==DOMAIN_AIR)
 		return false;
 
-	int iDamageDealt = 0, iDamageReceived = 0;
+	int iDamageDealt = 0;
+	int iDamageReceived = 0;
 
 	//if we're not adjacent we don't know the plot the attacker will use in the end
 	CvPlot* pAttackerPlot = NULL;
@@ -6844,7 +6851,8 @@ bool TacticalAIHelpers::CanKillTarget(const CvUnit* pAttacker, CvPlot* pTarget)
 			return true;
 
 		//see how an attack would go just in case
-		int iDamageDealt = 0, iDamageReceived = 0;
+		int iDamageDealt = 0;
+		int iDamageReceived = 0;
 		iDamageDealt = TacticalAIHelpers::GetSimulatedDamageFromAttackOnCity(pTargetCity, pAttacker, pAttacker->plot(), iDamageReceived, true, 0, true);
 
 		//ranged units can't capture themselves so we check for an adjacent melee unit
@@ -6873,7 +6881,8 @@ bool TacticalAIHelpers::CanKillTarget(const CvUnit* pAttacker, CvPlot* pTarget)
 	if (pDefender)
 	{
 		//see how the attack would go
-		int iDamageDealt = 0, iDamageReceived = 0;
+		int iDamageDealt = 0;
+		int iDamageReceived = 0;
 		iDamageDealt = TacticalAIHelpers::GetSimulatedDamageFromAttackOnUnit(pDefender, pAttacker, pDefender->plot(), pAttacker->plot(), iDamageReceived, true, 0, true);
 		//no suicide attacks ...
 		return iDamageDealt >= pDefender->GetCurrHitPoints() && (iDamageReceived == 0 || iDamageReceived < pAttacker->GetCurrHitPoints()-3);
@@ -9058,7 +9067,8 @@ bool CvTacticalPosition::isKillOrImprovedPosition() const
 
 	//if we did not make an attack, see if our units moved in the right way at least
 	//note that this comparison only works because we know we did not kill an enemy, which would change enemyDistance!
-	int iPositive = 0, iNegative = 0;
+	int iPositive = 0;
+	int iNegative = 0;
 	int iAttacksNoMove = 0;
 	for (size_t i = nFirstInterestingAssignment; i < assignedMoves.size(); i++)
 	{
@@ -10671,7 +10681,8 @@ bool TacticalAIHelpers::ExecuteUnitAssignments(PlayerTypes ePlayer, const std::v
 			//because of randomness in previous combat results, it may happen that we cannot actually kill the enemy
 			if (bPrecondition)
 			{
-				int iDamageDealt = 0, iDamageReceived = 0;
+				int iDamageDealt = 0;
+				int iDamageReceived = 0;
 				if (pToPlot->isEnemyCity(*pUnit))
 				{
 					CvCity* pCity = pToPlot->getPlotCity();

--- a/CvGameCoreDLL_Expansion2/CvTradeClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTradeClasses.cpp
@@ -7545,7 +7545,7 @@ void CvTradeAI::GetPrioritizedTradeRoutes(TradeConnectionList& aTradeConnectionL
 				}
 				
 				CvString playerName;
-				FILogFile* pLog;
+				FILogFile* pLog = NULL;
 				CvString strBaseString;
 				CvString strOutBuf;
 				CvString strFileName = "TradeRouteChoices.csv";


### PR DESCRIPTION
clang-tidy run with [readability-isolate-declaration](https://clang.llvm.org/extra/clang-tidy/checks/readability/isolate-declaration.html) and [cppcoreguidelines-init-variables](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/init-variables.html). v90 build works.