### PR TITLE
Builder ai rework

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvAStar.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAStar.cpp
@@ -2195,7 +2195,7 @@ static int BuildRouteVillageBonus(CvPlayer* pPlayer, CvPlot* pPlot, RouteTypes e
 		return 0;
 
 	// No villages on resources
-	if (pPlot->getResourceType() != NO_RESOURCE)
+	if (pPlot->getResourceType(pPlayer->getTeam()) != NO_RESOURCE)
 		return 0;
 
 	// No villages on mountains
@@ -3427,7 +3427,7 @@ int TradePathWaterValid(const CvAStarNode* parent, const CvAStarNode* node, cons
 		//only single plot canals on plots without resource
 		//not that this is asymmetric, we can build a canal into a city but not out of a city ... shouldn't matter too much
 		if (pPrevPlot->isWater() && !pNewPlot->isWater() && pNewPlot->getOwner() == pCacheData->GetPlayer())
-			return pNewPlot->getResourceType() == NO_RESOURCE;
+			return pNewPlot->getResourceType(pCacheData->GetTeam()) == NO_RESOURCE;
 	}
 
 	return FALSE;

--- a/CvGameCoreDLL_Expansion2/CvAStar.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAStar.cpp
@@ -2186,8 +2186,8 @@ int CityConnectionWaterValid(const CvAStarNode* parent, const CvAStarNode* node,
 /// Prefer building routes that can have villages.
 static int BuildRouteVillageBonus(CvPlayer* pPlayer, CvPlot* pPlot, RouteTypes eRouteType, CvBuilderTaskingAI* eBuilderTaskingAi)
 {
-	// If we're not the owner of this plot, bail out
-	if (!pPlot->isOwned() || pPlot->getOwner() != pPlayer->GetID())
+	// If someone else owns this plot, bail out
+	if (pPlot->isOwned() && pPlot->getOwner() != pPlayer->GetID())
 		return 0;
 
 	// Building a village here removes the route in this case
@@ -2198,62 +2198,38 @@ static int BuildRouteVillageBonus(CvPlayer* pPlayer, CvPlot* pPlot, RouteTypes e
 	if (pPlot->getResourceType() != NO_RESOURCE)
 		return 0;
 
-	int iBonus = 0;
+	// No villages on mountains
+	if (pPlot->getPlotType() == PLOT_MOUNTAIN)
+		return 0;
 
+	// No villages for China near cities, no villages for Brazil on jungle/forest, no villages for Netherlands on marshes.
+	if (!eBuilderTaskingAi->MayWantVillageOnPlot(pPlot))
+		return 0;
+
+	// If we have a town or village here, give a big bonus
 	ImprovementTypes eImprovement = pPlot->getImprovementType();
 	if (eImprovement != NO_IMPROVEMENT)
 	{
 		CvImprovementEntry* pkImprovementInfo = GC.getImprovementInfo(eImprovement);
+
 		if (pkImprovementInfo != NULL)
 		{
-			for (int iI = 0; iI < NUM_YIELD_TYPES; iI++)
+			for (int iI = 0; iI <= YIELD_FAITH; iI++)
 			{
 				YieldTypes eYield = (YieldTypes)iI;
 
-				// Heavily prioritize building routes over existing villages/towns
-				iBonus += pkImprovementInfo->GetRouteYieldChanges(eRouteType, eYield);
+				if (pkImprovementInfo->GetRouteYieldChanges(eRouteType, eYield) > 0)
+					return 30;
 			}
 		}
 
-		if (iBonus)
-			return iBonus * 3;
+		// If this is a great person improvement, we don't want to replace it (unless it's a town)
+		if (pkImprovementInfo->IsCreatedByGreatPerson())
+			return 0;
 	}
 
-	int iBestBonus = 0;
-	
-	for (int iI = 0; iI < GC.getNumBuildInfos(); iI++)
-	{
-		BuildTypes eBuild = (BuildTypes)iI;
-		CvBuildInfo* pkBuild = GC.getBuildInfo(eBuild);
-		if (!pkBuild)
-			continue;
-
-		// Set bTestEra to true as a hack to ensure that we consider villages even if we can not build the improvement yet
-		if (!pPlayer->canBuild(pPlot, eBuild, true))
-			continue;
-
-		eImprovement = (ImprovementTypes)pkBuild->getImprovement();
-		if (eImprovement == NO_IMPROVEMENT)
-			continue;
-
-		CvImprovementEntry* pkImprovementInfo = GC.getImprovementInfo(eImprovement);
-		if (pkImprovementInfo == NULL)
-			continue;
-
-		int iPotentialVillageBonus = 0;
-
-		for (int iYield = 0; iYield < NUM_YIELD_TYPES; iYield++)
-		{
-			YieldTypes eYield = (YieldTypes)iYield;
-
-			iPotentialVillageBonus += pkImprovementInfo->GetRouteYieldChanges(eRouteType, eYield);
-		}
-
-		if (iPotentialVillageBonus > iBestBonus)
-			iBestBonus = iPotentialVillageBonus;
-	}
-
-	return iBonus + iBestBonus;
+	// Villages and towns can be built pretty much anywhere
+	return 5;
 }
 
 //	--------------------------------------------------------------------------------
@@ -2266,13 +2242,21 @@ int BuildRouteCost(const CvAStarNode* /*parent*/, const CvAStarNode* node, const
 	RouteTypes eRouteType = data.eRouteType;
 	BuildTypes eBuildType = data.eBuildType;
 	int iCost = 0;
+	bool bGetSameRouteBenefitFromTrait = eBuilderTaskingAi->GetSameRouteBenefitFromTrait(pPlot, eRouteType);
 
-	if(pPlot->isCity() || eBuilderTaskingAi->GetRouteTypeWantedAtPlot(pPlot) >= eRouteType || eBuilderTaskingAi->GetRouteTypeNeededAtPlot(pPlot) >= eRouteType || eBuilderTaskingAi->GetSameRouteBenefitFromTrait(pPlot, eRouteType))
+	if (pPlot->isCity())
+		return 0;
+
+	if (bGetSameRouteBenefitFromTrait)
+	{
+		iCost = PATH_BASE_COST / 3;
+	}
+	else if(eBuilderTaskingAi->GetRouteTypeNeededAtPlot(pPlot) >= eRouteType)
 	{
 		// if we are planning to or have already built a road here, or get a free road here from our trait, provide a discount (cities always have a road)
 		iCost = PATH_BASE_COST * 7 / 12;
 	}
-	else if ((eBuilderTaskingAi->WantRouteAtPlot(pPlot) || eBuilderTaskingAi->NeedRouteAtPlot(pPlot)) && !eBuilderTaskingAi->GetSameRouteBenefitFromTrait(pPlot, ROUTE_ROAD))
+	else if (eBuilderTaskingAi->NeedRouteAtPlot(pPlot) && !bGetSameRouteBenefitFromTrait)
 	{
 		// if we are planning to build a lower tier route here, provide a smaller discount
 		iCost = PATH_BASE_COST * 3 / 4;
@@ -2292,7 +2276,7 @@ int BuildRouteCost(const CvAStarNode* /*parent*/, const CvAStarNode* node, const
 	}
 
 	//too dangerous, might be severed any time
-	if (pPlot->getOwner() == NO_PLAYER && pPlot->IsAdjacentOwnedByTeamOtherThan(pPlayer->getTeam(), false, false, true, true))
+	if (pPlot->getOwner() == NO_PLAYER && !bGetSameRouteBenefitFromTrait && pPlot->IsAdjacentOwnedByTeamOtherThan(pPlayer->getTeam(), false, false, true, true))
 		iCost *= 3;
 
 	if (data.bBenefitsVillages)

--- a/CvGameCoreDLL_Expansion2/CvAStar.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAStar.cpp
@@ -2203,7 +2203,7 @@ static int BuildRouteVillageBonus(CvPlayer* pPlayer, CvPlot* pPlot, RouteTypes e
 		return 0;
 
 	// No villages for China near cities, no villages for Brazil on jungle/forest, no villages for Netherlands on marshes.
-	if (!eBuilderTaskingAi->MayWantVillageOnPlot(pPlot))
+	if (eBuilderTaskingAi->SavePlotForUniqueImprovement(pPlot))
 		return 0;
 
 	// If we have a town or village here, give a big bonus

--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
@@ -48,6 +48,7 @@ void CvBuilderTaskingAI::Init(CvPlayer* pPlayer)
 	m_bKeepMarshes = false;
 	// special case code so Brazil doesn't remove jungle
 	m_bKeepJungle = false;
+	m_bKeepForest = false;
 
 	// special case to evaluate plots adjacent to friendly
 	m_bEvaluateAdjacent = false;
@@ -83,9 +84,13 @@ void CvBuilderTaskingAI::Init(CvPlayer* pPlayer)
 				{
 					m_bKeepMarshes = true;
 				}
-				else if (pkImprovementInfo->GetFeatureMakesValid(FEATURE_JUNGLE))
+				if (pkImprovementInfo->GetFeatureMakesValid(FEATURE_JUNGLE))
 				{
 					m_bKeepJungle = true;
+				}
+				if (pkImprovementInfo->GetFeatureMakesValid(FEATURE_FOREST))
+				{
+					m_bKeepForest = true;
 				}
 				if (pkImprovementInfo->IsAdjacentCity())
 				{
@@ -153,6 +158,7 @@ void CvBuilderTaskingAI::Uninit(void)
 
 	m_bKeepMarshes = false;
 	m_bKeepJungle = false;
+	m_bKeepForest = false;
 	m_bEvaluateAdjacent = false;
 	m_bMayPutGPTINextToCity = true;
 }
@@ -161,7 +167,6 @@ template<typename BuilderTaskingAI, typename Visitor>
 void CvBuilderTaskingAI::Serialize(BuilderTaskingAI& builderTaskingAI, Visitor& visitor)
 {
 	visitor(builderTaskingAI.m_routeNeededPlots);
-	visitor(builderTaskingAI.m_routeWantedPlots);
 	visitor(builderTaskingAI.m_canalWantedPlots);
 	visitor(builderTaskingAI.m_mainRoutePlots);
 	visitor(builderTaskingAI.m_shortcutRoutePlots);
@@ -198,6 +203,7 @@ void CvBuilderTaskingAI::Update(void)
 {
 	UpdateRoutePlots();
 	UpdateCanalPlots();
+	UpdateImprovementPlots();
 
 	if(m_bLogging)
 	{
@@ -295,12 +301,12 @@ void CvBuilderTaskingAI::ConnectCitiesToCapital(CvCity* pPlayerCapital, CvCity* 
 	if (bTargetingMinor && eRoute == ROUTE_RAILROAD)
 		return;
 
-	bool bHuman = m_pPlayer->isHuman();
 	// go through the route to see how long it is and how many plots already have roads
 	int iRoadLength = 0;
 	int iRoadMaintenanceLength = 0;
+	int iNumRoadsNeededToBuild = 0;
 
-	for (size_t i=0; i<path.vPlots.size(); i++)
+	for (size_t i = 1; i < path.vPlots.size() - 1; i++)
 	{
 		CvPlot* pPlot = path.get(i);
 		if(!pPlot)
@@ -313,7 +319,12 @@ void CvBuilderTaskingAI::ConnectCitiesToCapital(CvCity* pPlayerCapital, CvCity* 
 		iRoadLength++;
 
 		if (!GetSameRouteBenefitFromTrait(pPlot, eRoute))
+		{
 			iRoadMaintenanceLength++;
+
+			if (pPlot->getRouteType() < eRoute || pPlot->IsRoutePillaged())
+				iNumRoadsNeededToBuild++;
+		}
 	}
 
 	//see if the new route makes sense economically
@@ -321,25 +332,27 @@ void CvBuilderTaskingAI::ConnectCitiesToCapital(CvCity* pPlayerCapital, CvCity* 
 	if(bTargetingMinor)
 	{
 		//this is for a quest ... normal considerations don't apply
-		iValue = min(/*1000*/ GD_INT_GET(MINOR_CIV_ROUTE_QUEST_WEIGHT) / max(1, iRoadLength), MAX_SHORT);
+		iValue = min(/*1000*/ GD_INT_GET(MINOR_CIV_ROUTE_QUEST_WEIGHT) / max(1, iNumRoadsNeededToBuild), MAX_SHORT);
 	}
 	else
 	{
-		int iMaintenancePerTile = pRouteInfo->GetGoldMaintenance()*(100+m_pPlayer->GetImprovementGoldMaintenanceMod());
 		bool bHasCityConnection = m_pPlayer->IsCityConnectedToCity(pPlayerCapital, pTargetCity, eRoute);
-		int iGoldForRoute = !bHasCityConnection ? m_pPlayer->GetTreasury()->GetCityConnectionRouteGoldTimes100(pTargetCity) : 0;
 
 		//route has side benefits also (movement, village gold, trade route range, religion spread)
-		int iSideBenefits = 500 + iRoadLength * 100;
+		iValue = /*500*/ GD_INT_GET(BUILDER_TASKING_BASELINE_BUILD_ROUTES) * 4;
+
+		// Focus on almost completed roads first
+		if (iNumRoadsNeededToBuild < 100 && iNumRoadsNeededToBuild > 0)
+			iValue += 8000 / (iNumRoadsNeededToBuild * iNumRoadsNeededToBuild);
 
 		//assume one unhappiness is worth gold per turn per city
-		iSideBenefits += bHasCityConnection ? pTargetCity->GetUnhappinessFromIsolation() * (m_pPlayer->IsEmpireUnhappy() ? 200 : 100) : 0;
+		iValue += bHasCityConnection ? pTargetCity->GetUnhappinessFromIsolation() * (m_pPlayer->IsEmpireUnhappy() ? 200 : 100) : 0;
 
 		if(GC.getGame().GetIndustrialRoute() == eRoute)
 		{
 			if (!bHasCityConnection)
 			{
-				iSideBenefits += pTargetCity->getYieldRate(YIELD_PRODUCTION, false) * /*25 in CP, 0 in VP*/ GD_INT_GET(INDUSTRIAL_ROUTE_PRODUCTION_MOD);
+				iValue += pTargetCity->getYieldRate(YIELD_PRODUCTION, false) * /*25 in CP, 0 in VP*/ GD_INT_GET(INDUSTRIAL_ROUTE_PRODUCTION_MOD);
 
 #if defined(MOD_BALANCE_CORE)
 				// Target city would get a production and gold boost from a train station.
@@ -361,28 +374,18 @@ void CvBuilderTaskingAI::ConnectCitiesToCapital(CvCity* pPlayerCapital, CvCity* 
 
 					if (pTargetCity->HasBuilding(eBuilding))
 					{
-						iSideBenefits += 100 * iProductionYield * iProductionYieldRateModifier / (100 + iProductionYieldRateModifier);
-						iSideBenefits += 100 * iGoldYield * iGoldYieldRateModifier / (100 + iGoldYieldRateModifier);
+						iValue += 100 * iProductionYield * iProductionYieldRateModifier / (100 + iProductionYieldRateModifier);
+						iValue += 100 * iGoldYield * iGoldYieldRateModifier / (100 + iGoldYieldRateModifier);
 					}
 					else if (m_pPlayer->canConstruct(eBuilding) || eBuilding == pTargetCity->getProductionBuilding())
 					{
-						iSideBenefits += iProductionYield * iProductionYieldRateModifier;
-						iSideBenefits += iGoldYield * iGoldYieldRateModifier;
+						iValue += iProductionYield * iProductionYieldRateModifier;
+						iValue += iGoldYield * iGoldYieldRateModifier;
 					}
 				}
 #endif
 			}
-
-			// railroads have extra benefits over normal roads
-			iSideBenefits += iRoadLength * 150;
 		}
-
-		int iProfit = iGoldForRoute - (iRoadMaintenanceLength * iMaintenancePerTile) + iSideBenefits;
-
-		if (!bHuman && iProfit < 0)
-			return;
-
-		iValue = iProfit;
 	}
 
 	for (size_t i=0; i<path.vPlots.size(); i++)
@@ -428,7 +431,7 @@ void CvBuilderTaskingAI::ConnectCitiesForShortcuts(CvCity* pCity1, CvCity* pCity
 	int iRoadLength = 0;
 	int iRoadMaintenanceLength = 0;
 
-	for (size_t i = 0; i < newPath.vPlots.size(); i++)
+	for (size_t i = 1; i < newPath.vPlots.size() - 1; i++)
 	{
 		CvPlot* pPlot = newPath.get(i);
 		if (!pPlot)
@@ -438,8 +441,7 @@ void CvBuilderTaskingAI::ConnectCitiesForShortcuts(CvCity* pCity1, CvCity* pCity
 		if (pPlot->isCity())
 		{
 			// if we are going via a city, that isn't one of the two cities we are connecting, then this shortcut is not needed
-			CvCity* pPlotCity = pPlot->getPlotCity();
-			if (pPlotCity != pCity1 && pPlotCity != pCity2 && pPlotCity->getOwner() == m_pPlayer->GetID())
+			if (pPlot->getOwner() == m_pPlayer->GetID())
 				return;
 			continue;
 		}
@@ -450,21 +452,8 @@ void CvBuilderTaskingAI::ConnectCitiesForShortcuts(CvCity* pCity1, CvCity* pCity
 			iRoadMaintenanceLength++;
 	}
 
-	int iMaintenancePerTile = pRouteInfo->GetGoldMaintenance() * (100 + m_pPlayer->GetImprovementGoldMaintenanceMod());
-
 	//route has side benefits also (movement, village gold, trade route range, religion spread)
-	int iSideBenefits = 500 + iRoadLength * 100;
-
-	if (GC.getGame().GetIndustrialRoute() == eRoute)
-	{
-		// railroads have extra benefits over normal roads
-		iSideBenefits += iRoadLength * 150;
-	}
-
-	int iProfit = iSideBenefits - (iRoadMaintenanceLength * iMaintenancePerTile);
-
-	if (iProfit < 0)
-		return;
+	int iValue = /*500*/ GD_INT_GET(BUILDER_TASKING_BASELINE_BUILD_ROUTES) * 4;
 
 	for (size_t i=0; i<newPath.vPlots.size(); i++)
 	{
@@ -476,29 +465,103 @@ void CvBuilderTaskingAI::ConnectCitiesForShortcuts(CvCity* pCity1, CvCity* pCity
 			continue;
 
 		//remember it
-		if (AddRoutePlot(pPlot, eRoute, iProfit))
+		if (AddRoutePlot(pPlot, eRoute, iValue))
 			m_shortcutRoutePlots.insert(pPlot->GetPlotIndex());
 	}
 }
 
-//helper function. don't panic if a a plot isn't marked for a short time
-bool CvBuilderTaskingAI::WantRouteAtPlot(const CvPlot* pPlot) const
+void CvBuilderTaskingAI::ConnectPointsForStrategy(CvCity* pOriginCity, CvPlot* pTargetPlot, BuildTypes eBuild, RouteTypes eRoute, int iNetGoldTimes100)
 {
-	if (!pPlot)
-		return false;
+	// don't connect cities from different owners
+	if (pOriginCity->getOwner() != pTargetPlot->getOwner())
+		return;
 
-	RoutePlotContainer::const_iterator it = m_routeWantedPlots.find(pPlot->GetPlotIndex());
-	return (it != m_routeWantedPlots.end());
-}
+	// don't connect razing cities
+	if (pOriginCity->IsRazing())
+		return;
 
-RouteTypes CvBuilderTaskingAI::GetRouteTypeWantedAtPlot(const CvPlot* pPlot) const
-{
-	if (!pPlot)
-		return NO_ROUTE;
-	RoutePlotContainer::const_iterator it = m_routeWantedPlots.find(pPlot->GetPlotIndex());
-	if (it != m_routeWantedPlots.end())
-		return it->second.first;
-	return NO_ROUTE;
+	CvRouteInfo* pRouteInfo = GC.getRouteInfo(eRoute);
+	if (!pRouteInfo)
+		return;
+
+	// build a path between the two cities
+	SPathFinderUserData data(m_pPlayer->GetID(), PT_BUILD_ROUTE, eBuild, eRoute, false);
+	SPath path = GC.GetStepFinder().GetPath(pOriginCity->getX(), pOriginCity->getY(), pTargetPlot->getX(), pTargetPlot->getY(), data);
+
+	//  if no path, then bail!
+	if (!path)
+		return;
+
+	// go through the route to see how long it is and how many plots already have roads
+	int iRoadMaintenanceLength = 0;
+
+	for (size_t i = 1; i < path.vPlots.size(); i++)
+	{
+		CvPlot* pPlot = path.get(i);
+		if (!pPlot)
+			break;
+
+		if (pPlot->getOwner() != m_pPlayer->GetID())
+			return;
+
+		//don't count the cities themselves
+		if (pPlot->isCity())
+		{
+			// strategic routes never need to go through our cities
+			if (pPlot->getOwner() == m_pPlayer->GetID())
+				return;
+			continue;
+		}
+
+		if (!GetSameRouteBenefitFromTrait(pPlot, eRoute))
+			iRoadMaintenanceLength++;
+	}
+
+	//and this to see if we actually build it
+	int iCost = pRouteInfo->GetGoldMaintenance() * (100 + m_pPlayer->GetImprovementGoldMaintenanceMod());
+	iCost *= iRoadMaintenanceLength + 5; // add extra to account for ring tiles around fort
+
+	int iGoldDelta = iNetGoldTimes100 - iCost;
+
+	if (iGoldDelta < 0)
+		return;
+
+	// Need a decent gold buffer to build strategic routes, but don't remove them unless we are actually losing gold
+	int iValue = iGoldDelta >= 30 ? GD_INT_GET(BUILDER_TASKING_BASELINE_BUILD_ROUTES) * 4 : 0;
+
+	for (int i = 1; i < path.length(); i++)
+	{
+		CvPlot* pPlot = path.get(i);
+		if (!pPlot)
+			break;
+
+		// remember the plot
+		if (AddRoutePlot(pPlot, eRoute, iValue))
+			m_strategicRoutePlots.insert(pPlot->GetPlotIndex());
+	}
+
+	// Build a ring around the target plot
+	CvPlot** aPlotsToCheck = GC.getMap().getNeighborsUnchecked(path.get(path.length() - 1));
+	for (int iI = 0; iI < NUM_DIRECTION_TYPES; iI++)
+	{
+		CvPlot* pAdjacentPlot = aPlotsToCheck[iI];
+
+		if (pAdjacentPlot->isWater())
+			continue;
+
+		if (pAdjacentPlot->isCity())
+			continue;
+
+		if (pAdjacentPlot->getOwner() != m_pPlayer->GetID())
+			continue;
+
+		if (!pAdjacentPlot->isValidMovePlot(m_pPlayer->GetID()))
+			continue;
+
+		// Add these routes after the main route is completed
+		if (AddRoutePlot(pAdjacentPlot, eRoute, iValue - 1))
+			m_strategicRoutePlots.insert(pAdjacentPlot->GetPlotIndex());
+	}
 }
 
 bool CvBuilderTaskingAI::NeedRouteAtPlot(const CvPlot* pPlot) const
@@ -550,27 +613,17 @@ bool CvBuilderTaskingAI::AddRoutePlot(CvPlot* pPlot, RouteTypes eRoute, int iVal
 		iOldValue = it->second.second;
 	}
 
-	it = m_routeWantedPlots.find(pPlot->GetPlotIndex());
-	if (it != m_routeWantedPlots.end())
-	{
-		eOldRoute = it->second.first;
-		iOldValue = it->second.second;
-	}
-
 	// if we already want a better route, ignore this
 	if (eOldRoute > eRoute)
 		return false;
 
 	// if we wanted a lower tech route, ignore the old value
 	if (eOldRoute < eRoute)
-		iOldValue = 0;
+		m_routeNeededPlots[pPlot->GetPlotIndex()] = make_pair(eRoute, iValue);
+	else
+		m_routeNeededPlots[pPlot->GetPlotIndex()] = make_pair(eRoute, max(iOldValue, iValue));
 
 	//if it is the right route, add to needed plots
-	if (pPlot->getRouteType() == eRoute || GetSameRouteBenefitFromTrait(pPlot, eRoute))
-		m_routeNeededPlots[pPlot->GetPlotIndex()] = make_pair(eRoute, iValue + iOldValue);
-	else
-		//if no matching route, add to wanted plots
-		m_routeWantedPlots[pPlot->GetPlotIndex()] = make_pair(eRoute, iValue + iOldValue);
 	return true;
 }
 
@@ -579,19 +632,14 @@ int CvBuilderTaskingAI::GetRouteValue(CvPlot* pPlot)
 	if (!pPlot)
 		return false;
 
-	int iCreateValue = 0;
-	int iKeepValue = 0;
+	int iRouteValue = 0;
 	RoutePlotContainer::const_iterator it;
 
 	it = m_routeNeededPlots.find(pPlot->GetPlotIndex());
 	if (it != m_routeNeededPlots.end())
-		iKeepValue = it->second.second;
+		iRouteValue = it->second.second;
 
-	it = m_routeWantedPlots.find(pPlot->GetPlotIndex());
-	if (it != m_routeWantedPlots.end())
-		iCreateValue = it->second.second;
-
-	return max(iKeepValue,iCreateValue);
+	return iRouteValue;
 }
 
 set<int> CvBuilderTaskingAI::GetMainRoutePlots() const
@@ -622,6 +670,25 @@ bool CvBuilderTaskingAI::GetSameRouteBenefitFromTrait(CvPlot* pPlot, RouteTypes 
 			return true;
 	}
 	return false;
+}
+
+bool CvBuilderTaskingAI::MayWantVillageOnPlot(CvPlot* pPlot) const
+{
+	FeatureTypes eFeature = pPlot->getFeatureType();
+
+	if (m_bKeepJungle && eFeature == FEATURE_JUNGLE)
+		return false;
+
+	if (m_bKeepForest && eFeature == FEATURE_FOREST)
+		return false;
+
+	if (m_bKeepMarshes && eFeature == FEATURE_MARSH)
+		return false;
+
+	if (!m_bMayPutGPTINextToCity && pPlot->IsAdjacentCity())
+		return false;
+
+	return true;
 }
 
 void CvBuilderTaskingAI::UpdateCanalPlots()
@@ -719,59 +786,238 @@ void CvBuilderTaskingAI::ConnectCitiesForScenario(CvCity* pCity1, CvCity* pCity2
 	}
 }
 
-void CvBuilderTaskingAI::ConnectPointsForStrategy(CvCity* pOriginCity, CvPlot* pTargetPlot, BuildTypes eBuild, RouteTypes eRoute, int iNetGoldTimes100)
+vector<BuilderDirective> CvBuilderTaskingAI::GetDirectives()
 {
-	// don't connect cities from different owners
-	if (pOriginCity->getOwner() != pTargetPlot->getOwner())
-		return;
-
-	// only connect strategic points to the city they belong to
-	if (pTargetPlot->getOwningCity() != pOriginCity)
-		return;
-
-	CvRouteInfo* pRouteInfo = GC.getRouteInfo(eRoute);
-	if (!pRouteInfo)
-		return;
-
-	// build a path between the two cities
-	SPathFinderUserData data(m_pPlayer->GetID(),PT_BUILD_ROUTE,eBuild,eRoute,false);
-	SPath path = GC.GetStepFinder().GetPath(pOriginCity->getX(), pOriginCity->getY(), pTargetPlot->getX(), pTargetPlot->getY(), data);
-
-	//  if no path, then bail!
-	if (!path)
-		return;
-
-	//and this to see if we actually build it
-	int iCost = pRouteInfo->GetGoldMaintenance()*(100 + m_pPlayer->GetImprovementGoldMaintenanceMod());
-	iCost *= path.length();
-	if (iNetGoldTimes100 - iCost <= 6)
-		return;
-
-	for (int i = 0; i<path.length(); i++)
-	{
-		CvPlot* pPlot = path.get(i);
-		if (!pPlot)
-			break;
-
-		if (pPlot->isCity())
-			continue;
-
-		if (pPlot->getOwner() != m_pPlayer->GetID())
-			break;
-
-		// remember the plot
-		if (AddRoutePlot(pPlot, eRoute, 54))
-			m_strategicRoutePlots.insert(pPlot->GetPlotIndex());
-	}
+	return m_directives;
 }
-/// Looks at city connections and marks plots that can be added as routes by EvaluateBuilder
+
+BuilderDirective CvBuilderTaskingAI::GetAssignedDirective(CvUnit* pUnit)
+{
+	int iUnitID = pUnit->GetID();
+
+	if (m_assignedDirectives.find(iUnitID) != m_assignedDirectives.end())
+	{
+		return m_assignedDirectives[iUnitID];
+	}
+
+	return BuilderDirective();
+}
+
+void CvBuilderTaskingAI::SetAssignedDirective(CvUnit* pUnit, BuilderDirective eDirective)
+{
+	m_assignedDirectives[pUnit->GetID()] = eDirective;
+}
+
+bool CvBuilderTaskingAI::EvaluateBuilder(CvUnit* pUnit, BuilderDirective eDirective)
+{
+	CvPlot* pTargetPlot = GC.getMap().plot(eDirective.m_sX, eDirective.m_sY);
+	if (!pUnit->canBuild(pTargetPlot, eDirective.m_eBuild))
+		return false;
+
+	if (!ShouldBuilderConsiderPlot(pUnit, pTargetPlot))
+		return false;
+
+	return true;
+}
+
+int CvBuilderTaskingAI::GetBuilderNumTurnsAway(CvUnit* pUnit, BuilderDirective eDirective, int iMaxDistance)
+{
+	if (iMaxDistance < 0)
+		return INT_MAX;
+
+	CvPlot* pStartPlot = pUnit->plot();
+	CvPlot* pTargetPlot = GC.getMap().plot(eDirective.m_sX, eDirective.m_sY);
+
+	if (pStartPlot == pTargetPlot)
+		return 0;
+
+	SPathFinderUserData data(pUnit, CvUnit::MOVEFLAG_AI_ABORT_IN_DANGER, iMaxDistance);
+
+	if (pUnit->IsCombatUnit())
+		data.iMaxTurns = min(3, iMaxDistance);
+
+	SPath path = GC.GetPathFinder().GetPath(pUnit->plot(), pTargetPlot, data);
+
+	if (!!path)
+		return path.iTotalTurns;
+	else
+		return INT_MAX;
+}
+
+
+int CvBuilderTaskingAI::GetTurnsToBuild(CvUnit* pUnit, BuilderDirective eDirective, CvPlot* pPlot)
+{
+
+	BuildTypes eBuild = eDirective.m_eBuild;
+	PlayerTypes ePlayer = m_pPlayer->GetID();
+
+	int iBuildLeft = pPlot->getBuildTime(eBuild, ePlayer);
+	if (iBuildLeft == 0)
+		return 0;
+
+	int iBuildRate = pUnit->workRate(true);
+
+	if (iBuildRate == 0)
+	{
+		//this means it will take forever under current circumstances
+		return INT_MAX;
+	}
+
+	iBuildLeft -= pPlot->getBuildProgress(eBuild);
+	iBuildLeft = std::max(0, iBuildLeft);
+
+	int iTurnsLeft = (iBuildLeft / iBuildRate);
+	//round up
+	if (iTurnsLeft * iBuildRate < iBuildLeft)
+		iTurnsLeft++;
+
+	return iTurnsLeft;
+}
+
+//returns true if sucessful, false otherwise
+bool CvBuilderTaskingAI::ExecuteWorkerMove(CvUnit* pUnit, BuilderDirective aDirective)
+{
+	bool bSuccessful = false;
+
+	if (aDirective.m_eDirectiveType != BuilderDirective::NUM_DIRECTIVES)
+	{
+		switch (aDirective.m_eDirectiveType)
+		{
+		case BuilderDirective::BUILD_IMPROVEMENT_ON_RESOURCE:
+		case BuilderDirective::BUILD_IMPROVEMENT:
+		case BuilderDirective::REPAIR:
+		case BuilderDirective::BUILD_ROUTE:
+		case BuilderDirective::CHOP:
+		case BuilderDirective::REMOVE_ROAD:
+		{
+			CvPlot* pPlot = GC.getMap().plot(aDirective.m_sX, aDirective.m_sY);
+			MissionTypes eMission = CvTypes::getMISSION_MOVE_TO();
+			if (pUnit->getX() == aDirective.m_sX && pUnit->getY() == aDirective.m_sY)
+				eMission = CvTypes::getMISSION_BUILD();
+
+			if (GC.getLogging() && GC.GetBuilderAILogging())
+			{
+				// Open the log file
+				CvString strFileName = "BuilderTaskingLog.csv";
+				FILogFile* pLog = NULL;
+				pLog = LOGFILEMGR.GetLog(strFileName, FILogFile::kDontTimeStamp);
+
+				// write in data
+				CvString strLog;
+				CvString strTemp;
+
+				CvString strPlayerName;
+				strPlayerName = m_pPlayer->getCivilizationShortDescription();
+				strLog += strPlayerName;
+				strLog += ",";
+
+				strTemp.Format("%d,", GC.getGame().getGameTurn()); // turn
+				strLog += strTemp;
+
+				strTemp.Format("%d,", pUnit->GetID()); // unit id
+				strLog += strTemp;
+
+				switch (aDirective.m_eDirectiveType)
+				{
+				case BuilderDirective::BUILD_IMPROVEMENT_ON_RESOURCE:
+					strLog += "On resource,";
+					break;
+				case BuilderDirective::BUILD_IMPROVEMENT:
+					strLog += "On plot,";
+					break;
+				case BuilderDirective::REPAIR:
+					strLog += "Repairing,";
+					break;
+				case BuilderDirective::BUILD_ROUTE:
+					strLog += "Building route,";
+					break;
+				case BuilderDirective::CHOP:
+					strLog += "Removing resource for production,";
+					break;
+				case BuilderDirective::REMOVE_ROAD:
+					strLog += "Removing road,";
+					break;
+				}
+
+				if (eMission == CvTypes::getMISSION_BUILD())
+				{
+					if (aDirective.m_eDirectiveType == BuilderDirective::REPAIR)
+					{
+						if (pPlot->IsImprovementPillaged())
+						{
+							strLog += "Repairing improvement";
+						}
+						else
+						{
+							strLog += "Repairing route";
+						}
+					}
+					else if (aDirective.m_eDirectiveType == BuilderDirective::BUILD_ROUTE)
+					{
+						strLog += "Building route,";
+					}
+					else if (aDirective.m_eDirectiveType == BuilderDirective::BUILD_IMPROVEMENT || aDirective.m_eDirectiveType == BuilderDirective::BUILD_IMPROVEMENT_ON_RESOURCE)
+					{
+						strLog += "Building improvement,";
+					}
+					else if (aDirective.m_eDirectiveType == BuilderDirective::CHOP)
+					{
+						strLog += "Removing feature for production,";
+					}
+					else
+					{
+						strLog += "Removing road,";
+					}
+				}
+				else
+				{
+					strLog += "Moving to location,";
+				}
+
+				pLog->Msg(strLog);
+			}
+
+			if (eMission == CvTypes::getMISSION_MOVE_TO())
+			{
+				pUnit->PushMission(CvTypes::getMISSION_MOVE_TO(), aDirective.m_sX, aDirective.m_sY,
+					CvUnit::MOVEFLAG_NO_ENEMY_TERRITORY | CvUnit::MOVEFLAG_ABORT_IF_NEW_ENEMY_REVEALED, false, false, MISSIONAI_BUILD, pPlot);
+
+				//do we have movement left?
+				if (pUnit->getMoves() > 0)
+					eMission = CvTypes::getMISSION_BUILD();
+				else
+					bSuccessful = true;
+			}
+
+			if (eMission == CvTypes::getMISSION_BUILD())
+			{
+				// check to see if we already have this mission as the unit's head mission
+				const MissionData* pkMissionData = pUnit->GetHeadMissionData();
+				if (pkMissionData == NULL || pkMissionData->eMissionType != eMission || pkMissionData->iData1 != aDirective.m_eBuild)
+					pUnit->PushMission(CvTypes::getMISSION_BUILD(), aDirective.m_eBuild, aDirective.m_eDirectiveType, 0, false, false, MISSIONAI_BUILD, pPlot);
+
+				CvAssertMsg(!pUnit->ReadyToMove(), "Worker did not do their mission this turn. Could cause game to hang.");
+				bSuccessful = true;
+			}
+
+		}
+		break;
+		}
+	}
+
+	if (bSuccessful)
+		SetAssignedDirective(pUnit, aDirective);
+
+	return bSuccessful;
+}
+
+/// Looks at city connections and marks plots that can be added as routes by AddRouteDirective
 void CvBuilderTaskingAI::UpdateRoutePlots(void)
 {
 	// updating plots that are part of the road network
 	CvCityConnections* pCityConnections = m_pPlayer->GetCityConnections();
 
 	m_routeNeededPlots.clear();
-	m_routeWantedPlots.clear();
 	m_mainRoutePlots.clear();
 	m_shortcutRoutePlots.clear();
 	m_strategicRoutePlots.clear();
@@ -890,168 +1136,70 @@ void CvBuilderTaskingAI::UpdateRoutePlots(void)
 	}
 }
 
-CvUnit* CvBuilderTaskingAI::FindBestWorker(const std::map<int, ReachablePlots>& allWorkersReachablePlots, const CvPlot* pTarget) const
+/// Use the flavor settings to determine what to do
+void CvBuilderTaskingAI::UpdateImprovementPlots()
 {
-	if (!pTarget)
-		return NULL;
+	vector<OptionWithScore<BuilderDirective>> aDirectives;
 
-	int iBestScore = INT_MAX;
-	CvUnit* pBestWorker = NULL;
+	PlayerTypes ePlayer = m_pPlayer->GetID();
 
-	for (std::map<int, ReachablePlots>::const_iterator itUnit = allWorkersReachablePlots.begin(); itUnit != allWorkersReachablePlots.end(); ++itUnit)
+	vector<int> plotsToConsider = vector<int>();
+	CvPlot* pPlot;
+
+	for (int iI = 0; iI < GC.getMap().numPlots(); iI++)
 	{
-		ReachablePlots::const_iterator itPlot = itUnit->second.find(pTarget->GetPlotIndex());
-		if (itPlot == itUnit->second.end())
+		pPlot = GC.getMap().plotByIndexUnchecked(iI);
+
+		if (!ShouldAnyBuilderConsiderPlot(pPlot))
 			continue;
-
-		CvUnit* currentUnit = m_pPlayer->getUnit(itUnit->first);
-
-		int iTurns = itPlot->iPathLength;
-		//-1 means the plot is already targeted by another worker
-		if (iTurns < 0)
-			return currentUnit;
-
-		//use distance as a tiebreaker
-		int iScore = iTurns * 100 + plotDistance(*currentUnit->plot(), *pTarget);
-		if (iScore < iBestScore)
-		{
-			iBestScore = iScore;
-			pBestWorker = currentUnit;
-		}
-	}
-
-	return pBestWorker;
-}
-
-/// Use the flavor settings to determine what the worker should do
-BuilderDirective CvBuilderTaskingAI::EvaluateBuilder(CvUnit* pUnit, const map<int,ReachablePlots>& allWorkersReachablePlots)
-{
-	vector<OptionWithScore<BuilderDirective>> directives;
-
-	// check for no brainer bail-outs
-	// if the builder is already building something
-	if (pUnit->getBuildType() != NO_BUILD && pUnit->GetDanger() < pUnit->GetCurrHitPoints() / 2)
-	{
-		BuilderDirective nd;
-		nd.m_eDirective = BuilderDirective::BUILD_IMPROVEMENT;
-		nd.m_eBuild = pUnit->getBuildType();
-		nd.m_sX = pUnit->getX();
-		nd.m_sY = pUnit->getY();
-		nd.m_sMoveTurnsAway = 0;
-		return nd;
-	}
-
-	if (m_bLogging) {
-		CvString strLog;
-		strLog.Format(
-			"%i,Started handling unit,%d,%d",
-			pUnit->GetID(),
-			pUnit->getX(),
-			pUnit->getY()
-		);
-		LogInfo(strLog, m_pPlayer, true);
-	}
-
-	// go through all the plots this unit can reach
-	map<int, ReachablePlots>::const_iterator thisUnitPlots = allWorkersReachablePlots.find(pUnit->GetID());
-	if (thisUnitPlots == allWorkersReachablePlots.end())
-		return BuilderDirective();
-
-	for(ReachablePlots::const_iterator it=thisUnitPlots->second.begin(); it!=thisUnitPlots->second.end(); ++it)
-	{
-		CvPlot* pPlot = GC.getMap().plotByIndex(it->iPlotIndex);
-		int iMoveTurnsAway = it->iPathLength;
-
-		if(!ShouldBuilderConsiderPlot(pUnit, pPlot))
-		{
-			if (m_bLogging) {
-				CvString strLog;
-				strLog.Format(
-					"%i,Skipping plot,%d,%d",
-					pUnit->GetID(),
-					pPlot->getX(),
-					pPlot->getY()
-				);
-				LogInfo(strLog, m_pPlayer, true);
-			}
-			continue;
-		}
-
-		CvUnit* pBestWorker = FindBestWorker(allWorkersReachablePlots,pPlot);
-		if (pBestWorker != pUnit)
-		{
-			if (m_bLogging) {
-				CvString strLog;
-				strLog.Format(
-					"%i,Skipping plot because not best worker,%i,%d,%d",
-					pUnit->GetID(),
-					pBestWorker->GetID(),
-					pPlot->getX(),
-					pPlot->getY()
-				);
-				LogInfo(strLog, m_pPlayer, true);
-			}
-			continue;
-		}
 
 		//action may depend on city
 		CvCity* pWorkingCity = pPlot->getEffectiveOwningCity();
 
-		//in our own plots we can build anything
-		if (pPlot->getOwner() == pUnit->getOwner())
+		if (pPlot->getOwner() == ePlayer)
 		{
 			UpdateCurrentPlotYields(pPlot);
 
-			AddRouteDirectives(directives, pUnit, pPlot, pWorkingCity, iMoveTurnsAway);
-			AddImprovingResourcesDirectives(directives, pUnit, pPlot, pWorkingCity, iMoveTurnsAway);
-			AddImprovingPlotsDirectives(directives, pUnit, pPlot, pWorkingCity, iMoveTurnsAway);
-			if (pUnit->AI_getUnitAIType() == UNITAI_WORKER)
-			{
-				AddChopDirectives(directives, pUnit, pPlot, pWorkingCity, iMoveTurnsAway);
-				AddScrubFalloutDirectives(directives, pUnit, pPlot, pWorkingCity, iMoveTurnsAway);
-				AddRepairTilesDirectives(directives, pUnit, pPlot, pWorkingCity, iMoveTurnsAway);
-				AddRemoveRouteDirectives(directives, pUnit, pPlot, pWorkingCity, iMoveTurnsAway);
-			}
+			AddRouteDirective(aDirectives, pPlot, pWorkingCity);
+			AddImprovingResourcesDirective(aDirectives, pPlot, pWorkingCity);
+			AddImprovingPlotsDirective(aDirectives, pPlot, pWorkingCity);
+			AddChopDirectives(aDirectives, pPlot, pWorkingCity);
+			AddScrubFalloutDirectives(aDirectives, pPlot, pWorkingCity);
+			AddRepairTilesDirectives(aDirectives, pPlot, pWorkingCity);
+			AddRemoveRouteDirective(aDirectives, pPlot, pWorkingCity);
 		}
-		else if (m_bEvaluateAdjacent && !pPlot->isOwned() && pPlot->isAdjacentPlayer(pUnit->getOwner()))
+		else if (m_bEvaluateAdjacent && !pPlot->isOwned() && pPlot->isAdjacentPlayer(m_pPlayer->GetID()))
 		{
 			UpdateCurrentPlotYields(pPlot);
 
 			//some special improvements and roads
-			AddImprovingPlotsDirectives(directives, pUnit, pPlot, pWorkingCity, iMoveTurnsAway);
-			AddRouteDirectives(directives, pUnit, pPlot, pWorkingCity, iMoveTurnsAway);
-			if (pUnit->AI_getUnitAIType() == UNITAI_WORKER)
-			{
-				// May want to repair and remove road tiles outside of our territory
-				AddRepairTilesDirectives(directives, pUnit, pPlot, pWorkingCity, iMoveTurnsAway);
-				AddRemoveRouteDirectives(directives, pUnit, pPlot, pWorkingCity, iMoveTurnsAway);
-			}
+			AddImprovingPlotsDirective(aDirectives, pPlot, pWorkingCity);
+			AddRouteDirective(aDirectives, pPlot, pWorkingCity);
+			// May want to repair and remove road tiles outside of our territory
+			AddRepairTilesDirectives(aDirectives, pPlot, pWorkingCity);
+			AddRemoveRouteDirective(aDirectives, pPlot, pWorkingCity);
 		}
-		else
+		else if (NeedRouteAtPlot(pPlot) || pPlot->GetPlayerResponsibleForRoute() == m_pPlayer->GetID())
 		{
 			//only roads
-			AddRouteDirectives(directives, pUnit, pPlot, pWorkingCity, iMoveTurnsAway);
-			if (pUnit->AI_getUnitAIType() == UNITAI_WORKER)
-			{
-				// May want to repair and remove road tiles outside of our territory
-				AddRepairTilesDirectives(directives, pUnit, pPlot, pWorkingCity, iMoveTurnsAway);
-				AddRemoveRouteDirectives(directives, pUnit, pPlot, pWorkingCity, iMoveTurnsAway);
-			}
+			AddRouteDirective(aDirectives, pPlot, pWorkingCity);
+			// May want to repair and remove road tiles outside of our territory
+			AddRepairTilesDirectives(aDirectives, pPlot, pWorkingCity);
+			AddRemoveRouteDirective(aDirectives, pPlot, pWorkingCity);
 		}
 	}
 
-	std::stable_sort(directives.begin(), directives.end());
-	LogDirectives(directives, pUnit);
+	std::stable_sort(aDirectives.begin(), aDirectives.end());
+	LogDirectives(aDirectives);
 
-	//nothing found?
-	if (directives.empty())
-		return BuilderDirective();
-
-	return directives.front().option;
+	m_directives.clear();
+	m_assignedDirectives.clear();
+	for (vector<OptionWithScore<BuilderDirective>>::iterator it = aDirectives.begin(); it != aDirectives.end(); ++it)
+		m_directives.push_back((*it).option);
 }
 
 /// Evaluating a plot to see if we can build resources there
-void CvBuilderTaskingAI::AddImprovingResourcesDirectives(vector<OptionWithScore<BuilderDirective>>& directives, CvUnit* pUnit, CvPlot* pPlot, CvCity* pCity, int iMoveTurnsAway)
+void CvBuilderTaskingAI::AddImprovingResourcesDirective(vector<OptionWithScore<BuilderDirective>> &aDirectives, CvPlot* pPlot, CvCity* pCity)
 {
 	// check to see if a resource is here. If not, bail out!
 	ResourceTypes eResource = pPlot->getResourceType(m_pPlayer->getTeam());
@@ -1066,7 +1214,7 @@ void CvBuilderTaskingAI::AddImprovingResourcesDirectives(vector<OptionWithScore<
 	if (eExistingPlotImprovement != NO_IMPROVEMENT)
 	{
 		// Do we have a special improvement here? (great person improvement, gifted improvement from major civ)
-		if (pPlot->HasSpecialImprovement() || (GET_PLAYER(pUnit->getOwner()).isOption(PLAYEROPTION_SAFE_AUTOMATION) && GET_PLAYER(pUnit->getOwner()).isHuman()))
+		if (pPlot->HasSpecialImprovement() || (m_pPlayer->isOption(PLAYEROPTION_SAFE_AUTOMATION) && m_pPlayer->isHuman()))
 			return;
 
 		if (pPlot->IsImprovementPillaged())
@@ -1104,7 +1252,7 @@ void CvBuilderTaskingAI::AddImprovingResourcesDirectives(vector<OptionWithScore<
 			if(eImprovement == eExistingPlotImprovement)
 				continue;
 
-			if(!pUnit->canBuild(pPlot, eBuild))
+			if(!m_pPlayer->canBuild(pPlot, eBuild))
 				continue;
 
 			BuilderDirective::BuilderDirectiveType eDirectiveType = BuilderDirective::BUILD_IMPROVEMENT_ON_RESOURCE;
@@ -1150,7 +1298,7 @@ void CvBuilderTaskingAI::AddImprovingResourcesDirectives(vector<OptionWithScore<
 				}
 			}
 
-			int iBuildTimeWeight = GetBuildTimeWeight(pUnit, pPlot, eBuild, DoesBuildHelpRush(pUnit, pPlot, eBuild), iInvestedImprovementTime);
+			int iBuildTimeWeight = GetBuildTimeWeight(pPlot, eBuild, DoesBuildHelpRush(pPlot, eBuild), iInvestedImprovementTime);
 			iWeight += iBuildTimeWeight;
 
 			if (!bPrevImprovementConnects && !pkImprovementInfo->IsCreatedByGreatPerson())
@@ -1160,22 +1308,18 @@ void CvBuilderTaskingAI::AddImprovingResourcesDirectives(vector<OptionWithScore<
 			}
 
 			iWeight = min(iWeight,0x7FFF);
-			iWeight /= (iMoveTurnsAway*iMoveTurnsAway + 1);
-			iWeight -= plotDistance(*pUnit->plot(),*pPlot); //tiebreaker in case of multiple equal options
 
-			int iScore = ScorePlotBuild(pUnit, pPlot, eImprovement, eBuild);
+			int iScore = ScorePlotBuild(pPlot, eImprovement, eBuild);
 			iScore = min(iScore,0x7FFF);
 
-			if(iScore > 0)
+			if (iScore > 0)
 			{
-				if (pCity && pCity->GetCityCitizens()->IsWorkingPlot(pPlot))
-					iScore *= 2;
 				iWeight += iScore;
 			}
 
 			CvCity* pLogCity = NULL;
-			int iProduction = pPlot->getFeatureProduction(eBuild, pUnit->getOwner(), &pLogCity);
-			if(DoesBuildHelpRush(pUnit, pPlot, eBuild))
+			int iProduction = pPlot->getFeatureProduction(eBuild, m_pPlayer->GetID(), &pLogCity);
+			if(DoesBuildHelpRush(pPlot, eBuild))
 			{
 				iWeight += iProduction; // a nominal benefit for choosing this production
 
@@ -1192,21 +1336,13 @@ void CvBuilderTaskingAI::AddImprovingResourcesDirectives(vector<OptionWithScore<
 				continue;
 			}
 
-			BuilderDirective directive;
-			directive.m_eDirective = eDirectiveType;
-			directive.m_eBuild = eBuild;
-			directive.m_eResource = eResource;
-			directive.m_sX = pPlot->getX();
-			directive.m_sY = pPlot->getY();
-			//directive.m_iGoldCost = m_pPlayer->getBuildCost(pPlot, eBuild);
-			directive.m_sMoveTurnsAway = iMoveTurnsAway;
+			BuilderDirective directive(eDirectiveType, eBuild, eResource, pPlot->getX(), pPlot->getY(), iWeight);
 
 			if(m_bLogging)
 			{
 				CvString strTemp;
 				strTemp.Format(
-					"%d,Build Time Weight,%d,%i,%i,%d", 
-					pUnit->GetID(),
+					"Build Time Weight,%i,%i,%d,%d",
 					pPlot->getX(),
 					pPlot->getY(),
 					iBuildTimeWeight,
@@ -1215,27 +1351,26 @@ void CvBuilderTaskingAI::AddImprovingResourcesDirectives(vector<OptionWithScore<
 				LogInfo(strTemp, m_pPlayer);
 			}
 
-			directives.push_back( OptionWithScore<BuilderDirective>(directive, iWeight));
+			aDirectives.push_back(OptionWithScore<BuilderDirective>(directive, iWeight));
 		}
 	}
 }
 
 /// Evaluating a plot to determine what improvement could be best there
-void CvBuilderTaskingAI::AddImprovingPlotsDirectives(vector<OptionWithScore<BuilderDirective>>& directives, CvUnit* pUnit, CvPlot* pPlot, CvCity* pCity, int iMoveTurnsAway)
+void CvBuilderTaskingAI::AddImprovingPlotsDirective(vector<OptionWithScore<BuilderDirective>> &aDirectives, CvPlot* pPlot, CvCity* pCity)
 {
 	ImprovementTypes eExistingImprovement = pPlot->getImprovementType();
 
 	if (eExistingImprovement != NO_IMPROVEMENT)
 	{
 		// Do we have a special improvement here? (great person improvement, gifted improvement from major civ)
-		if (pPlot->HasSpecialImprovement() || (GET_PLAYER(pUnit->getOwner()).isOption(PLAYEROPTION_SAFE_AUTOMATION) && GET_PLAYER(pUnit->getOwner()).isHuman()))
+		if (pPlot->HasSpecialImprovement() || (m_pPlayer->isOption(PLAYEROPTION_SAFE_AUTOMATION) && m_pPlayer->isHuman()))
 		{
 			if (m_bLogging)
 			{
 				CvString strTemp;
 				strTemp.Format(
-					"%i,Weight,Improvement Blocked by Special Improvement,%s,%i,%i", 
-					pUnit->GetID(),
+					"%Weight,Improvement Blocked by Special Improvement,%s,%i,%i",
 					GC.getImprovementInfo(pPlot->getImprovementType())->GetType(),
 					pPlot->getX(),
 					pPlot->getY()
@@ -1248,7 +1383,7 @@ void CvBuilderTaskingAI::AddImprovingPlotsDirectives(vector<OptionWithScore<Buil
 			return;
 	}
 
-	if(!m_bEvaluateAdjacent && !pPlot->isWithinTeamCityRadius(pUnit->getTeam()))
+	if(!m_bEvaluateAdjacent && !pPlot->isWithinTeamCityRadius(m_pPlayer->getTeam()))
 		return;
 
 	// if city owning this plot is being razed, ignore this plot
@@ -1282,6 +1417,9 @@ void CvBuilderTaskingAI::AddImprovingPlotsDirectives(vector<OptionWithScore<Buil
 		BuildTypes eBuild = (BuildTypes)iBuildIndex;
 		CvBuildInfo* pkBuild = GC.getBuildInfo(eBuild);
 		if(pkBuild == NULL)
+			continue;
+
+		if (!m_pPlayer->canBuild(pPlot, eBuild))
 			continue;
 
 		ImprovementTypes eImprovement = (ImprovementTypes)pkBuild->getImprovement();
@@ -1329,7 +1467,7 @@ void CvBuilderTaskingAI::AddImprovingPlotsDirectives(vector<OptionWithScore<Buil
 		}
 
 		// Only check to make sure our unit can build this after possibly switching this to a repair build in the block of code above
-		if(!pUnit->canBuild(pPlot, eBuild))
+		if(!m_pPlayer->canBuild(pPlot, eBuild))
 		{
 			/*if (m_bLogging) {
 				CvString strTemp;
@@ -1357,8 +1495,7 @@ void CvBuilderTaskingAI::AddImprovingPlotsDirectives(vector<OptionWithScore<Buil
 			if(m_bLogging){
 				CvString strTemp;
 				strTemp.Format(
-					"%i,Weight,Marsh Remove,%s,%i,%i", 
-					pUnit->GetID(),
+					"Weight,Marsh Remove,%s,%i,%i",
 					GC.getBuildInfo(eBuild)->GetType(),
 					pPlot->getX(),
 					pPlot->getY()
@@ -1374,11 +1511,28 @@ void CvBuilderTaskingAI::AddImprovingPlotsDirectives(vector<OptionWithScore<Buil
 		// special case for Brazil
 		if (m_bKeepJungle && bWillRemoveJungle)
 		{
-			if(m_bLogging){
+			if (m_bLogging) {
 				CvString strTemp;
 				strTemp.Format(
-					"%i,Weight,Jungle Remove,%s,%i,%i", 
-					pUnit->GetID(),
+					"Weight,Jungle Remove,%s,%i,%i",
+					GC.getBuildInfo(eBuild)->GetType(),
+					pPlot->getX(),
+					pPlot->getY()
+				);
+				LogInfo(strTemp, m_pPlayer);
+			}
+			if (eResource == NO_RESOURCE)
+			{
+				continue;
+			}
+		}
+		// In VP Brazilwood camps can be built on forest as well
+		if (m_bKeepForest && bWillRemoveForest)
+		{
+			if (m_bLogging) {
+				CvString strTemp;
+				strTemp.Format(
+					"Weight,Forest Remove,%s,%i,%i",
 					GC.getBuildInfo(eBuild)->GetType(),
 					pPlot->getX(),
 					pPlot->getY()
@@ -1391,15 +1545,14 @@ void CvBuilderTaskingAI::AddImprovingPlotsDirectives(vector<OptionWithScore<Buil
 			}
 		}
 
-		if(GET_PLAYER(pUnit->getOwner()).isOption(PLAYEROPTION_LEAVE_FORESTS) && GET_PLAYER(pUnit->getOwner()).isHuman())
+		if(m_pPlayer->isOption(PLAYEROPTION_LEAVE_FORESTS) && m_pPlayer->isHuman())
 		{
 			if((bWillRemoveForest || bWillRemoveJungle || bWillRemoveMarsh) && eResource == NO_RESOURCE)
 			{
 				if(m_bLogging){
 					CvString strTemp;
 					strTemp.Format(
-						"%i,Weight,Keep Features,%s,%i,%i", 
-						pUnit->GetID(),
+						"Weight,Keep Features,%s,%i,%i",
 						GC.getBuildInfo(eBuild)->GetType(),
 						pPlot->getX(),
 						pPlot->getY()
@@ -1410,7 +1563,7 @@ void CvBuilderTaskingAI::AddImprovingPlotsDirectives(vector<OptionWithScore<Buil
 			}
 		}
 
-		int iScore = ScorePlotBuild(pUnit, pPlot, eImprovement, eBuild);
+		int iScore = ScorePlotBuild(pPlot, eImprovement, eBuild);
 		if (pCity && pCity->GetCityCitizens()->IsWorkingPlot(pPlot))
 			iScore *= 2;
 
@@ -1422,8 +1575,7 @@ void CvBuilderTaskingAI::AddImprovingPlotsDirectives(vector<OptionWithScore<Buil
 			if(m_bLogging){
 				CvString strTemp;
 				strTemp.Format(
-					"%i,Weight,Negative Score,%s,%i,%i,%i", 
-					pUnit->GetID(),
+					"Weight,Negative Score,%s,%i,%i,%i",
 					GC.getBuildInfo(eBuild)->GetType(), 
 					iScore, 
 					pPlot->getX(), 
@@ -1437,7 +1589,7 @@ void CvBuilderTaskingAI::AddImprovingPlotsDirectives(vector<OptionWithScore<Buil
 		int iWeight = /*100*/ GD_INT_GET(BUILDER_TASKING_BASELINE_BUILD_IMPROVEMENTS);
 		iWeight = GetBuildCostWeight(iWeight, pPlot, eBuild);
 
-		int iBuildTimeWeight = GetBuildTimeWeight(pUnit, pPlot, eBuild, DoesBuildHelpRush(pUnit, pPlot, eBuild));
+		int iBuildTimeWeight = GetBuildTimeWeight(pPlot, eBuild, DoesBuildHelpRush(pPlot, eBuild));
 		iWeight += iBuildTimeWeight;
 
 		if (bWillRemoveForest || bWillRemoveJungle)
@@ -1476,49 +1628,38 @@ void CvBuilderTaskingAI::AddImprovingPlotsDirectives(vector<OptionWithScore<Buil
 		}
 
 		iWeight = min(iWeight,0x7FFF);
-		iWeight /= (iMoveTurnsAway*iMoveTurnsAway + 1);
-		iWeight -= plotDistance(*pUnit->plot(), *pPlot); //tiebreaker in case of multiple equal options
 
 		//overflow danger here
 		iWeight += iScore;
 
-		BuilderDirective directive;
-		directive.m_eDirective = eDirectiveType;
-		directive.m_eBuild = eBuild;
-		directive.m_eResource = NO_RESOURCE;
-		directive.m_sX = pPlot->getX();
-		directive.m_sY = pPlot->getY();
-		directive.m_sMoveTurnsAway = iMoveTurnsAway;
+		BuilderDirective directive(eDirectiveType, eBuild, NO_RESOURCE, pPlot->getX(), pPlot->getY(), iWeight);
 
 		if(m_bLogging)
 		{
 			CvString strTemp;
 			strTemp.Format(
-				"%i,Weight,Directive Score Added,%s,%i,%i,%i,%d", 
-				pUnit->GetID(),
+				"Weight,Directive Score Added,%s,%i,%i,%d", 
 				GC.getBuildInfo(eBuild)->GetType(),
 				directive.m_sX,
 				directive.m_sY,
-				directive.m_sMoveTurnsAway,
 				iWeight
 			);
 			LogInfo(strTemp, m_pPlayer);
 		}
 
-		directives.push_back( OptionWithScore<BuilderDirective>(directive, iWeight));
+		aDirectives.push_back( OptionWithScore<BuilderDirective>(directive, iWeight));
 	}
 }
 
 /// Adds a directive if the unit can construct a road in the plot
-void CvBuilderTaskingAI::AddRemoveRouteDirectives(vector<OptionWithScore<BuilderDirective>>& directives, CvUnit* pUnit, CvPlot* pPlot, CvCity* /*pCity*/, int iMoveTurnsAway)
+void CvBuilderTaskingAI::AddRemoveRouteDirective(vector<OptionWithScore<BuilderDirective>> &aDirectives, CvPlot* pPlot, CvCity* /*pCity*/)
 {
 	//minors stay out
 	if (m_pPlayer->isMinorCiv())
 		return;
 
 	//can we even remove routes?
-	CvUnitEntry& kUnitInfo = pUnit->getUnitInfo();
-	if (m_eRemoveRouteBuild==NO_BUILD || !kUnitInfo.GetBuilds(m_eRemoveRouteBuild))
+	if (m_eRemoveRouteBuild==NO_BUILD || !m_pPlayer->canBuild(pPlot,m_eRemoveRouteBuild))
 		return;
 
 	// If "Automated Workers Don't Replace Improvements" option is enabled, don't remove roads
@@ -1537,17 +1678,11 @@ void CvBuilderTaskingAI::AddRemoveRouteDirectives(vector<OptionWithScore<Builder
 	if (pPlot->isCity())
 		return;
 
-	RouteTypes eWantedRoute = GetRouteTypeWantedAtPlot(pPlot);
-
-	// the plot was flagged recently, so ignore
-	if (eWantedRoute >= eRoute)
-		return;
+	RouteTypes eNeededRoute = GetRouteTypeNeededAtPlot(pPlot);
 
 	// keep routes which are needed
-	if (GetRouteTypeNeededAtPlot(pPlot) >= eRoute && !GetSameRouteBenefitFromTrait(pPlot, eWantedRoute))
-	{
+	if (eNeededRoute >= eRoute && !GetSameRouteBenefitFromTrait(pPlot, eNeededRoute))
 		return;
-	}
 
 	// we don't need to remove pillaged routes
 	if (pPlot->IsRoutePillaged())
@@ -1563,7 +1698,7 @@ void CvBuilderTaskingAI::AddRemoveRouteDirectives(vector<OptionWithScore<Builder
 		return;
 
 	//we want to be aggressive with this because of the cost.
-	int iWeight = /*500*/ GD_INT_GET(BUILDER_TASKING_BASELINE_BUILD_ROUTES) * 2;
+	int iWeight = /*500*/ GD_INT_GET(BUILDER_TASKING_BASELINE_BUILD_ROUTES) * 4;
 
 	//if we are in debt, be more aggressive
 	EconomicAIStrategyTypes eStrategyLosingMoney = (EconomicAIStrategyTypes)GC.getInfoTypeForString("ECONOMICAISTRATEGY_LOSING_MONEY");
@@ -1571,26 +1706,17 @@ void CvBuilderTaskingAI::AddRemoveRouteDirectives(vector<OptionWithScore<Builder
 		iWeight *= 3;
 
 	iWeight = GetBuildCostWeight(iWeight, pPlot, m_eRemoveRouteBuild);
-	iWeight += GetBuildTimeWeight(pUnit, pPlot, m_eRemoveRouteBuild, false);
-	iWeight /= (iMoveTurnsAway*iMoveTurnsAway + 1);
-	iWeight -= plotDistance(*pUnit->plot(), *pPlot); //tiebreaker in case of multiple equal options
+	iWeight += GetBuildTimeWeight(pPlot, m_eRemoveRouteBuild, false);
 
 	BuilderDirective::BuilderDirectiveType eDirectiveType = BuilderDirective::REMOVE_ROAD;
 
-	BuilderDirective directive;
-	directive.m_eDirective = eDirectiveType;
-	directive.m_eBuild = m_eRemoveRouteBuild;
-	directive.m_eResource = NO_RESOURCE;
-	directive.m_sX = pPlot->getX();
-	directive.m_sY = pPlot->getY();
-	directive.m_sMoveTurnsAway = iMoveTurnsAway;
+	BuilderDirective directive(eDirectiveType, m_eRemoveRouteBuild, NO_RESOURCE, pPlot->getX(), pPlot->getY(), iWeight);
 
 	if (m_bLogging)
 	{
 		CvString strTemp;
 		strTemp.Format(
-			"%i,RemoveRouteDirectives,%d,%d,%d",
-			pUnit->GetID(),
+			"RemoveRouteDirectives,%d,%d,%d",
 			pPlot->getX(), 
 			pPlot->getY(), 
 			iWeight
@@ -1598,32 +1724,35 @@ void CvBuilderTaskingAI::AddRemoveRouteDirectives(vector<OptionWithScore<Builder
 		LogInfo(strTemp, m_pPlayer);
 	}
 
-	directives.push_back( OptionWithScore<BuilderDirective>(directive, iWeight));
+	aDirectives.push_back( OptionWithScore<BuilderDirective>(directive, iWeight));
 }
 
 /// Adds a directive if the unit can construct a road in the plot
-void CvBuilderTaskingAI::AddRouteDirectives(vector<OptionWithScore<BuilderDirective>>& directives, CvUnit* pUnit, CvPlot* pPlot, CvCity* /*pCity*/, int iMoveTurnsAway)
+void CvBuilderTaskingAI::AddRouteDirective(vector<OptionWithScore<BuilderDirective>> &aDirectives, CvPlot* pPlot, CvCity* /*pCity*/)
 {
 	// the plot was not flagged recently, so ignore
-	if (!WantRouteAtPlot(pPlot))
+	if (!NeedRouteAtPlot(pPlot))
 		return;
 
-	RouteTypes eRoute = GetRouteTypeWantedAtPlot(pPlot);
+	RouteTypes eRoute = GetRouteTypeNeededAtPlot(pPlot);
 	if(eRoute == NO_ROUTE)
+		return;
+
+	if (GetSameRouteBenefitFromTrait(pPlot, eRoute))
 		return;
 
 	BuildTypes eRouteBuild = GetBuildRoute(eRoute);
 
 	// can we even build the desired route
-	CvUnitEntry& kUnitInfo = pUnit->getUnitInfo();
-	if(eRouteBuild == NO_BUILD || !kUnitInfo.GetBuilds(eRouteBuild))
+	m_pPlayer->canBuild(pPlot, eRouteBuild);
+	if(eRouteBuild == NO_BUILD || !m_pPlayer->canBuild(pPlot, eRouteBuild))
 		return;
 
 	// no matter if pillaged or not
 	if(pPlot->getRouteType() >= eRoute)
 		return;
 
-	if(GET_PLAYER(pUnit->getOwner()).isOption(PLAYEROPTION_LEAVE_FORESTS))
+	if(m_pPlayer->isOption(PLAYEROPTION_LEAVE_FORESTS))
 	{
 		FeatureTypes eFeature = pPlot->getFeatureType();
 		if(eFeature != NO_FEATURE)
@@ -1640,25 +1769,16 @@ void CvBuilderTaskingAI::AddRouteDirectives(vector<OptionWithScore<BuilderDirect
 	BuilderDirective::BuilderDirectiveType eDirectiveType = BuilderDirective::BUILD_ROUTE;
 
 	iWeight = GetBuildCostWeight(iWeight, pPlot, eRouteBuild);
-	iWeight += GetBuildTimeWeight(pUnit, pPlot, eRouteBuild, false);
+	iWeight += GetBuildTimeWeight(pPlot, eRouteBuild, false);
 	iWeight += GetRouteValue(pPlot);
-	iWeight /= (iMoveTurnsAway*iMoveTurnsAway + 1);
-	iWeight -= plotDistance(*pUnit->plot(), *pPlot); //tiebreaker in case of multiple equal options
 
-	BuilderDirective directive;
-	directive.m_eDirective = eDirectiveType;
-	directive.m_eBuild = eRouteBuild;
-	directive.m_eResource = NO_RESOURCE;
-	directive.m_sX = pPlot->getX();
-	directive.m_sY = pPlot->getY();
-	directive.m_sMoveTurnsAway = iMoveTurnsAway;
+	BuilderDirective directive(eDirectiveType, eRouteBuild, NO_RESOURCE, pPlot->getX(), pPlot->getY(), iWeight);
 
 	if(m_bLogging)
 	{
 		CvString strTemp;
 		strTemp.Format(
-			"%i,AddRouteDirectives,%d,%d,%d", 
-			pUnit->GetID(),
+			"%i,AddRouteDirectives,%d,%d", 
 			pPlot->getX(),
 			pPlot->getY(),
 			iWeight
@@ -1666,14 +1786,14 @@ void CvBuilderTaskingAI::AddRouteDirectives(vector<OptionWithScore<BuilderDirect
 		LogInfo(strTemp, m_pPlayer);
 	}
 
-	directives.push_back( OptionWithScore<BuilderDirective>(directive, iWeight));
+	aDirectives.push_back(OptionWithScore<BuilderDirective>(directive, iWeight));
 }
 
 /// Determines if the builder should "chop" the feature in the tile
-void CvBuilderTaskingAI::AddChopDirectives(vector<OptionWithScore<BuilderDirective>>& directives, CvUnit* pUnit, CvPlot* pPlot, CvCity* pCity, int iMoveTurnsAway)
+void CvBuilderTaskingAI::AddChopDirectives(vector<OptionWithScore<BuilderDirective>> &aDirectives, CvPlot* pPlot, CvCity* pCity)
 {
 	// if it's not within a city radius
-	if(!pPlot->isWithinTeamCityRadius(pUnit->getTeam()))
+	if(!pPlot->isWithinTeamCityRadius(m_pPlayer->getTeam()))
 	{
 		return;
 	}
@@ -1683,7 +1803,7 @@ void CvBuilderTaskingAI::AddChopDirectives(vector<OptionWithScore<BuilderDirecti
 		return;
 	}
 
-	if(GET_PLAYER(pUnit->getOwner()).isOption(PLAYEROPTION_LEAVE_FORESTS))
+	if(m_pPlayer->isOption(PLAYEROPTION_LEAVE_FORESTS))
 	{
 		return;
 	}
@@ -1747,7 +1867,7 @@ void CvBuilderTaskingAI::AddChopDirectives(vector<OptionWithScore<BuilderDirecti
 	{
 		BuildTypes eBuild = (BuildTypes)iBuildIndex;
 		CvBuildInfo* pkBuild = GC.getBuildInfo(eBuild);
-		if(NULL != pkBuild && pkBuild->getImprovement() == NO_IMPROVEMENT && pkBuild->isFeatureRemove(eFeature) && pkBuild->getFeatureProduction(eFeature) > 0 && pUnit->canBuild(pPlot, eBuild))
+		if(NULL != pkBuild && pkBuild->getImprovement() == NO_IMPROVEMENT && pkBuild->isFeatureRemove(eFeature) && pkBuild->getFeatureProduction(eFeature) > 0 && m_pPlayer->canBuild(pPlot, eBuild))
 		{
 			eChopBuild = eBuild;
 			break;
@@ -1761,15 +1881,15 @@ void CvBuilderTaskingAI::AddChopDirectives(vector<OptionWithScore<BuilderDirecti
 	}
 
 	pCity = NULL;
-	int iProduction = pPlot->getFeatureProduction(eChopBuild, pUnit->getOwner(), &pCity);
+	int iProduction = pPlot->getFeatureProduction(eChopBuild, m_pPlayer->GetID(), &pCity);
 
-	if(!DoesBuildHelpRush(pUnit, pPlot, eChopBuild))
+	if(!DoesBuildHelpRush(pPlot, eChopBuild))
 	{
 		return;
 	}
 
 	int iWeight = GetBuildCostWeight(/*1000*/ GD_INT_GET(BUILDER_TASKING_BASELINE_REPAIR), pPlot, eChopBuild);
-	iWeight += GetBuildTimeWeight(pUnit, pPlot, eChopBuild, false);
+	iWeight += GetBuildTimeWeight(pPlot, eChopBuild, false);
 	iWeight *= iProduction; // times the amount that the plot produces from the chopping
 
 	int iYieldDifferenceWeight = 0;
@@ -1853,52 +1973,18 @@ void CvBuilderTaskingAI::AddChopDirectives(vector<OptionWithScore<BuilderDirecti
 	}
 
 	iWeight = min(iWeight, 0x7FFF);
-	iWeight /= (iMoveTurnsAway * iMoveTurnsAway + 1);
-	iWeight -= plotDistance(*pUnit->plot(), *pPlot); //tiebreaker in case of multiple equal options
 
 	if(iWeight > 0)
 	{
-		BuilderDirective directive;
-		directive.m_eDirective = BuilderDirective::CHOP;
-		directive.m_eBuild = eChopBuild;
-		directive.m_eResource = NO_RESOURCE;
-		directive.m_sX = pPlot->getX();
-		directive.m_sY = pPlot->getY();
-		//directive.m_iGoldCost = m_pPlayer->getBuildCost(pPlot, eChopBuild);
-		directive.m_sMoveTurnsAway = iMoveTurnsAway;
+		BuilderDirective directive(BuilderDirective::CHOP, eChopBuild, NO_RESOURCE, pPlot->getX(), pPlot->getY(), iWeight);
 
-		directives.push_back( OptionWithScore<BuilderDirective>(directive, iWeight));
+		aDirectives.push_back(OptionWithScore<BuilderDirective>(directive, iWeight));
 	}
 }
 
-void CvBuilderTaskingAI::AddRepairTilesDirectives(vector<OptionWithScore<BuilderDirective>>& directives, CvUnit* pUnit, CvPlot* pPlot, CvCity* pWorkingCity, int iMoveTurnsAway)
+void CvBuilderTaskingAI::AddRepairTilesDirectives(vector<OptionWithScore<BuilderDirective>> &aDirectives, CvPlot* pPlot, CvCity* pWorkingCity)
 {
 	if (!pPlot)
-	{
-		return;
-	}
-
-	bool isOwned = pPlot->isOwned();
-	bool isOwnedByUs = pPlot->getOwner() == pUnit->getOwner();
-	// If it's owned by someone else, ignore it
-	if (isOwned && !isOwnedByUs)
-	{
-		return;
-	}
-	bool isPillagedRouteWeWantToRepair = NeedRouteAtPlot(pPlot) && pPlot->IsRoutePillaged();
-	// If it's owned by us, but it's being razed, ignore it (check actual owning city instead of working city)
-	if (isOwnedByUs && pPlot->getOwningCity() && pPlot->getOwningCity()->IsRazing() && !isPillagedRouteWeWantToRepair)
-	{
-		return;
-	}
-	// If it's not owned by us, and it's not a route we want to repair, ignore it
-	if (!isOwned && !isPillagedRouteWeWantToRepair)
-	{
-		return;
-	}
-
-	// if city owning this plot is being razed, and it's not a route we want to repair, ignore this plot
-	if (pWorkingCity && pWorkingCity->IsRazing() && !isPillagedRouteWeWantToRepair)
 	{
 		return;
 	}
@@ -1909,10 +1995,36 @@ void CvBuilderTaskingAI::AddRepairTilesDirectives(vector<OptionWithScore<Builder
 		return;
 	}
 
+	bool bIsOwned = pPlot->isOwned();
+	bool bIsOwnedByUs = pPlot->getOwner() == m_pPlayer->GetID();
+
+	RouteTypes eRouteNeeded = GetRouteTypeNeededAtPlot(pPlot);
+	RouteTypes eRoute = pPlot->getRouteType();
+	bool bIsPillagedRouteWeWantToRepair = eRouteNeeded > NO_ROUTE && eRouteNeeded <= eRoute && pPlot->IsRoutePillaged() && !GetSameRouteBenefitFromTrait(pPlot, eRoute);
+
+	// For routes, we ignore plot ownership
+	if (!bIsPillagedRouteWeWantToRepair)
+	{
+		// If it's owned by someone else or is unowned, ignore it
+		if ((bIsOwned && !bIsOwnedByUs) || !bIsOwned)
+		{
+			return;
+		}
+
+		CvCity* pOwningCity = pPlot->getOwningCity();
+
+		// If the city owning this plot is being razed, ignore it (check actual owning city instead of working city)
+		if (pOwningCity && pOwningCity->IsRazing())
+		{
+			return;
+		}
+	}
+
 	int iWeight = GetBuildCostWeight(100 * /*1000*/ GD_INT_GET(BUILDER_TASKING_BASELINE_REPAIR), pPlot, m_eRepairBuild);
-	iWeight += GetBuildTimeWeight(pUnit, pPlot, m_eRepairBuild, false);
-	iWeight /= (iMoveTurnsAway*iMoveTurnsAway + 1);
-	iWeight -= plotDistance(*pUnit->plot(), *pPlot); //tiebreaker in case of multiple equal options
+	iWeight += GetBuildTimeWeight(pPlot, m_eRepairBuild, false);
+
+	if (bIsPillagedRouteWeWantToRepair)
+		iWeight += GetRouteValue(pPlot);
 
 	if (pPlot->isRevealedFortification(m_pPlayer->getTeam()))
 		iWeight *= 10;
@@ -1920,36 +2032,22 @@ void CvBuilderTaskingAI::AddRepairTilesDirectives(vector<OptionWithScore<Builder
 	if (pWorkingCity && pWorkingCity->GetCityCitizens()->IsWorkingPlot(pPlot))
 		iWeight *= 2;
 
-	if (isPillagedRouteWeWantToRepair)
-	{
-		RoutePlotContainer::const_iterator it = m_routeNeededPlots.find(pPlot->GetPlotIndex());
-		if (it != m_routeNeededPlots.end())
-			iWeight += it->second.second;
-	}
-
 	if (iWeight > 0)
 	{
-		BuilderDirective directive;
-		directive.m_eDirective = BuilderDirective::REPAIR;
-		directive.m_eBuild = m_eRepairBuild;
-		directive.m_eResource = NO_RESOURCE;
-		directive.m_sX = pPlot->getX();
-		directive.m_sY = pPlot->getY();
-		//directive.m_iGoldCost = m_pPlayer->getBuildCost(pPlot, eChopBuild);
-		directive.m_sMoveTurnsAway = iMoveTurnsAway;
+		BuilderDirective directive(BuilderDirective::REPAIR, m_eRepairBuild, NO_RESOURCE, pPlot->getX(), pPlot->getY(), iWeight);
 
-		directives.push_back( OptionWithScore<BuilderDirective>(directive, iWeight));
+		aDirectives.push_back(OptionWithScore<BuilderDirective>(directive, iWeight));
 	}
 }
 // Everything means less than zero, hey
-void CvBuilderTaskingAI::AddScrubFalloutDirectives(vector<OptionWithScore<BuilderDirective>>& directives, CvUnit* pUnit, CvPlot* pPlot, CvCity* pCity, int iMoveTurnsAway)
+void CvBuilderTaskingAI::AddScrubFalloutDirectives(vector<OptionWithScore<BuilderDirective>> &aDirectives, CvPlot* pPlot, CvCity* pCity)
 {
 	if(m_eFalloutFeature == NO_FEATURE || m_eFalloutRemove == NO_BUILD)
 	{
 		return;
 	}
 
-	if (pPlot->getTeam() != pUnit->getTeam())
+	if (pPlot->getTeam() != m_pPlayer->getTeam())
 	{
 		return;
 	}
@@ -1958,31 +2056,55 @@ void CvBuilderTaskingAI::AddScrubFalloutDirectives(vector<OptionWithScore<Builde
 	if (pCity && pCity->IsRazing())
 		return;
 
-	if(pPlot->getFeatureType() == m_eFalloutFeature && pUnit->canBuild(pPlot, m_eFalloutRemove))
+	if(pPlot->getFeatureType() == m_eFalloutFeature && m_pPlayer->canBuild(pPlot, m_eFalloutRemove))
 	{
 		int iWeight = GetBuildCostWeight(1000 * /*20000*/ GD_INT_GET(BUILDER_TASKING_BASELINE_SCRUB_FALLOUT), pPlot, m_eFalloutRemove);
-		iWeight += GetBuildTimeWeight(pUnit, pPlot, m_eFalloutRemove, false);
-		iWeight /= (iMoveTurnsAway*iMoveTurnsAway + 1);
-		iWeight -= plotDistance(*pUnit->plot(), *pPlot); //tiebreaker in case of multiple equal options
+		iWeight += GetBuildTimeWeight(pPlot, m_eFalloutRemove, false);
 
-		BuilderDirective directive;
-		directive.m_eDirective = BuilderDirective::CHOP;
-		directive.m_eBuild = m_eFalloutRemove;
-		directive.m_eResource = NO_RESOURCE;
-		directive.m_sX = pPlot->getX();
-		directive.m_sY = pPlot->getY();
-		directive.m_sMoveTurnsAway = iMoveTurnsAway;
-		directives.push_back( OptionWithScore<BuilderDirective>(directive, iWeight));
+		BuilderDirective directive(BuilderDirective::CHOP, m_eFalloutRemove, NO_RESOURCE, pPlot->getX(), pPlot->getY(), iWeight);
+		aDirectives.push_back(OptionWithScore<BuilderDirective>(directive, iWeight));
 	}
 }
 
-/// Evaluates all the circumstances to determine if the builder can and should evaluate the given plot
-bool CvBuilderTaskingAI::ShouldBuilderConsiderPlot(CvUnit* pUnit, CvPlot* pPlot)
+/// Evaluates all the circumstances to determine if any builder should evaluate the given plot
+bool CvBuilderTaskingAI::ShouldAnyBuilderConsiderPlot(CvPlot* pPlot)
 {
-	if (!pPlot || !pUnit)
+	if (!pPlot)
 		return false;
 
 	if (pPlot->isCity())
+		return false;
+
+	//can't build in other major player's territory (unless they are our vassal)
+	if (pPlot->isOwned() && pPlot->getOwner() != m_pPlayer->GetID() && GET_PLAYER(pPlot->getOwner()).isMajorCiv() && !GET_TEAM(pPlot->getTeam()).IsVassal(m_pPlayer->getTeam()))
+		return false;
+
+	//check if we could be captured
+	vector<CvUnit*> vAttackers = m_pPlayer->GetPossibleAttackers(*pPlot, m_pPlayer->getTeam());
+	bool bMayStay = vAttackers.empty() || (vAttackers.size() == 1 && pPlot->getBestDefender(m_pPlayer->GetID()) != NULL);
+	if (!bMayStay)
+	{
+		if (GC.getLogging() && GC.getAILogging() && m_bLogging)
+		{
+			CvString strLog;
+			strLog.Format(
+				"Bailing due to potential attackers,%d,%d,%d",
+				pPlot->getX(),
+				pPlot->getY(),
+				m_pPlayer->GetPlotDanger(*pPlot, true)
+			);
+			m_pPlayer->GetHomelandAI()->LogHomelandMessage(strLog);
+		}
+		return false;
+	}
+
+	return true;
+}
+
+/// Evaluates all the circumstances to determine if this builder can and should evaluate the given plot
+bool CvBuilderTaskingAI::ShouldBuilderConsiderPlot(CvUnit* pUnit, CvPlot* pPlot)
+{
+	if (!pUnit)
 		return false;
 
 	//don't consider non-workable plots for GPs!
@@ -1992,10 +2114,6 @@ bool CvBuilderTaskingAI::ShouldBuilderConsiderPlot(CvUnit* pUnit, CvPlot* pPlot)
 		if (pClosestCity && pClosestCity->getWorkPlotDistance() < m_pPlayer->GetCityDistanceInPlots(pPlot))
 			return false;
 	}
-
-	//can't build in other major player's territory (unless they are our vassal)
-	if (pPlot->isOwned() && pPlot->getOwner()!=pUnit->getOwner() && GET_PLAYER(pPlot->getOwner()).isMajorCiv() && !GET_TEAM(pPlot->getTeam()).IsVassal(m_pPlayer->getTeam()))
-		return false;
 
 	// workers should not be able to work in plots that do not match their default domain
 	switch(pUnit->getDomainType())
@@ -2017,26 +2135,6 @@ bool CvBuilderTaskingAI::ShouldBuilderConsiderPlot(CvUnit* pUnit, CvPlot* pPlot)
 		break;
 	}
 
-	//check if we could be captured
-	vector<CvUnit*> vAttackers = m_pPlayer->GetPossibleAttackers(*pPlot, pUnit->getTeam());
-	bool bMayStay = vAttackers.empty() || (vAttackers.size() == 1 && pPlot->getBestDefender(pUnit->getOwner()) != NULL);
-	if (!bMayStay)
-	{
-		if(GC.getLogging() && GC.getAILogging() && m_bLogging)
-		{
-			CvString strLog;
-			strLog.Format(
-				"%i,Bailing due to potential attackers,%d,%d,%d", 
-				pUnit->GetID(),
-				pPlot->getX(), 
-				pPlot->getY(),
-				m_pPlayer->GetPlotDanger(*pPlot, true)
-			);
-			m_pPlayer->GetHomelandAI()->LogHomelandMessage(strLog);
-		}
-		return false;
-	}
-
 	//if there is fallout, try to scrub it in spite of the danger
 	if(pPlot->getFeatureType() == FEATURE_FALLOUT && !pUnit->ignoreFeatureDamage() && (pUnit->GetCurrHitPoints() < (pUnit->GetMaxHitPoints() / 2)))
 	{
@@ -2055,10 +2153,6 @@ bool CvBuilderTaskingAI::ShouldBuilderConsiderPlot(CvUnit* pUnit, CvPlot* pPlot)
 		return false;
 	}
 
-	//danger check is not enough - we don't want to be adjacent to enemy territory for example
-	if (pPlot->IsKnownVisibleToEnemy(m_pPlayer->GetID()))
-		return false;
-
 	if (!pUnit->canEndTurnAtPlot(pPlot))
 	{
 		if(m_bLogging)
@@ -2074,23 +2168,6 @@ bool CvBuilderTaskingAI::ShouldBuilderConsiderPlot(CvUnit* pUnit, CvPlot* pPlot)
 		}
 
 		return false;
-	}
-
-	//Another unit already working here? Bail!
-	const IDInfo* pUnitNode = pPlot->headUnitNode();
-	const CvUnit* pLoopUnit = NULL;
-	while(pUnitNode != NULL)
-	{
-		pLoopUnit = ::GetPlayerUnit(*pUnitNode);
-		pUnitNode = pPlot->nextUnitNode(pUnitNode);
-
-		if(pLoopUnit && pLoopUnit != pUnit)
-		{
-			if(pLoopUnit->IsWork() && pLoopUnit->getBuildType() != NO_BUILD)
-			{
-				return false;
-			}
-		}
 	}
 
 	return true;
@@ -2110,10 +2187,11 @@ int CvBuilderTaskingAI::GetBuildCostWeight(int iWeight, CvPlot* pPlot, BuildType
 }
 
 /// Get the weight determined by the building time of the item
-int CvBuilderTaskingAI::GetBuildTimeWeight(CvUnit* pUnit, CvPlot* pPlot, BuildTypes eBuild, bool bIgnoreFeatureTime, int iAdditionalTime)
+int CvBuilderTaskingAI::GetBuildTimeWeight(CvPlot* pPlot, BuildTypes eBuild, bool bIgnoreFeatureTime, int iAdditionalTime)
 {
 	int iBuildTimeNormal = pPlot->getBuildTime(eBuild, m_pPlayer->GetID());
-	int iBuildTurnsLeft = pPlot->getBuildTurnsLeft(eBuild, m_pPlayer->GetID(), pUnit->workRate(true), pUnit->workRate(true));
+	int iBuildProgress= pPlot->getBuildProgress(eBuild);
+	int iBuildTurnsLeft = iBuildTimeNormal - iBuildProgress;
 	int iBuildTime = min(iBuildTimeNormal, iBuildTurnsLeft);
 
 	if(bIgnoreFeatureTime)
@@ -2193,10 +2271,10 @@ int CvBuilderTaskingAI::GetResourceWeight(ResourceTypes eResource, ImprovementTy
 }
 
 /// Does this city want to rush a unit?
-bool CvBuilderTaskingAI::DoesBuildHelpRush(CvUnit* pUnit, CvPlot* pPlot, BuildTypes eBuild)
+bool CvBuilderTaskingAI::DoesBuildHelpRush(CvPlot* pPlot, BuildTypes eBuild)
 {
 	CvCity* pCity = NULL;
-	int iProduction = pPlot->getFeatureProduction(eBuild, pUnit->getOwner(), &pCity);
+	int iProduction = pPlot->getFeatureProduction(eBuild, m_pPlayer->GetID(), &pCity);
 	if(iProduction <= 0)
 	{
 		return false;
@@ -2215,7 +2293,7 @@ bool CvBuilderTaskingAI::DoesBuildHelpRush(CvUnit* pUnit, CvPlot* pPlot, BuildTy
 	}
 
 	//don't care about rush if this connects a resource.
-	if (pPlot->getResourceType(pUnit->getTeam()) != NO_RESOURCE)
+	if (pPlot->getResourceType(m_pPlayer->getTeam()) != NO_RESOURCE)
 		return true;
 
 	if(!(pCity->getOrderFromQueue(0)->bRush))
@@ -2227,7 +2305,7 @@ bool CvBuilderTaskingAI::DoesBuildHelpRush(CvUnit* pUnit, CvPlot* pPlot, BuildTy
 	return false;
 }
 
-int CvBuilderTaskingAI::ScorePlotBuild(CvUnit* pUnit, CvPlot* pPlot, ImprovementTypes eImprovement, BuildTypes eBuild)
+int CvBuilderTaskingAI::ScorePlotBuild(CvPlot* pPlot, ImprovementTypes eImprovement, BuildTypes eBuild)
 {
 	UpdateProjectedPlotYields(pPlot, eBuild);
 
@@ -2427,8 +2505,7 @@ int CvBuilderTaskingAI::ScorePlotBuild(CvUnit* pUnit, CvPlot* pPlot, Improvement
 									{
 										CvString strTemp;
 										strTemp.Format(
-											"%i,Weight,Found a Tile outside our Territory for our UI with Adjacency Bonus,%s,%i,%i,%i", 
-											pUnit->GetID(),
+											"Weight,Found a Tile outside our Territory for our UI with Adjacency Bonus,%s,%i,%i,%i",
 											GC.getBuildInfo(eBuild)->GetType(),
 											iScore,
 											pPlot->getX(),
@@ -2448,8 +2525,7 @@ int CvBuilderTaskingAI::ScorePlotBuild(CvUnit* pUnit, CvPlot* pPlot, Improvement
 							{
 								CvString strTemp;
 								strTemp.Format(
-									"%i,Weight,Found a Tile outside our Territory for our UI with Adjacency Bonus, but no adjacent tile yet,%s,%i,%i,%i", 
-									pUnit->GetID(),
+									"Weight,Found a Tile outside our Territory for our UI with Adjacency Bonus, but no adjacent tile yet,%s,%i,%i,%i",
 									GC.getBuildInfo(eBuild)->GetType(),
 									iScore,
 									pPlot->getX(),
@@ -2468,8 +2544,7 @@ int CvBuilderTaskingAI::ScorePlotBuild(CvUnit* pUnit, CvPlot* pPlot, Improvement
 						{
 							CvString strTemp;
 							strTemp.Format(
-								"%i,Weight,Found a Tile outside our Territory for our UI,%s,%i,%i,%i",
-								pUnit->GetID(),
+								"Weight,Found a Tile outside our Territory for our UI,%s,%i,%i,%i",
 								GC.getBuildInfo(eBuild)->GetType(),
 								iScore,
 								pPlot->getX(),
@@ -2486,8 +2561,7 @@ int CvBuilderTaskingAI::ScorePlotBuild(CvUnit* pUnit, CvPlot* pPlot, Improvement
 					{
 						CvString strTemp;
 						strTemp.Format(
-							"%i,Weight,Found a Tile inside our Territory for our UI,%s,%i,%i,%i", 
-							pUnit->GetID(),
+							"Weight,Found a Tile inside our Territory for our UI,%s,%i,%i,%i",
 							GC.getBuildInfo(eBuild)->GetType(),
 							iScore,
 							pPlot->getX(),
@@ -2811,44 +2885,6 @@ int CvBuilderTaskingAI::ScorePlotBuild(CvUnit* pUnit, CvPlot* pPlot, Improvement
 			}
 		}
 	}
-	//Do we have unimproved plots nearby? If so, let's not worry about replacing improvements right now.
-	if(pPlot->getImprovementType() != NO_IMPROVEMENT && !pImprovement->IsAdjacentCity())
-	{
-		//first off, reduce the value, because this is time consuming. It had better be worth it!
-		iYieldScore -= iMedBuff;
-
-		//If our current improvement is obsolete, let's half it's value, so that the potential replacement is stronger.
-		CvImprovementEntry* pOldImprovement = GC.getImprovementInfo(pPlot->getImprovementType());
-		if((pOldImprovement->GetObsoleteTech() != NO_TECH) && GET_TEAM(m_pPlayer->getTeam()).GetTeamTechs()->HasTech((TechTypes)pOldImprovement->GetObsoleteTech()))
-		{
-			iYieldScore -= iMedBuff;
-		}
-		int iNumWorkedPlots = 0;
-		int iNumImprovedPlots = 0;
-		// Look at the city we'll be improving to see how essential another improvement is.
-		if(pCity)
-		{
-			for (int iI = 0; iI < GC.getNumImprovementInfos(); iI++)
-			{
-				ImprovementTypes eWorkingImprovement = (ImprovementTypes) iI;
-				if(eWorkingImprovement != NO_IMPROVEMENT)
-				{
-					iNumImprovedPlots += pCity->GetNumImprovementWorked(eWorkingImprovement);
-				}
-			}
-			iNumWorkedPlots = pCity->getPopulation();
-			//if population is higher than # of plots, reduce value. Otherwise, increase it.
-			//one will remove penalty above - more than that and it becomes useful.
-			if (iNumWorkedPlots > iNumImprovedPlots)
-			{
-				iSecondaryScore -= ((iNumWorkedPlots - iNumImprovedPlots) * iSmallBuff);
-			}
-			else
-			{
-				iSecondaryScore += iSmallBuff * (iNumImprovedPlots - iNumWorkedPlots);
-			}
-		}
-	}
 
 	//Fort test.
 	static ImprovementTypes eFort = (ImprovementTypes)GC.getInfoTypeForString("IMPROVEMENT_FORT");
@@ -3043,7 +3079,7 @@ void CvBuilderTaskingAI::LogYieldInfo(const CvString& strNewLogStr, CvPlayer* pP
 }
 
 /// Logs all the directives for the unit
-void CvBuilderTaskingAI::LogDirectives(vector<OptionWithScore<BuilderDirective>> directives, CvUnit* pUnit)
+void CvBuilderTaskingAI::LogDirectives(vector<OptionWithScore<BuilderDirective>> directives)
 {
 	if(!m_bLogging)
 		return;
@@ -3053,20 +3089,17 @@ void CvBuilderTaskingAI::LogDirectives(vector<OptionWithScore<BuilderDirective>>
 		CvString strLog;
 		CvString strTemp;
 
-		strTemp.Format("%d,", pUnit->GetID()); // unit id
-		strLog += strTemp;
-
 		strLog += "No directives!";
 		LogInfo(strLog, m_pPlayer);
 	}
 	else
 	{
 		for(size_t i = 0; i < directives.size(); i++)
-			LogDirective(directives[i].option, pUnit, directives[i].score);
+			LogDirective(directives[i].option, directives[i].score);
 	}
 }
 
-void CvBuilderTaskingAI::LogDirective(BuilderDirective directive, CvUnit* pUnit, int iWeight, bool bChosen)
+void CvBuilderTaskingAI::LogDirective(BuilderDirective directive, int iWeight, bool bChosen)
 {
 	if(!m_bLogging)
 		return;
@@ -3075,14 +3108,10 @@ void CvBuilderTaskingAI::LogDirective(BuilderDirective directive, CvUnit* pUnit,
 		return;
 
 	CvString strLog;
-	CvString strTemp;
-
-	strTemp.Format("%d,", pUnit->GetID()); // unit id
-	strLog += strTemp;
 
 	strLog += "Evaluating,";
 
-	switch(directive.m_eDirective)
+	switch(directive.m_eDirectiveType)
 	{
 	case BuilderDirective::BUILD_IMPROVEMENT_ON_RESOURCE:
 		strLog += "BUILD_IMPROVEMENT_ON_RESOURCE,";
@@ -3124,7 +3153,7 @@ void CvBuilderTaskingAI::LogDirective(BuilderDirective directive, CvUnit* pUnit,
 		strLog += ",";
 	}
 
-	if(directive.m_eDirective == BuilderDirective::REPAIR)
+	if(directive.m_eDirectiveType == BuilderDirective::REPAIR)
 	{
 		CvPlot* pPlot = GC.getMap().plot(directive.m_sX, directive.m_sY);
 		if(pPlot->IsImprovementPillaged())
@@ -3164,10 +3193,8 @@ void CvBuilderTaskingAI::LogDirective(BuilderDirective directive, CvUnit* pUnit,
 	}
 	strLog += ",";
 
+	CvString strTemp;
 	strTemp.Format("%d,%d,", directive.m_sX, directive.m_sY);
-	strLog += strTemp;
-
-	strTemp.Format("%d,", directive.m_sMoveTurnsAway);
 	strLog += strTemp;
 
 	strTemp.Format("%d,", iWeight);
@@ -3178,7 +3205,7 @@ void CvBuilderTaskingAI::LogDirective(BuilderDirective directive, CvUnit* pUnit,
 		strLog += (", Chosen!");
 	}
 
-	LogInfo(strLog, m_pPlayer, GET_PLAYER(pUnit->getOwner()).isHuman());
+	LogInfo(strLog, m_pPlayer, m_pPlayer->isHuman());
 }
 
 // looks at the current plot to see what it's worth

--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -29722,7 +29722,7 @@ int CvCity::GetIndividualPlotScore(const CvPlot* pPlot) const
 
 	iRtnValue += iYieldValue;
 
-	if (GET_PLAYER(getOwner()).GetBuilderTaskingAI()->WantRouteAtPlot(pPlot))
+	if (GET_PLAYER(getOwner()).GetBuilderTaskingAI()->NeedRouteAtPlot(pPlot))
 	{
 		iRtnValue += /*80*/ GD_INT_GET(AI_PLOT_VALUE_STRATEGIC_RESOURCE);
 	}

--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -909,7 +909,7 @@ void CvCity::init(int iID, PlayerTypes eOwner, int iX, int iY, bool bBumpUnits, 
 	// Add Resource Quantity to total
 	if (plot()->getResourceType(getTeam()) != NO_RESOURCE)
 	{
-		if (GET_TEAM(getTeam()).IsResourceImproveable(plot()->getResourceType()))
+		if (GET_TEAM(getTeam()).IsResourceImproveable(plot()->getResourceType(getTeam())))
 		{
 			owningPlayer.connectResourcesOnPlot(plot(), true);
 		}
@@ -4439,7 +4439,7 @@ bool CvCity::IsCityEventChoiceValid(CityEventChoiceTypes eChosenEventChoice, Cit
 				continue;
 
 			// no resource on plot
-			if (pLoopPlot->getResourceType() == NO_RESOURCE)
+			if (pLoopPlot->getResourceType(getTeam()) == NO_RESOURCE)
 				continue;
 
 			ImprovementTypes eImprovement = pLoopPlot->getImprovementType();
@@ -4448,7 +4448,7 @@ bool CvCity::IsCityEventChoiceValid(CityEventChoiceTypes eChosenEventChoice, Cit
 			
 			//connected?
 			CvImprovementEntry* pImprovement = GC.getImprovementInfo(eImprovement);
-			if (pImprovement && pImprovement->IsConnectsResource(pLoopPlot->getResourceType()) && !pLoopPlot->IsImprovementPillaged())
+			if (pImprovement && pImprovement->IsConnectsResource(pLoopPlot->getResourceType(getTeam())) && !pLoopPlot->IsImprovementPillaged())
 			{
 				bImprovementFound = true;
 				break;
@@ -6221,7 +6221,7 @@ CvString CvCity::GetDisabledTooltip(CityEventChoiceTypes eChosenEventChoice, int
 				continue;
 
 			// no resource on plot
-			if (pLoopPlot->getResourceType() == NO_RESOURCE)
+			if (pLoopPlot->getResourceType(getTeam()) == NO_RESOURCE)
 				continue;
 
 			ImprovementTypes eImprovement = pLoopPlot->getImprovementType();
@@ -6230,7 +6230,7 @@ CvString CvCity::GetDisabledTooltip(CityEventChoiceTypes eChosenEventChoice, int
 
 			//connected?
 			CvImprovementEntry* pImprovement = GC.getImprovementInfo(eImprovement);
-			if (pImprovement && pImprovement->IsConnectsResource(pLoopPlot->getResourceType()) && !pLoopPlot->IsImprovementPillaged())
+			if (pImprovement && pImprovement->IsConnectsResource(pLoopPlot->getResourceType(getTeam())) && !pLoopPlot->IsImprovementPillaged())
 			{
 				bImprovementFound = true;
 				break;
@@ -7255,7 +7255,7 @@ void CvCity::DoEventChoice(CityEventChoiceTypes eEventChoice, CityEventTypes eCi
 								for (int iI = 0; iI < iRuns; iI++)
 								{
 									CvPlot* pPlot = aBestPlots.GetElement(iI);
-									if (pPlot != NULL && pPlot->getOwner() == getOwner() && pPlot->getResourceType() == eResource && pPlot->getImprovementType() != NO_IMPROVEMENT)
+									if (pPlot != NULL && pPlot->getOwner() == getOwner() && pPlot->getResourceType(getTeam()) == eResource && pPlot->getImprovementType() != NO_IMPROVEMENT)
 									{
 										pPlot->SetImprovementPillaged(true);
 										iNumber++;
@@ -7286,7 +7286,7 @@ void CvCity::DoEventChoice(CityEventChoiceTypes eEventChoice, CityEventTypes eCi
 						continue;
 
 					// no resource on plot
-					if (pLoopPlot->getResourceType() == NO_RESOURCE)
+					if (pLoopPlot->getResourceType(getTeam()) == NO_RESOURCE)
 						continue;
 
 					ImprovementTypes eImprovement = pLoopPlot->getImprovementType();
@@ -7295,7 +7295,7 @@ void CvCity::DoEventChoice(CityEventChoiceTypes eEventChoice, CityEventTypes eCi
 
 					//connected?
 					CvImprovementEntry* pImprovement = GC.getImprovementInfo(eImprovement);
-					if (pImprovement && pImprovement->IsConnectsResource(pLoopPlot->getResourceType()) && !pLoopPlot->IsImprovementPillaged())
+					if (pImprovement && pImprovement->IsConnectsResource(pLoopPlot->getResourceType(getTeam())) && !pLoopPlot->IsImprovementPillaged())
 					{
 						// this is a plot with an improved resource. check if it should be pillaged
 						if (iPillageResourceTilesChance == 100 || GC.getGame().randRangeInclusive(1, 100, CvSeeder::fromRaw(0xbe510f48).mix(iCityID).mix(iCityPlotLoop).mix(GC.getGame().getGameTurn())) <= iPillageResourceTilesChance)
@@ -9496,7 +9496,7 @@ void CvCity::UpdateTerrainImprovementNeed()
 
 				//todo: should we add more of the improvement is very valuable?
 				//for now give extra weight to resource plots
-				if (pLoopPlot->getResourceType() != NO_RESOURCE)
+				if (pLoopPlot->getResourceType(getTeam()) != NO_RESOURCE)
 					iImprovablePlots++;
 
 				break;
@@ -10412,7 +10412,7 @@ void CvCity::DoPickResourceDemanded()
 		CvPlot* pLoopPlot = iterateRingPlots(getX(), getY(), iPlotLoop);
 		if (pLoopPlot != NULL)
 		{
-			ResourceTypes eResource = pLoopPlot->getResourceType();
+			ResourceTypes eResource = pLoopPlot->getResourceType(getTeam());
 			if (eResource != NO_RESOURCE)
 			{
 				if (GC.getResourceInfo(eResource)->getResourceUsage() == RESOURCEUSAGE_LUXURY)
@@ -14379,7 +14379,7 @@ SPlotStats CvCity::getPlotStats() const
 		if (pLoopPlot->getFeatureType() != NO_FEATURE)
 			result.vFeatureCount[pLoopPlot->getFeatureType()]++;
 
-		if (pLoopPlot->getResourceType()!=NO_RESOURCE && pLoopPlot->getResourceType(getTeam()) != NO_RESOURCE)
+		if (pLoopPlot->getResourceType(getTeam())!=NO_RESOURCE && pLoopPlot->getResourceType(getTeam()) != NO_RESOURCE)
 			result.vResourceCount[pLoopPlot->getResourceType(getTeam())]++;
 	}
 
@@ -15400,7 +15400,7 @@ void CvCity::processBuilding(BuildingTypes eBuilding, int iChange, bool bFirst, 
 								if (pLoopPlot != NULL && pLoopPlot->getOwner() == owningPlayer.GetID() && !pLoopPlot->isCity() &&
 									pLoopPlot->isValidMovePlot(getOwner()) && !pLoopPlot->isWater() && !pLoopPlot->IsNaturalWonder() && !pLoopPlot->isMountain() && (pLoopPlot->getFeatureType() == NO_FEATURE))
 								{
-									if (pLoopPlot->getResourceType() == NO_RESOURCE && pLoopPlot->getImprovementType() == NO_IMPROVEMENT)
+									if (pLoopPlot->getResourceType(getTeam()) == NO_RESOURCE && pLoopPlot->getImprovementType() == NO_IMPROVEMENT)
 									{
 										pLoopPlot->setResourceType(NO_RESOURCE, 0, false);
 										pLoopPlot->setResourceType(eResourceToGive, 1, false);
@@ -15420,7 +15420,7 @@ void CvCity::processBuilding(BuildingTypes eBuilding, int iChange, bool bFirst, 
 									if (pLoopPlot != NULL && (pLoopPlot->getOwner() == NO_PLAYER) && pLoopPlot->isValidMovePlot(getOwner()) &&
 										!pLoopPlot->isWater() && !pLoopPlot->IsNaturalWonder() && (pLoopPlot->getFeatureType() != FEATURE_OASIS))
 									{
-										if (pLoopPlot->getResourceType() == NO_RESOURCE && pLoopPlot->getImprovementType() == NO_IMPROVEMENT)
+										if (pLoopPlot->getResourceType(getTeam()) == NO_RESOURCE && pLoopPlot->getImprovementType() == NO_IMPROVEMENT)
 										{
 											pLoopPlot->setResourceType(NO_RESOURCE, 0, false);
 											pLoopPlot->setResourceType(eResourceToGive, 1, false);
@@ -15435,7 +15435,7 @@ void CvCity::processBuilding(BuildingTypes eBuilding, int iChange, bool bFirst, 
 							}
 							if (iNumResourceGiven < iNumResourceTotal)
 							{
-								ResourceTypes eCurrentResource = plot()->getResourceType();
+								ResourceTypes eCurrentResource = plot()->getResourceType(getTeam());
 								if (eCurrentResource == NO_RESOURCE)
 									plot()->setResourceType(eResourceToGive, 1, false);
 							}
@@ -15817,7 +15817,7 @@ void CvCity::processBuilding(BuildingTypes eBuilding, int iChange, bool bFirst, 
 							pLoopPlot = iterateRingPlots(getX(), getY(), iCityPlotLoop);
 							if (pLoopPlot != NULL && ((pLoopPlot->getOwner() == owningPlayer.GetID()) || (pLoopPlot->getOwner() == NO_PLAYER && pLoopPlot->isValidMovePlot(getOwner()))) && !pLoopPlot->isCity())
 							{
-								if (pLoopPlot->canHaveResource(eResource, false, true) && pLoopPlot->getResourceType() == NO_RESOURCE)
+								if (pLoopPlot->canHaveResource(eResource, false, true) && pLoopPlot->getResourceType(getTeam()) == NO_RESOURCE)
 								{
 									ImprovementTypes eImprovement = pLoopPlot->getImprovementType();
 									if (eImprovement != NO_IMPROVEMENT)
@@ -15931,7 +15931,7 @@ void CvCity::processBuilding(BuildingTypes eBuilding, int iChange, bool bFirst, 
 
 				if (pLoopPlot != NULL && pLoopPlot->getOwner() == getOwner())
 				{
-					ResourceTypes eLoopResource = pLoopPlot->getResourceType();
+					ResourceTypes eLoopResource = pLoopPlot->getResourceType(getTeam());
 					if (eLoopResource != NO_RESOURCE && GC.getResourceInfo(eLoopResource)->getResourceUsage() == RESOURCEUSAGE_LUXURY)
 					{
 						if (owningTeam.IsResourceImproveable(eLoopResource))
@@ -29688,7 +29688,7 @@ int CvCity::GetIndividualPlotScore(const CvPlot* pPlot) const
 	{
 		YieldTypes eYield = (YieldTypes)iI;
 
-		int iYield = pPlot->calculateNatureYield(eYield, getOwner(), NULL);
+		int iYield = pPlot->calculateNatureYield(eYield, getOwner(), pPlot->getFeatureType(), pPlot->getResourceType(getTeam()), NULL);
 
 		int iTempValue = 0;
 
@@ -35474,7 +35474,7 @@ int CvCity::CountNumWorkedResource(ResourceTypes eResource)
 			continue;
 		}
 
-		if (pLoopPlot->getResourceType() == eResource)
+		if (pLoopPlot->getResourceType(getTeam()) == eResource)
 		{
 			iNum++;
 		}

--- a/CvGameCoreDLL_Expansion2/CvCityCitizens.h
+++ b/CvGameCoreDLL_Expansion2/CvCityCitizens.h
@@ -79,6 +79,8 @@ public:
 
 	int GetBonusPlotValue(CvPlot* pPlot, YieldTypes eYield, SPrecomputedExpensiveNumbers& cache);
 	int GetPlotValue(CvPlot* pPlot, SPrecomputedExpensiveNumbers& cache);
+	int GetYieldModifierTimes100(YieldTypes eYield);
+	void UpdateCache() const;
 	bool CityShouldEmphasizeFood(int iAssumedExcessFood) const;
 	bool CityShouldEmphasizeProduction() const;
 

--- a/CvGameCoreDLL_Expansion2/CvCityStrategyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCityStrategyAI.cpp
@@ -308,6 +308,11 @@ void CvCityStrategyAI::Reset()
 	m_eMostDeficientYield = NO_YIELD;
 	m_eMostAbundantYield = NO_YIELD;
 
+	for (int iI = 0; iI < NUM_YIELD_TYPES; iI++)
+	{
+		m_aiYieldModifier[iI] = 0;
+	}
+
 	// Reset sub AI objects
 	m_pBuildingProductionAI->Reset();
 	m_pUnitProductionAI->Reset();
@@ -552,24 +557,24 @@ void CvCityStrategyAI::SetTurnCityStrategyAdopted(AICityStrategyTypes eStrategy,
 }
 
 /// Get the sub-object tracking building production
-CvBuildingProductionAI* CvCityStrategyAI::GetBuildingProductionAI()
+CvBuildingProductionAI* CvCityStrategyAI::GetBuildingProductionAI() const
 {
 	return m_pBuildingProductionAI;
 }
 
 /// Get the sub-object tracking unit production
-CvUnitProductionAI* CvCityStrategyAI::GetUnitProductionAI()
+CvUnitProductionAI* CvCityStrategyAI::GetUnitProductionAI() const
 {
 	return m_pUnitProductionAI;
 }
 
 /// Get the sub-object tracking project production
-CvProjectProductionAI* CvCityStrategyAI::GetProjectProductionAI()
+CvProjectProductionAI* CvCityStrategyAI::GetProjectProductionAI() const
 {
 	return m_pProjectProductionAI;
 }
 
-CvProcessProductionAI* CvCityStrategyAI::GetProcessProductionAI()
+CvProcessProductionAI* CvCityStrategyAI::GetProcessProductionAI() const
 {
 	return m_pProcessProductionAI;
 }
@@ -626,42 +631,55 @@ CvString CvCityStrategyAI::GetProductionLogFileName(CvString& playerName, CvStri
 }
 
 /// Determines if the yield is below a sustainable amount
-YieldTypes CvCityStrategyAI::GetMostDeficientYield()
+YieldTypes CvCityStrategyAI::GetMostDeficientYield() const
 {
 	return m_eMostDeficientYield;
 }
 /// Determines if the yield is the best
-YieldTypes CvCityStrategyAI::GetMostAbundantYield()
+YieldTypes CvCityStrategyAI::GetMostAbundantYield() const
 {
 	return m_eMostAbundantYield;
+}
+
+int CvCityStrategyAI::GetYieldModifierTimes100(YieldTypes eYield) const
+{
+	CvAssertMsg(eYield > NO_YIELD, "Illegal yield");
+	CvAssertMsg(eYield < NUM_YIELD_TYPES, "Illegal yield");
+
+	return 100 + m_aiYieldModifier[eYield];
 }
 
 /// Get the average value of the yield for this city
 void CvCityStrategyAI::PrecalcYieldStats()
 {
-	vector<float> expectedYieldPerPop;
+	vector<float> expectedYieldPerPop100;
 	//add the values in the order of the yield enum
-	expectedYieldPerPop.push_back(100 * /*0.5*/ GD_FLOAT_GET(AI_CITYSTRATEGY_YIELD_DEFICIENT_FOOD));  // food is different because we include consumption
-	expectedYieldPerPop.push_back(100 * /*1.0*/ GD_FLOAT_GET(AI_CITYSTRATEGY_YIELD_DEFICIENT_PRODUCTION));
-	expectedYieldPerPop.push_back(100 * /*1.5*/ GD_FLOAT_GET(AI_CITYSTRATEGY_YIELD_DEFICIENT_GOLD));
-	expectedYieldPerPop.push_back(100 * /*2.5*/ GD_FLOAT_GET(AI_CITYSTRATEGY_YIELD_DEFICIENT_SCIENCE));
-	expectedYieldPerPop.push_back(100 * /*2.5*/ GD_FLOAT_GET(AI_CITYSTRATEGY_YIELD_DEFICIENT_CULTURE));
-	expectedYieldPerPop.push_back(100 * /*2.5*/ GD_FLOAT_GET(AI_CITYSTRATEGY_YIELD_DEFICIENT_FAITH));
+	expectedYieldPerPop100.push_back(100 * /*0.5*/ GD_FLOAT_GET(AI_CITYSTRATEGY_YIELD_DEFICIENT_FOOD));  // food is different because we include consumption
+	expectedYieldPerPop100.push_back(100 * /*1.0*/ GD_FLOAT_GET(AI_CITYSTRATEGY_YIELD_DEFICIENT_PRODUCTION));
+	expectedYieldPerPop100.push_back(100 * /*1.5*/ GD_FLOAT_GET(AI_CITYSTRATEGY_YIELD_DEFICIENT_GOLD));
+	expectedYieldPerPop100.push_back(100 * /*2.5*/ GD_FLOAT_GET(AI_CITYSTRATEGY_YIELD_DEFICIENT_SCIENCE));
+	expectedYieldPerPop100.push_back(100 * /*2.5*/ GD_FLOAT_GET(AI_CITYSTRATEGY_YIELD_DEFICIENT_CULTURE));
+	expectedYieldPerPop100.push_back(100 * /*2.5*/ GD_FLOAT_GET(AI_CITYSTRATEGY_YIELD_DEFICIENT_FAITH));
 
 	vector< OptionWithScore<YieldTypes> > deviations;
-	for (int iI = 0; iI <= YIELD_FAITH; iI++)
+	for (int iI = 0; iI < NUM_YIELD_TYPES; iI++)
 	{
 		YieldTypes eYield = (YieldTypes) iI;
-		int iYield = m_pCity->getYieldRateTimes100(eYield, false);
+		int iYieldTimes100 = m_pCity->getYieldRateTimes100(eYield, false);
 
 		//consider excess food only
 		if (eYield == YIELD_FOOD)
-			iYield -= (m_pCity->foodConsumptionTimes100());
+			iYieldTimes100 -= (m_pCity->foodConsumptionTimes100());
 		
-		int iYieldPerPop100 = (iYield*100) / max(1, m_pCity->getPopulation());
-		int iDeviation = iYieldPerPop100 - (int)expectedYieldPerPop[iI];
+		int iYieldPerPop100 = iYieldTimes100 / max(1, m_pCity->getPopulation());
+		int iExpectedYield100 = iI <= YIELD_FAITH ? (int)expectedYieldPerPop100[iI] : 100;
 
-		deviations.push_back( OptionWithScore<YieldTypes>(eYield,iDeviation) );
+		int iDelta = iExpectedYield100 - iYieldPerPop100;
+
+		if (iI <= YIELD_FAITH)
+			deviations.push_back( OptionWithScore<YieldTypes>(eYield,-iDelta) );
+
+		m_aiYieldModifier[iI] = iDelta > 0 ? iDelta : 0;
 	}
 
 	//this sorts in descending order

--- a/CvGameCoreDLL_Expansion2/CvCityStrategyAI.h
+++ b/CvGameCoreDLL_Expansion2/CvCityStrategyAI.h
@@ -192,10 +192,10 @@ public:
 	void SetUsingCityStrategy(AICityStrategyTypes eStrategy, bool bValue);
 	int GetTurnCityStrategyAdopted(AICityStrategyTypes eStrategy);
 	void SetTurnCityStrategyAdopted(AICityStrategyTypes eStrategy, int iValue);
-	CvBuildingProductionAI* GetBuildingProductionAI();
-	CvUnitProductionAI* GetUnitProductionAI();
-	CvProjectProductionAI* GetProjectProductionAI();
-	CvProcessProductionAI* GetProcessProductionAI();
+	CvBuildingProductionAI* GetBuildingProductionAI() const;
+	CvUnitProductionAI* GetUnitProductionAI() const;
+	CvProjectProductionAI* GetProjectProductionAI() const;
+	CvProcessProductionAI* GetProcessProductionAI() const;
 	CvString GetLogFileName(CvString& playerName, CvString& cityName) const;
 #if defined(MOD_BALANCE_CORE)
 	CvString GetProductionLogFileName(CvString& playerName, CvString& cityName) const;
@@ -203,8 +203,9 @@ public:
 #endif
 
 #if defined(MOD_BALANCE_CORE)
-	YieldTypes GetMostDeficientYield();
-	YieldTypes GetMostAbundantYield();
+	YieldTypes GetMostDeficientYield() const;
+	YieldTypes GetMostAbundantYield() const;
+	int GetYieldModifierTimes100(YieldTypes eYield) const;
 	void PrecalcYieldStats();
 #endif
 
@@ -250,6 +251,7 @@ private:
 
 	YieldTypes m_eMostDeficientYield;
 	YieldTypes m_eMostAbundantYield;
+	int m_aiYieldModifier[NUM_YIELD_TYPES];
 };
 
 FDataStream& operator>>(FDataStream&, CvCityStrategyAI&);

--- a/CvGameCoreDLL_Expansion2/CvDealAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDealAI.cpp
@@ -1606,7 +1606,7 @@ int CvDealAI::GetLuxuryResourceValue(ResourceTypes eResource, int iNumTurns, boo
 						for (int iPlotLoop = 0; iPlotLoop < iNumWorkablePlots; iPlotLoop++)
 						{
 							CvPlot* pLoopPlot = iterateRingPlots(iX, iY, iPlotLoop);
-							if (pLoopPlot && pLoopPlot->getResourceType() == eResource)
+							if (pLoopPlot && pLoopPlot->getResourceType(GetTeam()) == eResource)
 							{
 								iItemValue += OneGPTScaled * iNumYieldChangeBonuses; // Okay to double count; monopoly resources placed between two cities are extra valuable
 							}

--- a/CvGameCoreDLL_Expansion2/CvGame.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGame.cpp
@@ -9668,15 +9668,16 @@ void CvGame::updateMoves()
 
 		if(player.isAlive())
 		{
-			bool needsAIUpdate = player.hasUnitsThatNeedAIUpdate();
-			if(player.isTurnActive() || needsAIUpdate)
+			bool bAutomatedUnitNeedsUpdate = player.hasUnitsThatNeedAIUpdate();
+			bool bHomelandAINeedsUpdate = player.GetHomelandAI()->NeedsUpdate();
+			if(player.isTurnActive() || bAutomatedUnitNeedsUpdate || bHomelandAINeedsUpdate)
 			{
-				if(!(player.isAutoMoves()) || needsAIUpdate)
+				if(!(player.isAutoMoves()) || bAutomatedUnitNeedsUpdate || bHomelandAINeedsUpdate)
 				{
-					if(needsAIUpdate || !player.isHuman())
+					if(bAutomatedUnitNeedsUpdate || bHomelandAINeedsUpdate || !player.isHuman())
 					{
-						// ------- this is where the important stuff happens! --------------
-						player.AI_unitUpdate();
+					// ------- this is where the important stuff happens! --------------
+						player.AI_unitUpdate(bHomelandAINeedsUpdate);
 						NET_MESSAGE_DEBUG_OSTR_ALWAYS("UpdateMoves() : player.AI_unitUpdate() called for player " << player.GetID() << " " << player.getName()); 
 					}
 

--- a/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
@@ -48,6 +48,7 @@ void CvHomelandAI::Init(CvPlayer* pPlayer)
 {
 	// Store off the pointer to the objects we need elsewhere in the game engine
 	m_pPlayer = pPlayer;
+	m_bNeedsUpdate = true;
 
 	Reset();
 }
@@ -166,19 +167,15 @@ void CvHomelandAI::FindAutomatedUnits()
 	// Loop through our units
 	for(CvUnit* pLoopUnit = m_pPlayer->firstUnit(&iLoop); pLoopUnit != NULL; pLoopUnit = m_pPlayer->nextUnit(&iLoop))
 	{
-		if(!pLoopUnit->IsAutomated() || pLoopUnit->AI_getUnitAIType() == UNITAI_UNKNOWN)
+		if(!pLoopUnit->IsAutomated() || pLoopUnit->AI_getUnitAIType() == UNITAI_UNKNOWN || pLoopUnit->TurnProcessed())
 			continue;
 
-		if (pLoopUnit->GetMissionAIPlot())
-			m_automatedTargetPlots[pLoopUnit->AI_getUnitAIType()].push_back( std::make_pair(pLoopUnit->GetID(),pLoopUnit->GetMissionAIPlot()->GetPlotIndex()) );
-	
-		if (!pLoopUnit->TurnProcessed() && pLoopUnit->canMove())
-			m_CurrentTurnUnits.push_back(pLoopUnit->GetID());
+		m_CurrentTurnUnits.push_back(pLoopUnit->GetID());
 	}
 }
 
 /// Update the AI for units
-void CvHomelandAI::Update()
+void CvHomelandAI::Update(bool bUpdateImprovements)
 {
 
 	//no homeland for barbarians
@@ -198,18 +195,36 @@ void CvHomelandAI::Update()
 	else
 		RecruitUnits();
 
+	// If we've already done planning during this turn, don't do it again (e.g. if we just turned on automation for a worker).
+	if (bUpdateImprovements)
+		PlanImprovements();
+
 	// Make sure we have a unit to handle
 	if(!m_CurrentTurnUnits.empty())
 	{
 		// Put together lists of places we may want to move toward
 		FindHomelandTargets();
 
-		//so that workers know where to build roads
-		m_pPlayer->GetBuilderTaskingAI()->Update();
-
 		// Loop through each move assigning units when available
 		AssignHomelandMoves();
 	}
+	else
+	{
+		// Make sure non-automated human workers still know what to do
+		ExecuteWorkerMoves();
+	}
+
+	m_bNeedsUpdate = false;
+}
+
+void CvHomelandAI::Invalidate()
+{
+	m_bNeedsUpdate = true;
+}
+
+bool CvHomelandAI::NeedsUpdate()
+{
+	return m_bNeedsUpdate;
 }
 
 CvPlot* CvHomelandAI::GetBestExploreTarget(const CvUnit* pUnit, int nMinCandidates, int iMaxTurns) const
@@ -508,8 +523,6 @@ void CvHomelandAI::AssignHomelandMoves()
 	PlotPatrolMoves();
 
 	//civilians again
-	PlotWorkerMoves();
-	PlotWorkerSeaMoves();
 	PlotWriterMoves();
 	PlotArtistMoves();
 	PlotMusicianMoves();
@@ -519,6 +532,8 @@ void CvHomelandAI::AssignHomelandMoves()
 	PlotGeneralMoves();
 	PlotAdmiralMoves();
 	PlotProphetMoves();
+	PlotWorkerMoves();
+	PlotWorkerSeaMoves();
 	PlotMissionaryMoves();
 	PlotInquisitorMoves();
 
@@ -932,6 +947,14 @@ void CvHomelandAI::PlotOpportunisticSettlementMoves()
 	PossibleSettlerUnits.clear();
 }
 
+//so that workers know where to build improvements
+void CvHomelandAI::PlanImprovements()
+{
+	m_pPlayer->GetBuilderTaskingAI()->Update();
+	m_workedPlots.clear();
+	m_greatPeopleForImprovements.clear();
+}
+
 /// Find something for all workers to do
 void CvHomelandAI::PlotWorkerMoves(bool bSecondary)
 {
@@ -943,7 +966,7 @@ void CvHomelandAI::PlotWorkerMoves(bool bSecondary)
 		CvUnit* pUnit = m_pPlayer->getUnit(*it);
 		if (pUnit)
 		{
-			bool bUsePrimaryUnit = (pUnit->AI_getUnitAIType() == UNITAI_WORKER || pUnit->IsAutomated() && pUnit->getDomainType() == DOMAIN_LAND && pUnit->GetAutomateType() == AUTOMATE_BUILD);
+			bool bUsePrimaryUnit = pUnit->AI_getUnitAIType() == UNITAI_WORKER || (pUnit->IsAutomated() && pUnit->getDomainType() == DOMAIN_LAND && pUnit->GetAutomateType() == AUTOMATE_BUILD);
 			bool bUseSecondaryUnit = (pUnit->AI_getUnitAIType() != UNITAI_WORKER && (pUnit->getUnitInfo().GetUnitAIType(UNITAI_WORKER) || pUnit->getUnitInfo().GetUnitAIType(UNITAI_WORKER_SEA)) && pUnit->getDomainType() == DOMAIN_LAND);
 			if (m_pPlayer->IsAtWar())
 			{
@@ -974,7 +997,8 @@ void CvHomelandAI::PlotWorkerMoves(bool bSecondary)
 		}
 	}
 
-	if(m_CurrentMoveUnits.size() > 0)
+	// Human players may have only non-automated workers which nevertheless need to be given directives
+	if(m_CurrentMoveUnits.size() > 0 || m_pPlayer->isHuman())
 	{
 		ExecuteWorkerMoves();
 	}
@@ -1141,6 +1165,7 @@ void CvHomelandAI::PlotWorkerSeaMoves(bool bSecondary)
 		}
 	}
 }
+
 void CvHomelandAI::ExecuteUnitGift()
 {
 	if (!m_pPlayer->isMajorCiv() || m_pPlayer->isHuman())
@@ -2792,35 +2817,40 @@ bool CvHomelandAI::ExecuteExplorerMoves(CvUnit* pUnit)
 /// Moves units to improve plots
 void CvHomelandAI::ExecuteWorkerMoves()
 {
-	// where can our workers go
-	std::map<int,ReachablePlots> allWorkersReachablePlots;
-	std::set<int> workersToIgnore;
+	list<int> allWorkers;
+	set<int> processedWorkers;
+	set<int> nonAutomatedWorkers;
 
-	//see what each worker can do in its immediate vicinity
-	//if there is no work there, it will move towards the city which needs a worker most
+	// Automated and AI controlled workers
 	for(CHomelandUnitArray::iterator it = m_CurrentMoveUnits.begin(); it != m_CurrentMoveUnits.end(); ++it)
 	{
 		CvUnit* pUnit = m_pPlayer->getUnit(it->GetID());
 		if (!pUnit)
 			continue;
 
-		SPathFinderUserData data(pUnit, CvUnit::MOVEFLAG_AI_ABORT_IN_DANGER, 5);
-		allWorkersReachablePlots[pUnit->GetID()] = GC.GetPathFinder().GetPlotsInReach(pUnit->plot(), data);
+		allWorkers.push_back(pUnit->GetID());
 	}
 
-	//humans also have non-automated workers. pretend they are automated as well to avoid going where they are
-	//todo: what about great people?
+	// Great people that the AI wants to build improvements with
+	for (list<int>::iterator it = m_greatPeopleForImprovements.begin(); it != m_greatPeopleForImprovements.end(); ++it)
+	{
+		allWorkers.push_back(*it);
+	}
+
+	// Humans also have non-automated workers. Pretend they are automated as well to avoid going where they are.
+	// We also throw in all great people that can build anything here so they get recommendations as well.
 	if (m_pPlayer->isHuman())
 	{
 		int iLoop = 0;
 		for (CvUnit* pLoopUnit = m_pPlayer->firstUnit(&iLoop); pLoopUnit != NULL; pLoopUnit = m_pPlayer->nextUnit(&iLoop))
 		{
-			if (pLoopUnit->AI_getUnitAIType() == UNITAI_WORKER && allWorkersReachablePlots.find(pLoopUnit->GetID()) == allWorkersReachablePlots.end())
+			bool bIsBuilder = pLoopUnit->AI_getUnitAIType() == UNITAI_WORKER   || pLoopUnit->AI_getUnitAIType() == UNITAI_GENERAL
+	                       || pLoopUnit->AI_getUnitAIType() == UNITAI_ENGINEER || pLoopUnit->AI_getUnitAIType() == UNITAI_SCIENTIST
+				           || pLoopUnit->AI_getUnitAIType() == UNITAI_MERCHANT || pLoopUnit->AI_getUnitAIType() == UNITAI_PROPHET;
+			if (!pLoopUnit->TurnProcessed() && bIsBuilder && pLoopUnit->getDomainType() == DOMAIN_LAND && find(allWorkers.begin(), allWorkers.end(), pLoopUnit->GetID()) == allWorkers.end())
 			{
-				SPathFinderUserData data(pLoopUnit, CvUnit::MOVEFLAG_AI_ABORT_IN_DANGER, 5);
-				allWorkersReachablePlots[pLoopUnit->GetID()] = GC.GetPathFinder().GetPlotsInReach(pLoopUnit->plot(), data);
-
-				workersToIgnore.insert(pLoopUnit->GetID());
+				allWorkers.push_back(pLoopUnit->GetID());
+				nonAutomatedWorkers.insert(pLoopUnit->GetID());
 			}
 		}
 	}
@@ -2836,55 +2866,194 @@ void CvHomelandAI::ExecuteWorkerMoves()
 		{
 			if(MoveCivilianToSafety(pUnit))
 			{
-				workersToIgnore.insert(pUnit->GetID());
 				UnitProcessed(pUnit->GetID());
+				processedWorkers.insert(pUnit->GetID());
 				continue;
 			}
 		}
+	}
 
-		//how far around each worker should we be checking?
-		int iTurnLimit = pUnit->IsGreatPerson() ? 12 : 5;
+	// This is a bit complex but here's the gist
+	// * Get all possible BuilderDirectives that we can do (sorted by value)
+	// * For each: if there's one or more viable workers for it, assign the
+	//   closest worker to work it.
+	// * If there are several BuilderDirectives with the same value, prioritize
+	//   ones with close workers.
+	CvBuilderTaskingAI* pBuilderTaskingAI = m_pPlayer->GetBuilderTaskingAI();
+	vector<BuilderDirective> topDirectives = pBuilderTaskingAI->GetDirectives();
+	vector<BuilderDirective> ignoredDirectives;
 
-		if (pUnit->IsCombatUnit())
-			iTurnLimit = 3;
+	int iCurrentDirectiveValue = -1; // Current directive value
+	vector<BuilderDirective>::iterator iCurrentDirectiveIndex; // Keeps track of the index of the first directive with a shared score
 
-		//is the unit still busy? if so, less time for movement
-		int iBuildTimeLeft = 0;
-		BuildTypes eBuild = pUnit->getBuildType();
-		if (eBuild != NO_BUILD)
-			iBuildTimeLeft = pUnit->plot()->getBuildTurnsLeft(eBuild, pUnit->getOwner(), 0, 0);
+	CvUnit* pBestDirectiveBuilder = NULL;
+	BuilderDirective eBestDirective = BuilderDirective();
+	int iBestDirectiveBuilderTotalTurns = INT_MAX;
 
-		if (iTurnLimit >= iBuildTimeLeft)
+	// Cache plot to plot distance calculations for the workers to avoid unnecessary pathfinding calls.
+	// Helps if there are several workers in the same tile. Assumes all workers have the same move speed and haven't used any movement.
+	map<pair<int, int>, int> plotDistanceCache;
+
+	// First check if any workers were already assigned directives this turn (this happens e.g. when a unit is set to automated during this turn).
+	for (std::list<int>::iterator builderIterator = allWorkers.begin(); builderIterator != allWorkers.end(); ++builderIterator)
+	{
+		int iUnitId = *builderIterator;
+		CvUnit* pUnit = m_pPlayer->getUnit(iUnitId);
+
+		if (!pUnit)
+			continue;
+
+		bool bIsAutomated = !m_pPlayer->isHuman() || nonAutomatedWorkers.find(iUnitId) == nonAutomatedWorkers.end();
+
+		if (bIsAutomated)
 		{
-			SPathFinderUserData data(pUnit, CvUnit::MOVEFLAG_NO_ENEMY_TERRITORY| CvUnit::MOVEFLAG_AI_ABORT_IN_DANGER, iTurnLimit-iBuildTimeLeft);
-			ReachablePlots plots = GC.GetPathFinder().GetPlotsInReach(pUnit->getX(), pUnit->getY(), data);
-	
-			// add offset for fair comparison
-			for (ReachablePlots::iterator it2 = plots.begin(); it2 != plots.end(); ++it2)
-				it2->iPathLength += iBuildTimeLeft;
-			
-			allWorkersReachablePlots[pUnit->GetID()] = plots;
+			BuilderDirective eDirective = pBuilderTaskingAI->GetAssignedDirective(pUnit);
+
+			if (eDirective.m_eBuild != NO_BUILD && pBuilderTaskingAI->ExecuteWorkerMove(pUnit, eDirective))
+			{
+				UnitProcessed(iUnitId);
+
+				CvPlot* pDirectivePlot = GC.getMap().plot(eDirective.m_sX, eDirective.m_sY);
+
+				processedWorkers.insert(iUnitId);
+				ignoredDirectives.push_back(eDirective);
+				m_workedPlots.insert(pDirectivePlot->GetPlotIndex());
+			}
 		}
 	}
 
-	//see if we have work to do
-	for(std::map<int,ReachablePlots>::iterator it = allWorkersReachablePlots.begin(); it != allWorkersReachablePlots.end(); ++it)
+	// Loop through all the directives sorted by priority.
+	// Any directives with a shared score will be considered in parallel (and the closest one is chosen).
+	for (vector<BuilderDirective>::iterator directiveIterator = topDirectives.begin(); directiveIterator != topDirectives.end() && allWorkers.size() > processedWorkers.size(); ++directiveIterator)
 	{
-		int currentUnitId = it->first;
-		CvUnit* pUnit = m_pPlayer->getUnit(currentUnitId);
+		BuilderDirective eDirective = *directiveIterator;
 
-		//cannot use m_CurrentMoveUnits here, need to update the reachable plots ... but not all units in allWorkersReachablePlots are supposed to be used
-		if (workersToIgnore.find(currentUnitId) != workersToIgnore.end())
+		bool bIgnore = false;
+		for (vector<BuilderDirective>::iterator dirIter2 = ignoredDirectives.begin(); dirIter2 != ignoredDirectives.end(); ++dirIter2)
+			if ((*dirIter2) == eDirective)
+			{
+				bIgnore = true;
+				break;
+			}
+
+		if (bIgnore)
 			continue;
 
-		//this checks for work in the immediate neighborhood of the workers
-		CvPlot* pTarget = ExecuteWorkerMove(pUnit, allWorkersReachablePlots);
-		if (pTarget)
+		if (iCurrentDirectiveValue == eDirective.m_iScore && iBestDirectiveBuilderTotalTurns > 0)
 		{
-			//make sure no other worker tries to target the same plot
-			it->second.clear();
-			it->second.insertWithIndex( SMovePlot(pTarget->GetPlotIndex(),-1,0,0) );
-			UnitProcessed(currentUnitId);
+			CvPlot* pDirectivePlot = GC.getMap().plot(eDirective.m_sX, eDirective.m_sY);
+
+			if (m_workedPlots.count(pDirectivePlot->GetPlotIndex()) > 0)
+				continue;
+
+			int iBestBuilderTotalTurns = INT_MAX;
+			CvUnit* pBestBuilder = NULL;
+
+			list<OptionWithScore<int>> sortedWorkers;
+
+			// First sort by plot distance between worker and directive, it's a good heuristic and reduces the number of needed calls to
+			// the pathfinder (and the max distance sent to the pathfinding algorithm when it is needed).
+			for (std::list<int>::iterator builderIterator = allWorkers.begin(); builderIterator != allWorkers.end(); ++builderIterator)
+			{
+				int iCurrentUnitId = *builderIterator;
+				CvUnit* pUnit = m_pPlayer->getUnit(iCurrentUnitId);
+
+				if (!pUnit)
+					continue;
+
+				if (processedWorkers.find(pUnit->GetID()) != processedWorkers.end())
+					continue;
+
+				int iPlotDistance = plotDistance(pDirectivePlot->getX(), pDirectivePlot->getY(), pUnit->getX(), pUnit->getY());
+
+				sortedWorkers.push_back(OptionWithScore<int>(iCurrentUnitId, -iPlotDistance));
+			}
+			std::stable_sort(sortedWorkers.begin(), sortedWorkers.end());
+
+			// Loop over the sorted workers to find the one closest to the directive plot
+			for (std::list<OptionWithScore<int>>::iterator builderIterator = sortedWorkers.begin(); builderIterator != sortedWorkers.end() && iBestBuilderTotalTurns > 0; ++builderIterator)
+			{
+				int iCurrentUnitId = (*builderIterator).option;
+				CvUnit* pUnit = m_pPlayer->getUnit(iCurrentUnitId);
+
+				if (!pBuilderTaskingAI->EvaluateBuilder(pUnit, eDirective))
+					continue;
+
+				int iBuilderImprovementTime = pBuilderTaskingAI->GetTurnsToBuild(pUnit, eDirective, pDirectivePlot);
+				if (iBuilderImprovementTime == INT_MAX)
+					continue;
+
+				pair<int, int> plotPair = make_pair<int, int>(pUnit->plot()->GetPlotIndex(), pDirectivePlot->GetPlotIndex());
+
+				int iCachedDistance = plotDistanceCache[plotPair];
+				int iBuilderDistance = iCachedDistance ? iCachedDistance - 1 : pBuilderTaskingAI->GetBuilderNumTurnsAway(pUnit, eDirective, iBestBuilderTotalTurns - iBuilderImprovementTime - 1);
+
+				if (iBuilderDistance == INT_MAX)
+					continue;
+
+				plotDistanceCache[plotPair] = iBuilderDistance + 1;
+
+				int iTotalTurns = iBuilderDistance + iBuilderImprovementTime;
+
+				// Use Unit ID as tie-breaker
+				if (iTotalTurns < iBestBuilderTotalTurns)
+				{
+					iBestBuilderTotalTurns = iTotalTurns;
+					pBestBuilder = pUnit;
+				}
+			}
+
+			if (iBestBuilderTotalTurns < iBestDirectiveBuilderTotalTurns)
+			{
+				iBestDirectiveBuilderTotalTurns = iBestBuilderTotalTurns;
+				pBestDirectiveBuilder = pBestBuilder;
+				eBestDirective = eDirective;
+			}
+		}
+		else
+		{
+
+			if (iBestDirectiveBuilderTotalTurns < INT_MAX)
+			{
+				iBestDirectiveBuilderTotalTurns = INT_MAX;
+				int iUnitID = pBestDirectiveBuilder->GetID();
+
+				if (pBuilderTaskingAI->GetAssignedDirective(pBestDirectiveBuilder).m_eBuild == NO_BUILD)
+				{
+					bool bIsAutomated = !m_pPlayer->isHuman() || nonAutomatedWorkers.find(iUnitID) == nonAutomatedWorkers.end();
+					if (bIsAutomated)
+					{
+						if (pBuilderTaskingAI->ExecuteWorkerMove(pBestDirectiveBuilder, eBestDirective))
+						{
+							UnitProcessed(iUnitID);
+
+							processedWorkers.insert(iUnitID);
+							ignoredDirectives.push_back(eBestDirective);
+							m_workedPlots.insert(GC.getMap().plot(eBestDirective.m_sX, eBestDirective.m_sY)->GetPlotIndex());
+
+							directiveIterator = iCurrentDirectiveIndex - 1;
+							continue;
+						}
+					}
+					else
+					{
+						// Assign non-automated worker to this directive
+						pBuilderTaskingAI->SetAssignedDirective(pBestDirectiveBuilder, eBestDirective);
+
+						processedWorkers.insert(iUnitID);
+						ignoredDirectives.push_back(eBestDirective);
+						m_workedPlots.insert(GC.getMap().plot(eBestDirective.m_sX, eBestDirective.m_sY)->GetPlotIndex());
+
+						directiveIterator = iCurrentDirectiveIndex - 1;
+						continue;
+					}
+				}
+			}
+
+			ignoredDirectives.clear();
+			iCurrentDirectiveValue = (*directiveIterator).m_iScore;
+			iCurrentDirectiveIndex = directiveIterator;
+			directiveIterator--;
 		}
 	}
 
@@ -2893,7 +3062,7 @@ void CvHomelandAI::ExecuteWorkerMoves()
 	map<int, int> mapCityNeed;
 	int iLoop = 0;
 	for (CvCity* pLoopCity = m_pPlayer->firstCity(&iLoop); pLoopCity != NULL; pLoopCity = m_pPlayer->nextCity(&iLoop))
-		mapCityNeed[pLoopCity->GetID()] = pLoopCity->GetTerrainImprovementNeed();
+		mapCityNeed[pLoopCity->GetID()] = 0;
 
 	for (CHomelandUnitArray::iterator it = m_CurrentMoveUnits.begin(); it != m_CurrentMoveUnits.end(); ++it)
 	{
@@ -2916,11 +3085,7 @@ void CvHomelandAI::ExecuteWorkerMoves()
 		if (pBestCity && pUnit->GeneratePath(pBestCity->plot(), CvUnit::MOVEFLAG_NO_ENEMY_TERRITORY|CvUnit::MOVEFLAG_PRETEND_ALL_REVEALED, 23))
 		{
 			ExecuteMoveToTarget(pUnit, pBestCity->plot(), CvUnit::MOVEFLAG_NO_ENEMY_TERRITORY|CvUnit::MOVEFLAG_PRETEND_ALL_REVEALED);
-			int iCurrentNeed = mapCityNeed[pBestCity->GetID()];
-			if (iCurrentNeed > 0)
-				mapCityNeed[pBestCity->GetID()] = iCurrentNeed / 2; //reduce the score for this city in case we have multiple workers to distribute
-			else
-				mapCityNeed[pBestCity->GetID()]--; //in case all cities have all tiles improved, try spread the workers over all our cities
+			mapCityNeed[pBestCity->GetID()]--; //in case all cities have all tiles improved, try spread the workers over all our cities
 		}
 		else if (pUnit->IsCivilianUnit())
 		{
@@ -3397,11 +3562,7 @@ void CvHomelandAI::ExecuteScientistMoves()
 			}
 			break;
 		case GREAT_PEOPLE_DIRECTIVE_CONSTRUCT_IMPROVEMENT:
-			if (!ExecuteWorkerMove(pUnit))
-			{
-				MoveCivilianToSafety(pUnit);
-				UnitProcessed(pUnit->GetID());
-			}
+			m_greatPeopleForImprovements.push_back(pUnit->GetID());
 			break;
 		case NO_GREAT_PEOPLE_DIRECTIVE_TYPE:
 			MoveCivilianToSafety(pUnit);
@@ -3433,8 +3594,7 @@ void CvHomelandAI::ExecuteEngineerMoves()
 		switch(eDirective)
 		{
 		case GREAT_PEOPLE_DIRECTIVE_CONSTRUCT_IMPROVEMENT:
-			if (!ExecuteWorkerMove(pUnit))
-				MoveCivilianToSafety(pUnit);
+			m_greatPeopleForImprovements.push_back(pUnit->GetID());
 			break;
 		case GREAT_PEOPLE_DIRECTIVE_GOLDEN_AGE:
 			ExecuteGoldenAgeMove(pUnit);
@@ -3807,14 +3967,9 @@ void CvHomelandAI::ExecuteMerchantMoves()
 				if (pUnit->atPlot(*pTargetPlot) && pUnit->canMove())
 					pUnit->PushMission(CvTypes::getMISSION_BUILD(), eColonia);
 			}
-			else if (ExecuteWorkerMove(pUnit)) //regular merchant
-			{
-				UnitProcessed(pUnit->GetID());
-			}
 			else
 			{
-				MoveCivilianToSafety(pUnit);
-				UnitProcessed(pUnit->GetID());
+				m_greatPeopleForImprovements.push_back(pUnit->GetID());
 			}
 			break;
 		}
@@ -3847,11 +4002,7 @@ void CvHomelandAI::ExecuteProphetMoves()
 		switch(eDirective)
 		{
 		case GREAT_PEOPLE_DIRECTIVE_CONSTRUCT_IMPROVEMENT:
-			if (!ExecuteWorkerMove(pUnit))
-			{
-				MoveCivilianToSafety(pUnit);
-				UnitProcessed(pUnit->GetID());
-			}
+			m_greatPeopleForImprovements.push_back(pUnit->GetID());
 			break;
 
 		case GREAT_PEOPLE_DIRECTIVE_USE_POWER:
@@ -4820,6 +4971,11 @@ bool CvHomelandAI::MoveCivilianToSafety(CvUnit* pUnit)
 	return false;
 }
 
+set<int> CvHomelandAI::GetWorkedPlots()
+{
+	return m_workedPlots;
+}
+
 // Get a trade unit and send it to a city!
 void CvHomelandAI::ExecuteTradeUnitMoves()
 {
@@ -5401,153 +5557,6 @@ void CvHomelandAI::UnitProcessed(int iID)
 		pUnit->setHomelandMove(m_CurrentMoveUnits.getCurrentHomelandMove());
 		pUnit->SetTurnProcessed(true);
 	}
-}
-
-CvPlot* CvHomelandAI::ExecuteWorkerMove(CvUnit* pUnit)
-{
-	if (!pUnit)
-		return NULL;
-
-	//pretend there are no other workers ...
-	std::map<int,ReachablePlots> allWorkersReachablePlots;
-	SPathFinderUserData data(pUnit, CvUnit::MOVEFLAG_AI_ABORT_IN_DANGER, 13);
-	allWorkersReachablePlots[pUnit->GetID()] = GC.GetPathFinder().GetPlotsInReach(pUnit->plot(), data);
-	return ExecuteWorkerMove(pUnit, allWorkersReachablePlots);
-}
-
-//returns the target plot if sucessful, null otherwise
-CvPlot* CvHomelandAI::ExecuteWorkerMove(CvUnit* pUnit, const map<int,ReachablePlots>& allWorkersReachablePlots)
-{
-	// find work (considering all other workers as well)
-	BuilderDirective aDirective = m_pPlayer->GetBuilderTaskingAI()->EvaluateBuilder(pUnit, allWorkersReachablePlots);
-	if(aDirective.m_eDirective!=BuilderDirective::NUM_DIRECTIVES)
-	{
-		switch(aDirective.m_eDirective)
-		{
-		case BuilderDirective::BUILD_IMPROVEMENT_ON_RESOURCE:
-		case BuilderDirective::BUILD_IMPROVEMENT:
-		case BuilderDirective::REPAIR:
-		case BuilderDirective::BUILD_ROUTE:
-		case BuilderDirective::CHOP:
-		case BuilderDirective::REMOVE_ROAD:
-		{
-			CvPlot* pPlot = GC.getMap().plot(aDirective.m_sX, aDirective.m_sY);
-			MissionTypes eMission = CvTypes::getMISSION_MOVE_TO();
-			if(pUnit->getX() == aDirective.m_sX && pUnit->getY() == aDirective.m_sY)
-				eMission = CvTypes::getMISSION_BUILD();
-
-			if(GC.getLogging() && GC.GetBuilderAILogging())
-			{
-				// Open the log file
-				CvString strFileName = "BuilderTaskingLog.csv";
-				FILogFile* pLog = NULL;
-				pLog = LOGFILEMGR.GetLog(strFileName, FILogFile::kDontTimeStamp);
-
-				// write in data
-				CvString strLog;
-				CvString strTemp;
-
-				CvString strPlayerName;
-				strPlayerName = m_pPlayer->getCivilizationShortDescription();
-				strLog += strPlayerName;
-				strLog += ",";
-
-				strTemp.Format("%d,", GC.getGame().getGameTurn()); // turn
-				strLog += strTemp;
-
-				strTemp.Format("%d,", pUnit->GetID()); // unit id
-				strLog += strTemp;
-
-				switch(aDirective.m_eDirective)
-				{
-				case BuilderDirective::BUILD_IMPROVEMENT_ON_RESOURCE:
-					strLog += "On resource,";
-					break;
-				case BuilderDirective::BUILD_IMPROVEMENT:
-					strLog += "On plot,";
-					break;
-				case BuilderDirective::REPAIR:
-					strLog += "Repairing,";
-					break;
-				case BuilderDirective::BUILD_ROUTE:
-					strLog += "Building route,";
-					break;
-				case BuilderDirective::CHOP:
-					strLog += "Removing resource for production,";
-					break;
-				case BuilderDirective::REMOVE_ROAD:
-					strLog += "Removing road,";
-					break;
-				}
-
-				if(eMission == CvTypes::getMISSION_BUILD())
-				{
-					if(aDirective.m_eDirective == BuilderDirective::REPAIR)
-					{
-						if(pPlot->IsImprovementPillaged())
-						{
-							strLog += "Repairing improvement";
-						}
-						else
-						{
-							strLog += "Repairing route";
-						}
-					}
-					else if(aDirective.m_eDirective == BuilderDirective::BUILD_ROUTE)
-					{
-						strLog += "Building route,";
-					}
-					else if(aDirective.m_eDirective == BuilderDirective::BUILD_IMPROVEMENT || aDirective.m_eDirective == BuilderDirective::BUILD_IMPROVEMENT_ON_RESOURCE)
-					{
-						strLog += "Building improvement,";
-					}
-					else if(aDirective.m_eDirective == BuilderDirective::CHOP)
-					{
-						strLog += "Removing feature for production,";
-					}
-					else
-					{
-						strLog += "Removing road,";
-					}
-				}
-				else
-				{
-					strLog += "Moving to location,";
-				}
-
-				pLog->Msg(strLog);
-			}
-
-			if(eMission == CvTypes::getMISSION_MOVE_TO())
-			{
-				pUnit->PushMission(CvTypes::getMISSION_MOVE_TO(), aDirective.m_sX, aDirective.m_sY, 
-					CvUnit::MOVEFLAG_NO_ENEMY_TERRITORY|CvUnit::MOVEFLAG_ABORT_IF_NEW_ENEMY_REVEALED, false, false, MISSIONAI_BUILD, pPlot);
-
-				//do we have movement left?
-				if (pUnit->getMoves()>0)
-					eMission = CvTypes::getMISSION_BUILD();
-				else
-					UnitProcessed(pUnit->GetID());
-			}
-
-			if(eMission == CvTypes::getMISSION_BUILD())
-			{
-				// check to see if we already have this mission as the unit's head mission
-				const MissionData* pkMissionData = pUnit->GetHeadMissionData();
-				if(pkMissionData == NULL || pkMissionData->eMissionType != eMission || pkMissionData->iData1 != aDirective.m_eBuild)
-					pUnit->PushMission(CvTypes::getMISSION_BUILD(), aDirective.m_eBuild, aDirective.m_eDirective, 0, false, false, MISSIONAI_BUILD, pPlot);
-
-				CvAssertMsg(!pUnit->ReadyToMove(), "Worker did not do their mission this turn. Could cause game to hang.");
-				UnitProcessed(pUnit->GetID());
-			}
-
-			return GC.getMap().plot(aDirective.m_sX, aDirective.m_sY);
-		}
-		break;
-		}
-	}
-
-	return NULL;
 }
 
 bool CvHomelandAI::ExecuteCultureBlast(CvUnit* pUnit)

--- a/CvGameCoreDLL_Expansion2/CvHomelandAI.h
+++ b/CvGameCoreDLL_Expansion2/CvHomelandAI.h
@@ -208,7 +208,9 @@ public:
 	// Public turn update routines
 	void RecruitUnits();
 	void FindAutomatedUnits();
-	void Update();
+	void Update(bool bUpdateImprovements);
+	void Invalidate();
+	bool NeedsUpdate();
 
 	// Public exploration routines
 	CvPlot* GetBestExploreTarget(const CvUnit* pUnit, int nMinCandidatesToCheck, int iMaxTurns) const;
@@ -220,6 +222,8 @@ public:
 
 	bool MoveCivilianToGarrison(CvUnit* pUnit);
 	bool MoveCivilianToSafety(CvUnit* pUnit);
+
+	set<int> GetWorkedPlots();
 
 private:
 	// Internal turn update routines - commandeered unit processing
@@ -258,6 +262,7 @@ private:
 #endif
 //-------------------------------------
 
+	void PlanImprovements();
 	void PlotWorkerMoves(bool bSecondary = false);
 	void PlotWorkerSeaMoves(bool bSecondary = false);
 	void PlotWriterMoves();
@@ -313,8 +318,6 @@ private:
 	CvPlot* FindArchaeologistTarget(CvUnit *pUnit);
 
 	void UnitProcessed(int iID);
-	CvPlot* ExecuteWorkerMove(CvUnit* pUnit);
-	CvPlot* ExecuteWorkerMove(CvUnit* pUnit, const map<int,ReachablePlots>& allWorkersReachablePlots);
 	bool ExecuteCultureBlast(CvUnit* pUnit);
 	bool ExecuteGoldenAgeMove(CvUnit* pUnit);
 	bool IsValidExplorerEndTurnPlot(const CvUnit* pUnit, CvPlot* pPlot) const;
@@ -326,7 +329,10 @@ private:
 	// Class data
 	CvPlayer* m_pPlayer;
 	std::list<int> m_CurrentTurnUnits;
+	set<int> m_workedPlots;
+	list<int> m_greatPeopleForImprovements;
 	std::map<UnitAITypes,std::vector<std::pair<int,int>>> m_automatedTargetPlots; //for human units
+	bool m_bNeedsUpdate;
 
 	CHomelandUnitArray m_CurrentMoveUnits;
 

--- a/CvGameCoreDLL_Expansion2/CvHomelandAI.h
+++ b/CvGameCoreDLL_Expansion2/CvHomelandAI.h
@@ -361,6 +361,16 @@ struct SPatrolTarget {
 	bool operator==(const SPatrolTarget& rhs) const;
 };
 
+struct SBuilderState {
+	map<ResourceTypes, int> mExtraResources;
+	map<int, FeatureTypes> mChangedPlotFeatures;
+	map<int, ImprovementTypes> mChangedPlotImprovements;
+	map<int, int> mExtraDefense;
+	map<int, int> mExtraDamageToAdjacent;
+
+	SBuilderState(){};
+};
+
 namespace HomelandAIHelpers
 {
 bool CvHomelandUnitAuxIntSort(const CvHomelandUnit& obj1, const CvHomelandUnit& obj2);

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -35400,6 +35400,7 @@ void CvPlayer::setTurnActive(bool bNewValue, bool bDoTurn) // R: bDoTurn default
 				//no tactical AI for human, only make sure we have current postures in case we want the AI to take over (debugging)
 				if (isHuman() || /* if MP, invalidate for AI too */ kGame.isNetworkMultiPlayer()) {
 					GetTacticalAI()->GetTacticalAnalysisMap()->Invalidate();
+					GetHomelandAI()->Invalidate();
 				}
 
 				// update danger plots before the turn

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -17514,7 +17514,7 @@ int CvPlayer::GetWorldWonderYieldChange(int iYield)
 /// Can we eBuild on pPlot?
 bool CvPlayer::canBuild(const CvPlot* pPlot, BuildTypes eBuild, bool bTestEra, bool bTestVisible, bool bTestGold, bool bTestPlotOwner, const CvUnit* pUnit) const
 {
-	if(!(pPlot->canBuild(eBuild, GetID(), bTestVisible, bTestPlotOwner)))
+	if(pPlot && !(pPlot->canBuild(eBuild, GetID(), bTestVisible, bTestPlotOwner)))
 	{
 		return false;
 	}
@@ -17626,7 +17626,7 @@ bool CvPlayer::canBuild(const CvPlot* pPlot, BuildTypes eBuild, bool bTestEra, b
 	}
 #endif
 
-	if(!bTestVisible)
+	if(pPlot && !bTestVisible)
 	{
 		if(IsBuildBlockedByFeature(eBuild, pPlot->getFeatureType()))
 		{
@@ -50735,7 +50735,7 @@ CvPlot* CvPlayer::GetBestSettlePlot(const CvUnit* pUnit, CvAIOperation* pOpToIgn
 		if (bLogging)
 		{
 			iDanger = pUnit ? pUnit->GetDanger(pPlot) : 0;
-			iFertility = GC.getGame().GetSettlerSiteEvaluator()->PlotFertilityValue(pPlot,true);
+			iFertility = GC.getGame().GetSettlerSiteEvaluator()->PlotFertilityValue(pPlot,this,true);
 		}
 
 		if(!pPlot->isRevealed(eTeam))

--- a/CvGameCoreDLL_Expansion2/CvPlayer.h
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.h
@@ -2919,7 +2919,7 @@ public:
 	virtual void AI_doTurnPost() = 0;
 	virtual void AI_doTurnUnitsPre() = 0;
 	virtual void AI_doTurnUnitsPost() = 0;
-	virtual void AI_unitUpdate() = 0;
+	virtual void AI_unitUpdate(bool bHomelandAINeedsUpdate) = 0;
 	virtual void AI_conquerCity(CvCity* pCity, bool bGift, bool bAllowSphereRemoval) = 0;
 	bool HasSameIdeology(PlayerTypes ePlayer) const;
 

--- a/CvGameCoreDLL_Expansion2/CvPlayerAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayerAI.cpp
@@ -257,7 +257,7 @@ void CvPlayerAI::AI_doTurnUnitsPost()
 }
 
 //	---------------------------------------------------------------------------
-void CvPlayerAI::AI_unitUpdate()
+void CvPlayerAI::AI_unitUpdate(bool bUpdateHomelandAI)
 {
 	ICvEngineScriptSystem1* pkScriptSystem = gDLL->GetScriptSystem();
 	if(pkScriptSystem)
@@ -279,7 +279,7 @@ void CvPlayerAI::AI_unitUpdate()
 	{
 		CvUnit::dispatchingNetMessage(true);
 		GetTacticalAI()->UpdateVisibility();
-		GetHomelandAI()->Update();
+		GetHomelandAI()->Update(bUpdateHomelandAI);
 		GetTacticalAI()->CleanUp();
 		CvUnit::dispatchingNetMessage(false);
 	}
@@ -288,7 +288,7 @@ void CvPlayerAI::AI_unitUpdate()
 		// Now let the tactical AI run.  Putting it after the operations update allows units who have
 		// just been handed off to the tactical AI to get a move in the same turn they switch between
 		GetTacticalAI()->Update();
-		GetHomelandAI()->Update();
+		GetHomelandAI()->Update(true);
 		GetTacticalAI()->CleanUp();
 	}
 }

--- a/CvGameCoreDLL_Expansion2/CvPlayerAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayerAI.cpp
@@ -1772,7 +1772,7 @@ GreatPeopleDirectiveTypes CvPlayerAI::GetDirectiveGeneral(CvUnit* pGreatGeneral)
 	int iLoop = 0;
 	for (CvUnit* pLoopUnit = firstUnit(&iLoop); pLoopUnit; pLoopUnit = nextUnit(&iLoop))
 	{
-		if (pLoopUnit->IsGreatGeneral())
+		if (pLoopUnit != pGreatGeneral && pLoopUnit->IsGreatGeneral())
 		{
 			switch (pLoopUnit->GetGreatPeopleDirective())
 			{
@@ -1806,7 +1806,7 @@ GreatPeopleDirectiveTypes CvPlayerAI::GetDirectiveGeneral(CvUnit* pGreatGeneral)
 	{
 		CvPlot* pTargetPlot = FindBestCultureBombPlot(pGreatGeneral, eCitadel, vDummy, false);
 		if (pTargetPlot)
-			return GREAT_PEOPLE_DIRECTIVE_USE_POWER;
+		return GREAT_PEOPLE_DIRECTIVE_USE_POWER;
 	}
 	
 	// default
@@ -2574,6 +2574,7 @@ CvPlot* CvPlayerAI::FindBestCultureBombPlot(CvUnit* pUnit, BuildTypes eBuild, co
 
 	// we may build in one of our border tiles or in enemy tiles adjacent to them
 	std::set<int> setCandidates;
+	ImprovementTypes eImprovement = NO_IMPROVEMENT;
 	CvImprovementEntry* pkImprovementInfo = NULL;
 	int iRange = 0;
 
@@ -2591,7 +2592,7 @@ CvPlot* CvPlayerAI::FindBestCultureBombPlot(CvUnit* pUnit, BuildTypes eBuild, co
 		if (!pkBuildInfo)
 			return NULL;
 
-		ImprovementTypes eImprovement = (ImprovementTypes)pkBuildInfo->getImprovement();
+		eImprovement = (ImprovementTypes)pkBuildInfo->getImprovement();
 		pkImprovementInfo = GC.getImprovementInfo(eImprovement);
 		if (!pkImprovementInfo)
 			return NULL;
@@ -2652,7 +2653,7 @@ CvPlot* CvPlayerAI::FindBestCultureBombPlot(CvUnit* pUnit, BuildTypes eBuild, co
 				if (!pAdjacentPlot->IsAdjacentOwnedByTeamOtherThan(getTeam()))
 					continue;
 
-				if (pAdjacentPlot->GetDefenseBuildValue(GetID()) <= 0)
+				if (pAdjacentPlot->GetDefenseBuildValue(GetID(), eBuild, eImprovement) <= 0)
 					continue;
 			}
 
@@ -2690,7 +2691,7 @@ CvPlot* CvPlayerAI::FindBestCultureBombPlot(CvUnit* pUnit, BuildTypes eBuild, co
 	for (std::set<int>::iterator it = setCandidates.begin(); it != setCandidates.end(); ++it)
 	{
 		CvPlot* pPlot = GC.getMap().plotByIndexUnchecked(*it);
-		int iScore = (pkImprovementInfo && pkImprovementInfo->GetDefenseModifier() > 0) ? pPlot->GetDefenseBuildValue(GetID()) : 0;
+		int iScore = (pkImprovementInfo && (pkImprovementInfo->GetDefenseModifier() > 0 || pkImprovementInfo->GetNearbyEnemyDamage() > 0)) ? pPlot->GetDefenseBuildValue(GetID(), eBuild, eImprovement) : 0;
 
 		for (int iI=0; iI<RING_PLOTS[iRange]; iI++)
 		{
@@ -2766,7 +2767,7 @@ CvPlot* CvPlayerAI::FindBestCultureBombPlot(CvUnit* pUnit, BuildTypes eBuild, co
 			}
 
 			// score resource - this may be the dominant factor!
-			ResourceTypes eResource = pAdjacentPlot->getResourceType();
+			ResourceTypes eResource = pAdjacentPlot->getResourceType(getTeam());
 			if(eResource != NO_RESOURCE)
 			{
 				iScore += (GetBuilderTaskingAI()->GetResourceWeight(eResource, NO_IMPROVEMENT, pAdjacentPlot->getNumResource()) * iWeightFactor);

--- a/CvGameCoreDLL_Expansion2/CvPlayerAI.h
+++ b/CvGameCoreDLL_Expansion2/CvPlayerAI.h
@@ -40,7 +40,7 @@ public:
 	void AI_doTurnUnitsPre();
 	void AI_doTurnUnitsPost();
 
-	void AI_unitUpdate();
+	void AI_unitUpdate(bool bUpdateHomelandAI);
 	void AI_conquerCity(CvCity* pCity, bool bGift, bool bAllowSphereRemoval);
 
 	void AI_chooseFreeGreatPerson();

--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -2720,9 +2720,9 @@ bool CvPlot::canHaveImprovement(ImprovementTypes eImprovement, PlayerTypes ePlay
 			break;
 
 #if defined(MOD_BALANCE_CORE)
-		if (pkImprovementInfo->GetPrereqNatureYield(iI) > 0 && calculateNatureYield(((YieldTypes)iI), ePlayer, NULL) < pkImprovementInfo->GetPrereqNatureYield(iI))
+		if (pkImprovementInfo->GetPrereqNatureYield(iI) > 0 && calculateNatureYield(((YieldTypes)iI), ePlayer, getFeatureType(), getResourceType(GET_PLAYER(ePlayer).getTeam()), NULL) < pkImprovementInfo->GetPrereqNatureYield(iI))
 #else
-		if(calculateNatureYield(((YieldTypes)iI), eTeam) < pkImprovementInfo->GetPrereqNatureYield(iI))
+		if(calculateNatureYield(((YieldTypes)iI), ePlayer, getFeatureType(), getResourceType(GET_PLAYER(ePlayer).getTeam()), NULL) < pkImprovementInfo->GetPrereqNatureYield(iI))
 #endif
 		{
 			return false;
@@ -2881,7 +2881,7 @@ bool CvPlot::canBuild(BuildTypes eBuild, PlayerTypes ePlayer, bool bTestVisible,
 					{
 						if (bHasLuxuryRequirement)
 						{
-							ResourceTypes eResource = pAdjacentPlot->getResourceType();
+							ResourceTypes eResource = pAdjacentPlot->getResourceType(eTeam);
 							if (eResource != NO_RESOURCE)
 							{
 								CvResourceInfo *pkResourceInfo = GC.getResourceInfo(eResource);
@@ -3987,7 +3987,7 @@ int CvPlot::GetSeaBlockadeScore(PlayerTypes ePlayer) const
 		{
 			//there should really be a function that gives you a weighted score of all yields ...
 			iScore++;
-			if (pLoopPlot->getResourceType() != NO_RESOURCE)
+			if (pLoopPlot->getResourceType(GET_PLAYER(ePlayer).getTeam()) != NO_RESOURCE)
 				iScore++;
 			if (pLoopPlot->getFeatureType() != NO_FEATURE)
 				iScore++;
@@ -7213,8 +7213,8 @@ void CvPlot::setFeatureType(FeatureTypes eNewValue)
 				if ((YieldTypes)iI > YIELD_GOLDEN_AGE_POINTS && !MOD_BALANCE_CORE_JFD)
 					break;
 
-				pOwningCity->UpdateYieldPerXFeature((YieldTypes)iI, getFeatureType());
-				pOwningCity->UpdateYieldPerXUnimprovedFeature((YieldTypes)iI, getFeatureType());
+				pOwningCity->UpdateYieldPerXFeature((YieldTypes)iI, eNewValue);
+				pOwningCity->UpdateYieldPerXUnimprovedFeature((YieldTypes)iI, eNewValue);
 			}
 		}
 
@@ -7258,7 +7258,7 @@ void CvPlot::setFeatureType(FeatureTypes eNewValue)
 			}
 		}
 
-		if(getFeatureType() == NO_FEATURE)
+		if(eNewValue == NO_FEATURE)
 		{
 			if(getImprovementType() != NO_IMPROVEMENT)
 			{
@@ -8890,30 +8890,24 @@ bool CvPlot::HasSpecialImprovement() const
 				return true;
 			}
 		}
-	}
 
-	// Great person improvements
-	ImprovementTypes eImprovement = getImprovementType();
-	if (eImprovement != NO_IMPROVEMENT)
-	{
-		CvImprovementEntry* pImprovementInfo = GC.getImprovementInfo(eImprovement);
-		//Works like GP improvement.
-		if (pImprovementInfo && pImprovementInfo->IsCreatedByGreatPerson())
+		// Great person improvements
+		ImprovementTypes eImprovement = getImprovementType();
+		if (eImprovement != NO_IMPROVEMENT)
 		{
-			return true;
-		}
+			CvImprovementEntry* pImprovementInfo = GC.getImprovementInfo(eImprovement);
+			//Works like GP improvement.
+			if (pImprovementInfo && pImprovementInfo->IsCreatedByGreatPerson())
+			{
+				return true;
+			}
 
-		//Uniques
-		if (pImprovementInfo && pImprovementInfo->IsSpecificCivRequired())
-		{
-			return true;
-		}
-
-		//Don't delete landmarks!
-		ImprovementTypes eLandmark = (ImprovementTypes)GC.getInfoTypeForString("IMPROVEMENT_LANDMARK");
-		if (eLandmark != NO_IMPROVEMENT && eImprovement == eLandmark)
-		{
-			return true;
+			//Don't delete landmarks!
+			ImprovementTypes eLandmark = (ImprovementTypes)GC.getInfoTypeForString("IMPROVEMENT_LANDMARK");
+			if (eLandmark != NO_IMPROVEMENT && eImprovement == eLandmark)
+			{
+				return true;
+			}
 		}
 	}
 
@@ -9633,7 +9627,7 @@ void CvPlot::changeYield(YieldTypes eYield, int iChange)
     updateYield();
 }
 
-int CvPlot::calculateNatureYield(YieldTypes eYield, PlayerTypes ePlayer, const CvCity* pOwningCity, bool bIgnoreFeature, bool bDisplay) const
+int CvPlot::calculateNatureYield(YieldTypes eYield, PlayerTypes ePlayer, FeatureTypes eFeature, ResourceTypes eResource, const CvCity* pOwningCity, bool bDisplay) const
 {
 	int iYield = 0;
 	TeamTypes eTeam = (ePlayer!=NO_PLAYER) ? GET_PLAYER(ePlayer).getTeam() : NO_TEAM;
@@ -9654,9 +9648,9 @@ int CvPlot::calculateNatureYield(YieldTypes eYield, PlayerTypes ePlayer, const C
 	else
 	{
 		iYield = GC.getTerrainInfo(getTerrainType())->getYield(eYield);
-		if (eYield == YIELD_PRODUCTION && /*0*/ GD_INT_GET(BALANCE_CORE_PRODUCTION_DESERT_IMPROVEMENT) > 0 && getTerrainType() == TERRAIN_DESERT && !isHills() && getFeatureType() == NO_FEATURE)
+		if (eYield == YIELD_PRODUCTION && /*0*/ GD_INT_GET(BALANCE_CORE_PRODUCTION_DESERT_IMPROVEMENT) > 0 && getTerrainType() == TERRAIN_DESERT && !isHills() && eFeature == NO_FEATURE)
 		{
-			if (getResourceType(eTeam) != NO_RESOURCE && getImprovementType() != NO_IMPROVEMENT)
+			if (eResource != NO_RESOURCE && getImprovementType() != NO_IMPROVEMENT)
 				iYield += GD_INT_GET(BALANCE_CORE_PRODUCTION_DESERT_IMPROVEMENT);
 		}
 	}
@@ -9678,29 +9672,25 @@ int CvPlot::calculateNatureYield(YieldTypes eYield, PlayerTypes ePlayer, const C
 	{
 		iYield += kYield.getLakeChange();
 	}
-	if(!bIgnoreFeature)
+	if(eFeature != NO_FEATURE)
 	{
-		if(getFeatureType() != NO_FEATURE)
+		CvFeatureInfo* pFeatureInfo = GC.getFeatureInfo(eFeature);
+
+		// Some Features REPLACE the Yield of the Plot instead of adding to it
+		int iYieldChange = pFeatureInfo->getYieldChange(eYield);
+
+		if(pFeatureInfo->isYieldNotAdditive())
 		{
-			CvFeatureInfo* pFeatureInfo = GC.getFeatureInfo(getFeatureType());
-
-			// Some Features REPLACE the Yield of the Plot instead of adding to it
-			int iYieldChange = pFeatureInfo->getYieldChange(eYield);
-
-			if(pFeatureInfo->isYieldNotAdditive())
-			{
-				iYield = iYieldChange;
-			}
-			else
-			{
-				iYield += iYieldChange;
-			}
+			iYield = iYieldChange;
+		}
+		else
+		{
+			iYield += iYieldChange;
 		}
 	}
 
 	if(eTeam != NO_TEAM)
 	{
-		ResourceTypes eResource = getResourceType(eTeam);
 		CvResourceInfo* pkResourceInfo = GC.getResourceInfo(eResource);
 
 		if(eResource != NO_RESOURCE && pkResourceInfo)
@@ -9711,22 +9701,22 @@ int CvPlot::calculateNatureYield(YieldTypes eYield, PlayerTypes ePlayer, const C
 
 	if(isRiver())
 	{
-		iYield += ((bIgnoreFeature || (getFeatureType() == NO_FEATURE)) ? GC.getTerrainInfo(getTerrainType())->getRiverYieldChange(eYield) : GC.getFeatureInfo(getFeatureType())->getRiverYieldChange(eYield));
+		iYield += eFeature == NO_FEATURE ? GC.getTerrainInfo(getTerrainType())->getRiverYieldChange(eYield) : GC.getFeatureInfo(eFeature)->getRiverYieldChange(eYield);
 	}
 
 	if(isHills())
 	{
-		iYield += ((bIgnoreFeature || (getFeatureType() == NO_FEATURE)) ? GC.getTerrainInfo(getTerrainType())->getHillsYieldChange(eYield) : GC.getFeatureInfo(getFeatureType())->getHillsYieldChange(eYield));
+		iYield += eFeature == NO_FEATURE ? GC.getTerrainInfo(getTerrainType())->getHillsYieldChange(eYield) : GC.getFeatureInfo(eFeature)->getHillsYieldChange(eYield);
 	}
 
 	if(isFreshWater())
 	{
-		iYield += ((bIgnoreFeature || (getFeatureType() == NO_FEATURE)) ? GC.getTerrainInfo(getTerrainType())->getFreshWaterYieldChange(eYield) : GC.getFeatureInfo(getFeatureType())->getFreshWaterYieldChange(eYield));
+		iYield += eFeature == NO_FEATURE ? GC.getTerrainInfo(getTerrainType())->getFreshWaterYieldChange(eYield) : GC.getFeatureInfo(eFeature)->getFreshWaterYieldChange(eYield);
 	}
 
 	if(isCoastalLand())
 	{
-		iYield += ((bIgnoreFeature || (getFeatureType() == NO_FEATURE)) ? GC.getTerrainInfo(getTerrainType())->getCoastalLandYieldChange(eYield) : GC.getFeatureInfo(getFeatureType())->getCoastalLandYieldChange(eYield));
+		iYield += eFeature == NO_FEATURE ? GC.getTerrainInfo(getTerrainType())->getCoastalLandYieldChange(eYield) : GC.getFeatureInfo(eFeature)->getCoastalLandYieldChange(eYield);
 	}
 
 #if defined(MOD_PLOTS_EXTENSIONS)
@@ -9874,15 +9864,13 @@ int CvPlot::calculateNatureYield(YieldTypes eYield, PlayerTypes ePlayer, const C
 	return std::max(0, iYield);
 }
 
-int CvPlot::calculateReligionNatureYield(YieldTypes eYield, PlayerTypes ePlayer, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon) const
+int CvPlot::calculateReligionNatureYield(YieldTypes eYield, PlayerTypes ePlayer, ImprovementTypes eImprovement, FeatureTypes eFeature, ResourceTypes eResource, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon) const
 {
 	if (!pMajorityReligion)
 		return 0;
 
 	if (ePlayer == NO_PLAYER)
 		return 0;
-
-	TeamTypes eTeam = GET_PLAYER(ePlayer).getTeam();
 
 	int iYield = 0;
 
@@ -9899,9 +9887,9 @@ int CvPlot::calculateReligionNatureYield(YieldTypes eYield, PlayerTypes ePlayer,
 	{
 		if (bRequiresBoth)
 		{
-			if (getImprovementType() != NO_IMPROVEMENT && getResourceType(eTeam) != NO_RESOURCE)
+			if (eImprovement != NO_IMPROVEMENT && eResource != NO_RESOURCE)
 			{
-				if (GC.getImprovementInfo(getImprovementType())->IsConnectsResource(getResourceType(eTeam)))
+				if (GC.getImprovementInfo(eImprovement)->IsConnectsResource(eResource))
 				{
 					iReligionChange += iValue;
 				}
@@ -9909,35 +9897,35 @@ int CvPlot::calculateReligionNatureYield(YieldTypes eYield, PlayerTypes ePlayer,
 		}
 		else if (bRequiresImprovement)
 		{
-			if (getImprovementType() != NO_IMPROVEMENT)
+			if (eImprovement != NO_IMPROVEMENT)
 			{
 				iReligionChange += iValue;
 			}
 		}
 		else if (bRequiresResource)
 		{
-			if (getResourceType(eTeam) != NO_RESOURCE)
+			if (eResource != NO_RESOURCE)
 			{
 				iReligionChange += iValue;
 			}
 		}
 		else if (bRequiresEmptyTile)
 		{
-			if (getImprovementType() == NO_IMPROVEMENT && getFeatureType() == NO_FEATURE)
+			if (eImprovement == NO_IMPROVEMENT && eFeature == NO_FEATURE)
 			{
 				iReligionChange += iValue;
 			}
 		}
 		else if (bRequiresNoImprovement)
 		{
-			if (getImprovementType() == NO_IMPROVEMENT)
+			if (eImprovement == NO_IMPROVEMENT)
 			{
 				iReligionChange += iValue;
 			}
 		}
 		else if (bRequiresNoFeature)
 		{
-			if (getFeatureType() == NO_FEATURE)
+			if (eFeature == NO_FEATURE)
 			{
 				iReligionChange += iValue;
 			}
@@ -9969,9 +9957,9 @@ int CvPlot::calculateReligionNatureYield(YieldTypes eYield, PlayerTypes ePlayer,
 		{
 			if (bRequiresBoth)
 			{
-				if (getImprovementType() != NO_IMPROVEMENT && getResourceType(eTeam) != NO_RESOURCE)
+				if (eImprovement != NO_IMPROVEMENT && eResource != NO_RESOURCE)
 				{
-					if (GC.getImprovementInfo(getImprovementType())->IsConnectsResource(getResourceType(eTeam)))
+					if (GC.getImprovementInfo(eImprovement)->IsConnectsResource(eResource))
 					{
 						iReligionChange += iValue;
 					}
@@ -9979,9 +9967,9 @@ int CvPlot::calculateReligionNatureYield(YieldTypes eYield, PlayerTypes ePlayer,
 			}
 			else if (bRequiresImprovement)
 			{
-				if (getImprovementType() != NO_IMPROVEMENT)
+				if (eImprovement != NO_IMPROVEMENT)
 				{
-					if (GC.getImprovementInfo(getImprovementType())->IsConnectsResource(getResourceType(eTeam)))
+					if (GC.getImprovementInfo(eImprovement)->IsConnectsResource(eResource))
 					{
 						iReligionChange += iValue;
 					}
@@ -9989,28 +9977,28 @@ int CvPlot::calculateReligionNatureYield(YieldTypes eYield, PlayerTypes ePlayer,
 			}
 			else if (bRequiresResource)
 			{
-				if (getResourceType(eTeam) != NO_RESOURCE)
+				if (eResource != NO_RESOURCE)
 				{
 					iReligionChange += iValue;
 				}
 			}
 			else if (bRequiresEmptyTile)
 			{
-				if (getImprovementType() == NO_IMPROVEMENT && getFeatureType() == NO_FEATURE)
+				if (eImprovement == NO_IMPROVEMENT && getFeatureType() == NO_FEATURE)
 				{
 					iReligionChange += iValue;
 				}
 			}
 			else if (bRequiresNoImprovement)
 			{
-				if (getImprovementType() == NO_IMPROVEMENT)
+				if (eImprovement == NO_IMPROVEMENT)
 				{
 					iReligionChange += iValue;
 				}
 			}
 			else if (bRequiresNoFeature)
 			{
-				if (getFeatureType() == NO_FEATURE)
+				if (eFeature == NO_FEATURE)
 				{
 					iReligionChange += iValue;
 				}
@@ -10043,14 +10031,14 @@ int CvPlot::calculateReligionNatureYield(YieldTypes eYield, PlayerTypes ePlayer,
 		}
 	}
 
-	if (getFeatureType() != NO_FEATURE)
+	if (eFeature != NO_FEATURE)
 	{
-		if (getImprovementType() == NO_IMPROVEMENT)
+		if (eImprovement == NO_IMPROVEMENT)
 		{
-			iYield += pMajorityReligion->m_Beliefs.GetUnimprovedFeatureYieldChange(getFeatureType(), eYield, ePlayer, pOwningCity);
+			iYield += pMajorityReligion->m_Beliefs.GetUnimprovedFeatureYieldChange(eFeature, eYield, ePlayer, pOwningCity);
 			if (pSecondaryPantheon)
 			{
-				iYield += pSecondaryPantheon->GetUnimprovedFeatureYieldChange(getFeatureType(), eYield);
+				iYield += pSecondaryPantheon->GetUnimprovedFeatureYieldChange(eFeature, eYield);
 			}
 		}
 
@@ -10058,17 +10046,17 @@ int CvPlot::calculateReligionNatureYield(YieldTypes eYield, PlayerTypes ePlayer,
 		iReligionChange = 0;
 		bool bRequiresNoImprovement = pMajorityReligion->m_Beliefs.RequiresNoImprovement(ePlayer);
 		bool bRequiresImprovement = pMajorityReligion->m_Beliefs.RequiresImprovement(ePlayer);
-		if (MOD_BALANCE_CORE_BELIEFS_RESOURCE && bRequiresNoImprovement && getImprovementType() == NO_IMPROVEMENT)
+		if (MOD_BALANCE_CORE_BELIEFS_RESOURCE && bRequiresNoImprovement && eImprovement == NO_IMPROVEMENT)
 		{
-			iReligionChange += pMajorityReligion->m_Beliefs.GetFeatureYieldChange(getFeatureType(), eYield, ePlayer, pOwningCity);
+			iReligionChange += pMajorityReligion->m_Beliefs.GetFeatureYieldChange(eFeature, eYield, ePlayer, pOwningCity);
 		}
-		else if (MOD_BALANCE_CORE_BELIEFS_RESOURCE && bRequiresImprovement && getImprovementType() != NO_IMPROVEMENT)
+		else if (MOD_BALANCE_CORE_BELIEFS_RESOURCE && bRequiresImprovement && eImprovement != NO_IMPROVEMENT)
 		{
-			iReligionChange += pMajorityReligion->m_Beliefs.GetFeatureYieldChange(getFeatureType(), eYield, ePlayer, pOwningCity);
+			iReligionChange += pMajorityReligion->m_Beliefs.GetFeatureYieldChange(eFeature, eYield, ePlayer, pOwningCity);
 		}
 		else
 		{
-			iReligionChange += pMajorityReligion->m_Beliefs.GetFeatureYieldChange(getFeatureType(), eYield, ePlayer, pOwningCity);
+			iReligionChange += pMajorityReligion->m_Beliefs.GetFeatureYieldChange(eFeature, eYield, ePlayer, pOwningCity);
 		}
 
 		iYield += iReligionChange;
@@ -10079,17 +10067,17 @@ int CvPlot::calculateReligionNatureYield(YieldTypes eYield, PlayerTypes ePlayer,
 			iReligionChange = 0;
 			bool bRequiresNoImprovement = pSecondaryPantheon->RequiresNoImprovement();
 			bool bRequiresImprovement = pSecondaryPantheon->RequiresImprovement();
-			if (MOD_BALANCE_CORE_BELIEFS_RESOURCE && bRequiresNoImprovement && getImprovementType() == NO_IMPROVEMENT)
+			if (MOD_BALANCE_CORE_BELIEFS_RESOURCE && bRequiresNoImprovement && eImprovement == NO_IMPROVEMENT)
 			{
-				iReligionChange += pSecondaryPantheon->GetFeatureYieldChange(getFeatureType(), eYield);
+				iReligionChange += pSecondaryPantheon->GetFeatureYieldChange(eFeature, eYield);
 			}
-			else if (MOD_BALANCE_CORE_BELIEFS_RESOURCE && bRequiresImprovement && getImprovementType() != NO_IMPROVEMENT)
+			else if (MOD_BALANCE_CORE_BELIEFS_RESOURCE && bRequiresImprovement && eImprovement != NO_IMPROVEMENT)
 			{
-				iReligionChange += pSecondaryPantheon->GetFeatureYieldChange(getFeatureType(), eYield);
+				iReligionChange += pSecondaryPantheon->GetFeatureYieldChange(eFeature, eYield);
 			}
 			else
 			{
-				iReligionChange += pSecondaryPantheon->GetFeatureYieldChange(getFeatureType(), eYield);
+				iReligionChange += pSecondaryPantheon->GetFeatureYieldChange(eFeature, eYield);
 			}
 
 			iYield += iReligionChange;
@@ -10105,12 +10093,12 @@ int CvPlot::calculateReligionNatureYield(YieldTypes eYield, PlayerTypes ePlayer,
 		}
 	}
 
-	if (getResourceType(eTeam) != NO_RESOURCE)
+	if (eResource != NO_RESOURCE)
 	{
-		iYield += pMajorityReligion->m_Beliefs.GetResourceYieldChange(getResourceType(eTeam), eYield, ePlayer, pOwningCity);
+		iYield += pMajorityReligion->m_Beliefs.GetResourceYieldChange(eResource, eYield, ePlayer, pOwningCity);
 		if (pSecondaryPantheon)
 		{
-			iYield += pSecondaryPantheon->GetResourceYieldChange(getResourceType(eTeam), eYield);
+			iYield += pSecondaryPantheon->GetResourceYieldChange(eResource, eYield);
 		}
 	}
 
@@ -10120,9 +10108,8 @@ int CvPlot::calculateReligionNatureYield(YieldTypes eYield, PlayerTypes ePlayer,
 //	--------------------------------------------------------------------------------
 int CvPlot::calculateBestNatureYield(YieldTypes eYield, PlayerTypes ePlayer) const
 {
-	return std::max(calculateNatureYield(eYield, ePlayer, NULL, false), calculateNatureYield(eYield, ePlayer, NULL, true));
+	return std::max(calculateNatureYield(eYield, ePlayer, getFeatureType(), getResourceType(GET_PLAYER(ePlayer).getTeam()), NULL), calculateNatureYield(eYield, ePlayer, NO_FEATURE, getResourceType(GET_PLAYER(ePlayer).getTeam()), NULL));
 }
-
 
 //	--------------------------------------------------------------------------------
 int CvPlot::calculateTotalBestNatureYield(PlayerTypes ePlayer) const
@@ -10130,29 +10117,27 @@ int CvPlot::calculateTotalBestNatureYield(PlayerTypes ePlayer) const
 	return (calculateBestNatureYield(YIELD_FOOD, ePlayer) + calculateBestNatureYield(YIELD_PRODUCTION, ePlayer) + calculateBestNatureYield(YIELD_GOLD, ePlayer));
 }
 
-int CvPlot::calculateReligionImprovementYield(YieldTypes eYield, PlayerTypes ePlayer, ImprovementTypes eImprovement, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon) const
+int CvPlot::calculateReligionImprovementYield(YieldTypes eYield, PlayerTypes ePlayer, ImprovementTypes eImprovement, ResourceTypes eResource, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon) const
 {
 	if (!pOwningCity || !pMajorityReligion || ePlayer == NO_PLAYER)
 		return 0;
 
-	if (eImprovement == NO_IMPROVEMENT || IsImprovementPillaged())
+	if (eImprovement == NO_IMPROVEMENT)
 		return 0;
 
-	CvImprovementEntry* pImprovement = GC.getImprovementInfo(eImprovement);
-	if (!pImprovement)
+	CvImprovementEntry* pkImprovementInfo = GC.getImprovementInfo(eImprovement);
+	if (!pkImprovementInfo)
 		return 0;
-
-	CvPlayer& kPlayer = GET_PLAYER(ePlayer);
 
 	int iReligionChange = 0;
 	bool bRequiresResource = pMajorityReligion->m_Beliefs.RequiresResource(pOwningCity->getOwner());
-	if (pImprovement->IsCreatedByGreatPerson() || pImprovement->IsAdjacentCity() || pImprovement->IsIgnoreOwnership())
+	if (pkImprovementInfo->IsCreatedByGreatPerson() || pkImprovementInfo->IsAdjacentCity() || pkImprovementInfo->IsIgnoreOwnership())
 	{
 		bRequiresResource = false;
 	}
 	if (MOD_BALANCE_CORE_BELIEFS_RESOURCE && bRequiresResource)
 	{
-		if (bRequiresResource && (getResourceType(kPlayer.getTeam()) != NO_RESOURCE) && pImprovement->IsImprovementResourceMakesValid(getResourceType(kPlayer.getTeam())))
+		if (bRequiresResource && eResource != NO_RESOURCE && (pkImprovementInfo->IsImprovementResourceMakesValid(eResource) || pkImprovementInfo->GetResourceFromImprovement() == eResource))
 		{
 			iReligionChange += pMajorityReligion->m_Beliefs.GetImprovementYieldChange(eImprovement, eYield, pOwningCity->getOwner(), pOwningCity);
 		}
@@ -10166,13 +10151,13 @@ int CvPlot::calculateReligionImprovementYield(YieldTypes eYield, PlayerTypes ePl
 		return iReligionChange;
 
 	bRequiresResource = pSecondaryPantheon->RequiresResource();
-	if (pImprovement->IsCreatedByGreatPerson() || pImprovement->IsAdjacentCity())
+	if (pkImprovementInfo->IsCreatedByGreatPerson() || pkImprovementInfo->IsAdjacentCity())
 	{
 		bRequiresResource = false;
 	}
 	if (MOD_BALANCE_CORE_BELIEFS_RESOURCE && bRequiresResource)
 	{
-		if ( (getResourceType(kPlayer.getTeam()) != NO_RESOURCE && pImprovement->IsImprovementResourceMakesValid(getResourceType(kPlayer.getTeam()))))
+		if (eResource != NO_RESOURCE && (pkImprovementInfo->IsImprovementResourceMakesValid(eResource) || pkImprovementInfo->GetResourceFromImprovement() == eResource))
 		{
 			iReligionChange += pSecondaryPantheon->GetImprovementYieldChange(eImprovement, eYield);
 		}
@@ -10185,41 +10170,40 @@ int CvPlot::calculateReligionImprovementYield(YieldTypes eYield, PlayerTypes ePl
 	return iReligionChange;
 }
 //	--------------------------------------------------------------------------------
-int CvPlot::calculateImprovementYield(YieldTypes eYield, PlayerTypes ePlayer, ImprovementTypes eImprovement, const CvCity* pOwningCity, bool bOptimal, RouteTypes eAssumeThisRoute) const
+int CvPlot::calculateImprovementYield(YieldTypes eYield, PlayerTypes ePlayer, ImprovementTypes eImprovement, RouteTypes eRoute, FeatureTypes eFeature, ResourceTypes eResource, bool bIsCityConnection, const CvCity* pOwningCity, bool bOptimal) const
 {
-	ResourceTypes eResource;
 	int iBestYield = 0;
 	int iYield = 0;
 	int iI = 0;
 
-	if (eImprovement == NO_IMPROVEMENT || IsImprovementPillaged())
+	if (eImprovement == NO_IMPROVEMENT)
 		return 0;
 
-	CvImprovementEntry* pImprovement = GC.getImprovementInfo(eImprovement);
-	if (!pImprovement)
+	CvImprovementEntry* pkImprovementInfo = GC.getImprovementInfo(eImprovement);
+	if (!pkImprovementInfo)
 		return 0;
 
 	bool bIsFreshWater = isFreshWater();
 
-	iYield = pImprovement->GetYieldChange(eYield);
+	iYield = pkImprovementInfo->GetYieldChange(eYield);
 
 	if (ePlayer != NO_PLAYER)
 	{
 		CvPlayerAI& kPlayer = GET_PLAYER(ePlayer);
 
-		int iAdjacentYield = pImprovement->GetYieldAdjacentSameType(eYield);
+		int iAdjacentYield = pkImprovementInfo->GetYieldAdjacentSameType(eYield);
 		if (iAdjacentYield > 0)
 		{
-			iYield += ComputeYieldFromAdjacentImprovement(*pImprovement, eImprovement, eYield);
+			iYield += ComputeYieldFromAdjacentImprovement(*pkImprovementInfo, eImprovement, eYield);
 		}
 
-		int iTwoAdjacentYield = pImprovement->GetYieldAdjacentTwoSameType(eYield);
+		int iTwoAdjacentYield = pkImprovementInfo->GetYieldAdjacentTwoSameType(eYield);
 		if (iTwoAdjacentYield > 0)
 		{
-			iYield += ComputeYieldFromTwoAdjacentImprovement(*pImprovement, eImprovement, eYield);
+			iYield += ComputeYieldFromTwoAdjacentImprovement(*pkImprovementInfo, eImprovement, eYield);
 		}
 
-		int iYieldChangePerEra = pImprovement->GetYieldChangePerEra(eYield);
+		int iYieldChangePerEra = pkImprovementInfo->GetYieldChangePerEra(eYield);
 		if (iYieldChangePerEra > 0)
 		{
 			int iPlotEra = GetArchaeologicalRecord().m_eEra;
@@ -10251,21 +10235,19 @@ int CvPlot::calculateImprovementYield(YieldTypes eYield, PlayerTypes ePlayer, Im
 
 				if (pAdjacentPlot->getFeatureType() != NO_FEATURE)
 				{
-					iYield += pImprovement->GetAdjacentFeatureYieldChanges(pAdjacentPlot->getFeatureType(), eYield);
+					iYield += pkImprovementInfo->GetAdjacentFeatureYieldChanges(pAdjacentPlot->getFeatureType(), eYield);
 				}
 
 				if (pAdjacentPlot->getResourceType(kPlayer.getTeam()) != NO_RESOURCE)
 				{
-					iYield += pImprovement->GetAdjacentResourceYieldChanges(pAdjacentPlot->getResourceType(), eYield);
+					iYield += pkImprovementInfo->GetAdjacentResourceYieldChanges(pAdjacentPlot->getResourceType(), eYield);
 				}
 			}
 		}
 
-		eResource = getResourceType(kPlayer.getTeam());
-
 		if (eResource != NO_RESOURCE)
 		{
-			iYield += pImprovement->GetImprovementResourceYield(eResource, eYield);
+			iYield += pkImprovementInfo->GetImprovementResourceYield(eResource, eYield);
 		}
 	}
 
@@ -10273,33 +10255,33 @@ int CvPlot::calculateImprovementYield(YieldTypes eYield, PlayerTypes ePlayer, Im
 	{
 		if (pOwningCity->GetWeLoveTheKingDayCounter() > 0)
 		{
-			iYield += pImprovement->GetWLTKDYieldChange(eYield);
+			iYield += pkImprovementInfo->GetWLTKDYieldChange(eYield);
 		}
 	}
 
 	if(isRiver())
 	{
-		iYield += pImprovement->GetRiverSideYieldChange(eYield);
+		iYield += pkImprovementInfo->GetRiverSideYieldChange(eYield);
 	}
 
 	if(isCoastalLand())
 	{
-		iYield += pImprovement->GetCoastalLandYieldChange(eYield);
+		iYield += pkImprovementInfo->GetCoastalLandYieldChange(eYield);
 	}
 
 	if(isHills())
 	{
-		iYield += pImprovement->GetHillsYieldChange(eYield);
+		iYield += pkImprovementInfo->GetHillsYieldChange(eYield);
 	}
 
-	if (getFeatureType() != NO_FEATURE)
+	if (eFeature != NO_FEATURE)
 	{
-		iYield += pImprovement->GetFeatureYieldChanges(getFeatureType(), eYield);
+		iYield += pkImprovementInfo->GetFeatureYieldChanges(eFeature, eYield);
 	}
 
 	// Check to see if there's a bonus to apply before doing any looping
-	if(pImprovement->GetAdjacentCityYieldChange(eYield) > 0 ||
-	        pImprovement->GetAdjacentMountainYieldChange(eYield) > 0)
+	if(pkImprovementInfo->GetAdjacentCityYieldChange(eYield) > 0 ||
+	        pkImprovementInfo->GetAdjacentMountainYieldChange(eYield) > 0)
 	{
 		for(iI = 0; iI < NUM_DIRECTION_TYPES; ++iI)
 		{
@@ -10312,12 +10294,12 @@ int CvPlot::calculateImprovementYield(YieldTypes eYield, PlayerTypes ePlayer, Im
 					// Is the owner of this Plot (with the Improvement) also the owner of an adjacent City?
 					if(pAdjacentPlot->getPlotCity()->getOwner() == getOwner())
 					{
-						iYield += pImprovement->GetAdjacentCityYieldChange(eYield);
+						iYield += pkImprovementInfo->GetAdjacentCityYieldChange(eYield);
 					}
 				}
 				if(pAdjacentPlot->isMountain())
 				{
-					iYield += pImprovement->GetAdjacentMountainYieldChange(eYield);
+					iYield += pkImprovementInfo->GetAdjacentMountainYieldChange(eYield);
 				}
 			}
 		}
@@ -10325,7 +10307,7 @@ int CvPlot::calculateImprovementYield(YieldTypes eYield, PlayerTypes ePlayer, Im
 
 	if (bIsFreshWater || bOptimal)
 	{
-		iYield += pImprovement->GetFreshWaterYieldChange(eYield);
+		iYield += pkImprovementInfo->GetFreshWaterYieldChange(eYield);
 	}
 
 	if(bOptimal)
@@ -10334,22 +10316,13 @@ int CvPlot::calculateImprovementYield(YieldTypes eYield, PlayerTypes ePlayer, Im
 
 		for(iI = 0; iI < GC.getNumRouteInfos(); ++iI)
 		{
-			iBestYield = std::max(iBestYield, pImprovement->GetRouteYieldChanges(iI, eYield));
+			iBestYield = std::max(iBestYield, pkImprovementInfo->GetRouteYieldChanges(iI, eYield));
 		}
 
 		iYield += iBestYield;
 	}
 	else
 	{
-		RouteTypes eRouteType = NO_ROUTE;
-		if(eAssumeThisRoute != NUM_ROUTE_TYPES)
-		{
-			eRouteType = eAssumeThisRoute;
-		}
-		else
-		{
-			eRouteType = getRouteType();
-		}
 		if(ePlayer != NO_PLAYER)
 		{
 			if(IsTradeUnitRoute())
@@ -10364,30 +10337,30 @@ int CvPlot::calculateImprovementYield(YieldTypes eYield, PlayerTypes ePlayer, Im
 				}
 			}
 
-			if (eRouteType != NO_ROUTE)
+			if (eRoute != NO_ROUTE || getRouteType() != NO_ROUTE)
 			{
 				if (MOD_BALANCE_YIELD_SCALE_ERA)
 				{
-					if (IsCityConnection(ePlayer))
+					if (bIsCityConnection)
 					{
-						if (IsRouteRailroad())
+						if (eRoute == ROUTE_RAILROAD)
 						{
-							iYield += pImprovement->GetRouteYieldChanges(ROUTE_RAILROAD, eYield);
+							iYield += pkImprovementInfo->GetRouteYieldChanges(ROUTE_RAILROAD, eYield);
 						}
-						else if (IsRouteRoad())
+						else if (eRoute == ROUTE_ROAD)
 						{
-							iYield += pImprovement->GetRouteYieldChanges(ROUTE_ROAD, eYield);
+							iYield += pkImprovementInfo->GetRouteYieldChanges(ROUTE_ROAD, eYield);
 						}
 					}
 				}
 				else
 				{
-					iYield += pImprovement->GetRouteYieldChanges(eRouteType, eYield);
+					iYield += pkImprovementInfo->GetRouteYieldChanges(eRoute, eYield);
 				}
 
-				if (!IsRoutePillaged())
+				if (eRoute != NO_ROUTE)
 				{
-					CvRouteInfo* pkRouteInfo = GC.getRouteInfo(eRouteType);
+					CvRouteInfo* pkRouteInfo = GC.getRouteInfo(eRoute);
 					if (pkRouteInfo)
 					{
 						iYield += pkRouteInfo->getYieldChange(eYield);
@@ -10401,15 +10374,15 @@ int CvPlot::calculateImprovementYield(YieldTypes eYield, PlayerTypes ePlayer, Im
 	{
 		for(iI = 0; iI < GC.getNumTechInfos(); ++iI)
 		{
-			iYield += pImprovement->GetTechYieldChanges(iI, eYield);
+			iYield += pkImprovementInfo->GetTechYieldChanges(iI, eYield);
 
 			if(bIsFreshWater)
 			{
-				iYield += pImprovement->GetTechFreshWaterYieldChanges(iI, eYield);
+				iYield += pkImprovementInfo->GetTechFreshWaterYieldChanges(iI, eYield);
 			}
 			else
 			{
-				iYield += pImprovement->GetTechNoFreshWaterYieldChanges(iI, eYield);
+				iYield += pkImprovementInfo->GetTechNoFreshWaterYieldChanges(iI, eYield);
 			}
 		}
 
@@ -10428,9 +10401,9 @@ int CvPlot::calculateImprovementYield(YieldTypes eYield, PlayerTypes ePlayer, Im
 }
 
 #if defined(MOD_RELIGION_PERMANENT_PANTHEON)
-int CvPlot::calculatePlayerYield(YieldTypes eYield, int iCurrentYield, PlayerTypes ePlayer, ImprovementTypes eImprovement, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon, const CvReligion* pPlayerPantheon, bool bDisplay) const
+int CvPlot::calculatePlayerYield(YieldTypes eYield, int iCurrentYield, PlayerTypes ePlayer, ImprovementTypes eImprovement, FeatureTypes eFeature, ResourceTypes eResource, bool bIsCityConnection, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon, const CvReligion* pPlayerPantheon, bool bDisplay) const
 #else
-int CvPlot::calculatePlayerYield(YieldTypes eYield, int iCurrentYield, PlayerTypes ePlayer, ImprovementTypes eImprovement, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon, bool bDisplay) const
+int CvPlot::calculatePlayerYield(YieldTypes eYield, int iCurrentYield, PlayerTypes ePlayer, ImprovementTypes eImprovement, FeatureTypes eFeature, ResourceTypes eResource, bool bIsCityConnection, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon, bool bDisplay) const
 #endif
 {
 	if (ePlayer == NO_PLAYER)
@@ -10443,7 +10416,6 @@ int CvPlot::calculatePlayerYield(YieldTypes eYield, int iCurrentYield, PlayerTyp
 	CvTeam& kTeam = GET_TEAM(kPlayer.getTeam());
 	CvImprovementEntry* pImprovement = GC.getImprovementInfo(eImprovement);
 	CvPlayerTraits* pTraits = kPlayer.GetPlayerTraits();
-	FeatureTypes eFeature = getFeatureType();
 	TerrainTypes eTerrain = getTerrainType();
 
 	//plot yields
@@ -10550,7 +10522,7 @@ int CvPlot::calculatePlayerYield(YieldTypes eYield, int iCurrentYield, PlayerTyp
 			}
 		}
 	}
-	if (eImprovement != NO_IMPROVEMENT && !IsImprovementPillaged())
+	if (eImprovement != NO_IMPROVEMENT)
 	{
 		// Policy improvement yield changes
 		iYield += kPlayer.getImprovementYieldChange(eImprovement, eYield);
@@ -10583,7 +10555,7 @@ int CvPlot::calculatePlayerYield(YieldTypes eYield, int iCurrentYield, PlayerTyp
 			int iBonus = pTraits->GetTerrainYieldChange(eTerrain, eYield);
 			if (iBonus > 0)
 			{
-				if (IsCityConnection(ePlayer) || IsTradeUnitRoute())
+				if (bIsCityConnection || IsTradeUnitRoute())
 				{
 					int iScale = 0;
 					int iEra = (kPlayer.GetCurrentEra() + 1);
@@ -10603,7 +10575,7 @@ int CvPlot::calculatePlayerYield(YieldTypes eYield, int iCurrentYield, PlayerTyp
 			int iBonus = pTraits->GetTerrainYieldChange(eTerrain, eYield);
 			if (iBonus > 0)
 			{
-				if (IsCityConnection(ePlayer) || IsTradeUnitRoute())
+				if (bIsCityConnection || IsTradeUnitRoute())
 				{
 					int iScale = 0;
 					int iEra = (kPlayer.GetCurrentEra() + 1);
@@ -10618,12 +10590,12 @@ int CvPlot::calculatePlayerYield(YieldTypes eYield, int iCurrentYield, PlayerTyp
 				}
 			}
 		}
-		if (eImprovement != NO_IMPROVEMENT && !IsImprovementPillaged())
+		if (eImprovement != NO_IMPROVEMENT)
 		{
 			int iBonus2 = pTraits->GetImprovementYieldChange(eImprovement, eYield);
 			if (iBonus2 > 0)
 			{
-				if (IsCityConnection(ePlayer) || IsTradeUnitRoute() || IsAdjacentToTradeRoute())
+				if (bIsCityConnection || IsTradeUnitRoute() || IsAdjacentToTradeRoute())
 				{
 					int iScale = 0;
 					int iEra = (kPlayer.GetCurrentEra() + 1);
@@ -10695,7 +10667,7 @@ int CvPlot::calculatePlayerYield(YieldTypes eYield, int iCurrentYield, PlayerTyp
 					iYield += iCityYield;
 				}
 
-				if (getResourceType(kPlayer.getTeam()) != NO_RESOURCE)
+				if (eResource != NO_RESOURCE)
 				{
 					if (!bDisplay || pOwningCity->isRevealed(GC.getGame().getActiveTeam(), false, false))
 					{
@@ -10718,7 +10690,7 @@ int CvPlot::calculatePlayerYield(YieldTypes eYield, int iCurrentYield, PlayerTyp
 			}
 		}
 
-		if (eImprovement != NO_IMPROVEMENT && !IsImprovementPillaged())
+		if (eImprovement != NO_IMPROVEMENT)
 		{
 			if (pImprovement->IsCreatedByGreatPerson())
 			{
@@ -10747,7 +10719,6 @@ int CvPlot::calculatePlayerYield(YieldTypes eYield, int iCurrentYield, PlayerTyp
 		
 		iYield += pOwningCity->GetPlotExtraYield(getPlotType(), eYield);
 
-		ResourceTypes eResource = getResourceType(kPlayer.getTeam());
 		if (eResource != NO_RESOURCE)
 		{
 			const CvResourceInfo* pkResourceInfo = GC.getResourceInfo(eResource);
@@ -10765,7 +10736,7 @@ int CvPlot::calculatePlayerYield(YieldTypes eYield, int iCurrentYield, PlayerTyp
 					}
 				}
 
-				iYield += pOwningCity->GetEventResourceYield(getResourceType(), eYield);
+				iYield += pOwningCity->GetEventResourceYield(eResource, eYield);
 				iYield += kPlayer.getResourceYieldChange(eResource, eYield);
 				iYield += pTraits->GetResourceYieldChange(eResource, eYield);
 
@@ -10795,10 +10766,10 @@ int CvPlot::calculatePlayerYield(YieldTypes eYield, int iCurrentYield, PlayerTyp
 
 				if (pAdjacentPlot != NULL && pAdjacentPlot->getImprovementType() != NO_IMPROVEMENT && pAdjacentPlot->getOwner() == ePlayer)
 				{
-					CvImprovementEntry* pImprovement2 = GC.getImprovementInfo(pAdjacentPlot->getImprovementType());
-					if (pImprovement2 && pImprovement2->GetAdjacentTerrainYieldChanges(eTerrain, eYield) > 0)
+					CvImprovementEntry* pkImprovementInfo2 = GC.getImprovementInfo(pAdjacentPlot->getImprovementType());
+					if (pkImprovementInfo2 && pkImprovementInfo2->GetAdjacentTerrainYieldChanges(eTerrain, eYield) > 0)
 					{
-						iYield += pImprovement2->GetAdjacentTerrainYieldChanges(eTerrain, eYield);
+						iYield += pkImprovementInfo2->GetAdjacentTerrainYieldChanges(eTerrain, eYield);
 					}
 				}
 			}
@@ -10812,7 +10783,7 @@ int CvPlot::calculatePlayerYield(YieldTypes eYield, int iCurrentYield, PlayerTyp
 	if (eFeature != NO_FEATURE)
 	{
 		// Player Trait
-		if (eImprovement == NO_IMPROVEMENT)
+		if (eImprovement == NO_IMPROVEMENT && getImprovementType() == NO_IMPROVEMENT)
 		{
 			iYield += pTraits->GetUnimprovedFeatureYieldChange(eFeature, eYield);
 			iYield += kPlayer.getUnimprovedFeatureYieldChange(eFeature, eYield);
@@ -10939,16 +10910,24 @@ int CvPlot::calculateYieldFast(YieldTypes eYield, bool bDisplay, const CvCity* p
 		}
 	}
 
-	int iYield = calculateNatureYield(eYield, ePlayer, pOwningCity, false, bDisplay);
-	iYield += calculateReligionImprovementYield(eYield, ePlayer, eImprovement, pOwningCity, pMajorityReligion, pSecondaryPantheon);
-	iYield += calculateReligionNatureYield(eYield, ePlayer, pOwningCity, pMajorityReligion, pSecondaryPantheon);
-	iYield += calculateImprovementYield(eYield, ePlayer, eImprovement, pOwningCity, false, eRoute);
-	iYield += calculatePlayerYield(eYield, iYield, ePlayer, eImprovement, pOwningCity, pMajorityReligion, pSecondaryPantheon, pPlayerPantheon, bDisplay);
+	if (IsImprovementPillaged())
+		eImprovement = NO_IMPROVEMENT;
+	if (IsRoutePillaged())
+		eRoute = NO_ROUTE;
+
+	FeatureTypes eFeature = getFeatureType();
+	ResourceTypes eResource = getResourceType(GET_PLAYER(ePlayer).getTeam());
+
+	int iYield = calculateNatureYield(eYield, ePlayer, eFeature, eResource, pOwningCity, bDisplay);
+	iYield += calculateReligionImprovementYield(eYield, ePlayer, eImprovement, eResource, pOwningCity, pMajorityReligion, pSecondaryPantheon);
+	iYield += calculateReligionNatureYield(eYield, ePlayer, eImprovement, eFeature, eResource, pOwningCity, pMajorityReligion, pSecondaryPantheon);
+	iYield += calculateImprovementYield(eYield, ePlayer, eImprovement, eRoute, eFeature, eResource, IsCityConnection(ePlayer), pOwningCity, false);
+	iYield += calculatePlayerYield(eYield, iYield, ePlayer, eImprovement, eFeature, eResource, IsCityConnection(ePlayer), pOwningCity, pMajorityReligion, pSecondaryPantheon, pPlayerPantheon, bDisplay);
 #if defined(MOD_RELIGION_PERMANENT_PANTHEON)
 	if (MOD_RELIGION_PERMANENT_PANTHEON && pPlayerPantheon != NULL)
 	{
-		iYield += calculateReligionImprovementYield(eYield, ePlayer, eImprovement, pOwningCity, pPlayerPantheon, NULL);
-		iYield += calculateReligionNatureYield(eYield, ePlayer, pOwningCity, pPlayerPantheon, NULL);
+		iYield += calculateReligionImprovementYield(eYield, ePlayer, eImprovement, eResource, pOwningCity, pPlayerPantheon, NULL);
+		iYield += calculateReligionNatureYield(eYield, ePlayer, eImprovement, eFeature, eResource, pOwningCity, pPlayerPantheon, NULL);
 	}
 #endif
 
@@ -11076,8 +11055,8 @@ int CvPlot::GetExplorationBonus(const CvPlayer* pPlayer, const CvUnit* pUnit)
 		if (pPlayer->getCapitalCity())
 		{
 			//do not use the founding values here, they are expensive to compute
-			int iFertility = GC.getGame().GetSettlerSiteEvaluator()->PlotFertilityValue(this, true);
-			int iRefFertility = GC.getGame().GetSettlerSiteEvaluator()->PlotFertilityValue(pPlayer->getCapitalCity()->plot(), true);
+			int iFertility = GC.getGame().GetSettlerSiteEvaluator()->PlotFertilityValue(this, pPlayer, true);
+			int iRefFertility = GC.getGame().GetSettlerSiteEvaluator()->PlotFertilityValue(pPlayer->getCapitalCity()->plot(), pPlayer, true);
 			iBonus = range((iFertility * 100) / MAX(1, iRefFertility), 0, 100);
 		}
 
@@ -13598,9 +13577,9 @@ void CvPlot::getVisibleResourceState(ResourceTypes& eType, bool& bImproved, bool
 
 //	--------------------------------------------------------------------------------
 #if defined(MOD_RELIGION_PERMANENT_PANTHEON)
-int CvPlot::getYieldWithBuild(BuildTypes eBuild, YieldTypes eYield, bool bWithUpgrade, PlayerTypes ePlayer, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon, const CvReligion* pPlayerPantheon) const
+int CvPlot::getYieldWithBuild(BuildTypes eBuild, YieldTypes eYield, bool bWithUpgrade, bool bIsCityConnection, PlayerTypes ePlayer, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon, const CvReligion* pPlayerPantheon) const
 #else
-int CvPlot::getYieldWithBuild(BuildTypes eBuild, YieldTypes eYield, bool bWithUpgrade, PlayerTypes ePlayer, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon) const
+int CvPlot::getYieldWithBuild(BuildTypes eBuild, YieldTypes eYield, bool bWithUpgrade, bool bIsCityConnection, PlayerTypes ePlayer, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon) const
 #endif
 {
 	int iYield = 0;
@@ -13611,36 +13590,97 @@ int CvPlot::getYieldWithBuild(BuildTypes eBuild, YieldTypes eYield, bool bWithUp
 	if(!isPotentialCityWork())
 		return 0;
 
-	// Will the build remove the feature?
-	bool bIgnoreFeature = false;
-	if(getFeatureType() != NO_FEATURE)
-	{
-		if(GC.getBuildInfo(eBuild)->isFeatureRemove(getFeatureType()))
-			bIgnoreFeature = true;
-	}
-
-	ImprovementTypes eImprovement = (ImprovementTypes)GC.getBuildInfo(eBuild)->getImprovement();
-
-	// Nature yield
-	iYield = calculateNatureYield(eYield, ePlayer, pOwningCity, bIgnoreFeature);
-	iYield += calculateReligionNatureYield(eYield, ePlayer, pOwningCity, pMajorityReligion, pSecondaryPantheon);
+	FeatureTypes eFeature = getFeatureType();
+	ResourceTypes eResource = getResourceType(GET_PLAYER(ePlayer).getTeam());
+	CvBuildInfo* pkBuildInfo = GC.getBuildInfo(eBuild);
+	ImprovementTypes eNewImprovement = (ImprovementTypes)pkBuildInfo->getImprovement();
+	ImprovementTypes eOldImprovement = getImprovementType();
+	CvImprovementEntry* pkOldImprovementInfo = GC.getImprovementInfo(eOldImprovement);
 
 	// If we're not changing the improvement that's here, use the improvement that's here already
-	if(eImprovement == NO_IMPROVEMENT)
+	if (eNewImprovement == NO_IMPROVEMENT)
 	{
-		if(!IsImprovementPillaged() || GC.getBuildInfo(eBuild)->isRepair())
+		if (!IsImprovementPillaged() || GC.getBuildInfo(eBuild)->isRepair())
 		{
-			eImprovement = getImprovementType();
+			// If we are removing a feature that the previous improvement required, don't use the old improvement
+			if (!pkBuildInfo->isFeatureRemove(eFeature) || !pkOldImprovementInfo || !pkOldImprovementInfo->GetFeatureMakesValid(eFeature))
+			{
+				eNewImprovement = eOldImprovement;
+			}
 		}
 	}
 
-	if(eImprovement != NO_IMPROVEMENT)
+	RouteTypes eNewRoute = (RouteTypes)pkBuildInfo->getRoute();
+
+	// If we're not changing the route that's here, use the improvement that's here already
+	if (eNewRoute == NO_ROUTE)
+	{
+		if (!IsRoutePillaged() || (GC.getBuildInfo(eBuild)->isRepair() && !IsImprovementPillaged()))
+		{
+			eNewRoute = getRouteType();
+		}
+		else if (bIsCityConnection && !IsCityConnection(ePlayer))
+		{
+			eNewRoute = GET_PLAYER(ePlayer).GetBuilderTaskingAI()->GetRouteTypeNeededAtPlot(this);
+		}
+	}
+
+	// Will the build remove the feature?
+	if (getFeatureType() != NO_FEATURE)
+	{
+		if (GC.getBuildInfo(eBuild)->isFeatureRemove(getFeatureType()))
+		{
+			eFeature = NO_FEATURE;
+		}
+	}
+
+	if (eNewImprovement != eOldImprovement)
+	{
+		// Was the previous improvement granting a feature/resource?
+		if (eOldImprovement != NO_IMPROVEMENT)
+		{
+			FeatureTypes eOldCreatedFeature = pkOldImprovementInfo->GetCreatedFeature();
+			if (eOldCreatedFeature != NO_FEATURE)
+			{
+				eFeature = NO_FEATURE;
+			}
+
+			ResourceTypes eOldCreatedResource = (ResourceTypes)pkOldImprovementInfo->GetResourceFromImprovement();
+			if (eOldCreatedResource != NO_RESOURCE)
+			{
+				eResource = NO_RESOURCE;
+			}
+		}
+
+		// Will the new improvement grant a feature/resource?
+		if (eNewImprovement != NO_IMPROVEMENT)
+		{
+			CvImprovementEntry* pkImprovement = GC.getImprovementInfo(eNewImprovement);
+			FeatureTypes eCreatedFeature = pkImprovement->GetCreatedFeature();
+			if (eCreatedFeature != NO_FEATURE)
+			{
+				eFeature = eCreatedFeature;
+			}
+
+			ResourceTypes eCreatedResource = (ResourceTypes)pkImprovement->GetResourceFromImprovement();
+			if (eCreatedResource != NO_RESOURCE)
+			{
+				eResource = eCreatedResource;
+			}
+		}
+	}
+
+	// Nature yield
+	iYield = calculateNatureYield(eYield, ePlayer, eFeature, eResource, pOwningCity);
+	iYield += calculateReligionNatureYield(eYield, ePlayer, eNewImprovement, eFeature, eResource, pOwningCity, pMajorityReligion, pSecondaryPantheon);
+
+	if(eNewImprovement != NO_IMPROVEMENT)
 	{
 		if(bWithUpgrade)
 		{
 			//in the case that improvements upgrade, use 2 upgrade levels higher for the
 			//yield calculations.
-			ImprovementTypes eUpgradeImprovement = (ImprovementTypes)GC.getImprovementInfo(eImprovement)->GetImprovementUpgrade();
+			ImprovementTypes eUpgradeImprovement = (ImprovementTypes)GC.getImprovementInfo(eNewImprovement)->GetImprovementUpgrade();
 			if(eUpgradeImprovement != NO_IMPROVEMENT)
 			{
 				//unless it's trade on a low food tile, in which case only use 1 level higher
@@ -13654,147 +13694,26 @@ int CvPlot::getYieldWithBuild(BuildTypes eBuild, YieldTypes eYield, bool bWithUp
 				}
 			}
 
-			if((eUpgradeImprovement != NO_IMPROVEMENT) && (eUpgradeImprovement != eImprovement))
+			if((eUpgradeImprovement != NO_IMPROVEMENT) && (eUpgradeImprovement != eNewImprovement))
 			{
-				eImprovement = eUpgradeImprovement;
+				eNewImprovement = eUpgradeImprovement;
 			}
 		}
 
-		iYield += calculateImprovementYield(eYield, ePlayer, eImprovement, pOwningCity, false, getRouteType()) + calculateReligionImprovementYield(eYield, ePlayer, eImprovement, pOwningCity, pMajorityReligion, pSecondaryPantheon);
+		iYield += calculateImprovementYield(eYield, ePlayer, eNewImprovement, eNewRoute, eFeature, eResource, bIsCityConnection, pOwningCity, false) + calculateReligionImprovementYield(eYield, ePlayer, eNewImprovement, eResource, pOwningCity, pMajorityReligion, pSecondaryPantheon);
 #if defined(MOD_RELIGION_PERMANENT_PANTHEON)
 		if (MOD_RELIGION_PERMANENT_PANTHEON && pPlayerPantheon != NULL)
 		{
-			iYield += calculateReligionImprovementYield(eYield, ePlayer, eImprovement, pOwningCity, pPlayerPantheon, NULL);
+			iYield += calculateReligionImprovementYield(eYield, ePlayer, eNewImprovement, eResource, pOwningCity, pPlayerPantheon, NULL);
 		}
 #endif
 	}
 
 #if defined(MOD_RELIGION_PERMANENT_PANTHEON)
-	iYield += calculatePlayerYield(eYield, iYield, ePlayer, eImprovement, pOwningCity, pMajorityReligion, pSecondaryPantheon, pPlayerPantheon, false);
+	iYield += calculatePlayerYield(eYield, iYield, ePlayer, eNewImprovement, eFeature, eResource, bIsCityConnection, pOwningCity, pMajorityReligion, pSecondaryPantheon, pPlayerPantheon, false);
 #else
-	iYield += calculatePlayerYield(eYield, iYield, ePlayer, eImprovement, pOwningCity, pMajorityReligion, pSecondaryPantheon, false);
+	iYield += calculatePlayerYield(eYield, iYield, ePlayer, eNewImprovement, eFeature, eResource, bIsCityConnection, pOwningCity, pMajorityReligion, pSecondaryPantheon, false);
 #endif
-
-	RouteTypes eRoute = (RouteTypes)GC.getBuildInfo(eBuild)->getRoute();
-
-	// If we're not changing the route that's here, use the route that's here already
-	if(eRoute == NO_ROUTE)
-	{
-		if(!IsRoutePillaged() || GC.getBuildInfo(eBuild)->isRepair())
-		{
-			eRoute = getRouteType();
-		}
-	}
-
-	if(eRoute != NO_ROUTE)
-	{
-		eImprovement = getImprovementType(); // potentially problematic - will ALWAYS calculate for existing improvement, no matter what the build is
-		if(eImprovement != NO_IMPROVEMENT)
-		{
-			if(ePlayer != NO_PLAYER)
-			{
-				int iRouteYield = 0;
-				if(IsCityConnection(ePlayer))
-				{
-					if(IsRouteRailroad())
-					{
-						iRouteYield += GC.getImprovementInfo(eImprovement)->GetRouteYieldChanges(ROUTE_RAILROAD, eYield);
-					}
-					else if(IsRouteRoad())
-					{
-						iRouteYield += GC.getImprovementInfo(eImprovement)->GetRouteYieldChanges(ROUTE_ROAD, eYield);
-					}
-				}
-				if(IsTradeUnitRoute())
-				{
-					if( GET_PLAYER(ePlayer).GetCurrentEra()>=4 )
-					{
-						iRouteYield += GC.getImprovementInfo(eImprovement)->GetRouteYieldChanges(ROUTE_RAILROAD, eYield);
-					}
-					else
-					{
-						iRouteYield += GC.getImprovementInfo(eImprovement)->GetRouteYieldChanges(ROUTE_ROAD, eYield);
-					}
-				}
-				if(iRouteYield > 0)
-				{
-					iYield += iRouteYield;
-				}
-
-				if(GET_PLAYER(ePlayer).GetPlayerTraits()->IsTradeRouteOnly())
-				{
-					if(IsCityConnection(ePlayer) || IsTradeUnitRoute())
-					{
-						if (getOwner() == GET_PLAYER(ePlayer).GetID())
-						{
-#if defined(MOD_USE_TRADE_FEATURES)
-							if(getFeatureType() == NO_FEATURE && !MOD_USE_TRADE_FEATURES)
-#endif
-							{
-								int iBonus = GET_PLAYER(ePlayer).GetPlayerTraits()->GetTerrainYieldChange(getTerrainType(), eYield);
-								if(iBonus > 0)
-								{
-									int iScale = 0;
-									int iEra = (GET_PLAYER(ePlayer).GetCurrentEra() + 1);
-
-									iScale = ((iBonus * iEra) / 4);
-
-									if(iScale <= 0)
-									{
-										iScale = 1;
-									}
-									iYield += iScale;
-								}
-							}
-#if defined(MOD_USE_TRADE_FEATURES)
-							else if(MOD_USE_TRADE_FEATURES)
-#endif
-							{
-								int iBonus = GET_PLAYER(ePlayer).GetPlayerTraits()->GetTerrainYieldChange(getTerrainType(), eYield);
-								if(iBonus > 0)
-								{
-									int iScale = 0;
-									int iEra = (GET_PLAYER(ePlayer).GetCurrentEra() + 1);
-
-									iScale = ((iBonus * iEra) / 4);
-
-									if(iScale <= 0)
-									{
-										iScale = 1;
-									}
-									iYield += iScale;
-								}
-							}
-						}
-					}
-					int iBonus2 = GET_PLAYER(ePlayer).GetPlayerTraits()->GetImprovementYieldChange(eImprovement, eYield);
-					if(iBonus2 > 0)
-					{
-						if (getOwner() == GET_PLAYER(ePlayer).GetID())
-						{
-							if(IsCityConnection(ePlayer) || IsTradeUnitRoute() || IsAdjacentToTradeRoute())
-							{
-								int iScale = 0;
-								int iEra = (GET_PLAYER(ePlayer).GetCurrentEra() + 1);
-
-								iScale = ((iBonus2 * iEra) / 2);
-
-								if(iScale <= 0)
-								{
-									iScale = 1;
-								}
-								iYield += iScale;
-							}
-						}
-					}
-				}
-				else
-				{
-					iYield += GET_PLAYER(ePlayer).GetPlayerTraits()->GetTerrainYieldChange(getTerrainType(), eYield);
-				}
-			}
-		}
-	}
 
 	//no overhead if empty
 	for (size_t i=0; i<m_vExtraYields.size(); i++)
@@ -15497,116 +15416,263 @@ int CvPlot::GetNumSpecificPlayerUnitsAdjacent(PlayerTypes ePlayer, const CvUnit*
 ///-------------------------------------
 
 #if defined(MOD_BALANCE_CORE)
-int CvPlot::GetDefenseBuildValue(PlayerTypes eOwner)
+int CvPlot::GetDefenseBuildValue(PlayerTypes eOwner, BuildTypes eBuild, ImprovementTypes eImprovement, SBuilderState sState) const
 {
 	TeamTypes eTeam = GET_PLAYER(eOwner).getTeam();
 	if(eTeam == NO_TEAM)
 		return 0;
 
-	static const ImprovementTypes eFort = (ImprovementTypes)GC.getInfoTypeForString("IMPROVEMENT_FORT");
-	static const ImprovementTypes eCitadel = (ImprovementTypes)GC.getInfoTypeForString("IMPROVEMENT_CITADEL");
-
-	if(eFort == NO_IMPROVEMENT && eCitadel == NO_IMPROVEMENT)
+	if (eImprovement == NO_IMPROVEMENT)
 		return 0;
 
-	// See how many outside plots are nearby to monitor
-	int iAdjacentUnowned = 0;
-	int iAdjacentOwnedOther = 0;
-	int iNearbyForts = 0;
-	int iNearbyOwnedOther = 0;
-	int iBadNearby = 0;
-	int iBadAdjacent = 0;
+	CvBuildInfo* pkBuild = GC.getBuildInfo(eBuild);
+	CvImprovementEntry* pkImprovementInfo = GC.getImprovementInfo(eImprovement);
+	int iImprovementDefenseModifier = pkImprovementInfo->GetDefenseModifier();
+	int iImprovementDamage = pkImprovementInfo->GetNearbyEnemyDamage();
 
+	bool bHuman = GET_PLAYER(eOwner).isHuman();
+	CvDiplomacyAI* pDiplomacyAI = GET_PLAYER(eOwner).GetDiplomacyAI();
+
+	// Evaluate based on surrounding plots
+	int iAdjacentUnownedLand = 0;
+	int iNearbyUnownedLand = 0;
+
+	int iAdjacentThreat = 0;
+	int iNearbyThreat = 0;
+
+	int iAdjacentCoast = 0;
+	int iNearbyCoast = 0;
+
+	bool bAdjacentCity = false;
+	int iNearbyCities = 0;
+
+	int iAdjacentOwnedLand = 0;
+	int iAdjacentDamage = 0;
+	int iAdjacentDefenseModifiers = 0;
+	int iNearbyDefenseModifiers = 0;
+
+	// Directly adjacent tiles
 	for (int iI = 0; iI < NUM_DIRECTION_TYPES; iI++)
 	{
 		CvPlot* pLoopAdjacentPlot = plotDirection(getX(), getY(), ((DirectionTypes)iI));
 
-		//Don't want them adjacent to cities, but we do want to check for plot ownership.
 		if (pLoopAdjacentPlot != NULL)
 		{	
-			//Adjacent to city? Break!
-			if(pLoopAdjacentPlot->isCity())
-				return 0;
 
 			//impassable is uninteresting
 			if(pLoopAdjacentPlot->isImpassable(eTeam))
 				continue;
 
+			//coasts are easy avenues of attack
+			if (pLoopAdjacentPlot->isWater())
+			{
+				if (!pLoopAdjacentPlot->isLake())
+					iAdjacentCoast++;
+
+				continue;
+			}
+
 			if(pLoopAdjacentPlot->getOwner() == eOwner)
 			{
-				//don't build other defenses near citadels (next to forts is ok)
-				if (pLoopAdjacentPlot->getImprovementType() == eCitadel)
-					return 0;
+				iAdjacentOwnedLand++;
+
+				// Avoid building next to cities
+				if (pLoopAdjacentPlot->isCity())
+					bAdjacentCity = true;
+
+				// try to leave room around improvements that damage adjacent units
+				CvImprovementEntry* pkAdjacentImprovement = GC.getImprovementInfo(pLoopAdjacentPlot->getImprovementType());
+				int iNearbyDamage = pkAdjacentImprovement ? pkAdjacentImprovement->GetNearbyEnemyDamage() : 0;
+				iNearbyDamage += sState.mExtraDamageToAdjacent[pLoopAdjacentPlot->GetPlotIndex()];
+				if (iNearbyDamage > 0)
+					iAdjacentDamage += iNearbyDamage;
+
+				int iDefenseModifier = pkAdjacentImprovement ? pkAdjacentImprovement->GetDefenseModifier() : 0;
+				iDefenseModifier += sState.mExtraDefense[pLoopAdjacentPlot->GetPlotIndex()];
+				if (iDefenseModifier > 0)
+					iAdjacentDefenseModifiers += iDefenseModifier;
 			}
-			else if(pLoopAdjacentPlot->getOwner() == NO_PLAYER)
+			else if(!pLoopAdjacentPlot->isOwned())
 			{
-				iAdjacentUnowned++;
+				iAdjacentUnownedLand++;
 			}
 			else if(GET_PLAYER(pLoopAdjacentPlot->getOwner()).isMajorCiv())
 			{
-				iAdjacentOwnedOther++;
-				if (GET_PLAYER(eOwner).GetDiplomacyAI()->GetCivOpinion(pLoopAdjacentPlot->getOwner()) <= CIV_OPINION_NEUTRAL)
-					iBadAdjacent++;
+
+				if (bHuman)
+				{
+					iAdjacentThreat += 4;
+				}
+				else
+				{
+					int iOpinionMultiplier = 1;
+					int iStrengthMultiplier = 1;
+
+					CivOpinionTypes eOpinion = pDiplomacyAI->GetCivOpinion(pLoopAdjacentPlot->getOwner());
+
+					if (eOpinion == CIV_OPINION_NEUTRAL)
+						iOpinionMultiplier = 2;
+					else if (eOpinion < CIV_OPINION_NEUTRAL)
+						iOpinionMultiplier = 4;
+
+					StrengthTypes eStrengthRelativeToUs = pDiplomacyAI->GetMilitaryStrengthComparedToUs(pLoopAdjacentPlot->getOwner());
+					if (eStrengthRelativeToUs == STRENGTH_STRONG)
+						iStrengthMultiplier = 2;
+					else if (eStrengthRelativeToUs == STRENGTH_POWERFUL)
+						iStrengthMultiplier = 4;
+					else if (eStrengthRelativeToUs == STRENGTH_IMMENSE)
+						iStrengthMultiplier = 8;
+
+					iAdjacentThreat += iOpinionMultiplier * iStrengthMultiplier;
+				}
 			}
 		}
 	}
 
-	//if there are no unowned or enemy tiles, don't bother
-	if(iAdjacentUnowned+iAdjacentOwnedOther < 3 && iBadAdjacent == 0)
-		return 0;
-
-	//check the wider area for enemy tiles. may also be on another landmass
+	// Wider area
 	for (int i=RING1_PLOTS; i<RING2_PLOTS; i++)
 	{
 		CvPlot* pLoopNearbyPlot = iterateRingPlots(this, i);
 
-		//Don't want them adjacent to cities, but we do want to check for plot ownership.
 		if (pLoopNearbyPlot != NULL && pLoopNearbyPlot->isRevealed(eTeam))
 		{
-			if (!pLoopNearbyPlot->isOwned())
+			//impassable is uninteresting
+			if (pLoopNearbyPlot->isImpassable(eTeam))
 				continue;
 
-			if (pLoopNearbyPlot->getOwner() != eOwner)
+			if (pLoopNearbyPlot->isWater())
+			{
+				if (!pLoopNearbyPlot->isLake())
+					iNearbyCoast++;
+
+				continue;
+			}
+
+			if (pLoopNearbyPlot->getOwner() == eOwner)
+			{
+				// Avoid building next to cities
+				if (pLoopNearbyPlot->isCity())
+					iNearbyCities++;
+
+				CvImprovementEntry* pkNearbyImprovement = GC.getImprovementInfo(pLoopNearbyPlot->getImprovementType());
+				int iDefenseModifier = pkNearbyImprovement ? pkNearbyImprovement->GetDefenseModifier() : 0;
+				iDefenseModifier += sState.mExtraDefense[pLoopNearbyPlot->GetPlotIndex()];
+				if (iDefenseModifier > 0)
+					iNearbyDefenseModifiers += iDefenseModifier;
+			}
+			else if (!pLoopNearbyPlot->isOwned())
+			{
+				iNearbyUnownedLand++;
+			}
+			else if (pLoopNearbyPlot->getOwner() != eOwner)
 			{
 				if (GET_PLAYER(pLoopNearbyPlot->getOwner()).isMajorCiv())
 				{
-					iNearbyOwnedOther++;
-					if (GET_PLAYER(eOwner).GetDiplomacyAI()->GetCivOpinion(pLoopNearbyPlot->getOwner()) <= CIV_OPINION_NEUTRAL)
-						iBadNearby++;
+					if (bHuman)
+					{
+						iNearbyThreat += 4;
+					}
+					else
+					{
+						int iOpinionMultiplier = 1;
+						int iStrengthMultiplier = 1;
+
+						CivOpinionTypes eOpinion = pDiplomacyAI->GetCivOpinion(pLoopNearbyPlot->getOwner());
+
+						if (eOpinion == CIV_OPINION_NEUTRAL)
+							iOpinionMultiplier = 2;
+						else if (eOpinion < CIV_OPINION_NEUTRAL)
+							iOpinionMultiplier = 4;
+
+						StrengthTypes eStrengthRelativeToUs = pDiplomacyAI->GetMilitaryStrengthComparedToUs(pLoopNearbyPlot->getOwner());
+						if (eStrengthRelativeToUs == STRENGTH_STRONG)
+							iStrengthMultiplier = 2;
+						else if (eStrengthRelativeToUs == STRENGTH_POWERFUL)
+							iStrengthMultiplier = 4;
+						else if (eStrengthRelativeToUs == STRENGTH_IMMENSE)
+							iStrengthMultiplier = 8;
+
+						iNearbyThreat += iOpinionMultiplier * iStrengthMultiplier;
+					}
 				}
 			}
-
-				//Let's check for owned nearby forts as well
-			if(pLoopNearbyPlot->getImprovementType() != NO_IMPROVEMENT && pLoopNearbyPlot->getOwner() == eOwner)
-				if(eFort == pLoopNearbyPlot->getImprovementType() || eCitadel == pLoopNearbyPlot->getImprovementType())
-					iNearbyForts++;
 		}
 	}
 
-	//only build a fort if it's somewhat close to the enemy and there aren't forts nearby. We shouldn't be spamming them.
-	if (iNearbyForts > 2)
+	//Get score for this fortification
+	int iDefensiveValue = 0;
+
+	// When we can cross oceans, start increasing the threat level of coast tiles
+	if (GET_TEAM(eTeam).canEmbarkAllWaterPassage())
+	{
+		//Coastal tiles
+		iDefensiveValue += iNearbyCoast * 1;
+		iDefensiveValue += iAdjacentCoast * 2;
+	}
+
+	// Unowned tiles
+	iDefensiveValue += iNearbyUnownedLand * 1;
+	iDefensiveValue += iAdjacentUnownedLand * 2;
+
+	// Threatening civs (unfriendly and/or powerful)
+	iDefensiveValue += (iNearbyThreat * 10);
+	iDefensiveValue += (iAdjacentThreat * 20);
+
+	// No defensive utility from building here
+	if (iDefensiveValue == 0)
 		return 0;
 
-	//Get score for this fortification
-	int iScore = defenseModifier(eTeam, true, true);
+	//Avoid fort spam
+	iDefensiveValue -= iNearbyDefenseModifiers * 4;
+	iDefensiveValue -= iAdjacentDefenseModifiers * 8;
 
-	//Bonus for nearby owned tiles
-	iScore += (iNearbyOwnedOther * 3);
-		
-	//Big Bonus if adjacent to territory.
-	iScore += (iAdjacentOwnedOther * 4);
+	//Leave room around improvements that deal damage
+	iDefensiveValue -= iAdjacentDamage * 20;
 
-	//Big Bonus if adjacent to enemy territory.
-	iScore += (iBadAdjacent * 16);
+	//Avoid building next to cities
+	iDefensiveValue -= iNearbyCities * 250;
+	if (bAdjacentCity)
+		iDefensiveValue -= 500;
 
-	//Big Bonus if adjacent to enemy territory.
-	iScore += (iBadNearby * 10);
+	if (iDefensiveValue <= 0)
+		return 0;
+
+	int iBaseDefenseModifier = defenseModifier(eTeam, true, true);
+	int iOldDefenseModifier = defenseModifier(eTeam, false, false);
+
+	ImprovementTypes eOldImprovement = getImprovementType();
+	CvImprovementEntry* pkOldImprovementInfo = GC.getImprovementInfo(eOldImprovement);
+
+	int iOldImprovementDamage = eOldImprovement != NO_IMPROVEMENT && pkOldImprovementInfo ? pkOldImprovementInfo->GetNearbyEnemyDamage() : 0;
+
+	int iNewDefenseModifier = defenseModifier(eTeam, true, pkBuild && pkBuild->isFeatureRemove(getFeatureType())) + iImprovementDefenseModifier;
+
+	// Encampments provide a defensive buff in all owned tiles in a large radius, consider only adjacent tiles, since other encampments can provide the buff in further tiles
+	bool bIsEncampment = MOD_BALANCE_VP && pkImprovementInfo->IsSpecificCivRequired() && pkImprovementInfo->GetRequiredCivilization() == (CivilizationTypes)GC.getInfoTypeForString("CIVILIZATION_SHOSHONE", true);
+	if (bIsEncampment)
+		iNewDefenseModifier += 20 * iAdjacentOwnedLand;
+
+	if (eOldImprovement != NO_IMPROVEMENT && pkOldImprovementInfo)
+	{
+		bool bIsOldEncampment = MOD_BALANCE_VP && pkOldImprovementInfo->IsSpecificCivRequired() && pkOldImprovementInfo->GetRequiredCivilization() == (CivilizationTypes)GC.getInfoTypeForString("CIVILIZATION_SHOSHONE", true);
+		if (bIsOldEncampment)
+			iOldDefenseModifier += 20 * iAdjacentOwnedLand;
+	}
+
+	// Scale defensive value by how much this fortification will increase the defense of the tile (and how much damage it will deal to enemy units)
+	// This can be negative, if we are replacing a better defensive improvement
+	int iDefenseMultiplier = (iNewDefenseModifier + iImprovementDamage * 2) - (iOldDefenseModifier + iOldImprovementDamage * 2);
 
 	//Big bonus if chokepoint
 	if(IsChokePoint())
-		iScore += 17;
+		iDefenseMultiplier *= 2;
 
-	return iScore;
+	// Bonus for plots that are not too exposed
+	int iDefensibilityTimes10 = ((iAdjacentOwnedLand / 2) + 2) * 5;
+
+	if (iDefenseMultiplier > 0)
+		return ((iDefensiveValue + iBaseDefenseModifier) * iDefenseMultiplier * iDefensibilityTimes10) / 200;
+	return (iDefensiveValue * iDefenseMultiplier * iDefensibilityTimes10) / 200;
 }
 
 #endif

--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -10170,7 +10170,7 @@ int CvPlot::calculateReligionImprovementYield(YieldTypes eYield, PlayerTypes ePl
 	return iReligionChange;
 }
 //	--------------------------------------------------------------------------------
-int CvPlot::calculateImprovementYield(YieldTypes eYield, PlayerTypes ePlayer, ImprovementTypes eImprovement, RouteTypes eRoute, FeatureTypes eFeature, ResourceTypes eResource, bool bIsCityConnection, const CvCity* pOwningCity, bool bOptimal) const
+int CvPlot::calculateImprovementYield(YieldTypes eYield, PlayerTypes ePlayer, ImprovementTypes eImprovement, RouteTypes eRoute, FeatureTypes eFeature, ResourceTypes eResource, bool bIgnoreCityConnection, const CvCity* pOwningCity, bool bOptimal) const
 {
 	int iBestYield = 0;
 	int iYield = 0;
@@ -10341,7 +10341,7 @@ int CvPlot::calculateImprovementYield(YieldTypes eYield, PlayerTypes ePlayer, Im
 			{
 				if (MOD_BALANCE_YIELD_SCALE_ERA)
 				{
-					if (bIsCityConnection)
+					if (IsCityConnection() && !bIgnoreCityConnection)
 					{
 						if (eRoute == ROUTE_RAILROAD)
 						{
@@ -10355,7 +10355,7 @@ int CvPlot::calculateImprovementYield(YieldTypes eYield, PlayerTypes ePlayer, Im
 				}
 				else
 				{
-					iYield += pkImprovementInfo->GetRouteYieldChanges(eRoute, eYield);
+					iYield += pkImprovementInfo->GetRouteYieldChanges(eRoute != NO_ROUTE ? eRoute : getRouteType(), eYield);
 				}
 
 				if (eRoute != NO_ROUTE)
@@ -10401,9 +10401,9 @@ int CvPlot::calculateImprovementYield(YieldTypes eYield, PlayerTypes ePlayer, Im
 }
 
 #if defined(MOD_RELIGION_PERMANENT_PANTHEON)
-int CvPlot::calculatePlayerYield(YieldTypes eYield, int iCurrentYield, PlayerTypes ePlayer, ImprovementTypes eImprovement, FeatureTypes eFeature, ResourceTypes eResource, bool bIsCityConnection, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon, const CvReligion* pPlayerPantheon, bool bDisplay) const
+int CvPlot::calculatePlayerYield(YieldTypes eYield, int iCurrentYield, PlayerTypes ePlayer, ImprovementTypes eImprovement, FeatureTypes eFeature, ResourceTypes eResource, bool bIgnoreCityConnection, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon, const CvReligion* pPlayerPantheon, bool bDisplay) const
 #else
-int CvPlot::calculatePlayerYield(YieldTypes eYield, int iCurrentYield, PlayerTypes ePlayer, ImprovementTypes eImprovement, FeatureTypes eFeature, ResourceTypes eResource, bool bIsCityConnection, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon, bool bDisplay) const
+int CvPlot::calculatePlayerYield(YieldTypes eYield, int iCurrentYield, PlayerTypes ePlayer, ImprovementTypes eImprovement, FeatureTypes eFeature, ResourceTypes eResource, bool bIgnoreCityConnection, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon, bool bDisplay) const
 #endif
 {
 	if (ePlayer == NO_PLAYER)
@@ -10555,7 +10555,7 @@ int CvPlot::calculatePlayerYield(YieldTypes eYield, int iCurrentYield, PlayerTyp
 			int iBonus = pTraits->GetTerrainYieldChange(eTerrain, eYield);
 			if (iBonus > 0)
 			{
-				if (bIsCityConnection || IsTradeUnitRoute())
+				if ((IsCityConnection() && !bIgnoreCityConnection) || IsTradeUnitRoute())
 				{
 					int iScale = 0;
 					int iEra = (kPlayer.GetCurrentEra() + 1);
@@ -10575,7 +10575,7 @@ int CvPlot::calculatePlayerYield(YieldTypes eYield, int iCurrentYield, PlayerTyp
 			int iBonus = pTraits->GetTerrainYieldChange(eTerrain, eYield);
 			if (iBonus > 0)
 			{
-				if (bIsCityConnection || IsTradeUnitRoute())
+				if ((IsCityConnection() && !bIgnoreCityConnection) || IsTradeUnitRoute())
 				{
 					int iScale = 0;
 					int iEra = (kPlayer.GetCurrentEra() + 1);
@@ -10595,7 +10595,7 @@ int CvPlot::calculatePlayerYield(YieldTypes eYield, int iCurrentYield, PlayerTyp
 			int iBonus2 = pTraits->GetImprovementYieldChange(eImprovement, eYield);
 			if (iBonus2 > 0)
 			{
-				if (bIsCityConnection || IsTradeUnitRoute() || IsAdjacentToTradeRoute())
+				if ((IsCityConnection() && !bIgnoreCityConnection) || IsTradeUnitRoute() || IsAdjacentToTradeRoute())
 				{
 					int iScale = 0;
 					int iEra = (kPlayer.GetCurrentEra() + 1);
@@ -10921,8 +10921,8 @@ int CvPlot::calculateYieldFast(YieldTypes eYield, bool bDisplay, const CvCity* p
 	int iYield = calculateNatureYield(eYield, ePlayer, eFeature, eResource, pOwningCity, bDisplay);
 	iYield += calculateReligionImprovementYield(eYield, ePlayer, eImprovement, eResource, pOwningCity, pMajorityReligion, pSecondaryPantheon);
 	iYield += calculateReligionNatureYield(eYield, ePlayer, eImprovement, eFeature, eResource, pOwningCity, pMajorityReligion, pSecondaryPantheon);
-	iYield += calculateImprovementYield(eYield, ePlayer, eImprovement, eRoute, eFeature, eResource, IsCityConnection(ePlayer), pOwningCity, false);
-	iYield += calculatePlayerYield(eYield, iYield, ePlayer, eImprovement, eFeature, eResource, IsCityConnection(ePlayer), pOwningCity, pMajorityReligion, pSecondaryPantheon, pPlayerPantheon, bDisplay);
+	iYield += calculateImprovementYield(eYield, ePlayer, eImprovement, eRoute, eFeature, eResource, false, pOwningCity, false);
+	iYield += calculatePlayerYield(eYield, iYield, ePlayer, eImprovement, eFeature, eResource, false, pOwningCity, pMajorityReligion, pSecondaryPantheon, pPlayerPantheon, bDisplay);
 #if defined(MOD_RELIGION_PERMANENT_PANTHEON)
 	if (MOD_RELIGION_PERMANENT_PANTHEON && pPlayerPantheon != NULL)
 	{
@@ -13577,9 +13577,9 @@ void CvPlot::getVisibleResourceState(ResourceTypes& eType, bool& bImproved, bool
 
 //	--------------------------------------------------------------------------------
 #if defined(MOD_RELIGION_PERMANENT_PANTHEON)
-int CvPlot::getYieldWithBuild(BuildTypes eBuild, YieldTypes eYield, bool bWithUpgrade, bool bIsCityConnection, PlayerTypes ePlayer, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon, const CvReligion* pPlayerPantheon) const
+int CvPlot::getYieldWithBuild(BuildTypes eBuild, YieldTypes eYield, bool bWithUpgrade, bool bIgnoreCityConnection, PlayerTypes ePlayer, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon, const CvReligion* pPlayerPantheon) const
 #else
-int CvPlot::getYieldWithBuild(BuildTypes eBuild, YieldTypes eYield, bool bWithUpgrade, bool bIsCityConnection, PlayerTypes ePlayer, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon) const
+int CvPlot::getYieldWithBuild(BuildTypes eBuild, YieldTypes eYield, bool bWithUpgrade, bool bIgnoreCityConnection, PlayerTypes ePlayer, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon) const
 #endif
 {
 	int iYield = 0;
@@ -13602,26 +13602,17 @@ int CvPlot::getYieldWithBuild(BuildTypes eBuild, YieldTypes eYield, bool bWithUp
 	{
 		if (!IsImprovementPillaged() || GC.getBuildInfo(eBuild)->isRepair())
 		{
-			// If we are removing a feature that the previous improvement required, don't use the old improvement
-			if (!pkBuildInfo->isFeatureRemove(eFeature) || !pkOldImprovementInfo || !pkOldImprovementInfo->GetFeatureMakesValid(eFeature))
-			{
-				eNewImprovement = eOldImprovement;
-			}
+			eNewImprovement = eOldImprovement;
 		}
 	}
 
-	RouteTypes eNewRoute = (RouteTypes)pkBuildInfo->getRoute();
-
 	// If we're not changing the route that's here, use the improvement that's here already
+	RouteTypes eNewRoute = (RouteTypes)pkBuildInfo->getRoute();
 	if (eNewRoute == NO_ROUTE)
 	{
 		if (!IsRoutePillaged() || (GC.getBuildInfo(eBuild)->isRepair() && !IsImprovementPillaged()))
 		{
 			eNewRoute = getRouteType();
-		}
-		else if (bIsCityConnection && !IsCityConnection(ePlayer))
-		{
-			eNewRoute = GET_PLAYER(ePlayer).GetBuilderTaskingAI()->GetRouteTypeNeededAtPlot(this);
 		}
 	}
 
@@ -13630,6 +13621,9 @@ int CvPlot::getYieldWithBuild(BuildTypes eBuild, YieldTypes eYield, bool bWithUp
 	{
 		if (GC.getBuildInfo(eBuild)->isFeatureRemove(getFeatureType()))
 		{
+			if (GET_PLAYER(ePlayer).GetPlayerTraits()->IsWoodlandMovementBonus() && (eFeature == FEATURE_FOREST || eFeature == FEATURE_JUNGLE) && eNewRoute == NO_ROUTE)
+				bIgnoreCityConnection = true;
+
 			eFeature = NO_FEATURE;
 		}
 	}
@@ -13700,7 +13694,7 @@ int CvPlot::getYieldWithBuild(BuildTypes eBuild, YieldTypes eYield, bool bWithUp
 			}
 		}
 
-		iYield += calculateImprovementYield(eYield, ePlayer, eNewImprovement, eNewRoute, eFeature, eResource, bIsCityConnection, pOwningCity, false) + calculateReligionImprovementYield(eYield, ePlayer, eNewImprovement, eResource, pOwningCity, pMajorityReligion, pSecondaryPantheon);
+		iYield += calculateImprovementYield(eYield, ePlayer, eNewImprovement, eNewRoute, eFeature, eResource, bIgnoreCityConnection, pOwningCity, false) + calculateReligionImprovementYield(eYield, ePlayer, eNewImprovement, eResource, pOwningCity, pMajorityReligion, pSecondaryPantheon);
 #if defined(MOD_RELIGION_PERMANENT_PANTHEON)
 		if (MOD_RELIGION_PERMANENT_PANTHEON && pPlayerPantheon != NULL)
 		{
@@ -13710,9 +13704,9 @@ int CvPlot::getYieldWithBuild(BuildTypes eBuild, YieldTypes eYield, bool bWithUp
 	}
 
 #if defined(MOD_RELIGION_PERMANENT_PANTHEON)
-	iYield += calculatePlayerYield(eYield, iYield, ePlayer, eNewImprovement, eFeature, eResource, bIsCityConnection, pOwningCity, pMajorityReligion, pSecondaryPantheon, pPlayerPantheon, false);
+	iYield += calculatePlayerYield(eYield, iYield, ePlayer, eNewImprovement, eFeature, eResource, bIgnoreCityConnection, pOwningCity, pMajorityReligion, pSecondaryPantheon, pPlayerPantheon, false);
 #else
-	iYield += calculatePlayerYield(eYield, iYield, ePlayer, eNewImprovement, eFeature, eResource, bIsCityConnection, pOwningCity, pMajorityReligion, pSecondaryPantheon, false);
+	iYield += calculatePlayerYield(eYield, iYield, ePlayer, eNewImprovement, eFeature, eResource, bIgnoreCityConnection, pOwningCity, pMajorityReligion, pSecondaryPantheon, false);
 #endif
 
 	//no overhead if empty
@@ -15615,24 +15609,24 @@ int CvPlot::GetDefenseBuildValue(PlayerTypes eOwner, BuildTypes eBuild, Improvem
 	iDefensiveValue += iAdjacentUnownedLand * 2;
 
 	// Threatening civs (unfriendly and/or powerful)
-	iDefensiveValue += (iNearbyThreat * 10);
-	iDefensiveValue += (iAdjacentThreat * 20);
+	iDefensiveValue += (iNearbyThreat * 30);
+	iDefensiveValue += (iAdjacentThreat * 60);
 
 	// No defensive utility from building here
 	if (iDefensiveValue == 0)
 		return 0;
 
 	//Avoid fort spam
-	iDefensiveValue -= iNearbyDefenseModifiers * 4;
-	iDefensiveValue -= iAdjacentDefenseModifiers * 8;
+	iDefensiveValue -= iNearbyDefenseModifiers * 2;
+	iDefensiveValue -= iAdjacentDefenseModifiers * 4;
 
 	//Leave room around improvements that deal damage
 	iDefensiveValue -= iAdjacentDamage * 20;
 
 	//Avoid building next to cities
-	iDefensiveValue -= iNearbyCities * 250;
+	iDefensiveValue -= iNearbyCities * 100;
 	if (bAdjacentCity)
-		iDefensiveValue -= 500;
+		iDefensiveValue -= 200;
 
 	if (iDefensiveValue <= 0)
 		return 0;
@@ -15671,8 +15665,8 @@ int CvPlot::GetDefenseBuildValue(PlayerTypes eOwner, BuildTypes eBuild, Improvem
 	int iDefensibilityTimes10 = ((iAdjacentOwnedLand / 2) + 2) * 5;
 
 	if (iDefenseMultiplier > 0)
-		return ((iDefensiveValue + iBaseDefenseModifier) * iDefenseMultiplier * iDefensibilityTimes10) / 200;
-	return (iDefensiveValue * iDefenseMultiplier * iDefensibilityTimes10) / 200;
+		return ((iDefensiveValue + iBaseDefenseModifier) * iDefenseMultiplier * iDefensibilityTimes10) / 600;
+	return (iDefensiveValue * iDefenseMultiplier * iDefensibilityTimes10) / 600;
 }
 
 #endif

--- a/CvGameCoreDLL_Expansion2/CvPlot.h
+++ b/CvGameCoreDLL_Expansion2/CvPlot.h
@@ -28,6 +28,7 @@
 #include "CvGame.h"
 #include "CvEnums.h"
 #include "CvSerialize.h"
+#include "CvHomelandAI.h"
 
 #pragma warning( disable: 4251 )		// needs to have dll-interface to be used by clients of class
 
@@ -564,25 +565,25 @@ public:
 	int getYield(YieldTypes eIndex) const;
     void changeYield(YieldTypes eYield, int iChange);
 
-	int calculateNatureYield(YieldTypes eYield, PlayerTypes ePlayer, const CvCity* pOwningCity, bool bIgnoreFeature = false, bool bDisplay = false) const;
+	int calculateNatureYield(YieldTypes eYield, PlayerTypes ePlayer, FeatureTypes eFeature, ResourceTypes eResource, const CvCity* pOwningCity, bool bDisplay = false) const;
 
 	int calculateBestNatureYield(YieldTypes eYield, PlayerTypes ePlayer) const;
 	int calculateTotalBestNatureYield(PlayerTypes ePlayer) const;
 
-	int calculateImprovementYield(YieldTypes eYield, PlayerTypes ePlayer, ImprovementTypes eImprovement,  const CvCity* pOwningCity, bool bOptimal = false, RouteTypes eAssumeThisRoute = NUM_ROUTE_TYPES) const;
+	int calculateImprovementYield(YieldTypes eYield, PlayerTypes ePlayer, ImprovementTypes eImprovement, RouteTypes eRoute, FeatureTypes eFeature, ResourceTypes eResource, bool bIsCityConnection,  const CvCity* pOwningCity, bool bOptimal = false) const;
 
 #if defined(MOD_RELIGION_PERMANENT_PANTHEON)
-	int calculatePlayerYield(YieldTypes eYield, int iCurrentYield, PlayerTypes ePlayer, ImprovementTypes eImprovement, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon, const CvReligion* pPlayerPantheon, bool bDisplay) const;
+	int calculatePlayerYield(YieldTypes eYield, int iCurrentYield, PlayerTypes ePlayer, ImprovementTypes eImprovement, FeatureTypes eFeature, ResourceTypes eResource, bool bIsCityConnection, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon, const CvReligion* pPlayerPantheon, bool bDisplay) const;
 #else
-	int calculatePlayerYield(YieldTypes eYield, int iCurrentYield, PlayerTypes ePlayer, ImprovementTypes eImprovement, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon, bool bDisplay) const;
+	int calculatePlayerYield(YieldTypes eYield, int iCurrentYield, PlayerTypes ePlayer, ImprovementTypes eImprovement, FeatureTypes eFeature, ResourceTypes eResource, bool bIsCityConnection, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon, bool bDisplay) const;
 #endif
 
-	int calculateReligionNatureYield(YieldTypes eYield, PlayerTypes ePlayer, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon) const;
-	int calculateReligionImprovementYield(YieldTypes eYield, PlayerTypes ePlayer, ImprovementTypes eImprovement, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon) const;
+	int calculateReligionNatureYield(YieldTypes eYield, PlayerTypes ePlayer, ImprovementTypes eImprovement, FeatureTypes eFeature, ResourceTypes eResource, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon) const;
+	int calculateReligionImprovementYield(YieldTypes eYield, PlayerTypes ePlayer, ImprovementTypes eImprovement, ResourceTypes eResource, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon) const;
 
-	int calculateYield(YieldTypes eYield, bool bDisplay = false, const CvCity* pOwningCity = NULL);
+	int calculateYield(YieldTypes eYield, bool bDisplay = false, const CvCity* pOwningCity=NULL);
 #if defined(MOD_RELIGION_PERMANENT_PANTHEON)
-	int calculateYieldFast(YieldTypes eYield, bool bDisplay, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon, const CvReligion* pPlayerPantheon = NULL);
+	int calculateYieldFast(YieldTypes eYield, bool bDisplay, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon, const CvReligion* pPlayerPantheon=NULL);
 #else
 	int calculateYieldFast(YieldTypes eYield, bool bDisplay, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon);
 #endif
@@ -597,9 +598,9 @@ public:
 #endif
 
 #if defined(MOD_RELIGION_PERMANENT_PANTHEON)
-	int getYieldWithBuild(BuildTypes eBuild, YieldTypes eYield, bool bWithUpgrade, PlayerTypes ePlayer, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon, const CvReligion* pPlayerPantheon = NULL) const;
+	int getYieldWithBuild(BuildTypes eBuild, YieldTypes eYield, bool bWithUpgrade, bool bIsCityConnection, PlayerTypes ePlayer, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon, const CvReligion* pPlayerPantheon = NULL) const;
 #else
-	int getYieldWithBuild(BuildTypes eBuild, YieldTypes eYield, bool bWithUpgrade, PlayerTypes ePlayer, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon) const;
+	int getYieldWithBuild(BuildTypes eBuild, YieldTypes eYield, bool bWithUpgrade, bool bIsCityConnection, PlayerTypes ePlayer, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon) const;
 #endif
 
 	int countNumAirUnits(TeamTypes eTeam, bool bNoSuicide = false) const;
@@ -849,7 +850,7 @@ public:
 	bool IsFriendlyUnitAdjacent(TeamTypes eMyTeam, bool bCombatUnit) const;
 	int GetNumSpecificPlayerUnitsAdjacent(PlayerTypes ePlayer, const CvUnit* pUnitToExclude = NULL, const CvUnit* pExampleUnitType = NULL, bool bCombatOnly = true) const;
 
-	int GetDefenseBuildValue(PlayerTypes eOwner);
+	int GetDefenseBuildValue(PlayerTypes eOwner, BuildTypes eBuild=NO_BUILD, ImprovementTypes eImprovement=NO_IMPROVEMENT, SBuilderState sState=SBuilderState()) const;
 
 	void updateImpassable(TeamTypes eTeam = NO_TEAM);
 

--- a/CvGameCoreDLL_Expansion2/CvPlot.h
+++ b/CvGameCoreDLL_Expansion2/CvPlot.h
@@ -570,12 +570,12 @@ public:
 	int calculateBestNatureYield(YieldTypes eYield, PlayerTypes ePlayer) const;
 	int calculateTotalBestNatureYield(PlayerTypes ePlayer) const;
 
-	int calculateImprovementYield(YieldTypes eYield, PlayerTypes ePlayer, ImprovementTypes eImprovement, RouteTypes eRoute, FeatureTypes eFeature, ResourceTypes eResource, bool bIsCityConnection,  const CvCity* pOwningCity, bool bOptimal = false) const;
+	int calculateImprovementYield(YieldTypes eYield, PlayerTypes ePlayer, ImprovementTypes eImprovement, RouteTypes eRoute, FeatureTypes eFeature, ResourceTypes eResource, bool bIgnoreCityConnection,  const CvCity* pOwningCity, bool bOptimal = false) const;
 
 #if defined(MOD_RELIGION_PERMANENT_PANTHEON)
-	int calculatePlayerYield(YieldTypes eYield, int iCurrentYield, PlayerTypes ePlayer, ImprovementTypes eImprovement, FeatureTypes eFeature, ResourceTypes eResource, bool bIsCityConnection, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon, const CvReligion* pPlayerPantheon, bool bDisplay) const;
+	int calculatePlayerYield(YieldTypes eYield, int iCurrentYield, PlayerTypes ePlayer, ImprovementTypes eImprovement, FeatureTypes eFeature, ResourceTypes eResource, bool bIgnoreCityConnection, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon, const CvReligion* pPlayerPantheon, bool bDisplay) const;
 #else
-	int calculatePlayerYield(YieldTypes eYield, int iCurrentYield, PlayerTypes ePlayer, ImprovementTypes eImprovement, FeatureTypes eFeature, ResourceTypes eResource, bool bIsCityConnection, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon, bool bDisplay) const;
+	int calculatePlayerYield(YieldTypes eYield, int iCurrentYield, PlayerTypes ePlayer, ImprovementTypes eImprovement, FeatureTypes eFeature, ResourceTypes eResource, bool bIgnoreCityConnection, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon, bool bDisplay) const;
 #endif
 
 	int calculateReligionNatureYield(YieldTypes eYield, PlayerTypes ePlayer, ImprovementTypes eImprovement, FeatureTypes eFeature, ResourceTypes eResource, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon) const;
@@ -598,9 +598,9 @@ public:
 #endif
 
 #if defined(MOD_RELIGION_PERMANENT_PANTHEON)
-	int getYieldWithBuild(BuildTypes eBuild, YieldTypes eYield, bool bWithUpgrade, bool bIsCityConnection, PlayerTypes ePlayer, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon, const CvReligion* pPlayerPantheon = NULL) const;
+	int getYieldWithBuild(BuildTypes eBuild, YieldTypes eYield, bool bWithUpgrade, bool bIgnoreCityConnection, PlayerTypes ePlayer, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon, const CvReligion* pPlayerPantheon = NULL) const;
 #else
-	int getYieldWithBuild(BuildTypes eBuild, YieldTypes eYield, bool bWithUpgrade, bool bIsCityConnection, PlayerTypes ePlayer, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon) const;
+	int getYieldWithBuild(BuildTypes eBuild, YieldTypes eYield, bool bWithUpgrade, bool bIgnoreCityConnection, PlayerTypes ePlayer, const CvCity* pOwningCity, const CvReligion* pMajorityReligion, const CvBeliefEntry* pSecondaryPantheon) const;
 #endif
 
 	int countNumAirUnits(TeamTypes eTeam, bool bNoSuicide = false) const;

--- a/CvGameCoreDLL_Expansion2/CvSiteEvaluationClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvSiteEvaluationClasses.cpp
@@ -892,16 +892,16 @@ int CvSiteEvaluatorForSettler::PlotFoundValue(CvPlot* pPlot, const CvPlayer* pPl
 }
 
 /// Retrieve the relative fertility of this plot (alone)
-int CvCitySiteEvaluator::PlotFertilityValue(CvPlot* pPlot, bool bIncludeCoast)
+int CvCitySiteEvaluator::PlotFertilityValue(CvPlot* pPlot, const CvPlayer* pPlayer, bool bIncludeCoast)
 {
 	int rtnValue = 0;
 	if( (!pPlot->isWater() && pPlot->isValidMovePlot(NO_PLAYER)) || (bIncludeCoast && pPlot->isShallowWater() ) )
 	{
-		rtnValue += ComputeFoodValue(pPlot, NULL);
-		rtnValue += ComputeProductionValue(pPlot, NULL);
-		rtnValue += ComputeGoldValue(pPlot, NULL);
-		rtnValue += ComputeScienceValue(pPlot, NULL);
-		rtnValue += ComputeTradeableResourceValue(pPlot, NULL);
+		rtnValue += ComputeFoodValue(pPlot, pPlayer);
+		rtnValue += ComputeProductionValue(pPlot, pPlayer);
+		rtnValue += ComputeGoldValue(pPlot, pPlayer);
+		rtnValue += ComputeScienceValue(pPlot, pPlayer);
+		rtnValue += ComputeTradeableResourceValue(pPlot, pPlayer);
 	}
 
 	if(rtnValue < 0) rtnValue = 0;
@@ -930,8 +930,9 @@ vector<int> CvCitySiteEvaluator::GetAllCitySiteValues(const CvPlayer* pPlayer)
 /// Value of plot for providing food
 int CvCitySiteEvaluator::ComputeFoodValue(CvPlot* pPlot, const CvPlayer* pPlayer)
 {
+	TeamTypes eTeam = pPlayer ? pPlayer->getTeam() : NO_TEAM;
 	// From tile yield
-	int rtnValue = pPlot->calculateNatureYield(YIELD_FOOD, pPlayer ? pPlayer->GetID() : NO_PLAYER, NULL);
+	int rtnValue = pPlot->calculateNatureYield(YIELD_FOOD, pPlayer ? pPlayer->GetID() : NO_PLAYER, pPlot->getFeatureType(), pPlot->getResourceType(eTeam), NULL);
 
 	// assume a farm or similar on suitable terrain ... should be build sooner or later. value averages out with other improvements
 	if (((pPlot->getTerrainType()==TERRAIN_GRASS || pPlot->getTerrainType()==TERRAIN_PLAINS) && pPlot->getFeatureType() == NO_FEATURE) || pPlot->getFeatureType() == FEATURE_FLOOD_PLAINS)
@@ -942,7 +943,6 @@ int CvCitySiteEvaluator::ComputeFoodValue(CvPlot* pPlot, const CvPlayer* pPlayer
 		rtnValue += 1;
 
 	// From resource
-	TeamTypes eTeam = pPlayer ? pPlayer->getTeam() : NO_TEAM;
 	ResourceTypes eResource = pPlot->getResourceType(eTeam);
 	if(eResource != NO_RESOURCE)
 	{
@@ -961,14 +961,14 @@ int CvCitySiteEvaluator::ComputeFoodValue(CvPlot* pPlot, const CvPlayer* pPlayer
 /// Value of plot for providing hammers
 int CvCitySiteEvaluator::ComputeProductionValue(CvPlot* pPlot, const CvPlayer* pPlayer)
 {
-	int rtnValue = pPlot->calculateNatureYield(YIELD_PRODUCTION, pPlayer ? pPlayer->GetID() : NO_PLAYER, NULL);
+	TeamTypes eTeam = pPlayer ? pPlayer->getTeam() : NO_TEAM;
+	int rtnValue = pPlot->calculateNatureYield(YIELD_PRODUCTION, pPlayer ? pPlayer->GetID() : NO_PLAYER, pPlot->getFeatureType(), pPlot->getResourceType(eTeam), NULL);
 
 	// assume a mine or similar in friendly climate. don't run off into the snow
 	if (pPlot->isHills() && (pPlot->getTerrainType()==TERRAIN_GRASS || pPlot->getTerrainType()==TERRAIN_PLAINS || pPlot->getTerrainType()==TERRAIN_TUNDRA) && pPlot->getFeatureType() == NO_FEATURE)
 		rtnValue += 1;
 
 	// From resource
-	TeamTypes eTeam = pPlayer ? pPlayer->getTeam() : NO_TEAM;
 	ResourceTypes eResource = pPlot->getResourceType(eTeam);
 	if(eResource != NO_RESOURCE)
 	{
@@ -986,10 +986,10 @@ int CvCitySiteEvaluator::ComputeProductionValue(CvPlot* pPlot, const CvPlayer* p
 /// Value of plot for providing gold
 int CvCitySiteEvaluator::ComputeGoldValue(CvPlot* pPlot, const CvPlayer* pPlayer)
 {
-	int rtnValue = pPlot->calculateNatureYield(YIELD_GOLD, pPlayer ? pPlayer->GetID() : NO_PLAYER, NULL);
+	TeamTypes eTeam = pPlayer ? pPlayer->getTeam() : NO_TEAM;
+	int rtnValue = pPlot->calculateNatureYield(YIELD_GOLD, pPlayer ? pPlayer->GetID() : NO_PLAYER, pPlot->getFeatureType(), pPlot->getResourceType(eTeam), NULL);
 
 	// From resource
-	TeamTypes eTeam = pPlayer ? pPlayer->getTeam() : NO_TEAM;
 	ResourceTypes eResource = pPlot->getResourceType(eTeam);
 	if(eResource != NO_RESOURCE)
 	{
@@ -1008,10 +1008,10 @@ int CvCitySiteEvaluator::ComputeGoldValue(CvPlot* pPlot, const CvPlayer* pPlayer
 /// Value of plot for providing science
 int CvCitySiteEvaluator::ComputeScienceValue(CvPlot* pPlot, const CvPlayer* pPlayer)
 {
-	int rtnValue = pPlot->calculateNatureYield(YIELD_SCIENCE, pPlayer ? pPlayer->GetID() : NO_PLAYER, NULL);
+	TeamTypes eTeam = pPlayer ? pPlayer->getTeam() : NO_TEAM;
+	int rtnValue = pPlot->calculateNatureYield(YIELD_SCIENCE, pPlayer ? pPlayer->GetID() : NO_PLAYER, pPlot->getFeatureType(), pPlot->getResourceType(eTeam), NULL);
 
 	// From resource
-	TeamTypes eTeam = pPlayer ? pPlayer->getTeam() : NO_TEAM;
 	ResourceTypes eResource = pPlot->getResourceType(eTeam);
 	if(eResource != NO_RESOURCE)
 	{
@@ -1030,10 +1030,10 @@ int CvCitySiteEvaluator::ComputeScienceValue(CvPlot* pPlot, const CvPlayer* pPla
 /// Vale of plot for providing faith
 int CvCitySiteEvaluator::ComputeFaithValue(CvPlot* pPlot, const CvPlayer* pPlayer)
 {
-	int rtnValue = pPlot->calculateNatureYield(YIELD_FAITH, pPlayer ? pPlayer->GetID() : NO_PLAYER, NULL);
+	TeamTypes eTeam = pPlayer ? pPlayer->getTeam() : NO_TEAM;
+	int rtnValue = pPlot->calculateNatureYield(YIELD_FAITH, pPlayer ? pPlayer->GetID() : NO_PLAYER, pPlot->getFeatureType(), pPlot->getResourceType(eTeam), NULL);
 
 	// From resource
-	TeamTypes eTeam = pPlayer ? pPlayer->getTeam() : NO_TEAM;
 	ResourceTypes eResource = pPlot->getResourceType(eTeam);
 	if(eResource != NO_RESOURCE)
 	{

--- a/CvGameCoreDLL_Expansion2/CvSiteEvaluationClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvSiteEvaluationClasses.h
@@ -34,7 +34,7 @@ public:
 	virtual void ComputeFlavorMultipliers(const CvPlayer* pPlayer);
 	virtual bool CanFoundCity(const CvPlot* pPlot, const CvPlayer* pPlayer, bool bIgnoreDistanceToExistingCities) const;
 	virtual int PlotFoundValue(CvPlot* pPlot, const CvPlayer* pPlayer, const std::vector<int>& ignorePlots, bool bCoastOnly=false, CvString* pDebug=NULL);
-	virtual int PlotFertilityValue(CvPlot* pPlot, bool bIncludeCoast=false);
+	virtual int PlotFertilityValue(CvPlot* pPlot, const CvPlayer* pPlayer, bool bIncludeCoast=false);
 	virtual vector<int> GetAllCitySiteValues(const CvPlayer* pPlayer);
 
 protected:

--- a/CvGameCoreDLL_Expansion2/CvStartPositioner.cpp
+++ b/CvGameCoreDLL_Expansion2/CvStartPositioner.cpp
@@ -362,7 +362,7 @@ void CvStartPositioner::ComputeTileFertilityValues()
 		// Compute fertility and save off in player 0's found value slot
 		//   (Normally shouldn't be using a hard-coded player reference, but here in the pre-game initialization it is safe to do so.
 		//    Allows us to reuse this data storage instead of jamming even more data into the CvPlot class that will never be used at run-time).
-		int iFertility = m_pSiteEvaluator->PlotFertilityValue(pLoopPlot);
+		int iFertility = m_pSiteEvaluator->PlotFertilityValue(pLoopPlot, NULL);
 		pLoopPlot->setFoundValue((PlayerTypes)0, iFertility);
 
 		if(iFertility > 0)
@@ -785,7 +785,7 @@ bool PlotMeetsFoodRequirement(CvPlot* pPlot, PlayerTypes ePlayer, int iFoodRequi
 		}
 		else
 		{
-			if(pLoopPlot->calculateNatureYield(YIELD_FOOD, ePlayer, pLoopPlot->getOwningCity()) >= iFoodRequirement)
+			if(pLoopPlot->calculateNatureYield(YIELD_FOOD, ePlayer, pPlot->getFeatureType(), pPlot->getResourceType(GET_PLAYER(ePlayer).getTeam()), pLoopPlot->getOwningCity()) >= iFoodRequirement)
 			{
 				bFoundFoodPlot = true;
 				break;
@@ -940,7 +940,7 @@ void CvStartPositionerMerge::Run(int iNumRegionsRequired)
 	for (int iI = 0; iI < GC.getMap().numPlots(); iI++)
 	{
 		CvPlot* pLoopPlot = GC.getMap().plotByIndexUnchecked(iI);
-		int iPlotWorth = m_pSiteEvaluator->PlotFertilityValue(pLoopPlot,true);
+		int iPlotWorth = m_pSiteEvaluator->PlotFertilityValue(pLoopPlot,NULL,true);
 		
 		//the region id is the plot index of the original plot
 		if (iPlotWorth > 0)

--- a/CvGameCoreDLL_Expansion2/CvTacticalAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTacticalAI.cpp
@@ -609,7 +609,7 @@ void CvTacticalAI::FindTacticalTargets()
 					pLoopPlot->getRevealedImprovementType(m_pPlayer->getTeam()) != NO_IMPROVEMENT &&
 					!pLoopPlot->IsImprovementPillaged())
 				{
-					ResourceTypes eResource = pLoopPlot->getResourceType();
+					ResourceTypes eResource = pLoopPlot->getResourceType(m_pPlayer->getTeam());
 					int iExtraScore = 0;
 					//does this make a difference in the end?
 					if (m_pPlayer->isBarbarian() || m_pPlayer->GetPlayerTraits()->IsWarmonger())
@@ -7582,7 +7582,7 @@ STacticalAssignment ScorePlotForPillageMove(const SUnitStats& unit, const CvTact
 
 		if (TacticalAIHelpers::IsOtherPlayerCitadel(pTestPlot, assumedPosition.getPlayer(), true))
 			result.iScore = 500;
-		else if (pTestPlot->getResourceType() != NO_RESOURCE && GC.getResourceInfo(pTestPlot->getResourceType())->getResourceUsage() == RESOURCEUSAGE_STRATEGIC)
+		else if (pTestPlot->getResourceType(pUnit->getTeam()) != NO_RESOURCE && GC.getResourceInfo(pTestPlot->getResourceType(pUnit->getTeam()))->getResourceUsage() == RESOURCEUSAGE_STRATEGIC)
 			result.iScore = 200;
 		else if (pUnit->getDamage() >= /*25*/ GD_INT_GET(PILLAGE_HEAL_AMOUNT))
 			result.iScore = 100;

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -9941,7 +9941,7 @@ bool CvUnit::sellExoticGoods()
 						{
 
 							CvPlot* pLoopPlot = pCity->GetCityCitizens()->GetCityPlotFromIndex(iCityPlotLoop);
-							if (pLoopPlot != NULL && (pLoopPlot->getOwner() == ePlotOwner) && !pLoopPlot->isCity() && !pLoopPlot->isWater() && !pLoopPlot->isImpassable(getTeam()) && !pLoopPlot->IsNaturalWonder() && pLoopPlot->isCoastalLand() && (pLoopPlot->getResourceType() == NO_RESOURCE))
+							if (pLoopPlot != NULL && (pLoopPlot->getOwner() == ePlotOwner) && !pLoopPlot->isCity() && !pLoopPlot->isWater() && !pLoopPlot->isImpassable(getTeam()) && !pLoopPlot->IsNaturalWonder() && pLoopPlot->isCoastalLand() && (pLoopPlot->getResourceType(getTeam()) == NO_RESOURCE))
 							{
 								if (pLoopPlot->getImprovementType() != NO_IMPROVEMENT)
 								{
@@ -9959,7 +9959,7 @@ bool CvUnit::sellExoticGoods()
 							for (int iCityPlotLoop = 0; iCityPlotLoop < pCity->GetNumWorkablePlots(); iCityPlotLoop++)
 							{
 								CvPlot* pLoopPlot = pCity->GetCityCitizens()->GetCityPlotFromIndex(iCityPlotLoop);
-								if (pLoopPlot != NULL && (pLoopPlot->getOwner() == ePlotOwner) && !pLoopPlot->isCity() && !pLoopPlot->isWater() && !pLoopPlot->isImpassable(getTeam()) && !pLoopPlot->IsNaturalWonder() && pLoopPlot->isCoastalLand() && (pLoopPlot->getResourceType() == NO_RESOURCE))
+								if (pLoopPlot != NULL && (pLoopPlot->getOwner() == ePlotOwner) && !pLoopPlot->isCity() && !pLoopPlot->isWater() && !pLoopPlot->isImpassable(getTeam()) && !pLoopPlot->IsNaturalWonder() && pLoopPlot->isCoastalLand() && (pLoopPlot->getResourceType(getTeam()) == NO_RESOURCE))
 								{
 									//If we can build on an empty spot, do so.
 									if (pLoopPlot->getImprovementType() == NO_IMPROVEMENT)
@@ -13768,6 +13768,9 @@ bool CvUnit::canBuild(const CvPlot* pPlot, BuildTypes eBuild, bool bTestVisible,
 			return false;
 		}
 	}
+
+	if (!pPlot)
+		return true;
 
 	if (!(GET_PLAYER(getOwner()).canBuild(pPlot, eBuild, false, bTestVisible, bTestGold, true, this)))
 	{
@@ -24907,7 +24910,13 @@ void CvUnit::DoFinishBuildIfSafe()
 	{
 		int iBuildTimeLeft = plot()->getBuildTurnsLeft(eBuild, getOwner(), 0, 0);
 		if (iBuildTimeLeft == 0 && canMove() && GetDanger() == 0)
+		{
+			BuilderDirective eDirective = GET_PLAYER(m_eOwner).GetBuilderTaskingAI()->GetAssignedDirective(this);
+			if (eDirective.m_sX != m_iX || eDirective.m_sY != m_iY || eDirective.m_eBuild != eBuild)
+				return;
+
 			CvUnitMission::ContinueMission(this);
+		}
 	}
 }
 #endif 

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -3438,7 +3438,7 @@ bool CvUnit::isActionRecommended(int iAction)
 			if (pPlot != pDirectivePlot)
 				continue;
 
-			bool bCanBuild = GET_PLAYER(getOwner()).GetBuilderTaskingAI()->EvaluateBuilder(this, eDirective);
+			bool bCanBuild = GET_PLAYER(getOwner()).GetBuilderTaskingAI()->CanUnitPerformDirective(this, eDirective);
 
 			if (!bCanBuild)
 				continue;

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlot.cpp
@@ -1630,7 +1630,7 @@ int CvLuaPlot::lCalculateNatureYield(lua_State* L)
 	CvPlot* pkPlot = GetInstance(L); CHECK_PLOT_VALID(pkPlot);
 	const YieldTypes eIndex = (YieldTypes)lua_tointeger(L, 2);
 	const PlayerTypes ePlayer = (PlayerTypes)lua_tointeger(L, 2);
-	const int iResult = pkPlot->calculateNatureYield(eIndex, ePlayer, pkPlot->getPlotCity());
+	const int iResult = pkPlot->calculateNatureYield(eIndex, ePlayer, pkPlot->getFeatureType(), pkPlot->getResourceType(GET_PLAYER(ePlayer).getTeam()), pkPlot->getPlotCity());
 	lua_pushinteger(L, iResult);
 	return 1;
 }
@@ -1660,7 +1660,10 @@ int CvLuaPlot::lCalculateImprovementYieldChange(lua_State* L)
 	if (lua_gettop(L) == 6)
 		eRoute = (RouteTypes)lua_tointeger(L, 6);
 
-	const int iResult = pkPlot->calculateImprovementYield(eYield, ePlayer, eImprovement, pkPlot->getEffectiveOwningCity(), bOptimal, eRoute);
+	if (eRoute == NUM_ROUTE_TYPES)
+		eRoute = pkPlot->getRouteType();
+
+	const int iResult = pkPlot->calculateImprovementYield(eYield, ePlayer, eImprovement, eRoute, pkPlot->getFeatureType(), pkPlot->getResourceType(GET_PLAYER(ePlayer).getTeam()), pkPlot->IsCityConnection(ePlayer), pkPlot->getEffectiveOwningCity(), bOptimal);
 	lua_pushinteger(L, iResult);
 	return 1;
 }
@@ -1699,7 +1702,7 @@ int CvLuaPlot::lGetYieldWithBuild(lua_State* L)
 
 		const CvReligion* pReligion = (eMajority != NO_RELIGION) ? GC.getGame().GetGameReligions()->GetReligion(eMajority, pOwningCity->getOwner()) : 0;
 		const CvBeliefEntry* pBelief = (eSecondaryPantheon != NO_BELIEF) ? GC.GetGameBeliefs()->GetEntry(eSecondaryPantheon) : 0;
-		int iResult = pkPlot->getYieldWithBuild(eBuild, eYield, bUpgrade, ePlayer, pOwningCity, pReligion, pBelief);
+		int iResult = pkPlot->getYieldWithBuild(eBuild, eYield, bUpgrade, pkPlot->IsCityConnection(ePlayer), ePlayer, pOwningCity, pReligion, pBelief);
 #if defined(MOD_RELIGION_PERMANENT_PANTHEON)
 		// Mod for civs keeping their pantheon belief forever
 		if (MOD_RELIGION_PERMANENT_PANTHEON)
@@ -1712,7 +1715,7 @@ int CvLuaPlot::lGetYieldWithBuild(lua_State* L)
 				{
 					if (pReligion == NULL || (pReligion != NULL && !pReligion->m_Beliefs.IsPantheonBeliefInReligion(ePantheonBelief, eMajority, pOwningCity->getOwner()))) // check that the our religion does not have our belief, to prevent double counting
 					{
-						iResult += pkPlot->getYieldWithBuild(eBuild, eYield, bUpgrade, ePlayer, pOwningCity, pPantheon, NULL);
+						iResult += pkPlot->getYieldWithBuild(eBuild, eYield, bUpgrade, pkPlot->IsCityConnection(ePlayer), ePlayer, pOwningCity, pPantheon, NULL);
 					}
 				}
 			}
@@ -1723,7 +1726,7 @@ int CvLuaPlot::lGetYieldWithBuild(lua_State* L)
 	}
 	else
 	{
-		const int iResult = pkPlot->getYieldWithBuild(eBuild, eYield, bUpgrade, ePlayer, NULL, NULL, NULL);
+		const int iResult = pkPlot->getYieldWithBuild(eBuild, eYield, bUpgrade, pkPlot->IsCityConnection(ePlayer), ePlayer, NULL, NULL, NULL);
 		lua_pushinteger(L, iResult);
 		return 1;
 	}

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlot.cpp
@@ -1662,8 +1662,10 @@ int CvLuaPlot::lCalculateImprovementYieldChange(lua_State* L)
 
 	if (eRoute == NUM_ROUTE_TYPES)
 		eRoute = pkPlot->getRouteType();
+	if (pkPlot->IsRoutePillaged())
+		eRoute = NO_ROUTE;
 
-	const int iResult = pkPlot->calculateImprovementYield(eYield, ePlayer, eImprovement, eRoute, pkPlot->getFeatureType(), pkPlot->getResourceType(GET_PLAYER(ePlayer).getTeam()), pkPlot->IsCityConnection(ePlayer), pkPlot->getEffectiveOwningCity(), bOptimal);
+	const int iResult = pkPlot->calculateImprovementYield(eYield, ePlayer, eImprovement, eRoute, pkPlot->getFeatureType(), pkPlot->getResourceType(GET_PLAYER(ePlayer).getTeam()), false, pkPlot->getEffectiveOwningCity(), bOptimal);
 	lua_pushinteger(L, iResult);
 	return 1;
 }
@@ -1702,7 +1704,7 @@ int CvLuaPlot::lGetYieldWithBuild(lua_State* L)
 
 		const CvReligion* pReligion = (eMajority != NO_RELIGION) ? GC.getGame().GetGameReligions()->GetReligion(eMajority, pOwningCity->getOwner()) : 0;
 		const CvBeliefEntry* pBelief = (eSecondaryPantheon != NO_BELIEF) ? GC.GetGameBeliefs()->GetEntry(eSecondaryPantheon) : 0;
-		int iResult = pkPlot->getYieldWithBuild(eBuild, eYield, bUpgrade, pkPlot->IsCityConnection(ePlayer), ePlayer, pOwningCity, pReligion, pBelief);
+		int iResult = pkPlot->getYieldWithBuild(eBuild, eYield, bUpgrade, false, ePlayer, pOwningCity, pReligion, pBelief);
 #if defined(MOD_RELIGION_PERMANENT_PANTHEON)
 		// Mod for civs keeping their pantheon belief forever
 		if (MOD_RELIGION_PERMANENT_PANTHEON)
@@ -1715,7 +1717,7 @@ int CvLuaPlot::lGetYieldWithBuild(lua_State* L)
 				{
 					if (pReligion == NULL || (pReligion != NULL && !pReligion->m_Beliefs.IsPantheonBeliefInReligion(ePantheonBelief, eMajority, pOwningCity->getOwner()))) // check that the our religion does not have our belief, to prevent double counting
 					{
-						iResult += pkPlot->getYieldWithBuild(eBuild, eYield, bUpgrade, pkPlot->IsCityConnection(ePlayer), ePlayer, pOwningCity, pPantheon, NULL);
+						iResult += pkPlot->getYieldWithBuild(eBuild, eYield, bUpgrade, false, ePlayer, pOwningCity, pPantheon, NULL);
 					}
 				}
 			}
@@ -1726,7 +1728,7 @@ int CvLuaPlot::lGetYieldWithBuild(lua_State* L)
 	}
 	else
 	{
-		const int iResult = pkPlot->getYieldWithBuild(eBuild, eYield, bUpgrade, pkPlot->IsCityConnection(ePlayer), ePlayer, NULL, NULL, NULL);
+		const int iResult = pkPlot->getYieldWithBuild(eBuild, eYield, bUpgrade, false, ePlayer, NULL, NULL, NULL);
 		lua_pushinteger(L, iResult);
 		return 1;
 	}


### PR DESCRIPTION
### Divided into three parts (details in the 3 commits):

### Part 1, worker AI top-down approach:
Split improvement planning into two phases:
 - Phase 1: figure out the best improvement for each tile, and score all builds (improvements/routes/chops etc.) according to an evaluation function
 - Phase 2: choose the closest worker for each of the highest scoring building directives.

Human non-automated workers will be included in the second planning phase, but not moved. When selected their suggested action will be shown on the map.

Automated and AI workers will reevaluate their best job on each turn.

### Part 2, improvement evaluation rework:

Rework of improvement build evaluation functionality.

All builds (except pure chop and fallout removal builds, for now) are now evaluated using the same function.

Function makes very limited use of "magic numbers" and instead evaluates builds based on yields/resources/defensive bonuses and more.

Update phase 2 of the Part 1 rework to reevaluate other affected build directives when a build directive is chosen.
E.g., don't plan two adjacent improvements that can't be built next to each other, don't plan too many defensive buildings in the same place, etc.

### Part 3, road evaluation rework + weigh directives according to total time:

Update Part 1 rework to consider build time in phase 2 instead of phase 1.
Will prioritize builds that have a low total move+build time. Workers now put more emphasis on building improvements in their direct neighborhood.

Rework road evaluation functionality, will now evaluate roads based on:
 - City connection bonuses
 - Movement change from building the route
 - Village bonuses (current and potential)