### PR TITLE
Reduce TradePlayerRouteLog messages

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvTradeClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTradeClasses.cpp
@@ -5171,8 +5171,6 @@ void CvPlayerTrade::UpdateFurthestPossibleTradeRoute(DomainTypes eDomain, CvCity
 
 				if (iLength <= 0)
 				{
-					strMsg.Format("%s,%s,,Skipping", pOriginCity->getNameKey(), pDestCity->getNameKey());
-					LogTradeMsg(strMsg);
 					continue;
 				}
 
@@ -5206,11 +5204,6 @@ void CvPlayerTrade::UpdateFurthestPossibleTradeRoute(DomainTypes eDomain, CvCity
 					strMsg.Format("%s,%s,,Trade route is not the longest,%d", pOriginCity->getNameKey(), pDestCity->getNameKey(), iLength);
 					LogTradeMsg(strMsg);
 				}
-			}
-			else
-			{
-				strMsg.Format("%s,%s,,Can't create trade route", pOriginCity->getNameKey(), pDestCity->getNameKey());
-				LogTradeMsg(strMsg);
 			}
 		}
 	}


### PR DESCRIPTION
These log files can get way too big (350.000 lines of this written in 50 turns)
![tradelog](https://github.com/LoneGazebo/Community-Patch-DLL/assets/95587882/79d4cafa-5939-4de5-b37e-461f09b58f66)