### PR TITLE
Fix trade deal bug

### DIFF
--- a/(2) Vox Populi/Core Files/Overrides/EspionageOverview.lua
+++ b/(2) Vox Populi/Core Files/Overrides/EspionageOverview.lua
@@ -1475,14 +1475,9 @@ function OnNo( )
 end
 Controls.No:RegisterCallback( Mouse.eLClick, OnNo );
 
-function PendingDealButtonHandler( index, iIsCurrent )
-    local iPlayer = Game.GetActivePlayer();
+function PendingDealButtonHandler( iPlayer, index )
 
-    if( iIsCurrent == 1 ) then
-        UI.LoadCurrentDeal( iPlayer, index );
-    else
-        UI.LoadHistoricDeal( iPlayer, index );
-    end
+    UI.LoadCurrentDeal( iPlayer, index );
     
     local iBeginTurn = m_Deal:GetStartTurn();
     local iDuration  = m_Deal:GetDuration();
@@ -1495,7 +1490,7 @@ function PendingDealButtonHandler( index, iIsCurrent )
         Controls.TurnEnd:SetHide( true );
     end
     
-    OpenDealReview();
+    OpenDealReview(iPlayer);
 end
 
 function BuildDealButton( iPlayer, controlTable )    
@@ -1563,7 +1558,7 @@ function PopulateDealChooserDiplomat(iPlayer)
             controlTable = {};
             ContextPtr:BuildInstanceForControl( "DealButtonInstance", controlTable, Controls.CurrentDealsStack );
             
-            controlTable.DealButton:SetVoids( i, 1 );
+            controlTable.DealButton:SetVoids( iPlayer, i);
             controlTable.DealButton:RegisterCallback( Mouse.eLClick, PendingDealButtonHandler );
             
             UI.LoadCurrentDeal( iPlayer, i );

--- a/(2) Vox Populi/LUA/TradeLogic.lua
+++ b/(2) Vox Populi/LUA/TradeLogic.lua
@@ -458,11 +458,11 @@ end
 ----------------------------------------------------------------
 -- used by DiploOverview to display active deals
 ----------------------------------------------------------------
-function OpenDealReview()
+function OpenDealReview(OverridePlayer)
 
     --print( "OpenDealReview" );
     
-	g_iUs = Game:GetActivePlayer();
+	g_iUs = OverridePlayer or Game:GetActivePlayer();
 	g_pUs = Players[ g_iUs ];
 	g_iUsTeam = g_pUs:GetTeam();
 	g_pUsTeam = Teams[ g_iUsTeam ];
@@ -480,7 +480,7 @@ function OpenDealReview()
     g_bTradeReview = true;
 
 	DoClearTable();
-	DisplayDeal();
+	DisplayDeal(OverridePlayer);
 end
 
 
@@ -2654,7 +2654,7 @@ end
 
 ----------------------------------------------------------------        
 ----------------------------------------------------------------        
-function DisplayDeal()
+function DisplayDeal(OverridePlayer)
     g_UsTableCitiesIM:ResetInstances();
     g_ThemTableCitiesIM:ResetInstances();
     g_UsTableVoteIM:ResetInstances();
@@ -2694,8 +2694,8 @@ function DisplayDeal()
         local bFromUs = false;
         
 		--print("Adding trade item to active deal: " .. itemType);
-        
-        if( fromPlayer == Game.GetActivePlayer() ) then
+        		
+        if( fromPlayer == (OverridePlayer or Game.GetActivePlayer()) ) then
             bFromUs = true;
             iNumItemsFromUs = iNumItemsFromUs + 1;
         else

--- a/(3a) EUI Compatibility Files/LUA/TradeLogic.lua
+++ b/(3a) EUI Compatibility Files/LUA/TradeLogic.lua
@@ -459,11 +459,11 @@ end
 ----------------------------------------------------------------
 -- used by DiploOverview to display active deals
 ----------------------------------------------------------------
-function OpenDealReview()
+function OpenDealReview(OverridePlayer)
 
 	--print( "OpenDealReview" );
 
-	g_iUs = Game:GetActivePlayer();
+	g_iUs = OverridePlayer or Game:GetActivePlayer();
 	g_pUs = Players[ g_iUs ];
 	g_iUsTeam = g_pUs:GetTeam();
 	g_pUsTeam = Teams[ g_iUsTeam ];
@@ -481,7 +481,7 @@ function OpenDealReview()
 	g_bTradeReview = true;
 
 	DoClearTable();
-	DisplayDeal();
+	DisplayDeal(OverridePlayer);
 end
 
 
@@ -2647,7 +2647,7 @@ end
 
 ----------------------------------------------------------------
 ----------------------------------------------------------------
-function DisplayDeal()
+function DisplayDeal(OverridePlayer)
 	g_UsTableCitiesIM:ResetInstances();
 	g_ThemTableCitiesIM:ResetInstances();
 	if bnw_mode then
@@ -2693,7 +2693,7 @@ function DisplayDeal()
 
 		--print("Adding trade item to active deal: " .. itemType);
 
-		if( fromPlayer == Game.GetActivePlayer() ) then
+		if( fromPlayer == (OverridePlayer or Game.GetActivePlayer()) ) then
 			bFromUs = true;
 			iNumItemsFromUs = iNumItemsFromUs + 1;
 		else

--- a/CvGameCoreDLL_Expansion2/CvDealClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDealClasses.cpp
@@ -4500,6 +4500,19 @@ void CvGameDeals::ActivateDeal(PlayerTypes eFromPlayer, PlayerTypes eToPlayer, C
 	int iLatestItemLastTurn = 0;
 	int iLongestDuration = 0;
 
+	// if this is a renewed deal, the old deal should no longer be considered for renewal. otherwise it could happen that both players in an AI-AI deal renew the same deal and then two identical deals are active
+	if (kDeal.IsCheckedForRenewal())
+	{
+		for (DealList::iterator it = m_CurrentDeals.begin(); it != m_CurrentDeals.end(); ++it)
+		{
+			if (it->m_bConsideringForRenewal && it->m_eFromPlayer == eFromPlayer && it->m_eToPlayer == eToPlayer)
+			{
+				it->m_bConsideringForRenewal = false;
+				break;
+			}
+		}
+	}
+
 	// Set the surrendering player for a human v. human war (based on who puts what where).
 	bool bIsPeaceDeal = kDeal.IsPeaceTreatyTrade(eFromPlayer) || kDeal.IsPeaceTreatyTrade(eToPlayer);
 	bool bHumanToHuman = GET_PLAYER(eFromPlayer).isHuman() && GET_PLAYER(eToPlayer).isHuman();


### PR DESCRIPTION
Fixed a bug in the new espionage system that the trade deals of other players were not shown correctly. While doing so, I discovered and fixed a much more serious bug that caused expired AI-AI trade deals to be renewed twice. 