### PR TITLE
Make "save plot for unique improvement" more thorough

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvAStar.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAStar.cpp
@@ -2262,7 +2262,7 @@ int BuildRouteCost(const CvAStarNode* /*parent*/, const CvAStarNode* node, const
 	else if (bPlannedShortcutRoute)
 	{
 		// if we are planning to build a road here, provide a discount
-		iCost = (PATH_BASE_COST * 7) / 12;
+		iCost = (PATH_BASE_COST * 5) / 12;
 	}
 	else if (pPlot->getRouteType() >= eRoute)
 	{

--- a/CvGameCoreDLL_Expansion2/CvAStar.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAStar.cpp
@@ -2205,7 +2205,7 @@ static int BuildRouteVillageBonus(CvPlot* pPlot, RouteTypes eRouteType, CvBuilde
 				YieldTypes eYield = (YieldTypes)iI;
 
 				if (pkImprovementInfo->GetRouteYieldChanges(eRouteType, eYield) > 0)
-					return 3;
+					return 10;
 			}
 		}
 
@@ -2215,7 +2215,7 @@ static int BuildRouteVillageBonus(CvPlot* pPlot, RouteTypes eRouteType, CvBuilde
 	}
 
 	// Villages and towns can be built pretty much anywhere
-	return 2;
+	return 5;
 }
 
 //	--------------------------------------------------------------------------------
@@ -2247,13 +2247,13 @@ int BuildRouteCost(const CvAStarNode* /*parent*/, const CvAStarNode* node, const
 	if (data.eRoutePurpose == PURPOSE_CONNECT_CAPITAL && bPlannedCapitalRoute)
 	{
 		if (pPlot->getRouteType() >= eRoute || pPlot->getBuildProgress(eBuild) > 0)
-			iCost = 5;
+			iCost = 1;
 		else
-			iCost = 6;
+			iCost = 2;
 	}
 	else if (data.eRoutePurpose == PURPOSE_CONNECT_CAPITAL && bPlannedShortcutRoute)
 	{
-		iCost = 7;
+		iCost = 3;
 	}
 	else if (bGetSameRouteBenefitFromTrait)
 	{

--- a/CvGameCoreDLL_Expansion2/CvAStar.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAStar.cpp
@@ -2189,9 +2189,6 @@ static int BuildRouteVillageBonus(CvPlot* pPlot, RouteTypes eRouteType, CvBuilde
 	if (!MOD_BALANCE_VP)
 		return 0;
 
-	if (eBuilderTaskingAi->WillNeverBuildVillageOnPlot(pPlot, eRouteType, false/*bIgnoreUnowned*/))
-		return 0;
-
 	// If we have a town or village here, give a big bonus
 	ImprovementTypes eImprovement = pPlot->getImprovementType();
 	if (eImprovement != NO_IMPROVEMENT)
@@ -2214,8 +2211,11 @@ static int BuildRouteVillageBonus(CvPlot* pPlot, RouteTypes eRouteType, CvBuilde
 		}
 	}
 
+	if (eBuilderTaskingAi->WillNeverBuildVillageOnPlot(pPlot, eRouteType, false/*bIgnoreUnowned*/))
+		return 0;
+
 	// Villages and towns can be built pretty much anywhere
-	return 2;
+	return 1;
 }
 
 //	--------------------------------------------------------------------------------
@@ -2267,16 +2267,16 @@ int BuildRouteCost(const CvAStarNode* /*parent*/, const CvAStarNode* node, const
 	else if (pPlot->getRouteType() >= eRoute)
 	{
 		// if there is already a road here, provide a smaller discount
-		iCost = PATH_BASE_COST - 2;
+		iCost = PATH_BASE_COST - 3;
 	}
 	else if (pPlot->getBuildProgress(eBuild) > 0) {
 		// if we are currently building a road here, provide a smaller discount
-		iCost = PATH_BASE_COST - 2;
+		iCost = PATH_BASE_COST - 3;
 	}
 	else if (pPlot->getRouteType() >= ROUTE_ROAD || pPlayer->GetSameRouteBenefitFromTrait(pPlot, ROUTE_ROAD))
 	{
 		// if there is already any kind of road here, provide a smaller discount
-		iCost = PATH_BASE_COST - 1;
+		iCost = PATH_BASE_COST - 2;
 	}
 	else
 	{

--- a/CvGameCoreDLL_Expansion2/CvAStar.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAStar.cpp
@@ -2205,13 +2205,13 @@ static int BuildRouteVillageBonus(CvPlot* pPlot, RouteTypes eRouteType, CvBuilde
 				YieldTypes eYield = (YieldTypes)iI;
 
 				if (pkImprovementInfo->GetRouteYieldChanges(eRouteType, eYield) > 0)
-					return 10;
+					return 75;
 			}
-		}
 
-		// If this is a great person improvement, we don't want to replace it (unless it's a town)
-		if (pkImprovementInfo->IsCreatedByGreatPerson())
-			return 0;
+			// If this is a great person improvement, we don't want to replace it (unless it's a town)
+			if (pkImprovementInfo->IsCreatedByGreatPerson())
+				return 0;
+		}
 	}
 
 	// Villages and towns can be built pretty much anywhere

