### PR TITLE
Bug fixes + small visibility rework

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvAIOperation.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAIOperation.cpp
@@ -1615,7 +1615,7 @@ bool CvAIOperationMilitary::CheckTransitionToNextStage()
 					int nVisible = 0;
 					for (CvUnit* pUnit = pThisArmy->GetFirstUnit(); pUnit; pUnit = pThisArmy->GetNextUnit(pUnit))
 					{
-						if (GET_PLAYER(m_eOwner).GetTacticalAI()->IsVisibleToPlayer(pUnit->plot(), GET_PLAYER(m_eEnemy).getTeam()))
+						if (pUnit->plot()->IsKnownVisibleToTeam(GET_PLAYER(m_eEnemy).getTeam()))
 							nVisible++;
 					}
 

--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
@@ -259,6 +259,9 @@ int GetPlotYield(CvPlot* pPlot, YieldTypes eYield)
 
 void CvBuilderTaskingAI::ConnectCitiesToCapital(CvCity* pPlayerCapital, CvCity* pTargetCity, BuildTypes eBuild, RouteTypes eRoute)
 {
+	if (pPlayerCapital->getOwner() != m_pPlayer->GetID())
+		return;
+
 	if(pTargetCity->IsRazing())
 	{
 		return;
@@ -1513,10 +1516,6 @@ void CvBuilderTaskingAI::AddRemoveRouteDirectives(vector<OptionWithScore<Builder
 	if (m_pPlayer->isMinorCiv())
 		return;
 
-	//humans don't get a route cache, so ignore them.
-	if (m_pPlayer->isHuman())
-		return;
-
 	//can we even remove routes?
 	CvUnitEntry& kUnitInfo = pUnit->getUnitInfo();
 	if (m_eRemoveRouteBuild==NO_BUILD || !kUnitInfo.GetBuilds(m_eRemoveRouteBuild))
@@ -2053,7 +2052,7 @@ bool CvBuilderTaskingAI::ShouldBuilderConsiderPlot(CvUnit* pUnit, CvPlot* pPlot)
 	}
 
 	//danger check is not enough - we don't want to be adjacent to enemy territory for example
-	if (m_pPlayer->GetTacticalAI()->IsVisibleToEnemy(pPlot))
+	if (pPlot->IsKnownVisibleToEnemy(m_pPlayer->GetID()))
 		return false;
 
 	if (!pUnit->canEndTurnAtPlot(pPlot))

--- a/CvGameCoreDLL_Expansion2/CvDangerPlots.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDangerPlots.cpp
@@ -812,7 +812,7 @@ int CvDangerPlotContents::GetDanger(const CvUnit* pUnit, const UnitIdContainer& 
 			{
 				int iDummy = 0;
 				int iDamage = TacticalAIHelpers::GetSimulatedDamageFromAttackOnUnit(pUnit, pAttacker, m_pPlot, pAttacker->plot(), iDummy, false, 0, true);
-				if (!GET_PLAYER(pUnit->getOwner()).GetTacticalAI()->IsVisibleToPlayer(m_pPlot, pAttacker->getTeam()))
+				if (!m_pPlot->IsKnownVisibleToTeam(pAttacker->getTeam()))
 					iDamage = (iDamage * 80) / 100; //there's a chance they won't spot us
 				iPlotDamage += iDamage;
 			}
@@ -895,7 +895,7 @@ int CvDangerPlotContents::GetDanger(const CvUnit* pUnit, const UnitIdContainer& 
 			//if the attacker is not out of range, assume they need to move for the attack, so we don't know their plot
 			int iDamage = TacticalAIHelpers::GetSimulatedDamageFromAttackOnUnit(pUnit, pAttacker, m_pPlot, bOutOfRange ? pAttacker->plot() : NULL, iAttackerDamage, false, iExtraDamage, true);
 
-			if (!GET_PLAYER(pUnit->getOwner()).GetTacticalAI()->IsVisibleToPlayer(m_pPlot, pAttacker->getTeam()))
+			if (!m_pPlot->IsKnownVisibleToTeam(pAttacker->getTeam()))
 				iDamage = (iDamage * 80) / 100; //there's a chance they won't spot us
 
 			if (iAttackerDamage >= pAttacker->GetCurrHitPoints() && !pAttacker->isSuicide())

--- a/CvGameCoreDLL_Expansion2/CvMap.cpp
+++ b/CvGameCoreDLL_Expansion2/CvMap.cpp
@@ -320,6 +320,7 @@ CvMap::CvMap()
 	, m_pMapPlots(NULL)
 	, m_pPlotNeighbors(NULL)
 	, m_vVisibilityScratchpad()
+	, m_vKnownVisibilityScratchpad()
 	, m_pYields(NULL)
 	, m_pPlayerCityRadiusCount(NULL)
 	, m_pVisibilityCount(NULL)
@@ -456,6 +457,7 @@ void CvMap::InitPlots()
 	PrecalcNeighbors();
 
 	m_vVisibilityScratchpad = vector<int>(iNumPlots, 0);
+	m_vKnownVisibilityScratchpad = vector<int>(iNumPlots, 0);
 
 	OutputDebugString("realloc map\n");
 	m_vPlotsAtRange2.clear();

--- a/CvGameCoreDLL_Expansion2/CvMap.h
+++ b/CvGameCoreDLL_Expansion2/CvMap.h
@@ -281,6 +281,7 @@ public:
 	void PrecalcNeighbors();
 
 	vector<int>& GetVisibilityScratchpad() { return m_vVisibilityScratchpad; }
+	vector<int>& GetKnownVisibilityScratchpad() { return m_vKnownVisibilityScratchpad; }
 #endif
 
 	CvPlotManager& plotManager() { return m_kPlotManager; }
@@ -375,6 +376,7 @@ protected:
 	CvPlot** m_pPlotNeighbors;			//precomputed neighbors for each plot
 	CvPlot* m_apShuffledNeighbors[6];	//scratchpad for shuffled access to neighbors
 	vector<int> m_vVisibilityScratchpad;
+	vector<int> m_vKnownVisibilityScratchpad;
 #endif
 
 	uint8* m_pYields;

--- a/CvGameCoreDLL_Expansion2/CvPlot.h
+++ b/CvGameCoreDLL_Expansion2/CvPlot.h
@@ -664,8 +664,11 @@ public:
 	int getNumAdjacentNonrevealed(TeamTypes eTeam) const;
 	bool IsResourceForceReveal(TeamTypes eTeam) const;
 	void SetResourceForceReveal(TeamTypes eTeam, bool bValue);
+	void ChangeKnownAdjacentSight(TeamTypes eTeam, TeamTypes eMinorCivAlly, int iRange, DirectionTypes eFacingDirection);
 	int GetKnownVisibilityCount(TeamTypes eTeam) const;
-	void IncreaseKnownVisibilityCount(TeamTypes eTeam, int iAmount);
+	bool IsKnownVisibleToEnemy(PlayerTypes ePlayer) const;
+	bool IsKnownVisibleToTeam(TeamTypes eTeam) const;
+	void IncreaseKnownVisibilityCount(TeamTypes eTeam, TeamTypes eTeam2=NO_TEAM);
 	void ResetKnownVisibility();
 #if defined(MOD_BALANCE_CORE)
 	bool IsTeamImpassable(TeamTypes eTeam) const;

--- a/CvGameCoreDLL_Expansion2/CvTacticalAI.h
+++ b/CvGameCoreDLL_Expansion2/CvTacticalAI.h
@@ -344,8 +344,6 @@ public:
 	// Knowledge of other civs' vision
 	void UpdateVisibility();
 	void NewVisiblePlot(CvPlot* pPlot, bool bRevealed);
-	bool IsVisibleToPlayer(const CvPlot* pPlot, TeamTypes eOther);
-	bool IsVisibleToEnemy(const CvPlot* pPlot);
 
 	// For air units
 	bool ShouldRebase(CvUnit* pUnit) const;


### PR DESCRIPTION
Fix bug related to city state road building quest

AI will now only build city state quest routes from capital.

Fix Human automated workers never removing obsolete routes.

Update known visibility computation to align with actual visibility calculations. Uses same functionality as is used to calculate line of sight normally. This fixes visibility not being considered for some unit plots. Once again uses a bit more memory but not much.

Move some functions from CvTacticalAI into CvPlot.