### PR TITLE
Split TradeRoutePathCache into UI and DLL instances

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -400,7 +400,6 @@ CvCity::CvCity() :
 	, m_aiYieldFromPillage()
 	, m_aiYieldFromPillageGlobal()
 	, m_aiNumTimesAttackedThisTurn()
-	, m_aiLongestPotentialTradeRoute()
 	, m_aiNumProjects()
 	, m_aiYieldFromKnownPantheons()
 	, m_aiGoldenAgeYieldMod()
@@ -1432,7 +1431,6 @@ void CvCity::reset(int iID, PlayerTypes eOwner, int iX, int iY, bool bConstructo
 	m_iBaseTourism = 0;
 	m_iBaseTourismBeforeModifiers = 0;
 	m_aiNumTimesAttackedThisTurn.resize(REALLY_MAX_PLAYERS);
-	m_aiLongestPotentialTradeRoute.resize(NUM_DOMAIN_TYPES);
 	m_aiNumProjects.resize(GC.getNumProjectInfos());
 	m_aiSpecialistRateModifier.resize(GC.getNumSpecialistInfos());
 	m_aiYieldFromVictory.resize(NUM_YIELD_TYPES);
@@ -1484,10 +1482,6 @@ void CvCity::reset(int iID, PlayerTypes eOwner, int iX, int iY, bool bConstructo
 	for (iI = 0; iI < REALLY_MAX_PLAYERS; iI++)
 	{
 		m_aiNumTimesAttackedThisTurn[iI] = 0;
-	}
-	for (iI = 0; iI < NUM_DOMAIN_TYPES; iI++)
-	{
-		m_aiLongestPotentialTradeRoute[iI] = 0;
 	}
 #endif
 	m_miInstantYieldsTotal.clear();
@@ -2970,7 +2964,7 @@ int CvCity::GetTradeRouteLandDistanceModifier() const
 //	--------------------------------------------------------------------------------
 int CvCity::GetLongestPotentialTradeRoute(DomainTypes eDomain) const
 {
-	return m_aiLongestPotentialTradeRoute[eDomain];
+	return GC.getGame().GetGameTrade()->GetLongestPotentialTradeRoute(GetID(), eDomain);
 }
 //	--------------------------------------------------------------------------------
 void CvCity::SetLongestPotentialTradeRoute(int iValue, DomainTypes eDomain)
@@ -2978,7 +2972,7 @@ void CvCity::SetLongestPotentialTradeRoute(int iValue, DomainTypes eDomain)
 	VALIDATE_OBJECT
 	CvAssertMsg(eDomain >= 0, "eIndex1 is expected to be non-negative (invalid Index)");
 	CvAssertMsg(eDomain < NUM_DOMAIN_TYPES, "eIndex1 is expected to be within maximum bounds (invalid Index)");
-	m_aiLongestPotentialTradeRoute[eDomain] = iValue;
+	GC.getGame().GetGameTrade()->GetLongestPotentialTradeRoute(GetID(), eDomain);
 }
 
 bool CvCity::AreOurBordersTouching(PlayerTypes ePlayer)
@@ -33071,7 +33065,6 @@ void CvCity::Serialize(City& city, Visitor& visitor)
 	visitor(city.m_iCachedEmpireSizeModifier);
 	visitor(city.m_iYieldMediansCachedTurn);
 	visitor(city.m_aiNumProjects);
-	visitor(city.m_aiLongestPotentialTradeRoute);
 	visitor(city.m_aiNumTimesAttackedThisTurn);
 	visitor(city.m_aiYieldFromKnownPantheons);
 	visitor(city.m_aiYieldFromVictory);

--- a/CvGameCoreDLL_Expansion2/CvCity.h
+++ b/CvGameCoreDLL_Expansion2/CvCity.h
@@ -1921,7 +1921,6 @@ protected:
 	int m_iCachedEmpireSizeModifier;
 	int m_iYieldMediansCachedTurn;
 	std::vector<int> m_aiNumProjects;
-	std::vector<int> m_aiLongestPotentialTradeRoute;
 	std::vector<int> m_aiNumTimesAttackedThisTurn;
 	std::vector<int> m_aiYieldFromKnownPantheons;
 	std::vector<int> m_aiYieldFromVictory;
@@ -2311,7 +2310,6 @@ SYNC_ARCHIVE_VAR(int, m_iCachedTechNeedModifier)
 SYNC_ARCHIVE_VAR(int, m_iCachedEmpireSizeModifier)
 SYNC_ARCHIVE_VAR(int, m_iYieldMediansCachedTurn)
 SYNC_ARCHIVE_VAR(std::vector<int>, m_aiNumProjects)
-SYNC_ARCHIVE_VAR(std::vector<int>, m_aiLongestPotentialTradeRoute)
 SYNC_ARCHIVE_VAR(std::vector<int>, m_aiNumTimesAttackedThisTurn)
 SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldFromKnownPantheons)
 SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldFromVictory)

--- a/CvGameCoreDLL_Expansion2/CvGame.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGame.cpp
@@ -129,6 +129,7 @@ CvGame::CvGame() :
 	, m_bSavedOnce(false)
 #endif
 	, m_bArchaeologyTriggered(false)
+	, m_bIsDesynced(false)
 	, m_lastTurnAICivsProcessed(-1)
 	, m_processPlayerAutoMoves(false)
 	, m_cityDistancePathLength(NO_DOMAIN) //for now!
@@ -1166,6 +1167,7 @@ void CvGame::uninit()
 	m_bEverRightClickMoved = false;
 	m_bCombatWarned = false;
 	m_bArchaeologyTriggered = false;
+	m_bIsDesynced = false;
 
 	m_eHandicap = NO_HANDICAP;
 	m_ePausePlayer = NO_PLAYER;
