### PR TITLE
Allows Policy Table CapitalYieldPerPopChangeEmpire to stack.

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -18638,7 +18638,9 @@ void CvPlayer::ChangeCapitalYieldPerPopChangeEmpire(YieldTypes eYield, int iChan
 
 	if (iChange != 0)
 	{
-		m_aiCapitalYieldPerPopChangeEmpire[eYield] = m_aiCapitalYieldPerPopChangeEmpire[eYield] + iChange;
+        int iChangeTimes100 = 100 / iChange;
+        // (1/20 * 100 = 5)
+        m_aiCapitalYieldPerPopChangeEmpire[eYield] = m_aiCapitalYieldPerPopChangeEmpire[eYield] + iChangeTimes100;
 
 		updateYield();
 	}

--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -9567,6 +9567,8 @@ int CvPlot::calculateNatureYield(YieldTypes eYield, PlayerTypes ePlayer, const C
 			if (GET_PLAYER(ePlayer).GetCapitalYieldPerPopChangeEmpire(eYield) != 0)
 			{
 				int iPerPopYieldEmpire = GET_PLAYER(ePlayer).getTotalPopulation() / GET_PLAYER(ePlayer).GetCapitalYieldPerPopChangeEmpire(eYield);
+				//Implied 100x, see ChangeCapitalYieldPerPopChangeEmpire.
+				iPerPopYieldEmpire /= 100;
 				iYield += iPerPopYieldEmpire;
 			}
 		}


### PR DESCRIPTION
CapitalYieldPerPopChangeEmpire was not stacking with other yield types.

Unsure of save-game compatibility.