### PR TITLE
Create INDEX on Diplomacy_Responses table

### DIFF
--- a/(1) Community Patch/Community Patch.civ5proj
+++ b/(1) Community Patch/Community Patch.civ5proj
@@ -796,6 +796,10 @@
       <SubType>Lua</SubType>
       <ImportIntoVFS>False</ImportIntoVFS>
     </Content>
+    <Content Include="Core Files\Core Changes\DatabaseIndexes.sql">
+      <SubType>Lua</SubType>
+      <ImportIntoVFS>False</ImportIntoVFS>
+    </Content>
     <Content Include="Core Files\Core Changes\GreatArt\artifact.dds">
       <SubType>Lua</SubType>
       <ImportIntoVFS>True</ImportIntoVFS>

--- a/(1) Community Patch/Core Files/Core Changes/DatabaseIndexes.sql
+++ b/(1) Community Patch/Core Files/Core Changes/DatabaseIndexes.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_Diplomacy_Responses_ON_LeaderType_AND_ResponseType
+ON Diplomacy_Responses(LeaderType, ResponseType);


### PR DESCRIPTION
A little sip of performance on table queries to Diplomacy_Responses table.
On my machine queries from 0.14 microseconds to 0.04 microsecond per query.
Does not impact db size in any meaningful way.

Refers to:
1. https://github.com/LoneGazebo/Community-Patch-DLL/blob/1ed552043a72c9f7fc8335d933c06f554f629da3/CvGameCoreDLL_Expansion2/CvGame.cpp#L5743C8-L5743C8
2. https://github.com/LoneGazebo/Community-Patch-DLL/blob/1ed552043a72c9f7fc8335d933c06f554f629da3/CvGameCoreDLL_Expansion2/CvGame.cpp#L5768C4-L5768C4

Tested performance difference with code:
```js
const { Database } = require('sqlite3')
const { resolve } = require('node:path')

const HOME = require('os').homedir()
const dbPath = resolve(HOME, './Documents/My Games/Sid Meier\'s Civilization 5/cache/Civ5CoreDatabase.db')
const db = new Database(dbPath)

const queryTime = (query) => {
  return new Promise((resolve, reject) => {
    const start = performance.now()
    db.exec(query, (err) => {
      const end = performance.now()
      if (err) {
        reject(err)
      } else {
        resolve(end - start)
      }
    })
  })
}

const leaderTypes = require('./leaderTypes.json')
const responseTypes = require('./responseTypes.json')

const randomLeaderType = () => leaderTypes[Math.floor(Math.random() * leaderTypes.length)]
const randomResponseType = () => responseTypes[Math.floor(Math.random() * responseTypes.length)]


const avg = data => {
  if (data.length < 1) {
    return;
  }
  return data.reduce((prev, current) => prev + current) / data.length;
}

const times = []
async function execute () {
  for (let i = 0; i < 10_000; i++) {
    times.push(await queryTime(`
    SELECT * FROM Diplomacy_Responses 
    WHERE LeaderType = '${randomLeaderType()}' 
      AND ResponseType = '${randomResponseType()}'
  `))
  }
}

execute().then(() => {
  console.log(times.length)
  console.log('avg', avg(times))
})
```