### PR TITLE
CTD when AI liberating AI with simultaneous turns

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -35006,8 +35006,10 @@ void CvPlayer::setAlive(bool bNewValue, bool bNotify)
 	// Update turns/slot status if the player is now alive
 	if (bNewValue)
 	{
-		if (isSimultaneousTurns() || (GC.getGame().getNumGameTurnActive() == 0) || (GC.getGame().isSimultaneousTeamTurns() && GET_TEAM(getTeam()).isTurnActive()))
-		{
+		if (
+			((isSimultaneousTurns() || (GC.getGame().isSimultaneousTeamTurns() && GET_TEAM(getTeam()).isTurnActive())) && isHuman())
+			|| GC.getGame().getNumGameTurnActive() == 0
+		) {
 			setTurnActive(true);
 		}
 


### PR DESCRIPTION
Fixes #10234

See the discussion here: https://discord.com/channels/707403015845576735/1033469765794140242/1155288910126120980

When AI liberating another AI, with simultaneous turns they do their turns simultaneously, that's why CTD occurs. There is still some UI issue, but I will open another issue for it.