### PR TITLE
Fix of GP points counter

### DIFF
--- a/(3a) EUI Compatibility Files/LUA/CityView.lua
+++ b/(3a) EUI Compatibility Files/LUA/CityView.lua
@@ -2285,7 +2285,9 @@ local function UpdateCityViewNow()
 					local gpChange = specialist.GreatPeopleRateChange * city:GetSpecialistCount( specialist.ID )
 					for building in GameInfo.Buildings{SpecialistType = specialist.Type} do
 						if city:IsHasBuilding(building.ID) then
-							gpChange = gpChange + building.GreatPeopleRateChange
+							local iBuildingCopies = city:GetNumRealBuilding(building.ID)
+							
+							gpChange = gpChange + (building.GreatPeopleRateChange * iBuildingCopies)
 						end
 					end
 


### PR DESCRIPTION
Now if you have multiple dummies (or regular buildings) of the same type, giving +X flat GP points, then they are shown correctly in City View (CityView.lua).