### PR TITLE
Corporation Text Clarification + UI Update

### DIFF
--- a/(2) Vox Populi/Database Changes/Text/en_US/City/NewBuildingText.xml
+++ b/(2) Vox Populi/Database Changes/Text/en_US/City/NewBuildingText.xml
@@ -579,7 +579,7 @@
 		</Row>
 
 		<Row Tag="TXT_KEY_BUILDING_TRADER_SIDS_FRANCHISE">
-			<Text>Trader Sid's</Text>
+			<Text>Trader Sid's Franchise</Text>
 		</Row>
 		<Row Tag="TXT_KEY_BUILDING_TRADER_SIDS_FRANCHISE_STRATEGY">
 			<Text>This building can only be constructed in foreign Cities if you were the founder of Trader Sid's. To construct this building in a foreign City, send a Trade Route from an owned City with a Trader Sid's Office in it to a foreign City. When the Trade Route is complete, the building will automatically be constructed. There is also a 5% chance each turn that a franchise will appear on its own in a random foreign City.</Text>
@@ -612,7 +612,7 @@
 		</Row>
 
 		<Row Tag="TXT_KEY_BUILDING_LANDSEA_EXTRACTORS_FRANCHISE">
-			<Text>Centaurus Extractors</Text>
+			<Text>Centaurus Extractors Franchise</Text>
 		</Row>
 		<Row Tag="TXT_KEY_BUILDING_LANDSEA_EXTRACTORS_FRANCHISE_STRATEGY">
 			<Text>This building can only be constructed in foreign Cities if you were the founder of Centaurus Extractors. To construct this building in a foreign City, send a Trade Route from an owned City with a Centaurus Extractors Office in it to a foreign City. When the Trade Route is complete, the building will automatically be constructed. There is also a 5% chance each turn that a franchise will appear on its own in a random foreign City.</Text>
@@ -645,7 +645,7 @@
 		</Row>
 
 		<Row Tag="TXT_KEY_BUILDING_HEXXON_REFINERY_FRANCHISE">
-			<Text>Hexxon Refineries</Text>
+			<Text>Hexxon Refineries Franchise</Text>
 		</Row>
 		<Row Tag="TXT_KEY_BUILDING_HEXXON_REFINERY_FRANCHISE_STRATEGY">
 			<Text>This building can only be constructed in foreign Cities if you were the founder of Hexxon Refineries. To construct this building in a foreign City, send a Trade Route from an owned City with a Hexxon Refineries Office in it to a foreign City. When the Trade Route is complete, the building will automatically be constructed. There is also a 5% chance each turn that a franchise will appear on its own in a random foreign City.</Text>
@@ -678,7 +678,7 @@
 		</Row>
 
 		<Row Tag="TXT_KEY_BUILDING_GIORGIO_ARMEIER_FRANCHISE">
-			<Text>Giorgio Armeier</Text>
+			<Text>Giorgio Armeier Franchise</Text>
 		</Row>
 		<Row Tag="TXT_KEY_BUILDING_GIORGIO_ARMEIER_FRANCHISE_STRATEGY">
 			<Text>This building can only be constructed in foreign Cities if you were the founder of Giorgio Armeier . To construct this building in a foreign City, send a Trade Route from an owned City with a Giorgio Armeier Office in it to a foreign City. When the Trade Route is complete, the building will automatically be constructed. There is also a 5% chance each turn that a franchise will appear on its own in a random foreign City.</Text>
@@ -711,7 +711,7 @@
 		</Row>
 
 		<Row Tag="TXT_KEY_BUILDING_FIRAXITE_MATERIALS_FRANCHISE">
-			<Text>Firaxite Materials</Text>
+			<Text>Firaxite Materials Franchise</Text>
 		</Row>
 		<Row Tag="TXT_KEY_BUILDING_FIRAXITE_MATERIALS_FRANCHISE_STRATEGY">
 			<Text>This building can only be constructed in foreign Cities if you were the founder of Firaxite Materials. To construct this building in a foreign City, send a Trade Route from an owned City with a Firaxite Materials Office in it to a foreign City. When the Trade Route is complete, the building will automatically be constructed. There is also a 5% chance each turn that a franchise will appear on its own in a random foreign City.</Text>
@@ -744,7 +744,7 @@
 		</Row>
 
 		<Row Tag="TXT_KEY_BUILDING_TWOKAY_FOODS_FRANCHISE">
-			<Text>TwoKay Foods</Text>
+			<Text>TwoKay Foods Franchise</Text>
 		</Row>
 		<Row Tag="TXT_KEY_BUILDING_TWOKAY_FOODS_FRANCHISE_STRATEGY">
 			<Text>This building can only be constructed in foreign Cities if you were the founder of TwoKay Foods. To construct this building in a foreign City, send a Trade Route from an owned City with a TwoKay Foods Office in it to a foreign City. When the Trade Route is complete, the building will automatically be constructed. There is also a 5% chance each turn that a franchise will appear on its own in a random foreign City.</Text>
@@ -777,7 +777,7 @@
 		</Row>
 
 		<Row Tag="TXT_KEY_BUILDING_CIVILIZED_JEWELERS_FRANCHISE">
-			<Text>Civilized Jewelers</Text>
+			<Text>Civilized Jewelers Franchise</Text>
 		</Row>
 		<Row Tag="TXT_KEY_BUILDING_CIVILIZED_JEWELERS_FRANCHISE_STRATEGY">
 			<Text>This building can only be constructed in foreign Cities if you were the founder of Civilized Jewelers. To construct this building in a foreign City, send a Trade Route from an owned City with a Civilized Jewelers Office in it to a foreign City. When the Trade Route is complete, the building will automatically be constructed. There is also a 5% chance each turn that a franchise will appear on its own in a random foreign City.</Text>

--- a/(2) Vox Populi/Database Changes/Text/en_US/Corporations/NewCorporationText.xml
+++ b/(2) Vox Populi/Database Changes/Text/en_US/Corporations/NewCorporationText.xml
@@ -5,7 +5,7 @@
 			<Text>Trader Sid's, Inc.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CORPORATION_TRADER_SIDS_HELP">
