### PR TITLE
Investment Bugfixes

### DIFF
--- a/(2) Vox Populi/LUA/InfoTooltipInclude.lua
+++ b/(2) Vox Populi/LUA/InfoTooltipInclude.lua
@@ -5,7 +5,7 @@ print("This is the modded InfoTooltipInclude from CBP- CSD")
 
 
 -- UNIT
-function GetHelpTextForUnit(iUnitID, bIncludeRequirementsInfo)
+function GetHelpTextForUnit(iUnitID, bIncludeRequirementsInfo, pCity)
 	local pUnitInfo = GameInfo.Units[iUnitID];
 	
 	local pActivePlayer = Players[Game.GetActivePlayer()];
@@ -15,14 +15,25 @@ function GetHelpTextForUnit(iUnitID, bIncludeRequirementsInfo)
 	
 	-- Name
 	strHelpText = strHelpText .. Locale.ToUpper(Locale.ConvertTextKey( pUnitInfo.Description ));
-	
+	if (pCity ~= nil) then
+		if(pCity:GetUnitInvestment(iUnitID) > 0) then
+		strHelpText = strHelpText .. Locale.ConvertTextKey("TXT_KEY_INVESTED");
+		end
+	end
+			
 	-- Cost
 	strHelpText = strHelpText .. "[NEWLINE]----------------[NEWLINE]";
 	
 	-- Skip cost if it's 0
 	if(pUnitInfo.Cost > 0) then
-		strHelpText = strHelpText .. Locale.ConvertTextKey("TXT_KEY_PRODUCTION_COST", pActivePlayer:GetUnitProductionNeeded(iUnitID));
-	end
+		local iCost = pActivePlayer:GetUnitProductionNeeded(iUnitID);
+		if (pCity ~= nil) then
+			if(pCity:GetUnitInvestment(iUnitID) > 0) then
+				iCost = pCity:GetUnitInvestment(iUnitID);
+			end
+		end
+		strHelpText = strHelpText .. Locale.ConvertTextKey("TXT_KEY_PRODUCTION_COST", iCost);
+	end			
 	
 	-- Moves
 	if pUnitInfo.Domain ~= "DOMAIN_AIR" then

--- a/(2) Vox Populi/LUA/ProductionPopup.lua
+++ b/(2) Vox Populi/LUA/ProductionPopup.lua
@@ -143,13 +143,13 @@ function ProductionSelected( ePurchaseEnum, iData)
 		elseif (eOrder == OrderTypes.ORDER_CONSTRUCT) then
 			if (city:IsCanPurchase(true, true, -1, iData, -1, eYield)) then
 				Game.CityPurchaseBuilding(city, iData, eYield);
-				Network.SendUpdateCityCitizens(cityID);
 			end
 		elseif (eOrder == OrderTypes.ORDER_CREATE) then
 			if (city:IsCanPurchase(true, true, -1, -1, iData, eYield)) then
 				Game.CityPurchaseProject(city, iData, eYield);
 			end
 		end
+		Network.SendUpdateCityCitizens(cityID);
 		
 		if (eOrder == OrderTypes.ORDER_TRAIN or eOrder == OrderTypes.ORDER_CONSTRUCT or eOrder == OrderTypes.ORDER_CREATE) then
 			if (eYield == YieldTypes.YIELD_GOLD) then
@@ -824,7 +824,7 @@ function UpdateWindow( city )
 			Controls.ProductionPortrait:SetHide( false );
 			
 			-- Info for this thing
-			strToolTip = Locale.ConvertTextKey(GetHelpTextForUnit(unitProduction, true)) .. "[NEWLINE][NEWLINE]" .. strToolTip;
+			strToolTip = Locale.ConvertTextKey(GetHelpTextForUnit(unitProduction, true, city)) .. "[NEWLINE][NEWLINE]" .. strToolTip;
 			
 		else
 			Controls.ProductionPortrait:SetHide( true );
