### PR TITLE
Add AI visibility handling logic and fix some bugs

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvAIOperation.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAIOperation.cpp
@@ -1615,7 +1615,7 @@ bool CvAIOperationMilitary::CheckTransitionToNextStage()
 					int nVisible = 0;
 					for (CvUnit* pUnit = pThisArmy->GetFirstUnit(); pUnit; pUnit = pThisArmy->GetNextUnit(pUnit))
 					{
-						if (pUnit->plot()->isVisible( GET_PLAYER(m_eEnemy).getTeam() ))
+						if (GET_PLAYER(pUnit->getOwner()).GetTacticalAI()->IsVisibleToPlayer(pUnit->plot(), GET_PLAYER(m_eEnemy).getTeam()))
 							nVisible++;
 					}
 

--- a/CvGameCoreDLL_Expansion2/CvAStar.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAStar.cpp
@@ -2184,7 +2184,7 @@ int CityConnectionWaterValid(const CvAStarNode* parent, const CvAStarNode* node,
 
 //	--------------------------------------------------------------------------------
 /// Prefer building routes that can have villages.
-int BuildRouteVillageBonus(CvPlayer* pPlayer, CvPlot* pPlot, RouteTypes eRouteType, CvBuilderTaskingAI* eBuilderTaskingAi)
+static int BuildRouteVillageBonus(CvPlayer* pPlayer, CvPlot* pPlot, RouteTypes eRouteType, CvBuilderTaskingAI* eBuilderTaskingAi)
 {
 	// If we're not the owner of this plot, bail out
 	if (!pPlot->isOwned() || pPlot->getOwner() != pPlayer->GetID())
@@ -2239,9 +2239,6 @@ int BuildRouteVillageBonus(CvPlayer* pPlayer, CvPlot* pPlot, RouteTypes eRouteTy
 		if (pkImprovementInfo == NULL)
 			continue;
 
-		if (pkImprovementInfo->IsCreatedByGreatPerson())
-			continue;
-
 		for (int iYield = 0; iYield < NUM_YIELD_TYPES; iYield++)
 		{
 			YieldTypes eYield = (YieldTypes)iYield;
@@ -2289,10 +2286,10 @@ int BuildRouteCost(const CvAStarNode* /*parent*/, const CvAStarNode* node, const
 	}
 
 	//too dangerous, might be severed any time
-	if (pPlot->getOwner() == NO_PLAYER && pPlot->IsAdjacentOwnedByTeamOtherThan(pPlayer->getTeam()))
+	if (pPlot->getOwner() == NO_PLAYER && pPlot->IsAdjacentOwnedByTeamOtherThan(pPlayer->getTeam(), false, false, true, true))
 		iCost *= 3;
 
-	if (data.bIsForCapital)
+	if (data.bBenefitsVillages)
 		iCost -= BuildRouteVillageBonus(pPlayer, pPlot, eRouteType, eBuilderTaskingAi);
 
 	if (iCost < 0)
@@ -2301,26 +2298,38 @@ int BuildRouteCost(const CvAStarNode* /*parent*/, const CvAStarNode* node, const
 	return iCost;
 }
 
-bool IsSafeForRoute(CvPlot* pPlot, CvPlayer* ePlayer)
+static bool IsSafeForRoute(CvPlot* pPlot, CvPlayer* pPlayer)
 {
+	TeamTypes ePlotTeam = pPlot->getTeam();
+	TeamTypes ePlayerTeam = pPlayer->getTeam();
+	PlayerTypes ePlotOwner = pPlot->getOwner();
+
 	// Our plots and surrounding plots are safe
-	if (pPlot->getTeam() == ePlayer->getTeam() || pPlot->isAdjacentTeam(ePlayer->getTeam(), false))
+	if (ePlotTeam == ePlayerTeam || pPlot->isAdjacentTeam(pPlayer->getTeam(), false))
+	{
+		return true;
+	}
+
+	// Our vassal's plots and surrounding plots are safe
+	if (GET_TEAM(ePlotTeam).IsVassal(ePlayerTeam) || pPlot->isAdjacentOwnedByVassal(ePlayerTeam, false))
 	{
 		return true;
 	}
 
 	// City state plots and surrounding plots are safe
-	if (pPlot->isOwned() && GET_PLAYER(pPlot->getOwner()).isMinorCiv() && !GET_PLAYER(pPlot->getOwner()).GetMinorCivAI()->IsAtWarWithPlayersTeam(ePlayer->GetID()))
+	if (ePlotOwner != NO_PLAYER && GET_PLAYER(ePlotOwner).isMinorCiv() && !GET_PLAYER(ePlotOwner).GetMinorCivAI()->IsAtWarWithPlayersTeam(pPlayer->GetID()))
 	{
 		return true;
 	}
 	CvPlot** aPlotsToCheck = GC.getMap().getNeighborsUnchecked(pPlot);
+	PlayerTypes eAdjacentOwner;
 	for (int iI = 0; iI < NUM_DIRECTION_TYPES; iI++)
 	{
 		CvPlot* pAdjacentPlot = aPlotsToCheck[iI];
 		if (pAdjacentPlot != NULL)
 		{
-			if (pAdjacentPlot->isOwned() && GET_PLAYER(pAdjacentPlot->getOwner()).isMinorCiv() && !GET_PLAYER(pAdjacentPlot->getOwner()).GetMinorCivAI()->IsAtWarWithPlayersTeam(ePlayer->GetID()))
+			eAdjacentOwner = pAdjacentPlot->getOwner();
+			if (eAdjacentOwner != NO_PLAYER && GET_PLAYER(eAdjacentOwner).isMinorCiv() && !GET_PLAYER(eAdjacentOwner).GetMinorCivAI()->IsAtWarWithPlayersTeam(pPlayer->GetID()))
 			{
 				return true;
 			}
@@ -2357,7 +2366,7 @@ int BuildRouteValid(const CvAStarNode* parent, const CvAStarNode* node, const SP
 		return FALSE;
 
 	PlayerTypes ePlotOwnerPlayer = pNewPlot->getOwner();
-	if(ePlotOwnerPlayer != NO_PLAYER && pNewPlot->getTeam() != thisPlayer.getTeam())
+	if(ePlotOwnerPlayer != NO_PLAYER && pNewPlot->getTeam() != thisPlayer.getTeam() && !GET_TEAM(pNewPlot->getTeam()).IsVassal(thisPlayer.getTeam()))
 	{
 		PlayerTypes eMajorPlayer = NO_PLAYER;
 		PlayerTypes eMinorPlayer = NO_PLAYER;
@@ -2373,11 +2382,6 @@ int BuildRouteValid(const CvAStarNode* parent, const CvAStarNode* node, const SP
 			eMinorPlayer = ePlotOwnerPlayer;
 		}
 		else
-		{
-			return FALSE;
-		}
-
-		if(!GET_PLAYER(eMinorPlayer).GetMinorCivAI()->IsActiveQuestForPlayer(eMajorPlayer, MINOR_CIV_QUEST_ROUTE))
 		{
 			return FALSE;
 		}
@@ -3715,7 +3719,7 @@ SPathFinderUserData::SPathFinderUserData(const CvUnit* pUnit, int _iFlags, int _
 	iMaxNormalizedDistance = INT_MAX;
 	iMinMovesLeft = 0;
 	iStartMoves = pUnit ? pUnit->getMoves() : 0;
-	bIsForCapital = false;
+	bBenefitsVillages = false;
 }
 
 //	---------------------------------------------------------------------------
@@ -3733,7 +3737,7 @@ SPathFinderUserData::SPathFinderUserData(PlayerTypes _ePlayer, PathType _ePathTy
 	iMaxNormalizedDistance = INT_MAX;
 	iMinMovesLeft = 0;
 	iStartMoves = 0;
-	bIsForCapital = false;
+	bBenefitsVillages = false;
 }
 
 //	---------------------------------------------------------------------------
@@ -3751,7 +3755,7 @@ SPathFinderUserData::SPathFinderUserData(PlayerTypes _ePlayer, PathType _ePathTy
 	iMaxNormalizedDistance = INT_MAX;
 	iMinMovesLeft = 0;
 	iStartMoves = 0;
-	bIsForCapital = false;
+	bBenefitsVillages = false;
 }
 
 //	---------------------------------------------------------------------------
@@ -3769,12 +3773,12 @@ SPathFinderUserData::SPathFinderUserData(PlayerTypes _ePlayer, PathType _ePathTy
 	iMaxNormalizedDistance = INT_MAX;
 	iMinMovesLeft = 0;
 	iStartMoves = 0;
-	bIsForCapital = false;
+	bBenefitsVillages = false;
 }
 
 //	---------------------------------------------------------------------------
 //convenience constructor
-SPathFinderUserData::SPathFinderUserData(PlayerTypes _ePlayer, PathType _ePathType, BuildTypes _eBuildType, RouteTypes _eRouteType, bool _bIsForCapital)
+SPathFinderUserData::SPathFinderUserData(PlayerTypes _ePlayer, PathType _ePathType, BuildTypes _eBuildType, RouteTypes _eRouteType, bool _bBenefitsVillages)
 {
 	ePathType = _ePathType;
 	iFlags = 0;
@@ -3787,7 +3791,7 @@ SPathFinderUserData::SPathFinderUserData(PlayerTypes _ePlayer, PathType _ePathTy
 	iMaxNormalizedDistance = INT_MAX;
 	iMinMovesLeft = 0;
 	iStartMoves = 0;
-	bIsForCapital = _bIsForCapital;
+	bBenefitsVillages = _bBenefitsVillages;
 }
 
 CvPlot * SPath::get(int i) const

--- a/CvGameCoreDLL_Expansion2/CvAStarNode.h
+++ b/CvGameCoreDLL_Expansion2/CvAStarNode.h
@@ -136,12 +136,12 @@ public:
 //-------------------------------------------------------------------------------------------------
 struct SPathFinderUserData
 {
-	SPathFinderUserData() : ePathType(PT_GENERIC_SAME_AREA), iFlags(0), ePlayer(NO_PLAYER), eEnemy(NO_PLAYER), iUnitID(0), eBuildType(NO_BUILD), eRouteType(NO_ROUTE), bIsForCapital(false), iMaxTurns(INT_MAX), iMaxNormalizedDistance(INT_MAX), iMinMovesLeft(0), iStartMoves(60) {}
+	SPathFinderUserData() : ePathType(PT_GENERIC_SAME_AREA), iFlags(0), ePlayer(NO_PLAYER), eEnemy(NO_PLAYER), iUnitID(0), eBuildType(NO_BUILD), eRouteType(NO_ROUTE), bBenefitsVillages(false), iMaxTurns(INT_MAX), iMaxNormalizedDistance(INT_MAX), iMinMovesLeft(0), iStartMoves(60) {}
 	SPathFinderUserData(const CvUnit* pUnit, int iFlags=0, int iMaxTurns=INT_MAX); // PT_AIR_REBASE (special case, set after construction)
 	SPathFinderUserData(PlayerTypes ePlayer, PathType ePathType); // PT_TRADE_WATER, PT_TRADE_LAND, PT_LANDMASS_CONNECTION, PT_CITY_CONNECTION_WATER
 	SPathFinderUserData(PlayerTypes ePlayer, PathType ePathType, int iMaxTurns); // PT_AREA_CONNECTION (iMaxTurns is simple vs complex check (0/1)), PT_CITY_INFLUENCE
 	SPathFinderUserData(PlayerTypes ePlayer, PathType ePathType, PlayerTypes eEnemy, int iMaxTurns); // PT_GENERIC_SAME_AREA, PT_GENERIC_SAME_AREA_WIDE, PT_ARMY_LAND, PT_ARMY_WATER, PT_ARMY_MIXED
-	SPathFinderUserData(PlayerTypes ePlayer, PathType ePathType, BuildTypes eBuildType, RouteTypes eRouteType, bool bIsForCapital); // PT_BUILD_ROUTE, PT_BUILD_ROUTE_MIXED, PT_CITY_CONNECTION_LAND, PT_CITY_CONNECTION_MIXED
+	SPathFinderUserData(PlayerTypes ePlayer, PathType ePathType, BuildTypes eBuildType, RouteTypes eRouteType, bool bBenefitsVillages); // PT_BUILD_ROUTE, PT_BUILD_ROUTE_MIXED, PT_CITY_CONNECTION_LAND, PT_CITY_CONNECTION_MIXED
 
 	//do not compare max turns and max cost ...
 	bool operator==(const SPathFinderUserData& rhs) const 
@@ -151,7 +151,7 @@ struct SPathFinderUserData
 	PathType	ePathType;
 	RouteTypes  eRouteType;
 	BuildTypes  eBuildType;         //BuildType related to the RouteType
-	bool        bIsForCapital;
+	bool        bBenefitsVillages;
 	int			iFlags;				//see CvUnit::MOVEFLAG*
 	PlayerTypes ePlayer;			//optional
 	PlayerTypes eEnemy;

--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.h
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.h
@@ -106,7 +106,7 @@ public:
 	FeatureTypes GetFalloutFeature(void);
 	BuildTypes GetFalloutRemove(void);
 	BuildTypes GetRemoveRoute(void);
-	BuildTypes GetBuildRoute(void);
+	BuildTypes GetBuildRoute(RouteTypes eRoute);
 
 	static void LogInfo(const CvString& str, CvPlayer* pPlayer, bool bWriteToOutput = false);
 	static void LogYieldInfo(const CvString& strNewLogStr, CvPlayer* pPlayer); //Log yield related info to BuilderTaskingYieldLog.csv.
@@ -121,8 +121,8 @@ protected:
 	void LogDirectives(vector<OptionWithScore<BuilderDirective>> directives, CvUnit* pUnit);
 	void LogDirective(BuilderDirective directive, CvUnit* pUnit, int iWeight, bool bChosen = false);
 
-	void ConnectCitiesToCapital(CvCity* pPlayerCapital, CvCity* pTargetCity, BuildTypes eBuild, RouteTypes eRoute, int iNetGoldTimes100);
-	void ConnectCitiesForShortcuts(CvCity* pFirstCity, CvCity* pSecondCity, BuildTypes eBuild, RouteTypes eRoute, int iNetGoldTimes100);
+	void ConnectCitiesToCapital(CvCity* pPlayerCapital, CvCity* pTargetCity, BuildTypes eBuild, RouteTypes eRoute);
+	void ConnectCitiesForShortcuts(CvCity* pFirstCity, CvCity* pSecondCity, BuildTypes eBuild, RouteTypes eRoute);
 	void ConnectCitiesForScenario(CvCity* pFirstCity, CvCity* pSecondCity, BuildTypes eBuild, RouteTypes eRoute);
 	void ConnectPointsForStrategy(CvCity* pOriginCity, CvPlot* pTargetPlot, BuildTypes eBuild, RouteTypes eRoute, int iNetGoldTimes100);
 
@@ -154,7 +154,6 @@ protected:
 	FeatureTypes m_eFalloutFeature;
 	BuildTypes m_eFalloutRemove;
 	BuildTypes m_eRemoveRouteBuild;
-	BuildTypes m_eRouteBuild;
 
 	//some player dependent flags for unique improvements
 	bool m_bKeepMarshes;

--- a/CvGameCoreDLL_Expansion2/CvDangerPlots.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDangerPlots.cpp
@@ -812,7 +812,7 @@ int CvDangerPlotContents::GetDanger(const CvUnit* pUnit, const UnitIdContainer& 
 			{
 				int iDummy = 0;
 				int iDamage = TacticalAIHelpers::GetSimulatedDamageFromAttackOnUnit(pUnit, pAttacker, m_pPlot, pAttacker->plot(), iDummy, false, 0, true);
-				if (!m_pPlot->isVisible(pAttacker->getTeam()))
+				if (!GET_PLAYER(pUnit->getOwner()).GetTacticalAI()->IsVisibleToPlayer(m_pPlot, pAttacker->getTeam()))
 					iDamage = (iDamage * 80) / 100; //there's a chance they won't spot us
 				iPlotDamage += iDamage;
 			}
@@ -895,7 +895,7 @@ int CvDangerPlotContents::GetDanger(const CvUnit* pUnit, const UnitIdContainer& 
 			//if the attacker is not out of range, assume they need to move for the attack, so we don't know their plot
 			int iDamage = TacticalAIHelpers::GetSimulatedDamageFromAttackOnUnit(pUnit, pAttacker, m_pPlot, bOutOfRange ? pAttacker->plot() : NULL, iAttackerDamage, false, iExtraDamage, true);
 
-			if (!m_pPlot->isVisible(pAttacker->getTeam()))
+			if (!GET_PLAYER(pUnit->getOwner()).GetTacticalAI()->IsVisibleToPlayer(m_pPlot, pAttacker->getTeam()))
 				iDamage = (iDamage * 80) / 100; //there's a chance they won't spot us
 
 			if (iAttackerDamage >= pAttacker->GetCurrHitPoints() && !pAttacker->isSuicide())

--- a/CvGameCoreDLL_Expansion2/CvPlayerAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayerAI.cpp
@@ -287,6 +287,7 @@ void CvPlayerAI::AI_unitUpdate()
 		// just been handed off to the tactical AI to get a move in the same turn they switch between
 		GetTacticalAI()->Update();
 		GetHomelandAI()->Update();
+		GetTacticalAI()->CleanUp();
 	}
 }
 

--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -204,6 +204,7 @@ void CvPlot::reset()
 	m_eResourceType = NO_RESOURCE;
 	m_eImprovementType = NO_IMPROVEMENT;
 	m_ePlayerBuiltImprovement = NO_PLAYER;
+	m_ePlayerBuiltRoute = NO_PLAYER;
 	m_ePlayerResponsibleForImprovement = NO_PLAYER;
 	m_ePlayerResponsibleForRoute = NO_PLAYER;
 	m_ePlayerThatClearedBarbCampHere = NO_PLAYER;
@@ -3418,19 +3419,27 @@ bool CvPlot::isAdjacentPlayer(PlayerTypes ePlayer, bool bLandOnly) const
 }
 
 //	--------------------------------------------------------------------------------
-bool CvPlot::IsAdjacentOwnedByTeamOtherThan(TeamTypes eTeam, bool bAllowNoTeam, bool bIgnoreImpassable) const
+bool CvPlot::IsAdjacentOwnedByTeamOtherThan(TeamTypes eTeam, bool bAllowNoTeam, bool bIgnoreImpassable, bool bIgnoreMinor, bool bIgnoreVassal) const
 {
 	CvPlot** aPlotsToCheck = GC.getMap().getNeighborsUnchecked(this);
 	for(int iI=0; iI<NUM_DIRECTION_TYPES; iI++)
 	{
 		CvPlot* pAdjacentPlot = aPlotsToCheck[iI];
-		if(pAdjacentPlot != NULL && pAdjacentPlot->getTeam() != eTeam)
-		{
-			if (bIgnoreImpassable && pAdjacentPlot->isImpassable(pAdjacentPlot->getTeam()))
-				continue;
+		if(pAdjacentPlot == NULL)
+			continue;
 
-			if (bAllowNoTeam || pAdjacentPlot->getTeam() != NO_TEAM)
-				return true; 
+		if (bIgnoreImpassable && pAdjacentPlot->isImpassable(pAdjacentPlot->getTeam()))
+			continue;
+
+		if (bIgnoreMinor && GET_PLAYER(pAdjacentPlot->getOwner()).isMinorCiv())
+			continue;
+
+		if (bIgnoreVassal && GET_TEAM(pAdjacentPlot->getTeam()).IsVassal(eTeam))
+			continue;
+
+		if (pAdjacentPlot->getTeam() != eTeam && (pAdjacentPlot->getTeam() != NO_TEAM || bAllowNoTeam))
+		{
+			return true; 
 		}
 	}
 
@@ -3513,6 +3522,28 @@ bool CvPlot::IsAdjacentOwnedByEnemy(TeamTypes eTeam) const
 			if(pAdjacentPlot->getTeam() != NO_TEAM && GET_TEAM(eTeam).isAtWar(pAdjacentPlot->getTeam()))
 			{
 				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
+//	--------------------------------------------------------------------------------
+bool CvPlot::isAdjacentOwnedByVassal(TeamTypes eTeam, bool bLandOnly) const
+{
+	CvPlot** aPlotsToCheck = GC.getMap().getNeighborsUnchecked(this);
+	for (int iI=0; iI<NUM_DIRECTION_TYPES; iI++)
+	{
+		CvPlot* pAdjacentPlot = aPlotsToCheck[iI];
+		if(pAdjacentPlot != NULL)
+		{
+			if(pAdjacentPlot->getTeam() != NO_TEAM && GET_TEAM(pAdjacentPlot->getTeam()).IsVassal(eTeam))
+			{
+				if(!bLandOnly || !(pAdjacentPlot->isWater()))
+				{
+					return true;
+				}
 			}
 		}
 	}
@@ -4061,26 +4092,6 @@ bool CvPlot::isVisibleToAnyTeam(bool bNoMinor) const
 		if(GET_TEAM((TeamTypes)iI).isAlive())
 		{
 			if(isVisible(((TeamTypes)iI)))
-			{
-				return true;
-			}
-		}
-	}
-
-	return false;
-}
-
-//	--------------------------------------------------------------------------------
-bool CvPlot::isVisibleToEnemy(PlayerTypes eFriendlyPlayer) const
-{
-	const std::vector<PlayerTypes>& vEnemies = GET_PLAYER(eFriendlyPlayer).GetPlayersAtWarWith();
-
-	for (std::vector<PlayerTypes>::const_iterator it = vEnemies.begin(); it != vEnemies.end(); ++it)
-	{
-		CvPlayer& kEnemy = GET_PLAYER(*it);
-		if (kEnemy.isAlive() && kEnemy.IsAtWarWith(eFriendlyPlayer))
-		{
-			if (isVisible(kEnemy.getTeam()))
 			{
 				return true;
 			}
@@ -7361,6 +7372,7 @@ void CvPlot::setIsCity(bool bValue, int iCityID, int iWorkRange)
 		{
 			// Maintenance change!
 			SetPlayerResponsibleForRoute(getOwner());
+			SetPlayerThatBuiltRoute(getOwner());
 		}
 
 		// plot ownership will be changed in CvCity::preKill
@@ -8710,6 +8722,9 @@ void CvPlot::setRouteType(RouteTypes eNewValue, PlayerTypes eBuilder)
 			SetPlayerResponsibleForRoute(NO_PLAYER);
 		}
 
+		if(eOldRoute != eNewValue)
+			SetPlayerThatBuiltRoute(eBuilder);
+
 		// Route switch here!
 		m_eRouteType = eNewValue;
 
@@ -8832,6 +8847,20 @@ PlayerTypes CvPlot::GetPlayerThatBuiltImprovement() const
 void CvPlot::SetPlayerThatBuiltImprovement(PlayerTypes eBuilder)
 {
 	m_ePlayerBuiltImprovement = eBuilder;
+}
+
+//	--------------------------------------------------------------------------------
+/// Who built this Road?  Could be NO_PLAYER
+PlayerTypes CvPlot::GetPlayerThatBuiltRoute() const
+{
+	return (PlayerTypes)m_ePlayerBuiltRoute;
+}
+
+//	--------------------------------------------------------------------------------
+/// Who built this Improvement?  Could be NO_PLAYER
+void CvPlot::SetPlayerThatBuiltRoute(PlayerTypes eBuilder)
+{
+	m_ePlayerBuiltRoute= eBuilder;
 }
 
 //	--------------------------------------------------------------------------------
@@ -11302,6 +11331,15 @@ bool CvPlot::setRevealed(TeamTypes eTeam, bool bNewValue, CvUnit* pUnit, bool bT
 
 	bool bVisbilityUpdated = false;
 	bool bRevealed = isRevealed(eTeam) != bNewValue;
+
+	// Update tactical AI, let it know that the tile was made visible
+	const CivsList pPlayers = GET_TEAM(eTeam).getPlayers();
+	for (size_t iJ = 0; iJ < pPlayers.size(); iJ++)
+	{
+		if (pPlayers[iJ] == GC.getGame().getActivePlayer())
+			GET_PLAYER(pPlayers[iJ]).GetTacticalAI()->NewVisiblePlot(this, bRevealed);
+	}
+
 	if(bRevealed)
 	{
 		bVisbilityUpdated = true;
@@ -12861,6 +12899,7 @@ void CvPlot::Serialize(Plot& plot, Visitor& visitor)
 
 	visitor(plot.m_ePlayerBuiltImprovement);
 	visitor(plot.m_ePlayerResponsibleForImprovement);
+	visitor(plot.m_ePlayerBuiltRoute);
 	visitor(plot.m_ePlayerResponsibleForRoute);
 	visitor(plot.m_ePlayerThatClearedBarbCampHere);
 	visitor(plot.m_ePlayerThatClearedDigHere);

--- a/CvGameCoreDLL_Expansion2/CvPlot.h
+++ b/CvGameCoreDLL_Expansion2/CvPlot.h
@@ -207,9 +207,10 @@ public:
 
 	bool isAdjacentOwned() const;
 	bool isAdjacentPlayer(PlayerTypes ePlayer, bool bLandOnly = false) const;
-	bool IsAdjacentOwnedByTeamOtherThan(TeamTypes eTeam, bool bAllowNoTeam=false, bool bIgnoreImpassable=false) const;
+	bool IsAdjacentOwnedByTeamOtherThan(TeamTypes eTeam, bool bAllowNoTeam=false, bool bIgnoreImpassable=false, bool bIgnoreMinor=false, bool bIgnoreVassal=false) const;
 	bool IsAdjacentOwnedByUnfriendly(PlayerTypes ePlayer, vector<PlayerTypes>& vUnfriendlyMajors) const;
 	bool IsAdjacentOwnedByEnemy(TeamTypes eTeam) const;
+	bool isAdjacentOwnedByVassal(TeamTypes eTeam, bool bLandOnly = false) const;
 	bool isAdjacentTeam(TeamTypes eTeam, bool bLandOnly = false) const;
 	bool IsAdjacentCity(TeamTypes eTeam = NO_TEAM) const;
 	CvCity* GetAdjacentFriendlyCity(TeamTypes eTeam, bool bLandOnly = false) const;
@@ -242,7 +243,6 @@ public:
 	bool isActiveVisible() const;
 	bool isVisibleToAnyTeam(bool bNoMinor = false) const;
 
-	bool isVisibleToEnemy(PlayerTypes eFriendlyPlayer) const;
 	bool isVisibleToWatchingHuman() const;
 	bool isAdjacentVisible(TeamTypes eTeam, bool bDebug=false) const;
 	bool isAdjacentNonvisible(TeamTypes eTeam) const;
@@ -501,6 +501,9 @@ public:
 	// Who built the improvement in this plot?
 	PlayerTypes GetPlayerThatBuiltImprovement() const;
 	void SetPlayerThatBuiltImprovement(PlayerTypes eBuilder);
+
+	PlayerTypes GetPlayerThatBuiltRoute() const;
+	void SetPlayerThatBuiltRoute(PlayerTypes eBuilder);
 	
 	// Someone footing the bill for an improvement/route in an unowned plot?
 	PlayerTypes GetPlayerResponsibleForImprovement() const;
@@ -969,6 +972,7 @@ protected:
 	char /*ResourceTypes*/ m_eResourceType;
 	char /*ImprovementTypes*/ m_eImprovementType;
 	char /*PlayerTypes*/ m_ePlayerBuiltImprovement;
+	char /*PlayerTypes*/ m_ePlayerBuiltRoute;
 	char /*PlayerTypes*/ m_ePlayerResponsibleForImprovement;
 	char /*PlayerTypes*/ m_ePlayerResponsibleForRoute;
 	char /*PlayerTypes*/ m_ePlayerThatClearedBarbCampHere;

--- a/CvGameCoreDLL_Expansion2/CvTacticalAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTacticalAI.cpp
@@ -314,6 +314,7 @@ void CvTacticalAI::RecruitUnits()
 /// Update the AI for units
 void CvTacticalAI::Update()
 {
+	ResetVisibility();
 	DropOldFocusAreas();
 	FindTacticalTargets();
 
@@ -322,6 +323,14 @@ void CvTacticalAI::Update()
 
 	// Loop through each dominance zone assigning moves
 	ProcessDominanceZones();
+}
+
+/// Clear up unnecessary memory usage
+void CvTacticalAI::CleanUp()
+{
+	m_plotsVisibleToOtherPlayer.clear();
+	m_AllTargets.clear();
+	m_ZoneTargets.clear();
 }
 
 /// Add a temporary focus of attention around a short-term target
@@ -373,16 +382,144 @@ bool CvTacticalAI::IsInFocusArea(const CvPlot* pPlot) const
 	return false;
 }
 
+/// Reset what we know of other civ's seen plots
+void CvTacticalAI::ResetVisibility()
+{
+	m_plotsVisibleToOtherPlayer.clear();
+
+	TeamTypes eTeam = m_pPlayer->getTeam();
+
+	CvPlot* pLoopPlot;
+
+	for (int iI = 0; iI < GC.getMap().numPlots(); iI++)
+	{
+		pLoopPlot = GC.getMap().plotByIndexUnchecked(iI);
+
+		if (!pLoopPlot->isRevealed(eTeam))
+			continue;
+
+		UpdateVisibilityFromBorders(pLoopPlot, false);
+
+		if (!pLoopPlot->isVisible(eTeam))
+			continue;
+
+		NewVisiblePlot(pLoopPlot, false);
+	}
+}
+
+/// Check if there are any units owned by other players in this tile and what they can see
+void CvTacticalAI::NewVisiblePlot(CvPlot* pPlot, bool bRevealed=false)
+{
+	if (!pPlot)
+		return;
+
+	TeamTypes eTeam = m_pPlayer->getTeam();
+
+	// If we just revealed the tile, check if it or a nearby plot is owned by another player
+	if (bRevealed)
+	{
+		UpdateVisibilityFromBorders(pPlot, bRevealed);
+	}
+
+	if (pPlot->getNumUnits() > 0)
+	{
+		TeamTypes eOtherTeam;
+		CvUnit* pLoopUnit;
+
+		for (int iI = 0; iI < pPlot->getNumUnits(); iI++)
+		{
+			pLoopUnit = pPlot->getUnitByIndex(iI);
+			eOtherTeam = pLoopUnit->getTeam();
+			if (eOtherTeam != eTeam && !pLoopUnit->isInvisible(eTeam, false))
+			{
+				for (int iRange = 2; iRange <= pLoopUnit->visibilityRange(); iRange++)
+				{
+					const vector<CvPlot*>& vPlots = GC.getMap().GetPlotsAtRangeX(pPlot, iRange, true, true);
+
+					for (size_t iJ = 0; iJ < vPlots.size(); iJ++)
+					{
+						if ((vPlots[iJ]) == NULL)
+							continue;
+
+						m_plotsVisibleToOtherPlayer[eOtherTeam].insert(vPlots[iJ]->GetPlotIndex());
+					}
+				}
+			}
+		}
+	}
+}
+
+/// Do we know that the other civ can see this tile?
+bool CvTacticalAI::IsVisibleToPlayer(const CvPlot* pPlot, TeamTypes eOther)
+{
+	return m_plotsVisibleToOtherPlayer.count(eOther) > 0 && m_plotsVisibleToOtherPlayer[eOther].count(pPlot->GetPlotIndex()) > 0;
+}
+
+/// Do we know that an enemy civ can see this tile?
+bool CvTacticalAI::IsVisibleToEnemy(const CvPlot* pPlot)
+{
+	const std::vector<PlayerTypes>& vEnemies = m_pPlayer->GetPlayersAtWarWith();
+
+	for (std::vector<PlayerTypes>::const_iterator it = vEnemies.begin(); it != vEnemies.end(); ++it)
+	{
+		CvPlayer& kEnemy = GET_PLAYER(*it);
+		if (kEnemy.isAlive() && kEnemy.IsAtWarWith(m_pPlayer->GetID()))
+		{
+			if (IsVisibleToPlayer(pPlot, kEnemy.getTeam()))
+			{
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
 // PRIVATE METHODS
+
+void CvTacticalAI::UpdateVisibilityFromBorders(CvPlot* pPlot, bool bRevealed)
+{
+	TeamTypes eTeam = m_pPlayer->getTeam();
+	TeamTypes eOtherTeam = pPlot->getTeam();
+	CvPlot** aPlotsToCheck = GC.getMap().getNeighborsUnchecked(pPlot);
+	CvPlot* pAdjacentPlot;
+
+	if (eOtherTeam != NO_TEAM && eOtherTeam != eTeam)
+	{
+		// Plot is owned by another player
+		m_plotsVisibleToOtherPlayer[eOtherTeam].insert(pPlot->GetPlotIndex());
+
+		if (bRevealed)
+		{
+			for (int iI = 0; iI < NUM_DIRECTION_TYPES; iI++)
+			{
+				pAdjacentPlot = aPlotsToCheck[iI];
+
+				if (pAdjacentPlot != NULL && pAdjacentPlot->isVisible(eTeam))
+					// We knew about this plot before but we may not previously have known that this player was neighboring it
+					m_plotsVisibleToOtherPlayer[eOtherTeam].insert(pAdjacentPlot->GetPlotIndex());
+			}
+		}
+	}
+
+	for (int iI = 0; iI < NUM_DIRECTION_TYPES; iI++)
+	{
+		pAdjacentPlot = aPlotsToCheck[iI];
+
+		if (pAdjacentPlot != NULL && pAdjacentPlot->isVisible(eTeam)) {
+			eOtherTeam = pAdjacentPlot->getTeam();
+
+			if (eOtherTeam != eTeam && pAdjacentPlot->getTeam() != NO_TEAM)
+				// Neighbors a plot owned by another player
+				m_plotsVisibleToOtherPlayer[eOtherTeam].insert(pAdjacentPlot->GetPlotIndex());
+		}
+	}
+}
 
 /// Make lists of everything we might want to target with the tactical AI this turn
 void CvTacticalAI::FindTacticalTargets()
 {
 	CvPlayerTrade* pPlayerTrade = m_pPlayer->GetTrade();
-
-	// Clear out target list since we rebuild it each turn
-	m_AllTargets.clear();
-	m_ZoneTargets.clear();
 
 	bool bNoBarbsAllowedYet = GC.getGame().getGameTurn() < GC.getGame().GetBarbarianReleaseTurn();
 	vector<PlayerTypes> vUnfriendlyMajors = m_pPlayer->GetUnfriendlyMajors();
@@ -1205,7 +1342,7 @@ void CvTacticalAI::PlotMovesToSafety(bool bCombatUnits)
 		{
 			// try to flee or hide
 			int iDangerLevel = pUnit->GetDanger();
-			if(iDangerLevel > 0 || pUnit->plot()->isVisibleToEnemy(pUnit->getOwner()))
+			if(iDangerLevel > 0 || IsVisibleToEnemy(pUnit->plot()))
 			{
 				bool bAddUnit = false;
 				if(bCombatUnits)
@@ -6396,8 +6533,7 @@ CvPlot* TacticalAIHelpers::FindSafestPlotInReach(const CvUnit* pUnit, bool bAllo
 			iScore += 12;
 
 		//try to hide - if there are few enemy units, this might be a tiebreaker
-		//this is cheating a bit, really we need to check if the plot is visible for the enemy units visible to us
-		if (!pPlot->isVisibleToEnemy(pUnit->getOwner()))
+		if (!GET_PLAYER(pUnit->getOwner()).GetTacticalAI()->IsVisibleToEnemy(pPlot))
 			iScore -= iScore / 4;
 
 		//try to go avoid borders
@@ -7668,7 +7804,7 @@ int ScoreTurnEnd(const CvUnit* pUnit, eUnitAssignmentType eLastAssignment, const
 	if (testPlot.hasAirCover())
 		iResult+=3;
 	//when in doubt, hide from the enemy
-	if (!testPlot.isVisibleToEnemy())
+	if (!GET_PLAYER(pUnit->getOwner()).GetTacticalAI()->IsVisibleToEnemy(testPlot.getPlot()))
 		iResult++;
 
 	//try to occupy enemy citadels!
@@ -8194,7 +8330,7 @@ CvTacticalPlot::CvTacticalPlot(const CvPlot* plot, PlayerTypes ePlayer, const ve
 	//constant
 	bfBlockedByNonSimCombatUnit = 0;
 	bHasAirCover = pPlot->HasAirCover(ePlayer);
-	bIsVisibleToEnemy = pPlot->isVisibleToEnemy(ePlayer);
+	bIsVisibleToEnemy = kPlayer.GetTacticalAI()->IsVisibleToEnemy(pPlot);
 
 	//updated if necessary
 	bEdgeOfTheKnownWorldUnknown = true;

--- a/CvGameCoreDLL_Expansion2/CvTacticalAI.h
+++ b/CvGameCoreDLL_Expansion2/CvTacticalAI.h
@@ -333,12 +333,19 @@ public:
 
 	// Public turn update routines
 	void Update();
+	void CleanUp();
 
 	// temporary focus of attention
 	void AddFocusArea(CvPlot* pPlot, int iRadius, int iDuration);
 	void DeleteFocusArea(CvPlot* pPlot);
 	void DropOldFocusAreas();
 	bool IsInFocusArea(const CvPlot* pPlot) const;
+
+	// Knowledge of other civs' vision
+	void ResetVisibility();
+	void NewVisiblePlot(CvPlot* pPlot, bool bRevealed);
+	bool IsVisibleToPlayer(const CvPlot* pPlot, TeamTypes eOther);
+	bool IsVisibleToEnemy(const CvPlot* pPlot);
 
 	// For air units
 	bool ShouldRebase(CvUnit* pUnit) const;
@@ -466,6 +473,7 @@ private:
 	bool FindEmbarkedUnitsAroundTarget(CvPlot *pTargetPlot, int iMaxDistance);
 	bool FindCitiesWithinStrikingDistance(CvPlot* pTargetPlot);
 	CvPlot* FindAirTargetNearTarget(CvUnit* pUnit, CvPlot* pTargetPlot);
+	void UpdateVisibilityFromBorders(CvPlot* pPlot, bool bRevealed);
 
 	int GetRecruitRange() const;
 
@@ -511,6 +519,9 @@ private:
 	int m_eCurrentTargetType;
 	int m_iCurrentTargetIndex;
 	int m_iCurrentUnitTargetIndex;
+
+	// Visibility info
+	std::map<TeamTypes, std::set<int>> m_plotsVisibleToOtherPlayer;
 
 	std::vector<CvFocusArea> m_focusAreas;
 };


### PR DESCRIPTION
Add mechanism for AI to keep track of what plots other AI players can see. Now instead of cheating by checking what another player can see directly, it will now base its knowledge on known enemy territory and unit placements. Currently does not handle the case where an enemy unit moves during your turn (retreating). Shouldn't have a big impact overall.

Fix AI never building improvements near their own capital if they are at war with a civ with a spy there (part of new visibility mechanism).

Possibly fixes AI mistakenly cancelling sneak operations based on bad information.

Fix AI never building lower level roads even when it's supposed to.

Fix vassals removing their master's roads.

Masters will now build routes through vassals' lands when needed.

Fix AI being less prone to remove roads when losing gold, rather than the other way round.

Minor cleanup regarding road building and removing. Should fix potential Iroquois and Songhai issues.

Fix incorrect planned road maintenance cost calculation.

AI will no longer build villages on roads that are about to be removed.

Fix AI sometimes not clearing their route caches if they only have one city.

AI can build routes through minor civs even if they don't have a quest for it.

AI will now not avoid building routes through their vassals' lands.

Routes between non-capital cities also benefit villages and towns, update pathfinding to take this into account.

Include Towns in route pathfinding logic.

Up route removal priority a little bit.

Clean up some route logic, always build profitable roads, even if we are losing gold.

Don't build railroads for city state quests.