-			<Text>Provides benefits geared toward [ICON_GOLD] Gold generation. Increases [ICON_INTERNATIONAL_TRADE] Trade Unit limit by one and doubles Land [ICON_INTERNATIONAL_TRADE] Trade Unit maximum distance.[NEWLINE][NEWLINE]Caravansaries and Markets in all Cities produce +3 [ICON_GOLD] Gold. Every Franchise in a foreign Civilization's Cities increases your [ICON_TOURISM] Tourism with them by 2%.</Text>
+			<Text>Provides benefits geared toward [ICON_GOLD] Gold generation and land trading.[NEWLINE][ICON_BULLET]+1 [ICON_INTERNATIONAL_TRADE] Trade Routes.[NEWLINE][ICON_BULLET]+100% [ICON_CARAVAN] Land Trade Route Range.[NEWLINE][ICON_BULLET]+3 [ICON_GOLD] Gold to {TXT_KEY_BUILDING_CARAVANSARY} and {TXT_KEY_BUILDING_MARKET} in all Cities.[NEWLINE][ICON_BULLET]Every [ICON_VP_FRANCHISE] Franchise in a foreign Civilization''s Cities increases [ICON_TOURISM] Tourism with them by 2%.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CORPORATION_RESOURCE_BONUS_TRADER_SIDS">
 			<Text>[ICON_RES_SPICES] Cinnamon, [ICON_RES_SUGAR] Sugar, [ICON_RES_SALT] Salt, [ICON_RES_NUTMEG] Nutmeg, [ICON_RES_CLOVES] Cloves, [ICON_RES_PEPPER] Pepper, [ICON_RES_COCOA] Cocoa, and [ICON_RES_TOBACCO] Tobacco provide +1 [ICON_GOLD] Gold in all Cities with a Trader Sid's Franchise.</Text>
@@ -14,7 +14,7 @@
 			<Text>+4 [ICON_GOLD] Gold for every Global Franchise, and [ICON_INTERNATIONAL_TRADE] Trade Routes to this City generate +2 [ICON_GOLD] Gold.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CORPORATION_TRADE_ROUTE_BONUS_TRADER_SIDS">
-			<Text>[ICON_INTERNATIONAL_TRADE] Trade Routes from owned Cities with a Trader Sid's Office to foreign Cities with a Trader Sid's Franchise produce +25% additional [ICON_GOLD] Gold.</Text>
+			<Text>[ICON_INTERNATIONAL_TRADE] Trade Routes from Cities with a Trader Sid''s Office to Cities with a Trader Sid''s Franchise produce +25% additional [ICON_GOLD] Gold.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CORPORATION_TRADER_SIDS_OFFICE_BENEFIT_HELP">
 			<Text>Current Office Bonus: {1_String}</Text>
@@ -24,7 +24,7 @@
 			<Text>Centaurus Extractors, Inc.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CORPORATION_LANDSEA_EXTRACTORS_HELP">
-			<Text>Provides benefits geared toward [ICON_PRODUCTION] Production and coastal Cities. Increases [ICON_INTERNATIONAL_TRADE] Trade Unit limit by one and doubles sea [ICON_INTERNATIONAL_TRADE] Trade Unit maximum range.[NEWLINE][NEWLINE]Harbors and Seaports in all Cities also produce +2 [ICON_PRODUCTION] Production. Every Franchise in a foreign Civilization's Cities increases your [ICON_TOURISM] Tourism with them by 2%.</Text>
+			<Text>Provides benefits geared toward maritime [ICON_PRODUCTION] Production and coastal Cities.[NEWLINE][ICON_BULLET]+1 [ICON_INTERNATIONAL_TRADE] Trade Routes.[NEWLINE][ICON_BULLET]+100% [ICON_CARGO_SHIP] Sea Trade Route Range.[NEWLINE][ICON_BULLET]+2 [ICON_PRODUCTION] Production to {TXT_KEY_BUILDING_HARBOR} and {TXT_KEY_BUILDING_SEAPORT} in all Cities.[NEWLINE][ICON_BULLET]Every [ICON_VP_FRANCHISE] Franchise in a foreign Civilization''s Cities increases [ICON_TOURISM] Tourism with them by 2%.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CORPORATION_RESOURCE_BONUS_LANDSEA_EXTRACTORS">
 			<Text>[ICON_RES_HORSE] Horse, [ICON_RES_WHALE] Whales, [ICON_RES_CRAB] Crab, [ICON_RES_IVORY] Ivory, and [ICON_RES_CORAL] Coral provide +1 [ICON_PRODUCTION] Production in all Cities with a Centaurus Extractors Franchise.</Text>
@@ -33,7 +33,7 @@
 			<Text>+3 [ICON_PRODUCTION] Production for every Global Franchise, and +1 [ICON_PRODUCTION] Production on all Sea Tiles near the City.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CORPORATION_TRADE_ROUTE_BONUS_LANDSEA_EXTRACTORS">
-			<Text>[ICON_INTERNATIONAL_TRADE] Trade Routes to a foreign City with a Centaurus Extractors Franchise grant +10% [ICON_RESEARCH] Science rate in the origin City.</Text>
+			<Text>[ICON_INTERNATIONAL_TRADE] Trade Routes from Cities with a Centaurus Extractors'' Office to Cities with a Centaurus Extractors'' Franchise grant +10% [ICON_RESEARCH] Science to the origin City.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CORPORATION_LANDSEA_EXTRACTORS_OFFICE_BENEFIT_HELP">
 			<Text>Current Office Bonus: {1_String}</Text>
@@ -43,7 +43,7 @@
 			<Text>Hexxon Refinery, Inc.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CORPORATION_HEXXON_REFINERY_HELP">
