### PR TITLE
MP diplomacy fixes

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
@@ -9294,13 +9294,6 @@ void CvDiplomacyAI::DoTurn(DiplomacyMode eDiploMode, PlayerTypes ePlayer)
 	// These functions actually DO things, and we don't want the shadow AI behind a human player doing things for him
 	if (!GetPlayer()->isHuman())
 	{
-#if defined(MOD_ACTIVE_DIPLOMACY)
-		if(eDiploMode == DIPLO_HUMAN_PLAYERS && GC.getGame().isReallyNetworkMultiPlayer() && MOD_ACTIVE_DIPLOMACY)
-		{
-			// in the beginning of turn - remove all the proposed deals from/to this AI
-			GC.getGame().GetGameDeals().DoCancelAllProposedMPDealsWithPlayer(GetID(), DIPLO_ALL_PLAYERS);
-		}
-#endif
 		DetermineVassalTaxRates();
 		DoUpdateDemands();
 		MakeWar();

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyRequests.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyRequests.cpp
@@ -534,14 +534,6 @@ void CvDiplomacyRequests::SendRequest(PlayerTypes eFromPlayer, PlayerTypes eToPl
 #if defined(MOD_ACTIVE_DIPLOMACY)
 	if(GC.getGame().isReallyNetworkMultiPlayer() && MOD_ACTIVE_DIPLOMACY)
 	{
-		if (GC.getGame().isNetworkMultiPlayer() && eToPlayer != GC.getGame().getActivePlayer())
-		{
-			CvPlayer& kPlayer = GET_PLAYER(eToPlayer);
-			CvDiplomacyRequests* pkDiploRequests = kPlayer.GetDiplomacyRequests();
-			if (pkDiploRequests)
-				pkDiploRequests->Add(eFromPlayer, eDiploType, pszMessage, eAnimationType, iExtraGameData);
-			return;
-		}
 		CvPlayer& kPlayer = GET_PLAYER(eToPlayer);
 		CvDiplomacyRequests* pkDiploRequests = kPlayer.GetDiplomacyRequests();
 		if(pkDiploRequests)

--- a/CvGameCoreDLL_Expansion2/CvGame.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGame.cpp
@@ -8589,11 +8589,17 @@ void CvGame::doTurn()
 	// Dodgy business to cleanup all the completed requests from last turn. Any still here should just be ones that were processed on other clients anyway.
 	if (MOD_ACTIVE_DIPLOMACY)
 	{
+		bool isNetworkMultiPlayer = GC.getGame().isNetworkMultiPlayer();
 		for (int iI = 0; iI < MAX_MAJOR_CIVS; iI++)
 		{
 			CvPlayerAI& kPlayer = GET_PLAYER((PlayerTypes)iI);
 			CvAssertMsg((kPlayer.isLocalPlayer() && !kPlayer.GetDiplomacyRequests()->HasPendingRequests()) || !kPlayer.isLocalPlayer(), "Clearing requests, expected local player to be empty.");
 			kPlayer.GetDiplomacyRequests()->ClearAllRequests();
+
+			if (isNetworkMultiPlayer && !kPlayer.isHuman()) {
+				// in the beginning of turn - remove all the proposed deals from/to this player
+				GC.getGame().GetGameDeals().DoCancelAllProposedMPDealsWithPlayer((PlayerTypes)iI, DIPLO_ALL_PLAYERS);
+			}
 		}
 	}
 #endif


### PR DESCRIPTION
Fixes #10244

Moved `DoCancelAllProposedMPDealsWithPlayer` to `DoTurn` - it is a better place for such cleanup and also there is already similar `m_aRequests` cleanup. Also fixes silently disappearing "first contact" (only triggered via world league?) diplomacy requests (reproducible in #10244 at turn 173 -> 174).

Also removed `getActivePlayer()` check in `CvDiplomacyRequests::SendRequest`. It skips dummy deal creation if `player != getActivePlayer()`. I'm not sure whether such logic is intended for some behavior or not, but right now it causes desyncs. I don't see any purposes of such code, but probably I'm wrong. SO:

It makes "first contact" (only triggered via world league?) requests are counting just only for "active" player, as a result later with time human players receive different deals on each end. It works like so:
- Core logic runs on both ends, Rome sends "first contact" diplomacy request to Player B (non-host) via world league:
![image](https://github.com/LoneGazebo/Community-Patch-DLL/assets/3791221/805898ae-78e2-4b2e-8e82-cb46790df1f5)
- At Player A (host) end, Player B receives this request, but without dummy deal. 
- At Player B end dummy deal is created.
- Then any sent finalized deal triggers `CvDiplomacyRequests::CheckRemainingNotifications` for each player (it clears appeared invalid deals if any):
![image](https://github.com/LoneGazebo/Community-Patch-DLL/assets/3791221/ec6180a2-d476-4ace-89e5-0c5da8696cfc)
- If deal for request is `null`, then it is immediately invalid and such request got erased:
![image](https://github.com/LoneGazebo/Community-Patch-DLL/assets/3791221/b38b8008-29ff-4cb8-96b4-cb30249c5704)
- As a result, at Player A end: Player B has no "first contact" requests, because all of them don't have dummy deals
- At Player B end: Player B has all the "first contact" requests
- If makes deal order desynced on each end because later we have the following logic which decides whether to talk to human or not:
![image](https://github.com/LoneGazebo/Community-Patch-DLL/assets/3791221/200dd536-3f12-493a-bd5e-70028bf2ef63)
- As a result, at Player A end Rome will send some deal to Player B immediately after world league founded
- At Player B end Rome will send the same deal just only at next turn (because at current turn Player B already has "first contact" diplomacy request from Rome)

How this desync looks like in logs:
![5](https://github.com/LoneGazebo/Community-Patch-DLL/assets/3791221/46322a99-2261-47b3-ac8f-e924d5e03b66)