### PR TITLE
Various tweaks and fixes

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.h
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.h
@@ -89,7 +89,7 @@ public:
 
 	bool CanUnitPerformDirective(CvUnit* pUnit, BuilderDirective eDirective);
 	int GetBuilderNumTurnsAway(CvUnit* pUnit, BuilderDirective eDirective, int iMaxDistance=INT_MAX);
-	int GetTurnsToBuild(CvUnit* pUnit, BuilderDirective eDirective, CvPlot* pPlot);
+	int GetTurnsToBuild(const CvUnit* pUnit, BuildTypes eBuild, CvPlot* pPlot) const;
 	vector<BuilderDirective> GetDirectives();
 	bool ExecuteWorkerMove(CvUnit* pUnit, BuilderDirective aDirective);
 
@@ -105,7 +105,7 @@ public:
 	bool ShouldAnyBuilderConsiderPlot(CvPlot* pPlot);  // general checks for whether the plot should be considered
 	bool ShouldBuilderConsiderPlot(CvUnit* pUnit, CvPlot* pPlot);  // specific checks for this particular worker
 
-	int GetResourceWeight(ResourceTypes eResource, ImprovementTypes eImprovement, int iQuantity, int iAdditionalOwned=0);
+	int GetResourceWeight(ResourceTypes eResource, int iQuantity, int iAdditionalOwned=0);
 
 	bool DoesBuildHelpRush(CvPlot* pPlot, BuildTypes eBuild);
 	pair<RouteTypes, int> GetBestRouteTypeAndValue(const CvPlot* pPlot) const;
@@ -115,8 +115,9 @@ public:
 	ImprovementTypes SavePlotForUniqueImprovement(CvPlot* pPlot) const;
 
 	int ScorePlotBuild(CvPlot* pPlot, ImprovementTypes eImprovement, BuildTypes eBuild, SBuilderState sState=SBuilderState());
+	int GetTotalRouteBuildTime(const CvUnit* pUnit, const CvPlot* pPlot) const;
 
-	BuildTypes GetBuildTypeFromImprovement(ImprovementTypes eImprovement);
+	BuildTypes GetBuildTypeFromImprovement(ImprovementTypes eImprovement) const;
 	BuildTypes GetRepairBuild(void);
 	FeatureTypes GetFalloutFeature(void);
 	BuildTypes GetFalloutRemove(void);
@@ -159,6 +160,9 @@ protected:
 	int GetPlotYieldModifierTimes100(CvPlot* pPlot, YieldTypes eYield);
 	void GetPathValues(SPath path, RouteTypes eRoute, int& iVillageBonusesIfCityConnected, int& iTotalMoveCost, int& iNumRoadsNeededToBuild);
 
+	int GetRouteBuildTime(PlannedRoute plannedRoute, const CvUnit* pUnit = (CvUnit*)NULL) const;
+	bool CvBuilderTaskingAI::IsRouteCompleted(PlannedRoute plannedRoute) const;
+
 	void UpdateCanalPlots();
 
 	PlotPair GetPlotPair(int iPlotId1, int iPlotId2);
@@ -173,6 +177,7 @@ protected:
 	map<PlannedRoute, set<RoutePurpose>> m_plannedRoutePurposes; //serialized
 	set<pair<RoutePlot, RoutePurpose>> m_anyRoutePlanned; //serialized
 	map<int, RoutePlot> m_bestRouteTypeAndValue; //serialized
+	map<int, PlannedRoute> m_bestRouteForPlot;
 	set<int> m_canalWantedPlots; //serialized
 	vector<BuilderDirective> m_directives;
 	map<int, BuilderDirective> m_assignedDirectives;

--- a/CvGameCoreDLL_Expansion2/CvImprovementClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvImprovementClasses.cpp
@@ -1461,6 +1461,7 @@ int* CvImprovementEntry::GetAdjacentResourceYieldChangesArray(int i)
 	return m_ppiAdjacentResourceYieldChanges[i];
 }
 
+/// How much bonus yields an improvement gives to adjacent tiles with a certain terrain
 int CvImprovementEntry::GetAdjacentTerrainYieldChanges(int i, int j) const
 {
 	CvAssertMsg(i < GC.getNumTerrainInfos(), "Index out of bounds");
@@ -1475,6 +1476,7 @@ int* CvImprovementEntry::GetAdjacentTerrainYieldChangesArray(int i)
 	return m_ppiAdjacentTerrainYieldChanges[i];
 }
 
+/// How much an improvement yields if built next to a feature
 int CvImprovementEntry::GetAdjacentFeatureYieldChanges(int i, int j) const
 {
 	CvAssertMsg(i < GC.getNumPlotInfos(), "Index out of bounds");


### PR DESCRIPTION
### Route planning

Make a more strict ordering of priorities when planning routes:
1. Use features
2. Use other planned routes
3. Go through existing towns/villages
4. Use existing roads or roads that are under construction
5. Use lower tier existing roads
6. Go through plots that can have villages
7. Avoid going outside our borders

Reuse of other planned routes now more aggressive.

Reuse of existing roads now more aggressive.

AI should now be much less willing to reroute their road network.

Prefer towns over villages when planning routes.

Make route planning with regards to unique improvements more sensible. Will no longer avoid going through plots where we can not build our unique improvement.

Fix polynesia connection happiness trait not being accounted for when planning capital routes.

### Road evaluation

When evaluating any road build, will now consider the total build time for the entire road. I.e., a road consisting of 10 plots will no longer be evaluated as if it takes 3 turns in total to build.

Reduce value of building railroad when there is an existing road connection and vice versa.

### Improvement evaluation

Fix incorrect adjacency calculations. Some calculations were done twice, some not done at all, some done the wrong way.

Don't build resource creating improvements on existing resources.

Remove flavor weights for improvements on resources. Flavors are now not used when planning improvements.

Fix strategic resource evaluation not working correctly.

### Various

Remove redundant "run and hide" logic for workers.