-			<Text>Provides bonuses that enhance your ability to wage late-game warfare and amass Strategic Resources. Increases [ICON_INTERNATIONAL_TRADE] Trade Unit limit by one.[NEWLINE][NEWLINE]+15% [ICON_PRODUCTION] Production for all Units that require [ICON_RES_OIL] Oil, [ICON_RES_URANIUM] Uranium, or [ICON_RES_ALUMINUM] Aluminum to build. +3 [ICON_PRODUCTION] Production on all Refineries and Power Plants. Every Franchise in a foreign Civilization's Cities increases your [ICON_TOURISM] Tourism with them by 2%.</Text>
+			<Text>Provides bonuses that enhance your ability to wage late-game [ICON_WAR] warfare and amass Strategic Resources.[NEWLINE][ICON_BULLET]+1 [ICON_INTERNATIONAL_TRADE] Trade Routes.[NEWLINE][ICON_BULLET]+15% [ICON_PRODUCTION] Production for all Units that require [ICON_RES_OIL] Oil, [ICON_RES_URANIUM] Uranium, or [ICON_RES_ALUMINUM] Aluminum to build.[NEWLINE][ICON_BULLET]+3 [ICON_PRODUCTION] Production to {TXT_KEY_BUILDING_TIDAL_PLANT}s, {TXT_KEY_BUILDING_HYDRO_PLANT}s, {TXT_KEY_BUILDING_NUCLEAR_PLANT}s, {TXT_KEY_BUILDING_WIND_PLANT}s, and {TXT_KEY_BUILDING_SOLAR_PLANT}s in all Cities.[NEWLINE][ICON_BULLET]Every [ICON_VP_FRANCHISE] Franchise in a foreign Civilization''s Cities increases [ICON_TOURISM] Tourism with them by 2%.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CORPORATION_RESOURCE_BONUS_HEXXON_REFINERY">
 			<Text>[ICON_RES_COAL] Coal, [ICON_RES_OIL] Oil, [ICON_RES_INCENSE] Incense, [ICON_RES_URANIUM] Uranium, [ICON_RES_BRAZILWOOD] Brazilwood, [ICON_RES_PERFUME] Perfume, and [ICON_RES_GLASS] Glass provide +1 [ICON_PRODUCTION] Production in all Cities with a Hexxon Refineries Franchise.</Text>
@@ -52,7 +52,7 @@
 			<Text>+1 additional [ICON_RES_OIL] Oil and [ICON_RES_COAL] Coal for every three Global Franchises, and +15% [ICON_PRODUCTION] Production towards Military Units.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CORPORATION_TRADE_ROUTE_BONUS_HEXXON_REFINERY">
-			<Text>[ICON_INTERNATIONAL_TRADE] Trade Routes to a foreign City with a Hexxon Refinery Franchise grant +10% [ICON_PRODUCTION] Production in origin City.</Text>
+			<Text>[ICON_INTERNATIONAL_TRADE] Trade Routes from Cities with a Hexxon Refinery''s Office to Cities with a Hexxon Refinery''s Franchise grant +10% [ICON_PRODUCTION] Production in origin City.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CORPORATION_HEXXON_REFINERY_OFFICE_BENEFIT_HELP">
 			<Text>Current Office Bonus: {1_String}</Text>
@@ -62,7 +62,7 @@
 			<Text>Giorgio Armeier, Inc.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CORPORATION_GIORGIO_ARMEIER_HELP">
-			<Text>Provides benefits geared toward [ICON_CULTURE] Culture generation and Specialists. Increases [ICON_INTERNATIONAL_TRADE] Trade Unit limit by one.[NEWLINE][NEWLINE]+2 [ICON_CULTURE] Culture from all Museums and Opera Houses, and +2 [ICON_CULTURE] Culture from [ICON_VP_WRITER] Writers, [ICON_VP_ARTIST] Artists, and [ICON_VP_MUSICIAN] Musicians in all Cities. Every Franchise in a foreign Civilization's Cities increases your [ICON_TOURISM] Tourism with them by 2%.</Text>
+			<Text>Provides benefits geared toward [ICON_CULTURE] Culture generation and Specialists.[NEWLINE][ICON_BULLET]+1 [ICON_INTERNATIONAL_TRADE] Trade Routes.[NEWLINE][ICON_BULLET]+2 [ICON_CULTURE] Culture from [ICON_VP_WRITER] Writers, [ICON_VP_ARTIST] Artists, and [ICON_VP_MUSICIAN] Musicians.[NEWLINE][ICON_BULLET]+2 [ICON_CULTURE] Culture on {TXT_KEY_BUILDING_MUSEUM} and {TXT_KEY_BUILDING_OPERA_HOUSE} in all Cities.[NEWLINE][ICON_BULLET]Every [ICON_VP_FRANCHISE] Franchise in a foreign Civilization''s Cities increases [ICON_TOURISM] Tourism with them by 2%.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CORPORATION_RESOURCE_BONUS_GIORGIO_ARMEIER">
 			<Text>[ICON_RES_SILK] Silk, [ICON_RES_COTTON] Cotton, [ICON_RES_DYE] Dye, [ICON_RES_FUR] Furs, and [ICON_RES_LAPIS] Lapis Lazuli provide +1 [ICON_CULTURE] Culture in all Cities with a Giorgio Armeier Franchise.</Text>
@@ -71,7 +71,7 @@
 			<Text>+2 [ICON_CULTURE] Culture for every Global Franchise, and -1 [ICON_HAPPINESS_3] Unhappiness from [ICON_RESEARCH] Illiteracy and [ICON_CULTURE] Boredom.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CORPORATION_TRADE_ROUTE_BONUS_GIORGIO_ARMEIER">
-			<Text>[ICON_INTERNATIONAL_TRADE] Trade Routes to a foreign City with a Giorgio Armeier Franchise grant +10% [ICON_CULTURE] Culture to the origin City.</Text>
+			<Text>[ICON_INTERNATIONAL_TRADE] Trade Routes from Cities with a Giorgio Armeier''s Office to a City with a Giorgio Armeier''s Franchise grant +10% [ICON_GOLD] Gold +10% [ICON_CULTURE] Culture to the origin City.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CORPORATION_GIORGIO_ARMEIER_OFFICE_BENEFIT_HELP">
 			<Text>Current Office Bonus: {1_String}</Text>
@@ -81,7 +81,7 @@
 			<Text>Firaxite Materials, Inc.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CORPORATION_FIRAXITE_MATERIALS_HELP">
-			<Text>Generates large amounts of [ICON_RESEARCH] Science and boosts infrastructural development in your empire. Increases [ICON_INTERNATIONAL_TRADE] Trade Unit limit by one, and Trade Units cannot be plundered.[NEWLINE][NEWLINE]Factories and Universities in all Cities produce +3 [ICON_RESEARCH] Science. Every Franchise in a foreign Civilization's Cities increases your [ICON_TOURISM] Tourism with them by 2%.</Text>
+			<Text>Provides benefits geared toward [ICON_RESEARCH] Science innovation and infrastructural development.[NEWLINE][ICON_BULLET]+1 [ICON_INTERNATIONAL_TRADE] Trade Routes.[NEWLINE][ICON_BULLET]Trade Units cannot be plundered.[NEWLINE][ICON_BULLET]+3 [ICON_RESEARCH] Science to {TXT_KEY_BUILDING_FACTORY} and {TXT_KEY_BUILDING_UNIVERSITY} in all Cities.[NEWLINE][ICON_BULLET]Every [ICON_VP_FRANCHISE] Franchise in a foreign Civilization''s Cities increases [ICON_TOURISM] Tourism with them by 2%.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CORPORATION_RESOURCE_BONUS_FIRAXITE_MATERIALS">
 			<Text>[ICON_RES_IRON] Iron, [ICON_RES_ALUMINUM] Aluminum, [ICON_RES_MARBLE] Marble, [ICON_RES_COPPER] Copper, [ICON_RES_JADE] Jade, and [ICON_RES_PORCELAIN] Porcelain provide +1 [ICON_RESEARCH] Science in all Cities with a Firaxite Materials Franchise.</Text>