@@ -1237,7 +1237,7 @@ function AddProductionButton( id, description, orderType, turnsLeft, column, isD
 		
 		-- Tooltip
 		local bIncludeRequirementsInfo = false;
-		local strToolTip = Locale.ConvertTextKey(GetHelpTextForUnit(id, bIncludeRequirementsInfo));
+		local strToolTip = Locale.ConvertTextKey(GetHelpTextForUnit(id, bIncludeRequirementsInfo, pCity));
 		
 		-- Disabled help text
 		if (isDisabled) then

--- a/(2) Vox Populi/LUA/TechButtonInclude.lua
+++ b/(2) Vox Populi/LUA/TechButtonInclude.lua
@@ -778,7 +778,7 @@ function AdjustArtOnGrantedUnitButton( thisButton, thisUnitInfo, textureSize )
 		
 		-- Tooltip
 		local bIncludeRequirementsInfo = true;
-		thisButton:SetToolTipString( GetHelpTextForUnit(thisUnitInfo.ID, bIncludeRequirementsInfo) );
+		thisButton:SetToolTipString( GetHelpTextForUnit(thisUnitInfo.ID, bIncludeRequirementsInfo, nil) );
 		local portraitOffset, portraitAtlas = UI.GetUnitPortraitIcon(thisUnitInfo.ID);
 		local textureOffset, textureSheet = IconLookup( portraitOffset, textureSize, portraitAtlas );				
 		if textureOffset == nil then

--- a/(3a) EUI Compatibility Files/LUA/CityView.lua
+++ b/(3a) EUI Compatibility Files/LUA/CityView.lua
@@ -1098,6 +1098,7 @@ local function SelectionPurchase( orderID, itemID, yieldID, soundKey )
 			if orderID == OrderTypes.ORDER_TRAIN then
 				if cityIsCanPurchase( city, true, true, itemID, -1, -1, yieldID ) then
 					Game.CityPurchaseUnit( city, itemID, yieldID )
+					Network.SendUpdateCityCitizens( cityID )
 					isPurchase = true
 				end
 			elseif orderID == OrderTypes.ORDER_CONSTRUCT then
@@ -1124,6 +1125,7 @@ local function SelectionPurchase( orderID, itemID, yieldID, soundKey )
 			elseif orderID == OrderTypes.ORDER_CREATE then
 				if cityIsCanPurchase( city, true, true, -1, -1, itemID, yieldID ) then
 					Game.CityPurchaseProject( city, itemID, yieldID )
+					Network.SendUpdateCityCitizens( cityID )
 					isPurchase = true
 				end
 			end

--- a/CvGameCoreDLL_Expansion2/CvBuildingProductionAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuildingProductionAI.cpp
@@ -686,7 +686,6 @@ int CvBuildingProductionAI::CheckBuildingBuildSanity(BuildingTypes eBuilding, in
 	}
 	
 
-#if defined(MOD_BALANCE_CORE_BUILDING_INVESTMENTS)
 	if (MOD_BALANCE_CORE_BUILDING_INVESTMENTS && !bIgnoreSituational)
 	{
 		//Virtually force this.
@@ -696,7 +695,7 @@ int CvBuildingProductionAI::CheckBuildingBuildSanity(BuildingTypes eBuilding, in
 			iBonus += 1000;
 		}
 	}
-#endif
+
 	//Courthouse? Let's get it ASAP.
 	bool bCourthouse = false;
 	if(pkBuildingInfo->IsNoOccupiedUnhappiness())

--- a/CvGameCoreDLL_Expansion2/CvCity.h
+++ b/CvGameCoreDLL_Expansion2/CvCity.h
@@ -399,8 +399,8 @@ public:
 	int getProduction() const;
 	int getProductionTimes100() const;
 	int getProductionNeeded() const;
-	int getProductionNeeded(UnitTypes eUnit) const;
-	int getProductionNeeded(BuildingTypes eBuilding) const;
+	int getProductionNeeded(UnitTypes eUnit, bool bIgnoreInvestment = false) const;
+	int getProductionNeeded(BuildingTypes eBuilding, bool bIgnoreInvestment = false) const;
 	int getProductionNeeded(ProjectTypes eProject) const;
 	int getProductionNeeded(SpecialistTypes eSpecialist) const;
 	int getProductionTurnsLeft() const;
@@ -414,11 +414,13 @@ public:
 #endif
 #if defined(MOD_BALANCE_CORE)
 	void SetBuildingInvestment(BuildingClassTypes eBuildingClass, bool bValue);
+	int GetBuildingCostInvestmentReduction(BuildingClassTypes eBuildingClass) const;
 	bool IsBuildingInvestment(BuildingClassTypes eBuildingClass) const;
 
 	bool IsProcessInternationalProject(ProcessTypes eProcess) const;
 
 	void SetUnitInvestment(UnitClassTypes eUnitClass, bool bValue);
+	int GetUnitCostInvestmentReduction(UnitClassTypes eUnitClass) const;
 	bool IsUnitInvestment(UnitClassTypes eUnitClass) const;
 
 	void SetBuildingConstructed(BuildingClassTypes eBuildingClass, bool bValue);
@@ -1536,6 +1538,7 @@ public:
 	void popOrder(int iNum, bool bFinish = false, bool bChoose = false);
 	void swapOrder(int iNum);
 	bool hasOrder(OrderTypes eOrder, int iData1, int iData2) const;
+	bool hasOrder(OrderTypes eOrder, int iData1) const;
 	void startHeadOrder();
 	void stopHeadOrder();
 	int getOrderQueueLength() const;
@@ -2149,7 +2152,9 @@ protected:
 #if defined(MOD_BALANCE_CORE)
 	std::vector<bool> m_abOwedChosenBuilding;
 	std::vector<bool> m_abBuildingInvestment;
+	std::vector<int> m_aiBuildingCostInvestmentReduction;
 	std::vector<bool> m_abUnitInvestment;
+	std::vector<int> m_aiUnitCostInvestmentReduction;
 	std::vector<bool> m_abBuildingConstructed;
 	std::vector<int> m_aiBonusSightEspionage;
 #endif
@@ -2490,7 +2495,9 @@ SYNC_ARCHIVE_VAR(std::vector<int>, m_aiYieldRank)
 SYNC_ARCHIVE_VAR(std::vector<bool>, m_abYieldRankValid)
 SYNC_ARCHIVE_VAR(std::vector<bool>, m_abOwedChosenBuilding)
 SYNC_ARCHIVE_VAR(std::vector<bool>, m_abBuildingInvestment)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiBuildingCostInvestmentReduction)
 SYNC_ARCHIVE_VAR(std::vector<bool>, m_abUnitInvestment)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiUnitCostInvestmentReduction)
 SYNC_ARCHIVE_VAR(std::vector<bool>, m_abBuildingConstructed)
 SYNC_ARCHIVE_VAR(std::vector<int>, m_aiBonusSightEspionage)
 SYNC_ARCHIVE_END()

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaCity.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaCity.cpp
@@ -1239,8 +1239,7 @@ int CvLuaCity::lGetPurchaseUnitTooltip(lua_State* L)
 		const UnitClassTypes eUnitClass = (UnitClassTypes)thisUnitInfo->GetUnitClassType();
 		if (pkCity->IsUnitInvestment(eUnitClass))
 		{
-			int iValue = (/*-50*/ GD_INT_GET(BALANCE_UNIT_INVESTMENT_BASELINE) + GET_PLAYER(pkCity->getOwner()).GetPlayerTraits()->GetInvestmentModifier() + GET_PLAYER(pkCity->getOwner()).GetInvestmentModifier());
-			iValue *= -1;
+			int iValue = 100 * pkCity->GetUnitCostInvestmentReduction(eUnitClass) / pkCity->getProductionNeeded(eUnit, true);
 
 			Localization::String localizedText = Localization::Lookup("TXT_KEY_ALREADY_INVESTED_UNIT");
 			localizedText << iValue;
@@ -1416,13 +1415,7 @@ int CvLuaCity::lGetPurchaseBuildingTooltip(lua_State* L)
 			const BuildingClassTypes eBuildingClass = (BuildingClassTypes)(pGameBuilding->GetBuildingClassType());
 			if (pkCity->IsBuildingInvestment(eBuildingClass))
 			{
-				int iValue = (/*-50*/ GD_INT_GET(BALANCE_BUILDING_INVESTMENT_BASELINE) + GET_PLAYER(pkCity->getOwner()).GetPlayerTraits()->GetInvestmentModifier() + GET_PLAYER(pkCity->getOwner()).GetInvestmentModifier());
-				iValue *= -1;
-				const CvBuildingClassInfo& kBuildingClassInfo = pGameBuilding->GetBuildingClassInfo();
-				if (::isWorldWonderClass(kBuildingClassInfo))
-				{
-					iValue /= 2;
-				}
+				int iValue = 100 * pkCity->GetBuildingCostInvestmentReduction(eBuildingClass) / pkCity->getProductionNeeded(eBuilding, true);
 				Localization::String localizedText = Localization::Lookup("TXT_KEY_ALREADY_INVESTED");
 				localizedText << iValue;
 
@@ -1735,7 +1728,11 @@ int CvLuaCity::lGetProductionTimes100(lua_State* L)
 //int getProductionNeeded();
 int CvLuaCity::lGetProductionNeeded(lua_State* L)
 {
-	return BasicLuaMethod(L, &CvCity::getProductionNeeded);
+	CvCity* pkCity = GetInstance(L);
+	const int iResult = pkCity->getProductionNeeded();
+
+	lua_pushinteger(L, iResult);
+	return 1;
 }
 //------------------------------------------------------------------------------
 //int GetUnitProductionNeeded();
@@ -1776,15 +1773,7 @@ int CvLuaCity::lGetBuildingInvestment(lua_State* L)
 		const BuildingClassTypes eBuildingClass = (BuildingClassTypes)(pGameBuilding->GetBuildingClassType());
 		if (pkCity->IsBuildingInvestment(eBuildingClass))
 		{
-			iResult = GET_PLAYER(pkCity->getOwner()).getProductionNeeded(eBuildingType);
-			iTotalDiscount = (/*-50*/ GD_INT_GET(BALANCE_BUILDING_INVESTMENT_BASELINE) + GET_PLAYER(pkCity->getOwner()).GetPlayerTraits()->GetInvestmentModifier() + GET_PLAYER(pkCity->getOwner()).GetInvestmentModifier());
-			const CvBuildingClassInfo& kBuildingClassInfo = pGameBuilding->GetBuildingClassInfo();
-			if (::isWorldWonderClass(kBuildingClassInfo))
-			{
-				iTotalDiscount /= 2;
-			}
-			iResult *= (iTotalDiscount + 100);
-			iResult /= 100;
+			iResult = pkCity->getProductionNeeded(eBuildingType, true) - pkCity->GetBuildingCostInvestmentReduction(eBuildingClass);
 		}
 	}
 
@@ -1959,10 +1948,7 @@ int CvLuaCity::lGetUnitInvestment(lua_State* L)
 	const UnitClassTypes eUnitClass = (UnitClassTypes)(pGameUnit->GetUnitClassType());
 	if(pkCity->IsUnitInvestment(eUnitClass))
 	{
-		iResult = GET_PLAYER(pkCity->getOwner()).getProductionNeeded(eUnitType, false);
-		iTotalDiscount = (/*-50*/ GD_INT_GET(BALANCE_BUILDING_INVESTMENT_BASELINE) + GET_PLAYER(pkCity->getOwner()).GetPlayerTraits()->GetInvestmentModifier() + GET_PLAYER(pkCity->getOwner()).GetInvestmentModifier());
-		iResult *= (iTotalDiscount + 100);
-		iResult /= 100;
+		iResult = pkCity->getProductionNeeded(eUnitType, true) - pkCity->GetUnitCostInvestmentReduction(eUnitClass);
 	}
 
 	lua_pushinteger(L, iResult);


### PR DESCRIPTION
-- NOT SAVEGAME COMPATIBLE --

- Fix #10339
- Fix #10142 
- Fix #9287 
- Fix #9133 

- When investing in a spaceship part, the number of turns shown in the city screen is updated immediately
- In the production selection screen, purchased spaceship parts also have the (INVESTED) tag and have updated production costs (non-EUI only, I'm not familiar enough with EUI)