### PR TITLE
unused-comparison

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvDealAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDealAI.cpp
@@ -5184,7 +5184,7 @@ void CvDealAI::DoAddItemsToDealForPeaceTreaty(PlayerTypes eOtherPlayer, CvDeal* 
 			if (iCurrentCityValue == INT_MAX)
 				continue;
 
-			if (pLoopCity->plot()->GetNumEnemyUnitsAdjacent(pLoopCity->getTeam(), NO_DOMAIN, NULL, false, GET_PLAYER(eWinningPlayer).getTeam()) >= 2, true)
+			if (pLoopCity->plot()->GetNumEnemyUnitsAdjacent(pLoopCity->getTeam(), NO_DOMAIN, NULL, false, GET_PLAYER(eWinningPlayer).getTeam()) >= 2)
 			{
 				int iHPPercent = 100 * (pLoopCity->GetMaxHitPoints() - pLoopCity->getDamage()) / pLoopCity->GetMaxHitPoints();
 				if (iHPPercent < 10 + iWarScore / 10)


### PR DESCRIPTION
Small fix. v90 and clang build works. [Git blame](https://github.com/LoneGazebo/Community-Patch-DLL/blame/master/CvGameCoreDLL_Expansion2/CvDealAI.cpp#L5187): https://github.com/LoneGazebo/Community-Patch-DLL/pull/10344
```
==== C:\Users\IEUser\Documents\GitHub\Community-Patch-DLL\CvGameCoreDLL_Expansion2\CvDealAI.cpp ====
C:\Users\IEUser\Documents\GitHub\Community-Patch-DLL\CvGameCoreDLL_Expansion2\CvDealAI.cpp(5187,135) : warning: relational comparison result unused [-Wunused-comparison]
 5187 |                         if (pLoopCity->plot()->GetNumEnemyUnitsAdjacent(pLoopCity->getTeam(), NO_DOMAIN, NULL, false, GET_PLAYER(eWinningPlayer).getTeam()) >= 2, true)
      |                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
1 warning generated.
```