@@ -90,7 +90,7 @@
 			<Text>+2 [ICON_RESEARCH] Science for every Global Franchise, and +20% [ICON_PRODUCTION] Production when constructing Buildings.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CORPORATION_TRADE_ROUTE_BONUS_FIRAXITE_MATERIALS">
-			<Text>[ICON_INTERNATIONAL_TRADE] Trade Routes to foreign Cities with a Firaxite Materials Franchise produce +50% additional [ICON_RESEARCH] Science.</Text>
+			<Text>[ICON_INTERNATIONAL_TRADE] Trade Routes from Cities with a Firaxite Materials'' Office to Cities with a Firaxite Materials'' Franchise produce +50% additional [ICON_RESEARCH] Science.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CORPORATION_FIRAXITE_MATERIALS_OFFICE_BENEFIT_HELP">
 			<Text>Current Office Bonus: {1_String}</Text>
@@ -100,7 +100,7 @@
 			<Text>TwoKay Foods, Inc.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CORPORATION_TWOKAY_FOODS_HELP">
-			<Text>Provides benefits geared toward [ICON_FOOD] Food generation and City growth. Increases [ICON_INTERNATIONAL_TRADE] Trade Unit limit by one, and Trade Routes reveal the Fog of War.[NEWLINE][NEWLINE]Grocers, Hospitals, and Agribusiness in all Cities produce +3 [ICON_FOOD] Food. Every Franchise in a foreign Civilization's Cities increases your [ICON_TOURISM] Tourism with them by 2%.</Text>
+			<Text>Provides benefits geared toward [ICON_FOOD] Food generation and City growth.[NEWLINE][ICON_BULLET]+1 [ICON_INTERNATIONAL_TRADE] Trade Routes.[NEWLINE][ICON_BULLET]Trade Units reveal Fog of War.[NEWLINE][ICON_BULLET]+3 [ICON_FOOD] Food to {TXT_KEY_BUILDING_GROCER}, {TXT_KEY_BUILDING_HOSPITAL}, and {TXT_KEY_BUILDING_STOCKYARD} in all Cities.[NEWLINE][ICON_BULLET]Every [ICON_VP_FRANCHISE] Franchise in a foreign Civilization''s Cities increases [ICON_TOURISM] Tourism with them by 2%.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CORPORATION_RESOURCE_BONUS_TWOKAY_FOODS">
 			<Text>[ICON_RES_WINE] Wine, [ICON_RES_TRUFFLES] Truffles, [ICON_RES_CITRUS] Citrus, [ICON_RES_OLIVE] Olives, [ICON_RES_COFFEE] Coffee, and [ICON_RES_TEA] Tea provide +1 [ICON_FOOD] Food in all Cities with a TwoKay Foods Franchise.</Text>
@@ -109,7 +109,7 @@
 			<Text>+3 [ICON_FOOD] Food for every Global Franchise. +10% [ICON_FOOD] Food in the City. -1 [ICON_HAPPINESS_3] Unhappiness from all Needs and -5% to [ICON_CITY_STATE] Empire Size Modifier in all Cities.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CORPORATION_TRADE_ROUTE_BONUS_TWOKAY_FOODS">
-			<Text>[ICON_INTERNATIONAL_TRADE] Trade Routes to foreign Cities with a TwoKay Foods Franchise grant +10% [ICON_FOOD] Food to the origin City.</Text>
+			<Text>[ICON_INTERNATIONAL_TRADE] Trade Routes from Cities with a TwoKay Foods'' Office to Cities with a TwoKay Foods'' Franchise grant +10% [ICON_FOOD] Food to the origin City.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CORPORATION_TWOKAY_FOODS_OFFICE_BENEFIT_HELP">
 			<Text>Current Office Bonus: {1_String}</Text>
@@ -119,7 +119,7 @@
 			<Text>Civilized Jewelers, Inc.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CORPORATION_CIVILIZED_JEWELERS_HELP">
-			<Text>Provides benefits geared toward [ICON_GREAT_PEOPLE] Great People generation and [ICON_GOLDEN_AGE] Golden Ages. Increases [ICON_INTERNATIONAL_TRADE] Trade Unit limit by one, and all [ICON_INTERNATIONAL_TRADE] Trade Units move twice as fast.[NEWLINE][NEWLINE]Banks and Customs Houses in all Cities produce +4 [ICON_GOLDEN_AGE] Golden Age Points. Every Franchise in a foreign Civilization's Cities increases your [ICON_TOURISM] Tourism with them by 2%.</Text>
+			<Text>Provides benefits geared toward [ICON_FOOD] Food generation and City growth.[NEWLINE][ICON_BULLET]+1 [ICON_INTERNATIONAL_TRADE] Trade Routes.[NEWLINE][ICON_BULLET]Trade Units moves +200% faster.[NEWLINE][ICON_BULLET]+4 [ICON_GOLDEN_AGE] Golden Age Points to {TXT_KEY_BUILDING_MINT} and {TXT_KEY_BUILDING_BANK} in all Cities.[NEWLINE][ICON_BULLET]Every [ICON_VP_FRANCHISE] Franchise in a foreign Civilization''s Cities increases [ICON_TOURISM] Tourism with them by 2%.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CORPORATION_RESOURCE_BONUS_CIVILIZED_JEWELERS">
 			<Text>[ICON_RES_GOLD] Gold, [ICON_RES_SILVER] Silver, [ICON_RES_GEMS] Gems, [ICON_RES_PEARLS] Pearls, [ICON_RES_JEWELRY] Jewelry, and [ICON_RES_AMBER] Amber provide +1 [ICON_GOLDEN_AGE] Golden Age Points in all Cities with a Civilized Jewelers Franchise.</Text>
