### PR TITLE
Builder AI logic rework

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvAStar.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAStar.cpp
@@ -2207,6 +2207,7 @@ static int BuildRouteVillageBonus(CvPlayer* pPlayer, CvPlot* pPlot, RouteTypes e
 	if (eImprovement != NO_IMPROVEMENT)
 	{
 		CvImprovementEntry* pkImprovementInfo = GC.getImprovementInfo(eImprovement);
+
 		if (pkImprovementInfo != NULL)
 		{
 			for (int iI = 0; iI < NUM_YIELD_TYPES; iI++)
@@ -2217,6 +2218,10 @@ static int BuildRouteVillageBonus(CvPlayer* pPlayer, CvPlot* pPlot, RouteTypes e
 					return 30;
 			}
 		}
+
+		// If this is a great person improvement, we don't want to replace it (unless it's a town)
+		if (pkImprovementInfo->IsCreatedByGreatPerson())
+			return 0;
 	}
 
 	// Villages and towns can be built pretty much anywhere

--- a/CvGameCoreDLL_Expansion2/CvAStar.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAStar.cpp
@@ -2198,6 +2198,10 @@ static int BuildRouteVillageBonus(CvPlayer* pPlayer, CvPlot* pPlot, RouteTypes e
 	if (pPlot->getResourceType() != NO_RESOURCE)
 		return 0;
 
+	// No villages on mountains
+	if (pPlot->getTerrainType() == TERRAIN_MOUNTAIN)
+		return 0;
+
 	// No villages for China near cities, no villages for Brazil on jungle/forest, no villages for Netherlands on marshes.
 	if (!eBuilderTaskingAi->MayWantVillageOnPlot(pPlot))
 		return 0;

--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
@@ -498,6 +498,8 @@ void CvBuilderTaskingAI::ConnectPointsForStrategy(CvCity* pOriginCity, CvPlot* p
 	if (iNetGoldTimes100 - iCost <= 6)
 		return;
 
+	int iValue = GD_INT_GET(BUILDER_TASKING_BASELINE_BUILD_ROUTES) * 4;
+
 	for (int i = 0; i < path.length(); i++)
 	{
 		CvPlot* pPlot = path.get(i);
@@ -511,7 +513,7 @@ void CvBuilderTaskingAI::ConnectPointsForStrategy(CvCity* pOriginCity, CvPlot* p
 			break;
 
 		// remember the plot
-		if (AddRoutePlot(pPlot, eRoute, 54))
+		if (AddRoutePlot(pPlot, eRoute, iValue))
 			m_strategicRoutePlots.insert(pPlot->GetPlotIndex());
 	}
 }
@@ -2837,44 +2839,6 @@ int CvBuilderTaskingAI::ScorePlotBuild(CvPlot* pPlot, ImprovementTypes eImprovem
 			}
 		}
 	}
-	//Do we have unimproved plots nearby? If so, let's not worry about replacing improvements right now.
-	/*if (pPlot->getImprovementType() != NO_IMPROVEMENT && !pImprovement->IsAdjacentCity())
-	{
-		//first off, reduce the value, because this is time consuming. It had better be worth it!
-		iYieldScore -= iMedBuff;
-
-		//If our current improvement is obsolete, let's half it's value, so that the potential replacement is stronger.
-		CvImprovementEntry* pOldImprovement = GC.getImprovementInfo(pPlot->getImprovementType());
-		if((pOldImprovement->GetObsoleteTech() != NO_TECH) && GET_TEAM(m_pPlayer->getTeam()).GetTeamTechs()->HasTech((TechTypes)pOldImprovement->GetObsoleteTech()))
-		{
-			iYieldScore -= iMedBuff;
-		}
-		int iNumWorkedPlots = 0;
-		int iNumImprovedPlots = 0;
-		// Look at the city we'll be improving to see how essential another improvement is.
-		if(pCity)
-		{
-			for (int iI = 0; iI < GC.getNumImprovementInfos(); iI++)
-			{
-				ImprovementTypes eWorkingImprovement = (ImprovementTypes) iI;
-				if(eWorkingImprovement != NO_IMPROVEMENT)
-				{
-					iNumImprovedPlots += pCity->GetNumImprovementWorked(eWorkingImprovement);
-				}
-			}
-			iNumWorkedPlots = pCity->getPopulation();
-			//if population is higher than # of plots, reduce value. Otherwise, increase it.
-			//one will remove penalty above - more than that and it becomes useful.
-			if (iNumWorkedPlots > iNumImprovedPlots)
-			{
-				iSecondaryScore -= ((iNumWorkedPlots - iNumImprovedPlots) * iSmallBuff);
-			}
-			else
-			{
-				iSecondaryScore += iSmallBuff * (iNumImprovedPlots - iNumWorkedPlots);
-			}
-		}
-	}*/
 
 	//Fort test.
 	static ImprovementTypes eFort = (ImprovementTypes)GC.getInfoTypeForString("IMPROVEMENT_FORT");

--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
@@ -476,6 +476,10 @@ void CvBuilderTaskingAI::ConnectPointsForStrategy(CvCity* pOriginCity, CvPlot* p
 	if (pOriginCity->getOwner() != pTargetPlot->getOwner())
 		return;
 
+	// don't connect razing cities
+	if (pOriginCity->IsRazing())
+		return;
+
 	CvRouteInfo* pRouteInfo = GC.getRouteInfo(eRoute);
 	if (!pRouteInfo)
 		return;

--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
@@ -558,7 +558,8 @@ void CvBuilderTaskingAI::ConnectPointsForStrategy(CvCity* pOriginCity, CvPlot* p
 		if (!pAdjacentPlot->isValidMovePlot(m_pPlayer->GetID()))
 			continue;
 
-		if (AddRoutePlot(pAdjacentPlot, eRoute, iValue))
+		// Add these routes after the main route is completed
+		if (AddRoutePlot(pAdjacentPlot, eRoute, iValue - 1))
 			m_strategicRoutePlots.insert(pAdjacentPlot->GetPlotIndex());
 	}
 }

--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
@@ -520,10 +520,14 @@ void CvBuilderTaskingAI::ConnectPointsForStrategy(CvCity* pOriginCity, CvPlot* p
 	//and this to see if we actually build it
 	int iCost = pRouteInfo->GetGoldMaintenance() * (100 + m_pPlayer->GetImprovementGoldMaintenanceMod());
 	iCost *= iRoadMaintenanceLength + 5; // add extra to account for ring tiles around fort
-	if (iNetGoldTimes100 - iCost <= 6)
+
+	int iGoldDelta = iNetGoldTimes100 - iCost;
+
+	if (iGoldDelta < 0)
 		return;
 
-	int iValue = GD_INT_GET(BUILDER_TASKING_BASELINE_BUILD_ROUTES) * 4;
+	// Need a decent gold buffer to build strategic routes, but don't remove them unless we are actually losing gold
+	int iValue = iGoldDelta >= 30 ? GD_INT_GET(BUILDER_TASKING_BASELINE_BUILD_ROUTES) * 4 : 0;
 
 	for (int i = 1; i < path.length(); i++)
 	{

--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
@@ -346,7 +346,7 @@ void CvBuilderTaskingAI::ConnectCitiesToCapital(CvCity* pPlayerCapital, CvCity* 
 			iValue += 8000 / (iNumRoadsNeededToBuild * iNumRoadsNeededToBuild);
 
 		//assume one unhappiness is worth gold per turn per city
-		iValue += bHasCityConnection ? pTargetCity->GetUnhappinessFromIsolation() * (m_pPlayer->IsEmpireUnhappy() ? 200 : 100) : 0;
+		iValue += bHasCityConnection ? pTargetCity->GetUnhappinessFromIsolation() * (m_pPlayer->IsEmpireUnhappy() ? 1000 : 100) : 0;
 
 		if(GC.getGame().GetIndustrialRoute() == eRoute)
 		{

--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
@@ -637,7 +637,7 @@ bool CvBuilderTaskingAI::MayWantVillageOnPlot(CvPlot* pPlot) const
 	if (m_bKeepMarshes && eFeature == FEATURE_MARSH)
 		return false;
 
-	if (m_bMayPutGPTINextToCity && pPlot->IsAdjacentCity())
+	if (!m_bMayPutGPTINextToCity && pPlot->IsAdjacentCity())
 		return false;
 
 	return true;

--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
@@ -1592,12 +1592,6 @@ void CvBuilderTaskingAI::AddImprovingPlotsDirective(vector<OptionWithScore<Build
 		int iBuildTimeWeight = GetBuildTimeWeight(pPlot, eBuild, DoesBuildHelpRush(pPlot, eBuild));
 		iWeight += iBuildTimeWeight;
 
-		if (bWillRemoveForest || bWillRemoveJungle)
-		{
-			if (m_pPlayer->GetPlayerTraits()->IsWoodlandMovementBonus())
-				iWeight /= 100;
-		}
-
 		if (eFeature != NO_FEATURE && pkBuild->isFeatureRemove(eFeature))
 		{
 			CvCity* pCity = pPlot->getEffectiveOwningCity();
@@ -1631,6 +1625,12 @@ void CvBuilderTaskingAI::AddImprovingPlotsDirective(vector<OptionWithScore<Build
 
 		//overflow danger here
 		iWeight += iScore;
+
+		if (bWillRemoveForest || bWillRemoveJungle)
+		{
+			if (m_pPlayer->GetPlayerTraits()->IsWoodlandMovementBonus())
+				iWeight /= 100;
+		}
 
 		BuilderDirective directive(eDirectiveType, eBuild, NO_RESOURCE, pPlot->getX(), pPlot->getY(), iWeight);
 

--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
@@ -1564,9 +1564,6 @@ void CvBuilderTaskingAI::AddImprovingPlotsDirective(vector<OptionWithScore<Build
 		}
 
 		int iScore = ScorePlotBuild(pPlot, eImprovement, eBuild);
-		if (pCity && pCity->GetCityCitizens()->IsWorkingPlot(pPlot))
-			iScore *= 2;
-
 		iScore = min(iScore,0x7FFF);
 
 		// if we're going backward, bail out!

--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -29722,7 +29722,7 @@ int CvCity::GetIndividualPlotScore(const CvPlot* pPlot) const
 
 	iRtnValue += iYieldValue;
 
-	if (GET_PLAYER(getOwner()).GetBuilderTaskingAI()->WantRouteAtPlot(pPlot))
+	if (GET_PLAYER(getOwner()).GetBuilderTaskingAI()->NeedRouteAtPlot(pPlot))
 	{
 		iRtnValue += /*80*/ GD_INT_GET(AI_PLOT_VALUE_STRATEGIC_RESOURCE);
 	}

--- a/CvGameCoreDLL_Expansion2/CvCityConnections.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCityConnections.cpp
@@ -163,7 +163,7 @@ void CvCityConnections::UpdatePlotsToConnect(void)
 
 			//ignore plots which are not exposed
 			bool bCloseOtherCiv = false;
-			for (int i = RING0_PLOTS; i < RING3_PLOTS; i++)
+			for (int i = RING0_PLOTS; i < RING2_PLOTS; i++)
 			{
 				CvPlot* pAdjacentPlot = iterateRingPlots(pLoopPlot, i);
 				if (pAdjacentPlot == NULL)

--- a/CvGameCoreDLL_Expansion2/CvCityConnections.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCityConnections.cpp
@@ -126,9 +126,6 @@ void CvCityConnections::UpdatePlotsToConnect(void)
 {
 	m_plotIdsToConnect.clear();
 
-	bool bIsIndustrial = GET_TEAM(m_pPlayer->getTeam()).GetBestPossibleRoute() == GC.getGame().GetIndustrialRoute();
-	bool bHaveGoldToSpare = m_pPlayer->GetTreasury()->CalculateBaseNetGoldTimes100() > 1000;
-
 	vector<PlayerTypes> vTeamPlayers = GET_TEAM(m_pPlayer->getTeam()).getPlayers();
 	for (size_t i = 0; i < vTeamPlayers.size(); i++)
 	{
@@ -166,22 +163,13 @@ void CvCityConnections::UpdatePlotsToConnect(void)
 			if (vUnfriendlyMajors.empty() || !pLoopPlot->IsBorderLand(m_pPlayer->GetID(), vUnfriendlyMajors))
 				continue;
 
-			//natural defenses
-			if (pLoopPlot->defenseModifier(m_pPlayer->getTeam(), false, false) >= 25 || pLoopPlot->IsChokePoint())
-			{
-				m_plotIdsToConnect.push_back(pLoopPlot->GetPlotIndex());
-			}
-			else if (pLoopPlot->getImprovementType() != NO_IMPROVEMENT)
+			if (pLoopPlot->getImprovementType() != NO_IMPROVEMENT)
 			{
 				//citadels and forts
 				CvImprovementEntry* pImprovementInfo = GC.getImprovementInfo(pLoopPlot->getImprovementType());
 				if (pImprovementInfo && pImprovementInfo->GetDefenseModifier() >= 20)
 					m_plotIdsToConnect.push_back(pLoopPlot->GetPlotIndex());
 			}
-
-			//in industrial era, AI becomes much more generous with routes ...
-			if (bIsIndustrial && bHaveGoldToSpare && pLoopPlot->IsAdjacentOwnedByTeamOtherThan(m_pPlayer->getTeam(), false, true))
-				m_plotIdsToConnect.push_back(pLoopPlot->GetPlotIndex());
 		}
 	}
 

--- a/CvGameCoreDLL_Expansion2/CvGame.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGame.cpp
@@ -9668,15 +9668,16 @@ void CvGame::updateMoves()
 
 		if(player.isAlive())
 		{
-			bool needsAIUpdate = player.hasUnitsThatNeedAIUpdate();
-			if(player.isTurnActive() || needsAIUpdate)
+			bool bAutomatedUnitNeedsUpdate = player.hasUnitsThatNeedAIUpdate();
+			bool bHomelandAINeedsUpdate = player.GetHomelandAI()->NeedsUpdate();
+			if(player.isTurnActive() || bAutomatedUnitNeedsUpdate || bHomelandAINeedsUpdate)
 			{
-				if(!(player.isAutoMoves()) || needsAIUpdate)
+				if(!(player.isAutoMoves()) || bAutomatedUnitNeedsUpdate || bHomelandAINeedsUpdate)
 				{
-					if(needsAIUpdate || !player.isHuman())
+					if(bAutomatedUnitNeedsUpdate || bHomelandAINeedsUpdate || !player.isHuman())
 					{
-						// ------- this is where the important stuff happens! --------------
-						player.AI_unitUpdate();
+					// ------- this is where the important stuff happens! --------------
+						player.AI_unitUpdate(bHomelandAINeedsUpdate);
 						NET_MESSAGE_DEBUG_OSTR_ALWAYS("UpdateMoves() : player.AI_unitUpdate() called for player " << player.GetID() << " " << player.getName()); 
 					}
 

--- a/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
@@ -48,6 +48,7 @@ void CvHomelandAI::Init(CvPlayer* pPlayer)
 {
 	// Store off the pointer to the objects we need elsewhere in the game engine
 	m_pPlayer = pPlayer;
+	m_bNeedsUpdate = true;
 
 	Reset();
 }
@@ -166,19 +167,15 @@ void CvHomelandAI::FindAutomatedUnits()
 	// Loop through our units
 	for(CvUnit* pLoopUnit = m_pPlayer->firstUnit(&iLoop); pLoopUnit != NULL; pLoopUnit = m_pPlayer->nextUnit(&iLoop))
 	{
-		if(!pLoopUnit->IsAutomated() || pLoopUnit->AI_getUnitAIType() == UNITAI_UNKNOWN)
+		if(!pLoopUnit->IsAutomated() || pLoopUnit->AI_getUnitAIType() == UNITAI_UNKNOWN || pLoopUnit->TurnProcessed())
 			continue;
 
-		if (pLoopUnit->GetMissionAIPlot())
-			m_automatedTargetPlots[pLoopUnit->AI_getUnitAIType()].push_back( std::make_pair(pLoopUnit->GetID(),pLoopUnit->GetMissionAIPlot()->GetPlotIndex()) );
-	
-		if (!pLoopUnit->TurnProcessed() && pLoopUnit->canMove())
-			m_CurrentTurnUnits.push_back(pLoopUnit->GetID());
+		m_CurrentTurnUnits.push_back(pLoopUnit->GetID());
 	}
 }
 
 /// Update the AI for units
-void CvHomelandAI::Update()
+void CvHomelandAI::Update(bool bUpdateImprovements)
 {
 
 	//no homeland for barbarians
@@ -198,18 +195,36 @@ void CvHomelandAI::Update()
 	else
 		RecruitUnits();
 
+	// If we've already done planning during this turn, don't do it again (e.g. if we just turned on automation for a worker).
+	if (bUpdateImprovements)
+		PlanImprovements();
+
 	// Make sure we have a unit to handle
 	if(!m_CurrentTurnUnits.empty())
 	{
 		// Put together lists of places we may want to move toward
 		FindHomelandTargets();
 
-		//so that workers know where to build roads
-		m_pPlayer->GetBuilderTaskingAI()->Update();
-
 		// Loop through each move assigning units when available
 		AssignHomelandMoves();
 	}
+	else
+	{
+		// Make sure non-automated human workers still know what to do
+		ExecuteWorkerMoves();
+	}
+
+	m_bNeedsUpdate = false;
+}
+
+void CvHomelandAI::Invalidate()
+{
+	m_bNeedsUpdate = true;
+}
+
+bool CvHomelandAI::NeedsUpdate()
+{
+	return m_bNeedsUpdate;
 }
 
 CvPlot* CvHomelandAI::GetBestExploreTarget(const CvUnit* pUnit, int nMinCandidates, int iMaxTurns) const
@@ -508,8 +523,6 @@ void CvHomelandAI::AssignHomelandMoves()
 	PlotPatrolMoves();
 
 	//civilians again
-	PlotWorkerMoves();
-	PlotWorkerSeaMoves();
 	PlotWriterMoves();
 	PlotArtistMoves();
 	PlotMusicianMoves();
@@ -519,6 +532,8 @@ void CvHomelandAI::AssignHomelandMoves()
 	PlotGeneralMoves();
 	PlotAdmiralMoves();
 	PlotProphetMoves();
+	PlotWorkerMoves();
+	PlotWorkerSeaMoves();
 	PlotMissionaryMoves();
 	PlotInquisitorMoves();
 
@@ -932,6 +947,14 @@ void CvHomelandAI::PlotOpportunisticSettlementMoves()
 	PossibleSettlerUnits.clear();
 }
 
+//so that workers know where to build improvements
+void CvHomelandAI::PlanImprovements()
+{
+	m_pPlayer->GetBuilderTaskingAI()->Update();
+	m_workedPlots.clear();
+	m_greatPeopleForImprovements.clear();
+}
+
 /// Find something for all workers to do
 void CvHomelandAI::PlotWorkerMoves(bool bSecondary)
 {
@@ -943,7 +966,7 @@ void CvHomelandAI::PlotWorkerMoves(bool bSecondary)
 		CvUnit* pUnit = m_pPlayer->getUnit(*it);
 		if (pUnit)
 		{
-			bool bUsePrimaryUnit = (pUnit->AI_getUnitAIType() == UNITAI_WORKER || pUnit->IsAutomated() && pUnit->getDomainType() == DOMAIN_LAND && pUnit->GetAutomateType() == AUTOMATE_BUILD);
+			bool bUsePrimaryUnit = pUnit->AI_getUnitAIType() == UNITAI_WORKER || (pUnit->IsAutomated() && pUnit->getDomainType() == DOMAIN_LAND && pUnit->GetAutomateType() == AUTOMATE_BUILD);
 			bool bUseSecondaryUnit = (pUnit->AI_getUnitAIType() != UNITAI_WORKER && (pUnit->getUnitInfo().GetUnitAIType(UNITAI_WORKER) || pUnit->getUnitInfo().GetUnitAIType(UNITAI_WORKER_SEA)) && pUnit->getDomainType() == DOMAIN_LAND);
 			if (m_pPlayer->IsAtWar())
 			{
@@ -974,7 +997,8 @@ void CvHomelandAI::PlotWorkerMoves(bool bSecondary)
 		}
 	}
 
-	if(m_CurrentMoveUnits.size() > 0)
+	// Human players may have only non-automated workers which nevertheless need to be given directives
+	if(m_CurrentMoveUnits.size() > 0 || m_pPlayer->isHuman())
 	{
 		ExecuteWorkerMoves();
 	}
@@ -1141,6 +1165,7 @@ void CvHomelandAI::PlotWorkerSeaMoves(bool bSecondary)
 		}
 	}
 }
+
 void CvHomelandAI::ExecuteUnitGift()
 {
 	if (!m_pPlayer->isMajorCiv() || m_pPlayer->isHuman())
@@ -2792,35 +2817,40 @@ bool CvHomelandAI::ExecuteExplorerMoves(CvUnit* pUnit)
 /// Moves units to improve plots
 void CvHomelandAI::ExecuteWorkerMoves()
 {
-	// where can our workers go
-	std::map<int,ReachablePlots> allWorkersReachablePlots;
-	std::set<int> workersToIgnore;
+	list<int> allWorkers;
+	set<int> processedWorkers;
+	set<int> nonAutomatedWorkers;
 
-	//see what each worker can do in its immediate vicinity
-	//if there is no work there, it will move towards the city which needs a worker most
+	// Automated and AI controlled workers
 	for(CHomelandUnitArray::iterator it = m_CurrentMoveUnits.begin(); it != m_CurrentMoveUnits.end(); ++it)
 	{
 		CvUnit* pUnit = m_pPlayer->getUnit(it->GetID());
 		if (!pUnit)
 			continue;
 
-		SPathFinderUserData data(pUnit, CvUnit::MOVEFLAG_AI_ABORT_IN_DANGER, 5);
-		allWorkersReachablePlots[pUnit->GetID()] = GC.GetPathFinder().GetPlotsInReach(pUnit->plot(), data);
+		allWorkers.push_back(pUnit->GetID());
 	}
 
-	//humans also have non-automated workers. pretend they are automated as well to avoid going where they are
-	//todo: what about great people?
+	// Great people that the AI wants to build improvements with
+	for (list<int>::iterator it = m_greatPeopleForImprovements.begin(); it != m_greatPeopleForImprovements.end(); ++it)
+	{
+		allWorkers.push_back(*it);
+	}
+
+	// Humans also have non-automated workers. Pretend they are automated as well to avoid going where they are.
+	// We also throw in all great people that can build anything here so they get recommendations as well.
 	if (m_pPlayer->isHuman())
 	{
 		int iLoop = 0;
 		for (CvUnit* pLoopUnit = m_pPlayer->firstUnit(&iLoop); pLoopUnit != NULL; pLoopUnit = m_pPlayer->nextUnit(&iLoop))
 		{
-			if (pLoopUnit->AI_getUnitAIType() == UNITAI_WORKER && allWorkersReachablePlots.find(pLoopUnit->GetID()) == allWorkersReachablePlots.end())
+			bool bIsBuilder = pLoopUnit->AI_getUnitAIType() == UNITAI_WORKER   || pLoopUnit->AI_getUnitAIType() == UNITAI_GENERAL
+	                       || pLoopUnit->AI_getUnitAIType() == UNITAI_ENGINEER || pLoopUnit->AI_getUnitAIType() == UNITAI_SCIENTIST
+				           || pLoopUnit->AI_getUnitAIType() == UNITAI_MERCHANT || pLoopUnit->AI_getUnitAIType() == UNITAI_PROPHET;
+			if (!pLoopUnit->TurnProcessed() && bIsBuilder && pLoopUnit->getDomainType() == DOMAIN_LAND && find(allWorkers.begin(), allWorkers.end(), pLoopUnit->GetID()) == allWorkers.end())
 			{
-				SPathFinderUserData data(pLoopUnit, CvUnit::MOVEFLAG_AI_ABORT_IN_DANGER, 5);
-				allWorkersReachablePlots[pLoopUnit->GetID()] = GC.GetPathFinder().GetPlotsInReach(pLoopUnit->plot(), data);
-
-				workersToIgnore.insert(pLoopUnit->GetID());
+				allWorkers.push_back(pLoopUnit->GetID());
+				nonAutomatedWorkers.insert(pLoopUnit->GetID());
 			}
 		}
 	}
@@ -2836,55 +2866,193 @@ void CvHomelandAI::ExecuteWorkerMoves()
 		{
 			if(MoveCivilianToSafety(pUnit))
 			{
-				workersToIgnore.insert(pUnit->GetID());
 				UnitProcessed(pUnit->GetID());
+				processedWorkers.insert(pUnit->GetID());
 				continue;
 			}
 		}
+	}
 
-		//how far around each worker should we be checking?
-		int iTurnLimit = pUnit->IsGreatPerson() ? 12 : 5;
+	// This is a bit complex but here's the gist
+	// * Get all possible BuilderDirectives that we can do (sorted by value)
+	// * For each: if there's one or more viable workers for it, assign the
+	//   closest worker to work it.
+	// * If there are several BuilderDirectives with the same value, prioritize
+	//   ones with close workers.
+	CvBuilderTaskingAI* pBuilderTaskingAI = m_pPlayer->GetBuilderTaskingAI();
+	vector<BuilderDirective> topDirectives = pBuilderTaskingAI->GetDirectives();
+	vector<BuilderDirective> ignoredDirectives;
 
-		if (pUnit->IsCombatUnit())
-			iTurnLimit = 3;
+	int iCurrentDirectiveValue = -1; // Current directive value
+	vector<BuilderDirective>::iterator iCurrentDirectiveIndex; // Keeps track of the index of the first directive with a shared score
 
-		//is the unit still busy? if so, less time for movement
-		int iBuildTimeLeft = 0;
-		BuildTypes eBuild = pUnit->getBuildType();
-		if (eBuild != NO_BUILD)
-			iBuildTimeLeft = pUnit->plot()->getBuildTurnsLeft(eBuild, pUnit->getOwner(), 0, 0);
+	CvUnit* pBestDirectiveBuilder = NULL;
+	BuilderDirective eBestDirective = BuilderDirective();
+	int iBestDirectiveBuilderTotalTurns = INT_MAX;
 
-		if (iTurnLimit >= iBuildTimeLeft)
+	// Cache plot to plot distance calculations for the workers to avoid unnecessary pathfinding calls.
+	// Helps if there are several workers in the same tile. Assumes all workers have the same move speed and haven't used any movement.
+	map<pair<int, int>, int> plotDistanceCache;
+
+	// First check if any workers were already assigned directives this turn (this happens e.g. when a unit is set to automated during this turn).
+	for (std::list<int>::iterator builderIterator = allWorkers.begin(); builderIterator != allWorkers.end(); ++builderIterator)
+	{
+		int iUnitId = *builderIterator;
+		CvUnit* pUnit = m_pPlayer->getUnit(iUnitId);
+
+		if (!pUnit)
+			continue;
+
+		bool bIsAutomated = !m_pPlayer->isHuman() || nonAutomatedWorkers.find(iUnitId) == nonAutomatedWorkers.end();
+
+		if (bIsAutomated)
 		{
-			SPathFinderUserData data(pUnit, CvUnit::MOVEFLAG_NO_ENEMY_TERRITORY| CvUnit::MOVEFLAG_AI_ABORT_IN_DANGER, iTurnLimit-iBuildTimeLeft);
-			ReachablePlots plots = GC.GetPathFinder().GetPlotsInReach(pUnit->getX(), pUnit->getY(), data);
-	
-			// add offset for fair comparison
-			for (ReachablePlots::iterator it2 = plots.begin(); it2 != plots.end(); ++it2)
-				it2->iPathLength += iBuildTimeLeft;
-			
-			allWorkersReachablePlots[pUnit->GetID()] = plots;
+			BuilderDirective eDirective = pBuilderTaskingAI->GetAssignedDirective(pUnit);
+
+			if (eDirective.m_eBuild != NO_BUILD && pBuilderTaskingAI->ExecuteWorkerMove(pUnit, eDirective))
+			{
+				UnitProcessed(iUnitId);
+
+				CvPlot* pDirectivePlot = GC.getMap().plot(eDirective.m_sX, eDirective.m_sY);
+
+				processedWorkers.insert(iUnitId);
+				ignoredDirectives.push_back(eDirective);
+				m_workedPlots.insert(pDirectivePlot->GetPlotIndex());
+			}
 		}
 	}
 
-	//see if we have work to do
-	for(std::map<int,ReachablePlots>::iterator it = allWorkersReachablePlots.begin(); it != allWorkersReachablePlots.end(); ++it)
+	// Loop through all the directives sorted by priority.
+	// Any directives with a shared score will be considered in parallel (and the closest one is chosen).
+	for (vector<BuilderDirective>::iterator directiveIterator = topDirectives.begin(); directiveIterator != topDirectives.end() && allWorkers.size() > processedWorkers.size(); ++directiveIterator)
 	{
-		int currentUnitId = it->first;
-		CvUnit* pUnit = m_pPlayer->getUnit(currentUnitId);
+		BuilderDirective eDirective = *directiveIterator;
 
-		//cannot use m_CurrentMoveUnits here, need to update the reachable plots ... but not all units in allWorkersReachablePlots are supposed to be used
-		if (workersToIgnore.find(currentUnitId) != workersToIgnore.end())
+		bool bIgnore = false;
+		for (vector<BuilderDirective>::iterator dirIter2 = ignoredDirectives.begin(); dirIter2 != ignoredDirectives.end(); ++dirIter2)
+			if ((*dirIter2) == eDirective)
+			{
+				bIgnore = true;
+				break;
+			}
+
+		if (bIgnore)
 			continue;
 
-		//this checks for work in the immediate neighborhood of the workers
-		CvPlot* pTarget = ExecuteWorkerMove(pUnit, allWorkersReachablePlots);
-		if (pTarget)
+		if (iCurrentDirectiveValue == eDirective.m_iScore && iBestDirectiveBuilderTotalTurns > 0)
 		{
-			//make sure no other worker tries to target the same plot
-			it->second.clear();
-			it->second.insertWithIndex( SMovePlot(pTarget->GetPlotIndex(),-1,0,0) );
-			UnitProcessed(currentUnitId);
+			CvPlot* pDirectivePlot = GC.getMap().plot(eDirective.m_sX, eDirective.m_sY);
+
+			if (m_workedPlots.count(pDirectivePlot->GetPlotIndex()) > 0)
+				continue;
+
+			int iBestBuilderTotalTurns = INT_MAX;
+			CvUnit* pBestBuilder = NULL;
+
+			list<OptionWithScore<int>> sortedWorkers;
+
+			// First sort by plot distance between worker and directive, it's a good heuristic and reduces the number of needed calls to
+			// the pathfinder (and the max distance sent to the pathfinding algorithm when it is needed).
+			for (std::list<int>::iterator builderIterator = allWorkers.begin(); builderIterator != allWorkers.end(); ++builderIterator)
+			{
+				int iCurrentUnitId = *builderIterator;
+				CvUnit* pUnit = m_pPlayer->getUnit(iCurrentUnitId);
+
+				if (!pUnit)
+					continue;
+
+				if (processedWorkers.find(pUnit->GetID()) != processedWorkers.end())
+					continue;
+
+				int iPlotDistance = plotDistance(pDirectivePlot->getX(), pDirectivePlot->getY(), pUnit->getX(), pUnit->getY());
+
+				sortedWorkers.push_back(OptionWithScore<int>(iCurrentUnitId, -iPlotDistance));
+			}
+			std::stable_sort(sortedWorkers.begin(), sortedWorkers.end());
+
+			// Loop over the sorted workers to find the one closest to the directive plot
+			for (std::list<OptionWithScore<int>>::iterator builderIterator = sortedWorkers.begin(); builderIterator != sortedWorkers.end() && iBestBuilderTotalTurns > 0; ++builderIterator)
+			{
+				int iCurrentUnitId = (*builderIterator).option;
+				CvUnit* pUnit = m_pPlayer->getUnit(iCurrentUnitId);
+
+				if (!pBuilderTaskingAI->EvaluateBuilder(pUnit, eDirective))
+					continue;
+
+				int iBuilderImprovementTime = pBuilderTaskingAI->GetTurnsToBuild(pUnit, eDirective, pDirectivePlot);
+				if (iBuilderImprovementTime == INT_MAX)
+					continue;
+
+				pair<int, int> plotPair = make_pair<int, int>(pUnit->plot()->GetPlotIndex(), pDirectivePlot->GetPlotIndex());
+
+				int iCachedDistance = plotDistanceCache[plotPair];
+				int iBuilderDistance = iCachedDistance ? iCachedDistance - 1 : pBuilderTaskingAI->GetBuilderNumTurnsAway(pUnit, eDirective, iBestBuilderTotalTurns - iBuilderImprovementTime - 1);
+				plotDistanceCache[plotPair] = iBuilderDistance + 1;
+
+				if (iBuilderDistance == INT_MAX)
+					continue;
+
+				int iTotalTurns = iBuilderDistance + iBuilderImprovementTime;
+
+				// Use Unit ID as tie-breaker
+				if (iTotalTurns < iBestBuilderTotalTurns)
+				{
+					iBestBuilderTotalTurns = iTotalTurns;
+					pBestBuilder = pUnit;
+				}
+			}
+
+			if (iBestBuilderTotalTurns < iBestDirectiveBuilderTotalTurns)
+			{
+				iBestDirectiveBuilderTotalTurns = iBestBuilderTotalTurns;
+				pBestDirectiveBuilder = pBestBuilder;
+				eBestDirective = eDirective;
+			}
+		}
+		else
+		{
+
+			if (iBestDirectiveBuilderTotalTurns < INT_MAX)
+			{
+				iBestDirectiveBuilderTotalTurns = INT_MAX;
+				int iUnitID = pBestDirectiveBuilder->GetID();
+
+				if (pBuilderTaskingAI->GetAssignedDirective(pBestDirectiveBuilder).m_eBuild == NO_BUILD)
+				{
+					bool bIsAutomated = !m_pPlayer->isHuman() || nonAutomatedWorkers.find(iUnitID) == nonAutomatedWorkers.end();
+					if (bIsAutomated)
+					{
+						if (pBuilderTaskingAI->ExecuteWorkerMove(pBestDirectiveBuilder, eBestDirective))
+						{
+							UnitProcessed(iUnitID);
+
+							processedWorkers.insert(iUnitID);
+							ignoredDirectives.push_back(eBestDirective);
+							m_workedPlots.insert(GC.getMap().plot(eBestDirective.m_sX, eBestDirective.m_sY)->GetPlotIndex());
+
+							directiveIterator = iCurrentDirectiveIndex - 1;
+							continue;
+						}
+					}
+					else
+					{
+						// Assign non-automated worker to this directive
+						pBuilderTaskingAI->SetAssignedDirective(pBestDirectiveBuilder, eBestDirective);
+
+						processedWorkers.insert(iUnitID);
+						ignoredDirectives.push_back(eBestDirective);
+						m_workedPlots.insert(GC.getMap().plot(eBestDirective.m_sX, eBestDirective.m_sY)->GetPlotIndex());
+
+						directiveIterator = iCurrentDirectiveIndex - 1;
+						continue;
+					}
+				}
+			}
+
+			ignoredDirectives.clear();
+			iCurrentDirectiveValue = (*directiveIterator).m_iScore;
+			iCurrentDirectiveIndex = directiveIterator;
+			directiveIterator--;
 		}
 	}
 
@@ -2893,7 +3061,7 @@ void CvHomelandAI::ExecuteWorkerMoves()
 	map<int, int> mapCityNeed;
 	int iLoop = 0;
 	for (CvCity* pLoopCity = m_pPlayer->firstCity(&iLoop); pLoopCity != NULL; pLoopCity = m_pPlayer->nextCity(&iLoop))
-		mapCityNeed[pLoopCity->GetID()] = pLoopCity->GetTerrainImprovementNeed();
+		mapCityNeed[pLoopCity->GetID()] = 0;
 
 	for (CHomelandUnitArray::iterator it = m_CurrentMoveUnits.begin(); it != m_CurrentMoveUnits.end(); ++it)
 	{
@@ -2916,11 +3084,7 @@ void CvHomelandAI::ExecuteWorkerMoves()
 		if (pBestCity && pUnit->GeneratePath(pBestCity->plot(), CvUnit::MOVEFLAG_NO_ENEMY_TERRITORY|CvUnit::MOVEFLAG_PRETEND_ALL_REVEALED, 23))
 		{
 			ExecuteMoveToTarget(pUnit, pBestCity->plot(), CvUnit::MOVEFLAG_NO_ENEMY_TERRITORY|CvUnit::MOVEFLAG_PRETEND_ALL_REVEALED);
-			int iCurrentNeed = mapCityNeed[pBestCity->GetID()];
-			if (iCurrentNeed > 0)
-				mapCityNeed[pBestCity->GetID()] = iCurrentNeed / 2; //reduce the score for this city in case we have multiple workers to distribute
-			else
-				mapCityNeed[pBestCity->GetID()]--; //in case all cities have all tiles improved, try spread the workers over all our cities
+			mapCityNeed[pBestCity->GetID()]--; //in case all cities have all tiles improved, try spread the workers over all our cities
 		}
 		else if (pUnit->IsCivilianUnit())
 		{
@@ -3397,11 +3561,7 @@ void CvHomelandAI::ExecuteScientistMoves()
 			}
 			break;
 		case GREAT_PEOPLE_DIRECTIVE_CONSTRUCT_IMPROVEMENT:
-			if (!ExecuteWorkerMove(pUnit))
-			{
-				MoveCivilianToSafety(pUnit);
-				UnitProcessed(pUnit->GetID());
-			}
+			m_greatPeopleForImprovements.push_back(pUnit->GetID());
 			break;
 		case NO_GREAT_PEOPLE_DIRECTIVE_TYPE:
 			MoveCivilianToSafety(pUnit);
@@ -3433,8 +3593,7 @@ void CvHomelandAI::ExecuteEngineerMoves()
 		switch(eDirective)
 		{
 		case GREAT_PEOPLE_DIRECTIVE_CONSTRUCT_IMPROVEMENT:
-			if (!ExecuteWorkerMove(pUnit))
-				MoveCivilianToSafety(pUnit);
+			m_greatPeopleForImprovements.push_back(pUnit->GetID());
 			break;
 		case GREAT_PEOPLE_DIRECTIVE_GOLDEN_AGE:
 			ExecuteGoldenAgeMove(pUnit);
@@ -3807,14 +3966,9 @@ void CvHomelandAI::ExecuteMerchantMoves()
 				if (pUnit->atPlot(*pTargetPlot) && pUnit->canMove())
 					pUnit->PushMission(CvTypes::getMISSION_BUILD(), eColonia);
 			}
-			else if (ExecuteWorkerMove(pUnit)) //regular merchant
-			{
-				UnitProcessed(pUnit->GetID());
-			}
 			else
 			{
-				MoveCivilianToSafety(pUnit);
-				UnitProcessed(pUnit->GetID());
+				m_greatPeopleForImprovements.push_back(pUnit->GetID());
 			}
 			break;
 		}
@@ -3847,11 +4001,7 @@ void CvHomelandAI::ExecuteProphetMoves()
 		switch(eDirective)
 		{
 		case GREAT_PEOPLE_DIRECTIVE_CONSTRUCT_IMPROVEMENT:
-			if (!ExecuteWorkerMove(pUnit))
-			{
-				MoveCivilianToSafety(pUnit);
-				UnitProcessed(pUnit->GetID());
-			}
+			m_greatPeopleForImprovements.push_back(pUnit->GetID());
 			break;
 
 		case GREAT_PEOPLE_DIRECTIVE_USE_POWER:
@@ -4820,6 +4970,11 @@ bool CvHomelandAI::MoveCivilianToSafety(CvUnit* pUnit)
 	return false;
 }
 
+set<int> CvHomelandAI::GetWorkedPlots()
+{
+	return m_workedPlots;
+}
+
 // Get a trade unit and send it to a city!
 void CvHomelandAI::ExecuteTradeUnitMoves()
 {
@@ -5401,153 +5556,6 @@ void CvHomelandAI::UnitProcessed(int iID)
 		pUnit->setHomelandMove(m_CurrentMoveUnits.getCurrentHomelandMove());
 		pUnit->SetTurnProcessed(true);
 	}
-}
-
-CvPlot* CvHomelandAI::ExecuteWorkerMove(CvUnit* pUnit)
-{
-	if (!pUnit)
-		return NULL;
-
-	//pretend there are no other workers ...
-	std::map<int,ReachablePlots> allWorkersReachablePlots;
-	SPathFinderUserData data(pUnit, CvUnit::MOVEFLAG_AI_ABORT_IN_DANGER, 13);
-	allWorkersReachablePlots[pUnit->GetID()] = GC.GetPathFinder().GetPlotsInReach(pUnit->plot(), data);
-	return ExecuteWorkerMove(pUnit, allWorkersReachablePlots);
-}
-
-//returns the target plot if sucessful, null otherwise
-CvPlot* CvHomelandAI::ExecuteWorkerMove(CvUnit* pUnit, const map<int,ReachablePlots>& allWorkersReachablePlots)
-{
-	// find work (considering all other workers as well)
-	BuilderDirective aDirective = m_pPlayer->GetBuilderTaskingAI()->EvaluateBuilder(pUnit, allWorkersReachablePlots);
-	if(aDirective.m_eDirective!=BuilderDirective::NUM_DIRECTIVES)
-	{
-		switch(aDirective.m_eDirective)
-		{
-		case BuilderDirective::BUILD_IMPROVEMENT_ON_RESOURCE:
-		case BuilderDirective::BUILD_IMPROVEMENT:
-		case BuilderDirective::REPAIR:
-		case BuilderDirective::BUILD_ROUTE:
-		case BuilderDirective::CHOP:
-		case BuilderDirective::REMOVE_ROAD:
-		{
-			CvPlot* pPlot = GC.getMap().plot(aDirective.m_sX, aDirective.m_sY);
-			MissionTypes eMission = CvTypes::getMISSION_MOVE_TO();
-			if(pUnit->getX() == aDirective.m_sX && pUnit->getY() == aDirective.m_sY)
-				eMission = CvTypes::getMISSION_BUILD();
-
-			if(GC.getLogging() && GC.GetBuilderAILogging())
-			{
-				// Open the log file
-				CvString strFileName = "BuilderTaskingLog.csv";
-				FILogFile* pLog = NULL;
-				pLog = LOGFILEMGR.GetLog(strFileName, FILogFile::kDontTimeStamp);
-
-				// write in data
-				CvString strLog;
-				CvString strTemp;
-
-				CvString strPlayerName;
-				strPlayerName = m_pPlayer->getCivilizationShortDescription();
-				strLog += strPlayerName;
-				strLog += ",";
-
-				strTemp.Format("%d,", GC.getGame().getGameTurn()); // turn
-				strLog += strTemp;
-
-				strTemp.Format("%d,", pUnit->GetID()); // unit id
-				strLog += strTemp;
-
-				switch(aDirective.m_eDirective)
-				{
-				case BuilderDirective::BUILD_IMPROVEMENT_ON_RESOURCE:
-					strLog += "On resource,";
-					break;
-				case BuilderDirective::BUILD_IMPROVEMENT:
-					strLog += "On plot,";
-					break;
-				case BuilderDirective::REPAIR:
-					strLog += "Repairing,";
-					break;
-				case BuilderDirective::BUILD_ROUTE:
-					strLog += "Building route,";
-					break;
-				case BuilderDirective::CHOP:
-					strLog += "Removing resource for production,";
-					break;
-				case BuilderDirective::REMOVE_ROAD:
-					strLog += "Removing road,";
-					break;
-				}
-
-				if(eMission == CvTypes::getMISSION_BUILD())
-				{
-					if(aDirective.m_eDirective == BuilderDirective::REPAIR)
-					{
-						if(pPlot->IsImprovementPillaged())
-						{
-							strLog += "Repairing improvement";
-						}
-						else
-						{
-							strLog += "Repairing route";
-						}
-					}
-					else if(aDirective.m_eDirective == BuilderDirective::BUILD_ROUTE)
-					{
-						strLog += "Building route,";
-					}
-					else if(aDirective.m_eDirective == BuilderDirective::BUILD_IMPROVEMENT || aDirective.m_eDirective == BuilderDirective::BUILD_IMPROVEMENT_ON_RESOURCE)
-					{
-						strLog += "Building improvement,";
-					}
-					else if(aDirective.m_eDirective == BuilderDirective::CHOP)
-					{
-						strLog += "Removing feature for production,";
-					}
-					else
-					{
-						strLog += "Removing road,";
-					}
-				}
-				else
-				{
-					strLog += "Moving to location,";
-				}
-
-				pLog->Msg(strLog);
-			}
-
-			if(eMission == CvTypes::getMISSION_MOVE_TO())
-			{
-				pUnit->PushMission(CvTypes::getMISSION_MOVE_TO(), aDirective.m_sX, aDirective.m_sY, 
-					CvUnit::MOVEFLAG_NO_ENEMY_TERRITORY|CvUnit::MOVEFLAG_ABORT_IF_NEW_ENEMY_REVEALED, false, false, MISSIONAI_BUILD, pPlot);
-
-				//do we have movement left?
-				if (pUnit->getMoves()>0)
-					eMission = CvTypes::getMISSION_BUILD();
-				else
-					UnitProcessed(pUnit->GetID());
-			}
-
-			if(eMission == CvTypes::getMISSION_BUILD())
-			{
-				// check to see if we already have this mission as the unit's head mission
-				const MissionData* pkMissionData = pUnit->GetHeadMissionData();
-				if(pkMissionData == NULL || pkMissionData->eMissionType != eMission || pkMissionData->iData1 != aDirective.m_eBuild)
-					pUnit->PushMission(CvTypes::getMISSION_BUILD(), aDirective.m_eBuild, aDirective.m_eDirective, 0, false, false, MISSIONAI_BUILD, pPlot);
-
-				CvAssertMsg(!pUnit->ReadyToMove(), "Worker did not do their mission this turn. Could cause game to hang.");
-				UnitProcessed(pUnit->GetID());
-			}
-
-			return GC.getMap().plot(aDirective.m_sX, aDirective.m_sY);
-		}
-		break;
-		}
-	}
-
-	return NULL;
 }
 
 bool CvHomelandAI::ExecuteCultureBlast(CvUnit* pUnit)

--- a/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
@@ -2987,10 +2987,11 @@ void CvHomelandAI::ExecuteWorkerMoves()
 
 				int iCachedDistance = plotDistanceCache[plotPair];
 				int iBuilderDistance = iCachedDistance ? iCachedDistance - 1 : pBuilderTaskingAI->GetBuilderNumTurnsAway(pUnit, eDirective, iBestBuilderTotalTurns - iBuilderImprovementTime - 1);
-				plotDistanceCache[plotPair] = iBuilderDistance + 1;
 
 				if (iBuilderDistance == INT_MAX)
 					continue;
+
+				plotDistanceCache[plotPair] = iBuilderDistance + 1;
 
 				int iTotalTurns = iBuilderDistance + iBuilderImprovementTime;
 

--- a/CvGameCoreDLL_Expansion2/CvHomelandAI.h
+++ b/CvGameCoreDLL_Expansion2/CvHomelandAI.h
@@ -208,7 +208,9 @@ public:
 	// Public turn update routines
 	void RecruitUnits();
 	void FindAutomatedUnits();
-	void Update();
+	void Update(bool bUpdateImprovements);
+	void Invalidate();
+	bool NeedsUpdate();
 
 	// Public exploration routines
 	CvPlot* GetBestExploreTarget(const CvUnit* pUnit, int nMinCandidatesToCheck, int iMaxTurns) const;
@@ -220,6 +222,8 @@ public:
 
 	bool MoveCivilianToGarrison(CvUnit* pUnit);
 	bool MoveCivilianToSafety(CvUnit* pUnit);
+
+	set<int> GetWorkedPlots();
 
 private:
 	// Internal turn update routines - commandeered unit processing
@@ -258,6 +262,7 @@ private:
 #endif
 //-------------------------------------
 
+	void PlanImprovements();
 	void PlotWorkerMoves(bool bSecondary = false);
 	void PlotWorkerSeaMoves(bool bSecondary = false);
 	void PlotWriterMoves();
@@ -313,8 +318,6 @@ private:
 	CvPlot* FindArchaeologistTarget(CvUnit *pUnit);
 
 	void UnitProcessed(int iID);
-	CvPlot* ExecuteWorkerMove(CvUnit* pUnit);
-	CvPlot* ExecuteWorkerMove(CvUnit* pUnit, const map<int,ReachablePlots>& allWorkersReachablePlots);
 	bool ExecuteCultureBlast(CvUnit* pUnit);
 	bool ExecuteGoldenAgeMove(CvUnit* pUnit);
 	bool IsValidExplorerEndTurnPlot(const CvUnit* pUnit, CvPlot* pPlot) const;
@@ -326,7 +329,10 @@ private:
 	// Class data
 	CvPlayer* m_pPlayer;
 	std::list<int> m_CurrentTurnUnits;
+	set<int> m_workedPlots;
+	list<int> m_greatPeopleForImprovements;
 	std::map<UnitAITypes,std::vector<std::pair<int,int>>> m_automatedTargetPlots; //for human units
+	bool m_bNeedsUpdate;
 
 	CHomelandUnitArray m_CurrentMoveUnits;
 

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -35400,6 +35400,7 @@ void CvPlayer::setTurnActive(bool bNewValue, bool bDoTurn) // R: bDoTurn default
 				//no tactical AI for human, only make sure we have current postures in case we want the AI to take over (debugging)
 				if (isHuman() || /* if MP, invalidate for AI too */ kGame.isNetworkMultiPlayer()) {
 					GetTacticalAI()->GetTacticalAnalysisMap()->Invalidate();
+					GetHomelandAI()->Invalidate();
 				}
 
 				// update danger plots before the turn

--- a/CvGameCoreDLL_Expansion2/CvPlayer.h
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.h
@@ -2919,7 +2919,7 @@ public:
 	virtual void AI_doTurnPost() = 0;
 	virtual void AI_doTurnUnitsPre() = 0;
 	virtual void AI_doTurnUnitsPost() = 0;
-	virtual void AI_unitUpdate() = 0;
+	virtual void AI_unitUpdate(bool bHomelandAINeedsUpdate) = 0;
 	virtual void AI_conquerCity(CvCity* pCity, bool bGift, bool bAllowSphereRemoval) = 0;
 	bool HasSameIdeology(PlayerTypes ePlayer) const;
 

--- a/CvGameCoreDLL_Expansion2/CvPlayerAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayerAI.cpp
@@ -257,7 +257,7 @@ void CvPlayerAI::AI_doTurnUnitsPost()
 }
 
 //	---------------------------------------------------------------------------
-void CvPlayerAI::AI_unitUpdate()
+void CvPlayerAI::AI_unitUpdate(bool bUpdateHomelandAI)
 {
 	ICvEngineScriptSystem1* pkScriptSystem = gDLL->GetScriptSystem();
 	if(pkScriptSystem)
@@ -279,7 +279,7 @@ void CvPlayerAI::AI_unitUpdate()
 	{
 		CvUnit::dispatchingNetMessage(true);
 		GetTacticalAI()->UpdateVisibility();
-		GetHomelandAI()->Update();
+		GetHomelandAI()->Update(bUpdateHomelandAI);
 		GetTacticalAI()->CleanUp();
 		CvUnit::dispatchingNetMessage(false);
 	}
@@ -288,7 +288,7 @@ void CvPlayerAI::AI_unitUpdate()
 		// Now let the tactical AI run.  Putting it after the operations update allows units who have
 		// just been handed off to the tactical AI to get a move in the same turn they switch between
 		GetTacticalAI()->Update();
-		GetHomelandAI()->Update();
+		GetHomelandAI()->Update(true);
 		GetTacticalAI()->CleanUp();
 	}
 }

--- a/CvGameCoreDLL_Expansion2/CvPlayerAI.h
+++ b/CvGameCoreDLL_Expansion2/CvPlayerAI.h
@@ -40,7 +40,7 @@ public:
 	void AI_doTurnUnitsPre();
 	void AI_doTurnUnitsPost();
 
-	void AI_unitUpdate();
+	void AI_unitUpdate(bool bUpdateHomelandAI);
 	void AI_conquerCity(CvCity* pCity, bool bGift, bool bAllowSphereRemoval);
 
 	void AI_chooseFreeGreatPerson();

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -24907,7 +24907,13 @@ void CvUnit::DoFinishBuildIfSafe()
 	{
 		int iBuildTimeLeft = plot()->getBuildTurnsLeft(eBuild, getOwner(), 0, 0);
 		if (iBuildTimeLeft == 0 && canMove() && GetDanger() == 0)
+		{
+			BuilderDirective eDirective = GET_PLAYER(m_eOwner).GetBuilderTaskingAI()->GetAssignedDirective(this);
+			if (eDirective.m_sX != m_iX || eDirective.m_sY != m_iY || eDirective.m_eBuild != eBuild)
+				return;
+
 			CvUnitMission::ContinueMission(this);
+		}
 	}
 }
 #endif 

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -3435,7 +3435,7 @@ bool CvUnit::isActionRecommended(int iAction)
 			BuilderDirective eDirective = *it;
 			CvPlot* pDirectivePlot = GC.getMap().plot(eDirective.m_sX, eDirective.m_sY);
 
-			if (plot() != pDirectivePlot)
+			if (pPlot != pDirectivePlot)
 				continue;
 
 			bool bCanBuild = GET_PLAYER(getOwner()).GetBuilderTaskingAI()->EvaluateBuilder(this, eDirective);
@@ -3443,14 +3443,8 @@ bool CvUnit::isActionRecommended(int iAction)
 			if (!bCanBuild)
 				continue;
 
-			if (eDirective.m_eBuild == eBuild)
-			{
-				return true;
-			}
-			else
-			{
-				return false;
-			}
+			// If this is not the best improvement we can build on this tile, return false
+			return eDirective.m_eBuild == eBuild;
 		}
 	}
 

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -3425,16 +3425,32 @@ bool CvUnit::isActionRecommended(int iAction)
 		CvAssert(eBuild != NO_BUILD);
 		CvAssertMsg(eBuild < GC.getNumBuildInfos(), "Invalid Build");
 
-		//fake this, we're really only interested in one plot
-		ReachablePlots plots;
-		plots.insertWithIndex(SMovePlot(plot()->GetPlotIndex()));
-		map<int, ReachablePlots> allplots;
-		allplots[this->GetID()] = plots;
+		vector<BuilderDirective> directives = GET_PLAYER(getOwner()).GetBuilderTaskingAI()->GetDirectives();
 
-		BuilderDirective aDirective = GET_PLAYER(getOwner()).GetBuilderTaskingAI()->EvaluateBuilder(this,allplots);
-		if(aDirective.m_eDirective != BuilderDirective::NUM_DIRECTIVES && aDirective.m_eBuild == eBuild)
+		if (directives.empty())
+			return false;
+
+		for (vector<BuilderDirective>::iterator it = directives.begin(); it != directives.end(); ++it)
 		{
-			return true;
+			BuilderDirective eDirective = *it;
+			CvPlot* pDirectivePlot = GC.getMap().plot(eDirective.m_sX, eDirective.m_sY);
+
+			if (plot() != pDirectivePlot)
+				continue;
+
+			bool bCanBuild = GET_PLAYER(getOwner()).GetBuilderTaskingAI()->EvaluateBuilder(this, eDirective);
+
+			if (!bCanBuild)
+				continue;
+
+			if (eDirective.m_eBuild == eBuild)
+			{
+				return true;
+			}
+			else
+			{
+				return false;
+			}
 		}
 	}
 


### PR DESCRIPTION
Change AI worker logic into more of a "top-down" framework. The AI will start each turn by precomputing the value of each improvement on each plot. It will then assign the closest worker for each of the highest priority improvements.

Should have better performance than previous implementation and increases value of high priority plots at the expense of valuing local tiles, although local tiles are still preferred if the evaluation is the same. This should also greatly increase coordination between workers.

Work boats are not included in the rework.

Non-automated human workers and great people will get an assigned job together with the automated workers, which is shown as a recommendation when the unit is selected.

Update route evaluation code to be simpler. Give extra value to routes that are needed for connection to capital. Give extra value to shorter roads (capital roads only).

Merge m_routeNeededPlots and m_routeWantedPlots into one.

All workers will now reevaluate their current best job on each turn. Shouldn't cause any significant performance hit since the heavy computation is done on a "per-civ" basis rather than "per-worker". May cause workers to act seemingly more erratically, but that is because there is a better improvement to build than the one that is currently being built.

Remove "can any enemy see this plot" from the "should worker consider this plot" worker logic. Plot danger check is still done.

Fix poor road pathfinding performance by simplifying computation a lot.