### PR TITLE
Various tweaks and fixes

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvAStar.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAStar.cpp
@@ -2197,13 +2197,19 @@ static int BuildRouteVillageBonus(CvPlot* pPlot, RouteTypes eRouteType, CvBuilde
 
 		if (pkImprovementInfo != NULL)
 		{
+			int iYieldChangeTotal = 0;
 			for (int iI = 0; iI <= YIELD_FAITH; iI++)
 			{
 				YieldTypes eYield = (YieldTypes)iI;
-
-				if (pkImprovementInfo->GetRouteYieldChanges(eRouteType, eYield) > 0)
-					return 75;
+				int iYieldChanges = pkImprovementInfo->GetRouteYieldChanges(eRouteType, eYield);
+				if (iYieldChanges > 0)
+				{
+					iYieldChangeTotal += iYieldChanges;
+				}
 			}
+
+			if (iYieldChangeTotal > 0)
+				return 70 + iYieldChangeTotal;
 
 			// If this is a great person improvement, we don't want to replace it (unless it's a town)
 			if (pkImprovementInfo->IsCreatedByGreatPerson())

--- a/CvGameCoreDLL_Expansion2/CvAStar.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAStar.cpp
@@ -2264,7 +2264,7 @@ int BuildRouteCost(const CvAStarNode* /*parent*/, const CvAStarNode* node, const
 		// if we are planning to build a road here, provide a discount
 		iCost = (PATH_BASE_COST * 5) / 12;
 	}
-	else if (pPlot->getRouteType() >= eRoute)
+	else if (pPlot->getRouteType() >= eRoute && !pPlot->IsRoutePillaged())
 	{
 		// if there is already a road here, provide a smaller discount
 		iCost = PATH_BASE_COST - 4;
@@ -2273,7 +2273,7 @@ int BuildRouteCost(const CvAStarNode* /*parent*/, const CvAStarNode* node, const
 		// if we are currently building a road here, provide a smaller discount
 		iCost = PATH_BASE_COST - 4;
 	}
-	else if (pPlot->getRouteType() >= ROUTE_ROAD || pPlayer->GetSameRouteBenefitFromTrait(pPlot, ROUTE_ROAD))
+	else if ((pPlot->getRouteType() >= ROUTE_ROAD && !pPlot->IsRoutePillaged()) || pPlayer->GetSameRouteBenefitFromTrait(pPlot, ROUTE_ROAD))
 	{
 		// if there is already any kind of road here, provide a smaller discount
 		iCost = PATH_BASE_COST - 3;

--- a/CvGameCoreDLL_Expansion2/CvAStar.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAStar.cpp
@@ -2250,18 +2250,23 @@ int BuildRouteCost(const CvAStarNode* /*parent*/, const CvAStarNode* node, const
 	}
 
 	// if we only care about reaching the destination, and no other bonuses, heavily reuse existing planned roads and features
-	if (data.eRoutePurpose == PURPOSE_CONNECT_CAPITAL && bPlannedCapitalRoute)
+	if (data.eRoutePurpose == PURPOSE_CONNECT_CAPITAL)
 	{
-		if (pPlot->getRouteType() >= eRoute || pPlot->getBuildProgress(eBuild) > 0)
-			iCost = 1;
-		else
-			iCost = 2;
+		if (bPlannedCapitalRoute)
+		{
+			if (bGetSameRouteBenefitFromTrait)
+				return 0;
+			else if (pPlot->getRouteType() >= eRoute || pPlot->getBuildProgress(eBuild) > 0)
+				return 1;
+			else
+				return 5;
+		}
+		if (bPlannedShortcutRoute)
+		{
+			return 20;
+		}
 	}
-	else if (data.eRoutePurpose == PURPOSE_CONNECT_CAPITAL && bPlannedShortcutRoute)
-	{
-		iCost = 3;
-	}
-	else if (bGetSameRouteBenefitFromTrait)
+	if (bGetSameRouteBenefitFromTrait)
 	{
 		iCost = PATH_BASE_COST / 3;
 	}

--- a/CvGameCoreDLL_Expansion2/CvAStar.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAStar.cpp
@@ -2267,16 +2267,16 @@ int BuildRouteCost(const CvAStarNode* /*parent*/, const CvAStarNode* node, const
 	else if (pPlot->getRouteType() >= eRoute && !pPlot->IsRoutePillaged())
 	{
 		// if there is already a road here, provide a smaller discount
-		iCost = PATH_BASE_COST - 4;
+		iCost = (PATH_BASE_COST * 8) / 12;
 	}
 	else if (pPlot->getBuildProgress(eBuild) > 0) {
 		// if we are currently building a road here, provide a smaller discount
-		iCost = PATH_BASE_COST - 4;
+		iCost = (PATH_BASE_COST * 8) / 12;
 	}
 	else if ((pPlot->getRouteType() >= ROUTE_ROAD && !pPlot->IsRoutePillaged()) || pPlayer->GetSameRouteBenefitFromTrait(pPlot, ROUTE_ROAD))
 	{
 		// if there is already any kind of road here, provide a smaller discount
-		iCost = PATH_BASE_COST - 3;
+		iCost = (PATH_BASE_COST * 11) / 12;
 	}
 	else
 	{

--- a/CvGameCoreDLL_Expansion2/CvAStar.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAStar.cpp
@@ -2273,7 +2273,7 @@ int BuildRouteCost(const CvAStarNode* /*parent*/, const CvAStarNode* node, const
 		// if we are currently building a road here, provide a smaller discount
 		iCost = (PATH_BASE_COST * 8) / 12;
 	}
-	else if ((pPlot->getRouteType() >= ROUTE_ROAD && !pPlot->IsRoutePillaged()) || pPlayer->GetSameRouteBenefitFromTrait(pPlot, ROUTE_ROAD))
+	else if (pPlot->getRouteType() >= ROUTE_ROAD || pPlayer->GetSameRouteBenefitFromTrait(pPlot, ROUTE_ROAD) || pPlot->IsRoutePillaged())
 	{
 		// if there is already any kind of road here, provide a smaller discount
 		iCost = (PATH_BASE_COST * 11) / 12;

--- a/CvGameCoreDLL_Expansion2/CvAStar.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAStar.cpp
@@ -2287,7 +2287,7 @@ int BuildRouteCost(const CvAStarNode* /*parent*/, const CvAStarNode* node, const
 	else if (pPlot->getRouteType() >= ROUTE_ROAD || pPlayer->GetSameRouteBenefitFromTrait(pPlot, ROUTE_ROAD) || pPlot->IsRoutePillaged())
 	{
 		// if there is already any kind of road here, provide a smaller discount
-		iCost = (PATH_BASE_COST * 11) / 12;
+		iCost = PATH_BASE_COST - 1;
 	}
 	else
 	{

--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
@@ -1346,6 +1346,7 @@ void CvBuilderTaskingAI::UpdateRoutePlots(void)
 	m_plannedRoutePurposes.clear();
 	m_anyRoutePlanned.clear();
 	m_bestRouteTypeAndValue.clear();
+	m_bestRouteForPlot.clear();
 
 	// if there are fewer than 2 cities, we don't need to run this function
 	std::vector<int> plotsToConnect = pCityConnections->GetPlotsToConnect();

--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
@@ -955,7 +955,6 @@ bool CvBuilderTaskingAI::IsRouteCompleted(PlannedRoute plannedRoute) const
 	if (it == m_plannedRoutePlots.end())
 		return true;
 
-	int iTotalBuildTime = 0;
 	for (vector<int>::const_iterator it2 = it->second.begin(); it2 != it->second.end(); ++it2)
 	{
 		CvPlot* pPlot = GC.getMap().plotByIndexUnchecked(*it2);

--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
@@ -953,7 +953,7 @@ bool CvBuilderTaskingAI::IsRouteCompleted(PlannedRoute plannedRoute) const
 
 	map<PlannedRoute, vector<int>>::const_iterator it = m_plannedRoutePlots.find(plannedRoute);
 	if (it == m_plannedRoutePlots.end())
-		return true;
+		return false;
 
 	for (vector<int>::const_iterator it2 = it->second.begin(); it2 != it->second.end(); ++it2)
 	{
@@ -1596,7 +1596,7 @@ vector<OptionWithScore<BuilderDirective>> CvBuilderTaskingAI::GetRouteDirectives
 				bestRouteTypesAndValues[make_pair(plotPair, ROUTE_ROAD)] = plannedRouteTypeValues[plotPair][ROUTE_ROAD];
 
 				int iTotalNegativeModifier = iRoadTotalMaintenance;
-				if (IsRouteCompleted(make_pair(plotPair, ROUTE_RAILROAD)))
+				if (iRailroadValue > 0 && IsRouteCompleted(make_pair(plotPair, ROUTE_RAILROAD)))
 					iTotalNegativeModifier += iRailroadValue;
 
 				bestRouteNegativeModifiers[make_pair(plotPair, ROUTE_ROAD)] = iTotalNegativeModifier;
@@ -1606,7 +1606,7 @@ vector<OptionWithScore<BuilderDirective>> CvBuilderTaskingAI::GetRouteDirectives
 				bestRouteTypesAndValues[make_pair(plotPair, ROUTE_RAILROAD)] = plannedRouteTypeValues[plotPair][ROUTE_RAILROAD];
 
 				int iTotalNegativeModifier = iRailroadTotalMaintenance;
-				if (IsRouteCompleted(make_pair(plotPair, ROUTE_ROAD)))
+				if (iRoadValue > 0 && IsRouteCompleted(make_pair(plotPair, ROUTE_ROAD)))
 					iTotalNegativeModifier += iRoadValue;
 
 				bestRouteNegativeModifiers[make_pair(plotPair, ROUTE_RAILROAD)] = iTotalNegativeModifier;

--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.h
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.h
@@ -105,7 +105,7 @@ public:
 	bool ShouldAnyBuilderConsiderPlot(CvPlot* pPlot);  // general checks for whether the plot should be considered
 	bool ShouldBuilderConsiderPlot(CvUnit* pUnit, CvPlot* pPlot);  // specific checks for this particular worker
 
-	int GetResourceWeight(ResourceTypes eResource, ImprovementTypes eImprovement, int iQuantity, int iAdditionalOwned=0);
+	int GetResourceWeight(ResourceTypes eResource, int iQuantity, int iAdditionalOwned=0);
 
 	bool DoesBuildHelpRush(CvPlot* pPlot, BuildTypes eBuild);
 	pair<RouteTypes, int> GetBestRouteTypeAndValue(const CvPlot* pPlot) const;
@@ -116,7 +116,7 @@ public:
 
 	int ScorePlotBuild(CvPlot* pPlot, ImprovementTypes eImprovement, BuildTypes eBuild, SBuilderState sState=SBuilderState());
 
-	BuildTypes GetBuildTypeFromImprovement(ImprovementTypes eImprovement);
+	BuildTypes GetBuildTypeFromImprovement(ImprovementTypes eImprovement) const;
 	BuildTypes GetRepairBuild(void);
 	FeatureTypes GetFalloutFeature(void);
 	BuildTypes GetFalloutRemove(void);

--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.h
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.h
@@ -89,7 +89,7 @@ public:
 
 	bool CanUnitPerformDirective(CvUnit* pUnit, BuilderDirective eDirective);
 	int GetBuilderNumTurnsAway(CvUnit* pUnit, BuilderDirective eDirective, int iMaxDistance=INT_MAX);
-	int GetTurnsToBuild(CvUnit* pUnit, BuilderDirective eDirective, CvPlot* pPlot);
+	int GetTurnsToBuild(const CvUnit* pUnit, BuildTypes eBuild, CvPlot* pPlot) const;
 	vector<BuilderDirective> GetDirectives();
 	bool ExecuteWorkerMove(CvUnit* pUnit, BuilderDirective aDirective);
 
@@ -115,6 +115,8 @@ public:
 	ImprovementTypes SavePlotForUniqueImprovement(CvPlot* pPlot) const;
 
 	int ScorePlotBuild(CvPlot* pPlot, ImprovementTypes eImprovement, BuildTypes eBuild, SBuilderState sState=SBuilderState());
+	int GetRouteBuildTime(pair<pair<int, int>, RouteTypes> plannedRoute, const CvUnit* pUnit=(CvUnit*)NULL) const;
+	int GetTotalRouteBuildTime(const CvUnit* pUnit, const CvPlot* pPlot) const;
 
 	BuildTypes GetBuildTypeFromImprovement(ImprovementTypes eImprovement) const;
 	BuildTypes GetRepairBuild(void);
@@ -173,6 +175,7 @@ protected:
 	map<PlannedRoute, set<RoutePurpose>> m_plannedRoutePurposes; //serialized
 	set<pair<RoutePlot, RoutePurpose>> m_anyRoutePlanned; //serialized
 	map<int, RoutePlot> m_bestRouteTypeAndValue; //serialized
+	map<int, PlannedRoute> m_bestRouteForPlot;
 	set<int> m_canalWantedPlots; //serialized
 	vector<BuilderDirective> m_directives;
 	map<int, BuilderDirective> m_assignedDirectives;

--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.h
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.h
@@ -115,7 +115,6 @@ public:
 	ImprovementTypes SavePlotForUniqueImprovement(CvPlot* pPlot) const;
 
 	int ScorePlotBuild(CvPlot* pPlot, ImprovementTypes eImprovement, BuildTypes eBuild, SBuilderState sState=SBuilderState());
-	int GetRouteBuildTime(pair<pair<int, int>, RouteTypes> plannedRoute, const CvUnit* pUnit=(CvUnit*)NULL) const;
 	int GetTotalRouteBuildTime(const CvUnit* pUnit, const CvPlot* pPlot) const;
 
 	BuildTypes GetBuildTypeFromImprovement(ImprovementTypes eImprovement) const;
@@ -160,6 +159,9 @@ protected:
 	int GetMoveCostWithRoute(const CvPlot* pFromPlot, const CvPlot* pToPlot, RouteTypes eFromPlotRoute, RouteTypes eToPlotRoute);
 	int GetPlotYieldModifierTimes100(CvPlot* pPlot, YieldTypes eYield);
 	void GetPathValues(SPath path, RouteTypes eRoute, int& iVillageBonusesIfCityConnected, int& iTotalMoveCost, int& iNumRoadsNeededToBuild);
+
+	int GetRouteBuildTime(PlannedRoute plannedRoute, const CvUnit* pUnit = (CvUnit*)NULL) const;
+	bool CvBuilderTaskingAI::IsRouteCompleted(PlannedRoute plannedRoute) const;
 
 	void UpdateCanalPlots();
 

--- a/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
@@ -3195,7 +3195,7 @@ void CvHomelandAI::ExecuteWorkerMoves()
 			bool bImprovementStateChanged = false;
 
 			// Improvement considerations
-			if (eImprovement != pDirectivePlot->getImprovementType() || (pkBuildInfo->isRepair() && pDirectivePlot->IsImprovementPillaged()))
+			if (eImprovement != NO_IMPROVEMENT && eImprovement != pDirectivePlot->getImprovementType() || (pkBuildInfo->isRepair() && pDirectivePlot->IsImprovementPillaged()))
 			{
 				sState.mChangedPlotImprovements[pDirectivePlot->GetPlotIndex()] = eImprovement;
 				bImprovementStateChanged = true;
@@ -3268,7 +3268,7 @@ void CvHomelandAI::ExecuteWorkerMoves()
 				CvImprovementEntry* pkOtherImprovementInfo = GC.getImprovementInfo(eOtherImprovement);
 
 				// Reevaluating
-				if (bResourceStateChanged)
+				if (eOtherImprovement != NO_IMPROVEMENT && bResourceStateChanged)
 				{
 					// Connecting a resource may reduce or increase the value of connecting more instances of the same resource
 					if ((pOtherPlot->getResourceType(m_pPlayer->getTeam()) == eResource && pkOtherImprovementInfo && pkOtherImprovementInfo->IsConnectsResource(eResource)) || (pkOtherImprovementInfo && pkOtherImprovementInfo->GetResourceFromImprovement() == eResource))
@@ -3311,7 +3311,7 @@ void CvHomelandAI::ExecuteWorkerMoves()
 					}
 				}
 
-				if (bDefenseStateChanged && !bDirectiveUpdated)
+				if (eOtherImprovement != NO_IMPROVEMENT && bDefenseStateChanged && !bDirectiveUpdated)
 				{
 					// If we are building or removing a defensive improvement, recalculate nearby defensive structure changes
 					int iPlotDistance = plotDistance(eOtherDirective.m_sX, eOtherDirective.m_sY, eDirective.m_sX, eDirective.m_sY);
@@ -3341,7 +3341,7 @@ void CvHomelandAI::ExecuteWorkerMoves()
 					}
 				}
 
-				if (bImprovementStateChanged && !bDirectiveUpdated)
+				if (eOtherImprovement != NO_IMPROVEMENT && bImprovementStateChanged && !bDirectiveUpdated)
 				{
 					// If we are building or removing an improvement, give all adjacent plot directives yield increases/decreases from this change
 					// TODO check if we will actually change the yield value before we call ScorePlotBuild

--- a/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
@@ -3077,24 +3077,6 @@ void CvHomelandAI::ExecuteWorkerMoves()
 		}
 	}
 
-	for(CHomelandUnitArray::iterator it = m_CurrentMoveUnits.begin(); it != m_CurrentMoveUnits.end(); ++it)
-	{
-		CvUnit* pUnit = m_pPlayer->getUnit(it->GetID());
-		if (!pUnit)
-			continue;
-
-		//fallout also counts as danger, so set the threshold a bit higher than zero
-		if(pUnit->GetDanger()>pUnit->GetCurrHitPoints()/2)
-		{
-			if(MoveCivilianToSafety(pUnit))
-			{
-				UnitProcessed(pUnit->GetID());
-				processedWorkers.insert(pUnit->GetID());
-				continue;
-			}
-		}
-	}
-
 	CvBuilderTaskingAI* pBuilderTaskingAI = m_pPlayer->GetBuilderTaskingAI();
 	vector<BuilderDirective> topDirectives = pBuilderTaskingAI->GetDirectives();
 	set<BuilderDirective> ignoredDirectives;

--- a/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
@@ -2898,7 +2898,9 @@ static bool IsBestWeightedDirectiveForBuilderAndPlot(BuilderDirective eDirective
 		if (!pkOtherBuildInfo)
 			continue;
 
-		int iBuilderImprovementTime = pPlayer->GetBuilderTaskingAI()->GetTurnsToBuild(pUnit, eOtherDirective, pPlot);
+		int iBuilderImprovementTime = pkBuildInfo->getRoute() == NO_ROUTE
+			? pPlayer->GetBuilderTaskingAI()->GetTurnsToBuild(pUnit, eOtherDirective.m_eBuild, pPlot)
+			: pPlayer->GetBuilderTaskingAI()->GetTotalRouteBuildTime(pUnit, pPlot);
 		if (iBuilderImprovementTime == INT_MAX)
 			continue;
 
@@ -2973,7 +2975,9 @@ static vector<OptionWithScore<pair<CvUnit*, BuilderDirective>>> GetWeightedDirec
 		{
 			CvUnit* pUnit = (*builderIterator).option;
 
-			int iBuilderImprovementTime = pPlayer->GetBuilderTaskingAI()->GetTurnsToBuild(pUnit, eDirective, pDirectivePlot);
+			int iBuilderImprovementTime = GC.getBuildInfo(eDirective.m_eBuild)->getRoute() == NO_ROUTE
+				? pPlayer->GetBuilderTaskingAI()->GetTurnsToBuild(pUnit, eDirective.m_eBuild, pDirectivePlot)
+				: pPlayer->GetBuilderTaskingAI()->GetTotalRouteBuildTime(pUnit, pDirectivePlot);
 			if (iBuilderImprovementTime == INT_MAX)
 				continue;
 

--- a/CvGameCoreDLL_Expansion2/CvImprovementClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvImprovementClasses.cpp
@@ -1461,6 +1461,7 @@ int* CvImprovementEntry::GetAdjacentResourceYieldChangesArray(int i)
 	return m_ppiAdjacentResourceYieldChanges[i];
 }
 
+/// How much bonus yields an improvement gives to adjacent tiles with a certain terrain
 int CvImprovementEntry::GetAdjacentTerrainYieldChanges(int i, int j) const
 {
 	CvAssertMsg(i < GC.getNumTerrainInfos(), "Index out of bounds");
@@ -1475,6 +1476,7 @@ int* CvImprovementEntry::GetAdjacentTerrainYieldChangesArray(int i)
 	return m_ppiAdjacentTerrainYieldChanges[i];
 }
 
+/// How much an improvement yields if built next to a feature
 int CvImprovementEntry::GetAdjacentFeatureYieldChanges(int i, int j) const
 {
 	CvAssertMsg(i < GC.getNumPlotInfos(), "Index out of bounds");


### PR DESCRIPTION
### Make a more strict ordering of priorities when planning routes

1. Use features
2. Use other planned routes
3. Go through existing towns/villages
4. Use existing roads or roads that are under construction
5. Use lower tier existing roads
6. Go through plots that can have villages
7. Avoid going outside our borders

Reuse of other planned routes now more aggressive.

### Make "save plot for unique improvement" more thorough

Will now fully check if the improvement can be built in the plot, including adjacency checks. AI should no longer avoid building some improvements and routing through forests for e.g. the Maya/Brazil when their UIs can not be built in those specific forests(/jungles).

### Various

Fix strategic resource evaluation not working correctly.

Remove flavor weights for improvements on resources.

Remove unnecessary "run and hide" logic for workers