@@ -128,7 +128,7 @@
 			<Text>+3% [ICON_GOLDEN_AGE] Golden Age Length Modifier. +15% [ICON_GREAT_PEOPLE] Great Person Rate, and an additional +10% [ICON_GREAT_PEOPLE] Great Person Rate for every Global Franchise.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CORPORATION_TRADE_ROUTE_BONUS_CIVILIZED_JEWELERS">
-			<Text>[ICON_INTERNATIONAL_TRADE] Trade Routes to a foreign City with a Civilized Jewelers Franchise grant +10% [ICON_GOLD] Gold in the origin City.</Text>
+			<Text>[ICON_INTERNATIONAL_TRADE] Trade Routes from Cities with a Civilized Jewelers'' Office to a City with a Civilized Jewelers'' Franchise grant +10% [ICON_GOLD] Gold to the origin City.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CORPORATION_CIVILIZED_JEWELERS_OFFICE_BENEFIT_HELP">
 			<Text>Current Office Bonus: {1_String}</Text>

--- a/(2) Vox Populi/Database Changes/Text/en_US/Policies/NewPolicyText.xml
+++ b/(2) Vox Populi/Database Changes/Text/en_US/Policies/NewPolicyText.xml
@@ -32,7 +32,7 @@
 			<Text>Nationalization</Text>
 		</Row>
 		<Row Tag="TXT_KEY_POLICY_NATIONALIZATION_HELP">
-			<Text>[COLOR_POSITIVE_TEXT]Nationalization[ENDCOLOR]: Each Corporate Office counts as a Franchise. Foreign Franchises no longer benefit your Corporation, you can no longer construct Franchises in foreign Cities (except Vassals), and foreign Corporations can no longer set up Franchises in your Cities (except Masters). +2 [ICON_RESEARCH] Science from all Corporation Offices.</Text>
+			<Text>[COLOR_POSITIVE_TEXT]Nationalization[ENDCOLOR]: Each [ICON_VP_OFFICE] Corporate Office counts as a Franchise. Foreign Franchises no longer benefit your Corporation, you can no longer construct [ICON_VP_FRANCHISE] Franchises in foreign Cities (except Vassals), and foreign Corporations can no longer set up Franchises in your Cities (except Masters). +2 [ICON_RESEARCH] Science from all Corporation Offices.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_POLICY_NATIONALIZATION_TEXT">
 			<Text>Nationalization is the process of taking a private industry or private assets into public ownership by a national government or state. Nationalization usually refers to private assets, but may also mean assets owned by lower levels of government, such as municipalities, being transferred to be the state. The opposite of nationalization is usually privatization or de-nationalization, but may also be municipalization. Industries that are usually subject to nationalization include transport, communications, energy, banking and natural resources.</Text>
@@ -42,7 +42,7 @@
 			<Text>Transnationalism</Text>
 		</Row>
 		<Row Tag="TXT_KEY_POLICY_GLOBALIZATION_HELP">
-			<Text>[COLOR_POSITIVE_TEXT]Transnationalism[ENDCOLOR]: Each turn, increases the chance that a Corporate Franchise will appear in a foreign City to 15% (normally 5%). Global Franchise maximum increased by 25%, and every Town counts as a Franchise. +2 [ICON_CULTURE] Culture from all Corporation Offices.</Text>
+			<Text>[COLOR_POSITIVE_TEXT]Transnationalism[ENDCOLOR]: Each turn, increases the chance that a [ICON_VP_FRANCHISE] Corporate Franchise will appear in a foreign City to 15% (normally 5%). Global Franchise maximum increased by 25%, and every Town counts as a Franchise. +2 [ICON_CULTURE] Culture from all [ICON_VP_OFFICE] Corporation Offices.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_POLICY_GLOBALIZATION_TEXT">
 			<Text>Transnationalism as an economic process involves the global reorganization of the production process, in which various stages of the production of any product can occur in various countries, typically with the aim of minimizing costs. Economic transnationalism, commonly known as Globalization, was spurred in the latter half of the 20th century by the development of the internet and wireless communication, as well as the reduction in global transportation costs caused by containerization. Multinational corporations could be seen as a form of transnationalism, in that they seek to minimize costs, and hence maximize profits, by organizing their operations in the most efficient means possible irrespective of political boundaries.</Text>
@@ -52,7 +52,7 @@
 			<Text>Syndicalism</Text>
 		</Row>
 		<Row Tag="TXT_KEY_POLICY_INFILTRATION_HELP">
-			<Text>[COLOR_POSITIVE_TEXT]Syndicalism[ENDCOLOR]: Corporate Franchises count double in the Cities of Civilizations you are at least [COLOR_MAGENTA]Popular[ENDCOLOR] with, and this extra Franchise does not count against your Global Franchise maximum. Can establish 5 additional Franchises in foreign Cities. +2 [ICON_PRODUCTION] Production from all Corporation Offices.</Text>
+			<Text>[COLOR_POSITIVE_TEXT]Syndicalism[ENDCOLOR]: [ICON_VP_FRANCHISE] Corporate Franchises count double in the Cities of Civilizations you are at least [COLOR_MAGENTA]Popular[ENDCOLOR] with, and this extra Franchise does not count against your Global Franchise maximum. Can establish 5 additional [ICON_VP_FRANCHISE] Franchises in foreign Cities. +2 [ICON_PRODUCTION] Production from all [ICON_VP_OFFICE] Corporation Offices.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_POLICY_INFILTRATION_TEXT">
 			<Text>National syndicalism is an adaptation of syndicalism to suit the social agenda of integral nationalism. National syndicalism suggests that the people must defend themselves through the development of Syndicalist sections into massive economic worker movements. These should take immediate action to expropriate the capitalists. These should also take direct action to let the workers lead the production and to form peoples communes. National syndicalism seeks out principled reasons for direct economic action and denounces parliamentary action by representatives. The goal is not to make capitalism bearable, but the realisation of a free Nationalist and Socialist nation. National syndicalism aims to move the attention from the political terrain to the economic terrain. It wants the socialisation from the basis: a system of distribution from local units, in consultation with the National federation, on the fundament of a production and consumption statistic. As well as the organisation of the production by national industrial federations.</Text>