--- a/CvGameCoreDLL_Expansion2/CvAStar.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAStar.cpp
@@ -2215,7 +2215,7 @@ static int BuildRouteVillageBonus(CvPlot* pPlot, RouteTypes eRouteType, CvBuilde
 		return 0;
 
 	// Villages and towns can be built pretty much anywhere
-	return 1;
+	return 2;
 }
 
 //	--------------------------------------------------------------------------------
@@ -2267,16 +2267,16 @@ int BuildRouteCost(const CvAStarNode* /*parent*/, const CvAStarNode* node, const
 	else if (pPlot->getRouteType() >= eRoute)
 	{
 		// if there is already a road here, provide a smaller discount
-		iCost = PATH_BASE_COST - 3;
+		iCost = PATH_BASE_COST - 4;
 	}
 	else if (pPlot->getBuildProgress(eBuild) > 0) {
 		// if we are currently building a road here, provide a smaller discount
-		iCost = PATH_BASE_COST - 3;
+		iCost = PATH_BASE_COST - 4;
 	}
 	else if (pPlot->getRouteType() >= ROUTE_ROAD || pPlayer->GetSameRouteBenefitFromTrait(pPlot, ROUTE_ROAD))
 	{
 		// if there is already any kind of road here, provide a smaller discount
-		iCost = PATH_BASE_COST - 2;
+		iCost = PATH_BASE_COST - 3;
 	}
 	else
 	{
@@ -2286,10 +2286,6 @@ int BuildRouteCost(const CvAStarNode* /*parent*/, const CvAStarNode* node, const
 	if (!bGetSameRouteBenefitFromTrait && !pPlayer->IsPlotSafeForRoute(pPlot, false /*bIncludeAdjacent*/))
 	{
 		if (pPlot->IsAdjacentOwnedByTeamOtherThan(pPlayer->getTeam(), false, false, true, true))
-		{
-			iCost += 10;
-		}
-		else
 		{
 			iCost += 1;
 		}

--- a/CvGameCoreDLL_Expansion2/CvAStar.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAStar.cpp
@@ -2215,7 +2215,7 @@ static int BuildRouteVillageBonus(CvPlot* pPlot, RouteTypes eRouteType, CvBuilde
 	}
 
 	// Villages and towns can be built pretty much anywhere
-	return 5;
+	return 2;
 }
 
 //	--------------------------------------------------------------------------------
@@ -2236,7 +2236,7 @@ int BuildRouteCost(const CvAStarNode* /*parent*/, const CvAStarNode* node, const
 	bool bGetSameRouteBenefitFromTrait = pPlayer->GetSameRouteBenefitFromTrait(pPlot, eRoute);
 	bool bPlannedShortcutRoute = bGetSameRouteBenefitFromTrait || eBuilderTaskingAI->IsRoutePlanned(pPlot, eRoute, PURPOSE_SHORTCUT);
 	bool bPlannedCapitalRoute = bGetSameRouteBenefitFromTrait || (data.eRoutePurpose == PURPOSE_CONNECT_CAPITAL && eBuilderTaskingAI->IsRoutePlanned(pPlot, eRoute, PURPOSE_CONNECT_CAPITAL));
-	int iVillageBonus = data.eRoutePurpose == PURPOSE_CONNECT_CAPITAL || data.eRoutePurpose == PURPOSE_SHORTCUT ? BuildRouteVillageBonus(pPlot, eRoute, eBuilderTaskingAI) : 0;
+	int iVillageBonus = data.eRoutePurpose == PURPOSE_SHORTCUT && !bGetSameRouteBenefitFromTrait && !bPlannedShortcutRoute ? BuildRouteVillageBonus(pPlot, eRoute, eBuilderTaskingAI) : 0;
 
 	if (!bPlannedCapitalRoute && eRoute == ROUTE_ROAD)
 	{

--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
@@ -996,7 +996,7 @@ ImprovementTypes CvBuilderTaskingAI::SavePlotForUniqueImprovement(CvPlot* pPlot)
 		}
 	}
 
-	return NO_IMPROVEMENT;
+	return eSaveForImprovement;
 }
 
 void CvBuilderTaskingAI::UpdateCanalPlots()

--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.h
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.h
@@ -105,7 +105,7 @@ public:
 	bool ShouldAnyBuilderConsiderPlot(CvPlot* pPlot);  // general checks for whether the plot should be considered
 	bool ShouldBuilderConsiderPlot(CvUnit* pUnit, CvPlot* pPlot);  // specific checks for this particular worker
 
-	int GetResourceWeight(ResourceTypes eResource, ImprovementTypes eImprovement, int iQuantity, int iAdditionalOwned=0);
+	int GetResourceWeight(ResourceTypes eResource, int iQuantity, int iAdditionalOwned=0);
 
 	bool DoesBuildHelpRush(CvPlot* pPlot, BuildTypes eBuild);
 	pair<RouteTypes, int> GetBestRouteTypeAndValue(const CvPlot* pPlot) const;

--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.h
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.h
@@ -116,7 +116,7 @@ public:
 
 	int ScorePlotBuild(CvPlot* pPlot, ImprovementTypes eImprovement, BuildTypes eBuild, SBuilderState sState=SBuilderState());
 
-	BuildTypes GetBuildTypeFromImprovement(ImprovementTypes eImprovement);
+	BuildTypes GetBuildTypeFromImprovement(ImprovementTypes eImprovement) const;
 	BuildTypes GetRepairBuild(void);
 	FeatureTypes GetFalloutFeature(void);
 	BuildTypes GetFalloutRemove(void);

--- a/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
@@ -3077,24 +3077,6 @@ void CvHomelandAI::ExecuteWorkerMoves()
 		}
 	}
 
-	for(CHomelandUnitArray::iterator it = m_CurrentMoveUnits.begin(); it != m_CurrentMoveUnits.end(); ++it)
-	{
-		CvUnit* pUnit = m_pPlayer->getUnit(it->GetID());
-		if (!pUnit)
-			continue;
-
-		//fallout also counts as danger, so set the threshold a bit higher than zero
-		if(pUnit->GetDanger()>pUnit->GetCurrHitPoints()/2)
-		{
-			if(MoveCivilianToSafety(pUnit))
-			{
-				UnitProcessed(pUnit->GetID());
-				processedWorkers.insert(pUnit->GetID());
-				continue;
-			}
-		}
-	}
-
 	CvBuilderTaskingAI* pBuilderTaskingAI = m_pPlayer->GetBuilderTaskingAI();
 	vector<BuilderDirective> topDirectives = pBuilderTaskingAI->GetDirectives();
 	set<BuilderDirective> ignoredDirectives;


### PR DESCRIPTION
Will now fully check if the improvement can be built in the plot, including adjacency checks. AI should no longer avoid building some improvements and routing through forests for e.g. the Maya/Brazil when their UIs can not be built in those specific forests(/jungles).