### PR TITLE
Congress Proposal 6-13b

### DIFF
--- a/(2) Vox Populi/Database Changes/Units/UnitChanges.sql
+++ b/(2) Vox Populi/Database Changes/Units/UnitChanges.sql
@@ -671,14 +671,14 @@ UPDATE Units
 SET
 	BaseGold = 0,
 	NumGoldPerEra = 0,
-	BaseGoldTurnsToCount = 5,
+	BaseGoldTurnsToCount = 2,
 	BaseWLTKDTurns = 5
 WHERE Class = 'UNITCLASS_MERCHANT';
 
 INSERT INTO Unit_ScalingFromOwnedImprovements
 	(UnitType, ImprovementType, Amount)
 SELECT
-	Type, 'IMPROVEMENT_CUSTOMS_HOUSE', 25
+	Type, 'IMPROVEMENT_CUSTOMS_HOUSE', 20
 FROM Units
 WHERE Class = 'UNITCLASS_MERCHANT';
 

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -1,4 +1,4 @@
-/*	-------------------------------------------------------------------------------------------------------
+﻿/*	-------------------------------------------------------------------------------------------------------
 	© 1991-2012 Take-Two Interactive Software and its subsidiaries.  Developed by Firaxis Games.  
 	Sid Meier's Civilization V, Civ, Civilization, 2K Games, Firaxis Games, Take-Two Interactive Software 
 	and their respective logos are all trademarks of Take-Two interactive Software, Inc.  
@@ -43447,9 +43447,9 @@ int CvPlayer::getYieldPerTurnHistory(YieldTypes eYield, int iNumTurns, bool bIgn
 	int iYield = 0;
 	int iLoop = 0;
 
-	// Average over X turns unles iNumTurns is larger
+	// Average over X turns
 	int iNumHistory = /*10*/ GD_INT_GET(HISTORY_NUM_TURNS_TO_AVERAGE);
-	if (!MOD_BALANCE_VP || iNumTurns > iNumHistory)
+	if (!MOD_BALANCE_VP)
 		iNumHistory = iNumTurns;
 
 	std::vector<int>& viYieldHistory = m_aiYieldHistory[eYield];
@@ -43487,7 +43487,7 @@ int CvPlayer::getYieldPerTurnHistory(YieldTypes eYield, int iNumTurns, bool bIgn
 void CvPlayer::updateYieldPerTurnHistory()
 {
 	m_aiYieldHistory[YIELD_PRODUCTION].push_back(GetAverageProduction());
-	m_aiYieldHistory[YIELD_GOLD].push_back(calculateGoldRate());
+	m_aiYieldHistory[YIELD_GOLD].push_back(GetTreasury()->CalculateGrossGold());
 	m_aiYieldHistory[YIELD_SCIENCE].push_back(GetScience());
 	m_aiYieldHistory[YIELD_CULTURE].push_back(GetTotalJONSCulturePerTurn());
 	m_aiYieldHistory[YIELD_TOURISM].push_back(GetCulture()->GetTourism() / 100);


### PR DESCRIPTION
 - Change Yield per Turn History for Gold to GROSS from NET (only used by GM trade mission)
 - Reduce Great Merchant trade mission to 20% of last 10 turns from 50% of last 10 turns
 - Reduce Town Scaling to 20% from 25%
 - Number of turns to average is always /*10*/, removing exception for # turns greater than /*10*/ (results in zero balance changes as nothing in-game uses a value >10 right now)