--- a/(2) Vox Populi/Database Changes/Text/en_US/UI/NewUIText.sql
+++ b/(2) Vox Populi/Database Changes/Text/en_US/UI/NewUIText.sql
@@ -20,3 +20,54 @@ VALUES
 	('TXT_KEY_DUDE_23', 'Bede'),
 	('TXT_KEY_DUDE_24', 'Nestor'),
 	('TXT_KEY_DUDE_25', 'Nennius');
+
+-- Corporation Franchise (text update)
+-- Modmodders can copy this code if they're adding more resources toward a corporation!
+UPDATE Language_en_US
+SET Text = '+1 [ICON_GOLD] Gold on all Trader Sid''s Monopoly Resources ('
+	|| (SELECT GROUP_CONCAT(r.IconString, ", ") FROM Corporation_ResourceMonopolyOrs c, Resources r WHERE c.CorporationType = 'CORPORATION_TRADER_SIDS' AND c.ResourceType = r.Type) 
+	|| ') near the City. {TXT_KEY_CORPORATION_TRADE_ROUTE_BONUS_TRADER_SIDS}'
+WHERE Tag = 'TXT_KEY_BUILDING_TRADER_SIDS_FRANCHISE_HELP';
+
+UPDATE Language_en_US
+SET Text = '+1 [ICON_PRODUCTION] Production on all Centaurus Extractors'' Monopoly Resources ('
+	|| (SELECT GROUP_CONCAT(r.IconString, ", ") FROM Corporation_ResourceMonopolyOrs c, Resources r WHERE c.CorporationType = 'CORPORATION_LANDSEA_EXTRACTORS' AND c.ResourceType = r.Type) 
+	|| ') near the City. {TXT_KEY_CORPORATION_TRADE_ROUTE_BONUS_LANDSEA_EXTRACTORS}'
+WHERE Tag = 'TXT_KEY_BUILDING_LANDSEA_EXTRACTORS_FRANCHISE_HELP';
+
+UPDATE Language_en_US
+SET Text = '+1 [ICON_PRODUCTION] Production on Hexxon Refineries Monopoly Resources ('
+	|| (SELECT GROUP_CONCAT(r.IconString, ", ") FROM Corporation_ResourceMonopolyOrs c, Resources r WHERE c.CorporationType = 'CORPORATION_HEXXON_REFINERY' AND c.ResourceType = r.Type) 
+	|| ') near the City. {TXT_KEY_CORPORATION_TRADE_ROUTE_BONUS_HEXXON_REFINERY}'
+WHERE Tag = 'TXT_KEY_BUILDING_HEXXON_REFINERY_FRANCHISE_HELP';
+
+UPDATE Language_en_US
+SET Text = '+1 [ICON_CULTURE] Culture on all Giorgio Armeier''s Monopoly Resources ('
+	|| (SELECT GROUP_CONCAT(r.IconString, ", ") FROM Corporation_ResourceMonopolyOrs c, Resources r WHERE c.CorporationType = 'CORPORATION_GIORGIO_ARMEIER' AND c.ResourceType = r.Type) 
+	|| ') near the City. {TXT_KEY_CORPORATION_TRADE_ROUTE_BONUS_GIORGIO_ARMEIER}'
+WHERE Tag = 'TXT_KEY_BUILDING_GIORGIO_ARMEIER_FRANCHISE_HELP';
+
+UPDATE Language_en_US
+SET Text = '+1 [ICON_RESEARCH] Science on all Firaxite Materials'' Monopoly Resources ('
+	|| (SELECT GROUP_CONCAT(r.IconString, ", ") FROM Corporation_ResourceMonopolyOrs c, Resources r WHERE c.CorporationType = 'CORPORATION_FIRAXITE_MATERIALS' AND c.ResourceType = r.Type) 
+	|| ') near the City. {TXT_KEY_CORPORATION_TRADE_ROUTE_BONUS_FIRAXITE_MATERIALS}'
+WHERE Tag = 'TXT_KEY_BUILDING_FIRAXITE_MATERIALS_FRANCHISE_HELP';
+
+UPDATE Language_en_US
+SET Text = '+1 [ICON_FOOD] Food on all TwoKay Foods'' Monopoly Resources ('
+	|| (SELECT GROUP_CONCAT(r.IconString, ", ") FROM Corporation_ResourceMonopolyOrs c, Resources r WHERE c.CorporationType = 'CORPORATION_TWOKAY_FOODS' AND c.ResourceType = r.Type) 
+	|| ') near the City. {TXT_KEY_CORPORATION_TRADE_ROUTE_BONUS_TWOKAY_FOODS}'
+WHERE Tag = 'TXT_KEY_BUILDING_TWOKAY_FOODS_FRANCHISE_HELP';
+
+UPDATE Language_en_US
+SET Text = '+1 [ICON_GOLDEN_AGE] Golden Age Points on all Civilized Jewelers'' Monopoly Resources ('
+	|| (SELECT GROUP_CONCAT(r.IconString, ", ") FROM Corporation_ResourceMonopolyOrs c, Resources r WHERE c.CorporationType = 'CORPORATION_CIVILIZED_JEWELERS' AND c.ResourceType = r.Type) 
+	|| ') near the City. {TXT_KEY_CORPORATION_TRADE_ROUTE_BONUS_CIVILIZED_JEWELERS}'
+WHERE Tag = 'TXT_KEY_BUILDING_CIVILIZED_JEWELERS_FRANCHISE_HELP';
+
+--CORPORATION CITYBANNERMANAGER
+INSERT INTO Language_en_US (Tag, Text)
+SELECT 'TXT_KEY_CORPORATION_OFFICEHQ_TT', '[ICON_CAPITAL] Headquarters of [COLOR_POSITIVE_TEXT]{1_Name}[ENDCOLOR]' UNION ALL
+SELECT 'TXT_KEY_CORPORATION_OFFICEHQ_TT2', 'Capturing [COLOR_POSITIVE_TEXT]{1_Name}[ENDCOLOR] will always result in the destruction of the Headquarters, closing all active Offices and Franchises but permits others to rebuild its Headquarters once more.' UNION ALL
+SELECT 'TXT_KEY_CORPORATION_OFFICE_TT', 'Office of [COLOR_POSITIVE_TEXT]{1_Name}[ENDCOLOR]' UNION ALL
+SELECT 'TXT_KEY_CORPORATION_OFFICE_TT2', 'A completed [ICON_INTERNATIONAL_TRADE] Trade Route from or to [COLOR_POSITIVE_TEXT]{1_Name}[ENDCOLOR] will attempt to establish a [ICON_VP_FRANCHISE] [COLOR_POSITIVE_TEXT]Franchise[ENDCOLOR] in foreign cities.';