@@ -5981,6 +5983,22 @@ bool CvGame::isSimultaneousTeamTurns() const
 	return true;
 }
 
+
+bool CvGame::isDesynced() const
+{
+	if (!isNetworkMultiPlayer()) {
+		return false;
+	}
+	return m_bIsDesynced;
+}
+void CvGame::setDesynced(bool bNewValue)
+{
+	if (!isNetworkMultiPlayer()) {
+		return;
+	}
+	m_bIsDesynced = bNewValue;
+}
+
 //	--------------------------------------------------------------------------------
 bool CvGame::isFinalInitialized() const
 {
@@ -8800,9 +8818,17 @@ void CvGame::doTurn()
 
 	LogGameState();
 
-	//autosave after doing a turn
-	if (isNetworkMultiPlayer())
+	if (isNetworkMultiPlayer()) {
+		//autosave after doing a turn
 		gDLL->AutoSave(false, false);
+
+		if (isDesynced()) {
+			setDesynced(false);
+
+			CvString output; CvString::format(output, "Session is running in desynced state, undefined behaviour may appear. Please, fill the issue on GitHub.");
+			gGlobals.getDLLIFace()->sendChat(output, CHATTARGET_ALL, NO_PLAYER);
+		}
+	}
 }
 
 //	--------------------------------------------------------------------------------

--- a/CvGameCoreDLL_Expansion2/CvGame.h
+++ b/CvGameCoreDLL_Expansion2/CvGame.h
@@ -303,6 +303,9 @@ public:
 	bool isPitboss() const;
 	bool isSimultaneousTeamTurns() const;
 
+	bool isDesynced() const;
+	void setDesynced(bool bNewValue);
+
 	bool isFinalInitialized() const;
 	void setFinalInitialized(bool bNewValue);
 
@@ -893,6 +896,7 @@ protected:
 	bool m_bEndGameTechResearched;
 	bool m_bTunerEverConnected;
 	bool m_bDynamicTurnsSimultMode;		//if playing dynamic turn mode, are we currently running simultaneous turns?
+	bool m_bIsDesynced; // whether the game was desynced or not as a result of the very last sync
 	PlayerTypes m_eWaitDiploPlayer;
 	TechTypes m_eTechAstronomy;
 

--- a/CvGameCoreDLL_Expansion2/CvSerialize.h
+++ b/CvGameCoreDLL_Expansion2/CvSerialize.h
@@ -279,6 +279,8 @@ public:
 		if (!result) {
 			std::string desyncValues = std::string("Desync values, current ") + FSerialization::toString(currentValue()) + "; other " + FSerialization::toString(other) + std::string("\n");
 			gGlobals.getDLLIFace()->netMessageDebugLog(desyncValues);
+
+			gGlobals.getGame().setDesynced(true);
 		}
 
 		return result; // Place a conditional breakpoint here to help debug sync errors.

--- a/CvGameCoreDLL_Expansion2/CvTradeClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvTradeClasses.h
@@ -217,12 +217,24 @@ public:
 	void InvalidateTradePathCache(PlayerTypes iPlayer);
 	void InvalidateTradePathTeamCache(TeamTypes eTeam);
 
-protected:
+	void SetLongestPotentialTradeRoute(int iValue, int iCityIndex, DomainTypes eDomain);
+	int GetLongestPotentialTradeRoute(int iCityIndex, DomainTypes eDomain);
 
+private:
+	TradePathLookup& GetTradePathsCache(bool bWater);
+	std::map<PlayerTypes,int>& GetTradePathsCacheUpdateCounter();
+
+protected:
+	
+	// std::map<city index, std::map<DomainTypes, longest length>>
+	std::map<int, std::map<DomainTypes, int>> m_aiLongestPotentialTradeRoute;
 	TradeConnectionList m_aTradeConnections;
 	TradePathLookup m_aPotentialTradePathsLand;
 	TradePathLookup m_aPotentialTradePathsWater;
+	TradePathLookup m_aPotentialTradePathsLandUi;
+	TradePathLookup m_aPotentialTradePathsWaterUi;
 	std::map<PlayerTypes,int> m_lastTradePathUpdate;
+	std::map<PlayerTypes,int> m_lastTradePathUpdateUi;
 	std::vector<vector<int>> m_routesPerPlayer;
 	std::map<int, SPath> m_dummyTradePaths; //always empty, just for us to return a reference
 


### PR DESCRIPTION
Savegame incompatible (!) because I moved `m_aiLongestPotentialTradeRoute` from `CvCity` to `CvGameTrade`.

Split TradeRoutePathCache into UI and DLL instances to improve MP stability. After all my PRs it still desyncs, but splitting should finally resolve such issues.

Also added some kind of QoL improvement to MP games: when desync happened, desynced player sends a message to the chat. If you do MP stability test, you can do your report immideately after such message appeared, because we already have a desync and we have to investigate it, no sense to play until CTD or something like that. @Cyclopia31
If you play the real MP session, it can be just a signal that something is going wrong now. You may re-create session to restore the host's state to get rid of desync consequences, but no guarantees that it would be not triggered again.
`m_bIsDesynced` variable resets after each turn and new message will appear with next turn if something is still desynced, so maybe spamming is possible in real MP sessions if you just continue the game after a detected desync. We can discuss, maybe it would be better to send such message just once and don't reset the `m_bIsDesynced` variable.
Looks like so (with fake desync at each turn just for an example):
![1](https://github.com/LoneGazebo/Community-Patch-DLL/assets/3791221/677fac2d-448d-4016-986f-2ab82f921f3c)

@axatin @RecursiveVision @ilteroi please, check my CPP, because it can be error-prone a little bit 🌚