--- a/(2) Vox Populi/LUA/CityBannerManager.lua
+++ b/(2) Vox Populi/LUA/CityBannerManager.lua
@@ -366,6 +366,36 @@ function RefreshCityBanner(cityBanner, iActiveTeam, iActivePlayer)
 		else
 			controls.CityIsMined:SetHide(true);
 		end
+		
+		-- CityHasOffice Status
+		controls.CityHasOffice:SetHide( not city:HasOffice() )
+		if Players[city:GetOwner()]:GetCorporation() ~= -1 then
+			if (city == Game.GetCorporationHeadquarters(Players[city:GetOwner()]:GetCorporation())) then
+				controls.CityHasOffice:SetToolTipString(Locale.ConvertTextKey("TXT_KEY_CORPORATION_OFFICEHQ_TT", GameInfo.Corporations[Players[city:GetOwner()]:GetCorporation()].Description) .. "[NEWLINE][ICON_BULLET]" .. Locale.ConvertTextKey(GameInfo.Corporations[Players[city:GetOwner()]:GetCorporation()].Help) .. "[NEWLINE][ICON_BULLET]" .. Locale.ConvertTextKey("TXT_KEY_CORPORATION_OFFICEHQ_TT2", city:GetName()) .."[NEWLINE][ICON_BULLET]" .. Locale.ConvertTextKey("TXT_KEY_CORPORATION_OFFICE_TT2", city:GetName())); 
+			elseif (city:HasOffice()) then
+				controls.CityHasOffice:SetToolTipString(Locale.ConvertTextKey("TXT_KEY_CORPORATION_OFFICE_TT", GameInfo.Corporations[Players[city:GetOwner()]:GetCorporation()].Description) .. "[NEWLINE][ICON_BULLET]" .. Locale.ConvertTextKey(GameInfo.Corporations[Players[city:GetOwner()]:GetCorporation()].OfficeBonusHelp) .. "[NEWLINE][ICON_BULLET]" .. Locale.ConvertTextKey("TXT_KEY_CORPORATION_OFFICE_TT2", city:GetName()));
+			else
+				controls.CityHasOffice:SetToolTipString("");
+			end
+		end
+		
+		-- CityHasFranchise Status
+		if Game.GetNumCorporationsFounded() > 1 then
+			controls.CityHasFranchise:SetHide(true);
+			local FranchiseTT = "";
+			for corporation in GameInfo.Corporations() do
+				if Game.GetCorporationFounder(corporation.ID) ~= -1 and city:IsFranchised(Game.GetCorporationFounder(corporation.ID)) then
+					controls.CityHasFranchise:SetHide( false )
+					if (FranchiseTT ~= "") then
+						FranchiseTT = FranchiseTT .. "[NEWLINE]"
+					end
+					FranchiseTT = FranchiseTT .. "[ICON_BULLET][COLOR_POSITIVE_TEXT]" .. Locale.ConvertTextKey(GameInfo.Buildings[Players[Game.GetCorporationFounder(corporation.ID)]:GetSpecificBuildingType(corporation.FranchiseBuildingClass)].Description) .. "[ENDCOLOR]: " .. Locale.ConvertTextKey(GameInfo.Buildings[Players[Game.GetCorporationFounder(corporation.ID)]:GetSpecificBuildingType(corporation.FranchiseBuildingClass)].Help)
+				end
+			end
+			controls.CityHasFranchise:SetToolTipString(FranchiseTT);
+		else
+			controls.CityHasFranchise:SetHide(true);
+		end
 
 		-- CityHasAirport Status
 		if (city:IsHasBuilding(GameInfoTypes["BUILDING_AIRPORT"])) then

--- a/(2) Vox Populi/LUA/CityBannerManager.xml
+++ b/(2) Vox Populi/LUA/CityBannerManager.xml
@@ -102,6 +102,8 @@
 				<Label ID="CityStateIcon" Anchor="C,C" Offset="0,0" String="[ICON_CITY_STATE]" Hidden="1"/>
 				<Label ID="OccupiedIcon" Anchor="C,C" Offset="0,0" String="[ICON_OCCUPIED]" Hidden="1"/>
 				<Label ID="CityIsMined" Anchor="C,C" Offset="0,0" String="[ICON_MINEFIELD]" Hidden="1"/>
+				<Label ID="CityHasOffice" String="[ICON_VP_OFFICE]" Hidden="1"/>
+				<Label ID="CityHasFranchise" String="[ICON_VP_FRANCHISE]" Hidden="1"/>
 				<Label ID="CityHasAirport" Anchor="C,C" Offset="0,0" String="[ICON_AIRPORT]" Hidden="1"/>
 				<Label ID="CityIsAutomated" Anchor="C,C" Offset="0,0" String="[ICON_AUTOMATED]" Hidden="1"/>
 				<Label ID="UnhappyIcon" Anchor="C,C" Offset="0,0" String="[ICON_HAPPINESS_3]" Hidden="1"/>
@@ -175,6 +177,8 @@
 				<Label ID="CityStateIcon" Anchor="C,C" Offset="0,0" String="[ICON_CITY_STATE]" Font="TwCenMT18" FontStyle="Shadow" Hidden="1"/>
 				<Label ID="OccupiedIcon" Anchor="C,C" Offset="0,0" String="[ICON_OCCUPIED]" Font="TwCenMT18" FontStyle="Shadow" Hidden="1"/>
 				<Label ID="CityIsMined" Anchor="C,C" Offset="0,0" String="[ICON_MINEFIELD]" Font="TwCenMT18" FontStyle="Shadow" Hidden="1"/>
+				<Label ID="CityHasOffice" Anchor="C,C" Offset="0,0" String="[ICON_VP_OFFICE]" Font="TwCenMT18" FontStyle="Shadow" Hidden="1"/>
+				<Label ID="CityHasFranchise" Anchor="C,C" Offset="0,0" String="[ICON_VP_FRANCHISE]" Font="TwCenMT18" FontStyle="Shadow" Hidden="1"/>
 				<Label ID="CityHasAirport" Anchor="C,C" Offset="0,0" String="[ICON_AIRPORT]" Font="TwCenMT18" FontStyle="Shadow" Hidden="1"/>
 				<Label ID="UnhappyIcon" Anchor="C,C" Offset="0,0" String="[ICON_HAPPINESS_3]" Font="TwCenMT18" FontStyle="Shadow" Hidden="1"/>
 				<Label ID="CityIsAutomated" Anchor="C,C" Offset="0,0" String="[ICON_AUTOMATED]" Hidden="1"/>

--- a/(3a) EUI Compatibility Files/LUA/CityBannerManager.lua
+++ b/(3a) EUI Compatibility Files/LUA/CityBannerManager.lua
@@ -563,6 +563,33 @@ local g_cityToolTips = {
 	CityHasAirport = function()
 		return L"TXT_KEY_CITY_HAS_AIRPORT"
 	end,
+	CityHasOffice = function( city )
+		if Players[city:GetOwner()]:GetCorporation() ~= -1  then
+			if (city == Game.GetCorporationHeadquarters(Players[city:GetOwner()]:GetCorporation())) then
+				return L("TXT_KEY_CORPORATION_OFFICEHQ_TT", GameInfo.Corporations[Players[city:GetOwner()]:GetCorporation()].Description) .. "[NEWLINE][ICON_BULLET]" .. L(GameInfo.Corporations[Players[city:GetOwner()]:GetCorporation()].Help) .. "[NEWLINE][ICON_BULLET]" .. L("TXT_KEY_CORPORATION_OFFICEHQ_TT2", city:GetName()) .."[NEWLINE][ICON_BULLET]" .. L("TXT_KEY_CORPORATION_OFFICE_TT2", city:GetName())
+			else
+				return L("TXT_KEY_CORPORATION_OFFICE_TT", GameInfo.Corporations[Players[city:GetOwner()]:GetCorporation()].Description) .. "[NEWLINE][ICON_BULLET]" .. L(GameInfo.Corporations[Players[city:GetOwner()]:GetCorporation()].OfficeBonusHelp) .. "[NEWLINE][ICON_BULLET]" .. L("TXT_KEY_CORPORATION_OFFICE_TT2", city:GetName())
+			end
+		else
+			return ""
+		end
+	end,
+	CityHasFranchise = function( city )
+		if Game.GetNumCorporationsFounded() < 1 then
+			return ""
+		else
+			local FranchiseTT = "";
+			for corporation in GameInfo.Corporations() do
+				if Game.GetCorporationFounder(corporation.ID) ~= -1 and city:IsFranchised(Game.GetCorporationFounder(corporation.ID)) then
+					if (FranchiseTT ~= "") then
+						FranchiseTT = FranchiseTT .. "[NEWLINE]"
+					end
+					FranchiseTT = FranchiseTT .. "[ICON_BULLET][COLOR_POSITIVE_TEXT]" .. L(GameInfo.Buildings[Players[Game.GetCorporationFounder(corporation.ID)]:GetSpecificBuildingType(corporation.FranchiseBuildingClass)].Description) .. "[ENDCOLOR]: " .. L(GameInfo.Buildings[Players[Game.GetCorporationFounder(corporation.ID)]:GetSpecificBuildingType(corporation.FranchiseBuildingClass)].Help)
+				end
+			end
+			return FranchiseTT
+		end
+	end,
 	CityIsAutomated = function()
 		return L"TXT_KEY_CITY_PRODUCTION_AUTOMATED"
 	end,
@@ -1062,6 +1089,22 @@ local function RefreshCityBannersNow()
 
 			-- Has airport ?
 			instance.CityHasAirport:SetHide( not city:IsHasBuilding(GameInfoTypes["BUILDING_AIRPORT"]) )
+			
+			-- Has office ?
+			instance.CityHasOffice:SetHide( not city:HasOffice() )
+			
+			-- Has franchise ?
+			if Game.GetNumCorporationsFounded() > 0 then
+				instance.CityHasFranchise:SetHide( true )
+				for corporation in GameInfo.Corporations() do
+					if Game.GetCorporationFounder(corporation.ID) ~= -1 and city:IsFranchised(Game.GetCorporationFounder(corporation.ID)) then
+						instance.CityHasFranchise:SetHide( false )
+						break
+					end
+				end
+			else
+				instance.CityHasFranchise:SetHide( true )
+			end
 
 			-- Blockaded ? / Sapped ?
 			instance.CityIsBlockaded:SetHide( not city:IsBlockaded() )

--- a/(3a) EUI Compatibility Files/LUA/CityBannerManager.xml
+++ b/(3a) EUI Compatibility Files/LUA/CityBannerManager.xml
@@ -126,6 +126,8 @@
 				<Label ID="CityIsMined" String="[ICON_MINEFIELD]"/>
 				<Label ID="CityIsUnhappy" String="[ICON_HAPPINESS_3]"/>
 				<Label ID="CityHasAirport" String="[ICON_AIRPORT]"/>
+				<Label ID="CityHasOffice" String="[ICON_VP_OFFICE]"/>
+				<Label ID="CityHasFranchise" String="[ICON_VP_FRANCHISE]"/>
 			</Stack>
 			<!--  CityRangeStrikeButton -->
 			<Button ID="CityRangeStrikeButton" Anchor="C,C" Anchor="C,C" Offset="0,32" Size="64,64" Texture="CityBombard.dds" ToolTip="TXT_KEY_CITY_MAKE_RANGED_ATTACK">
@@ -222,6 +224,8 @@
 				<Label ID="CityIsMined" String="[ICON_MINEFIELD]"/>
 				<Label ID="CityIsUnhappy" String="[ICON_HAPPINESS_3]"/>
 				<Label ID="CityHasAirport" String="[ICON_AIRPORT]"/>
+				<Label ID="CityHasOffice" String="[ICON_VP_OFFICE]"/>
+				<Label ID="CityHasFranchise" String="[ICON_VP_FRANCHISE]"/>
 			</Stack>
 		</WorldAnchor>
 	</Instance>


### PR DESCRIPTION
Now Corporate Franchises and Offices are considered public knowledge since they were but you had to do some mental gymnasium to get that knowledge. A city with an Office icon will have an Office or its own HQ built there! While a city can have multiple franchises indicated by its franchised icon.

CityBannerManager.lua and CityBannerManager.xml has been changed (not sure if modders are using that mod again but just to keep in mind)