### PR TITLE
Revert dynamic_cast

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvDllCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDllCity.cpp
@@ -185,13 +185,13 @@ IDInfo CvDllCity::GetIDInfo() const
 //------------------------------------------------------------------------------
 bool CvDllCity::IsWorkingPlot(ICvPlot1* pPlot) const
 {
-	CvPlot* pkPlot = (NULL != pPlot)? dynamic_cast<CvDllPlot*>(pPlot)->GetInstance() : NULL;
+	CvPlot* pkPlot = (NULL != pPlot)? static_cast<CvDllPlot*>(pPlot)->GetInstance() : NULL;
 	return (NULL != pkPlot)? m_pCity->GetCityCitizens()->IsWorkingPlot(pkPlot) : false;
 }
 //------------------------------------------------------------------------------
 bool CvDllCity::CanWork(ICvPlot1* pPlot) const
 {
-	CvPlot* pkPlot = (NULL != pPlot)? dynamic_cast<CvDllPlot*>(pPlot)->GetInstance() : NULL;
+	CvPlot* pkPlot = (NULL != pPlot)? static_cast<CvDllPlot*>(pPlot)->GetInstance() : NULL;
 	return (NULL != pkPlot)? m_pCity->GetCityCitizens()->IsCanWork(pkPlot) : false;
 }
 //------------------------------------------------------------------------------

--- a/CvGameCoreDLL_Expansion2/CvDllContext.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDllContext.cpp
@@ -694,7 +694,7 @@ float CvDllGameContext::GetHexDebugLayerScale(const char* szLayerName)
 //------------------------------------------------------------------------------
 bool CvDllGameContext::GetHexDebugLayerString(ICvPlot1* pPlot, const char* szLayerName, PlayerTypes ePlayer, char* szBuffer, unsigned int uiBufferLength)
 {
-	CvPlot* pkPlot = (NULL != pPlot)? dynamic_cast<CvDllPlot*>(pPlot)->GetInstance() : NULL;
+	CvPlot* pkPlot = (NULL != pPlot)? static_cast<CvDllPlot*>(pPlot)->GetInstance() : NULL;
 	if(pkPlot != NULL)
 	{
 		return GC.GetHexDebugLayerString(pkPlot, szLayerName, ePlayer, szBuffer, uiBufferLength);

--- a/CvGameCoreDLL_Expansion2/CvDllDealAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDllDealAI.cpp
@@ -88,33 +88,33 @@ ICvPlayer1* CvDllDealAI::GetPlayer()
 //------------------------------------------------------------------------------
 int CvDllDealAI::DoHumanOfferDealToThisAI(ICvDeal1* pDeal)
 {
-	CvDeal* pkDeal = (NULL != pDeal)? dynamic_cast<CvDllDeal*>(pDeal)->GetInstance() : NULL;
+	CvDeal* pkDeal = (NULL != pDeal)? static_cast<CvDllDeal*>(pDeal)->GetInstance() : NULL;
 	return m_pDealAI->DoHumanOfferDealToThisAI(pkDeal);
 }
 //------------------------------------------------------------------------------
 void CvDllDealAI::DoAcceptedDeal(PlayerTypes eFromPlayer, ICvDeal1* pDeal, int iDealValueToMe, int iValueImOffering, int iValueTheyreOffering)
 {
-	CvDeal* pkDeal = (NULL != pDeal)? dynamic_cast<CvDllDeal*>(pDeal)->GetInstance() : NULL;
+	CvDeal* pkDeal = (NULL != pDeal)? static_cast<CvDllDeal*>(pDeal)->GetInstance() : NULL;
 	if(pkDeal != NULL)
 		m_pDealAI->DoAcceptedDeal(eFromPlayer, *pkDeal, iDealValueToMe, iValueImOffering, iValueTheyreOffering);
 }
 //------------------------------------------------------------------------------
 int CvDllDealAI::DoHumanDemand(ICvDeal1* pDeal)
 {
-	CvDeal* pkDeal = (NULL != pDeal)? dynamic_cast<CvDllDeal*>(pDeal)->GetInstance() : NULL;
+	CvDeal* pkDeal = (NULL != pDeal)? static_cast<CvDllDeal*>(pDeal)->GetInstance() : NULL;
 	return m_pDealAI->DoHumanDemand(pkDeal);
 }
 //------------------------------------------------------------------------------
 void CvDllDealAI::DoAcceptedDemand(PlayerTypes eFromPlayer, ICvDeal1* pDeal)
 {
-	CvDeal* pkDeal = (NULL != pDeal)? dynamic_cast<CvDllDeal*>(pDeal)->GetInstance() : NULL;
+	CvDeal* pkDeal = (NULL != pDeal)? static_cast<CvDllDeal*>(pDeal)->GetInstance() : NULL;
 	if(pkDeal != NULL)
 		m_pDealAI->DoAcceptedDemand(eFromPlayer, *pkDeal);
 }
 //------------------------------------------------------------------------------
 bool CvDllDealAI::DoEqualizeDealWithHuman(ICvDeal1* pDeal, PlayerTypes eOtherPlayer, bool bDontChangeMyExistingItems, bool bDontChangeTheirExistingItems, bool& bDealGoodToBeginWith, bool& bCantMatchOffer)
 {
-	CvDeal* pkDeal = (NULL != pDeal)? dynamic_cast<CvDllDeal*>(pDeal)->GetInstance() : NULL;
+	CvDeal* pkDeal = (NULL != pDeal)? static_cast<CvDllDeal*>(pDeal)->GetInstance() : NULL;
 	return m_pDealAI->DoEqualizeDeal(pkDeal, eOtherPlayer, bDealGoodToBeginWith, bCantMatchOffer, true);
 }
 //------------------------------------------------------------------------------

--- a/CvGameCoreDLL_Expansion2/CvDllGame.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDllGame.cpp
@@ -131,7 +131,7 @@ int CvDllGame::CountNumHumanGameTurnActive()
 //------------------------------------------------------------------------------
 bool CvDllGame::CyclePlotUnits(ICvPlot1* pPlot, bool bForward, bool bAuto, int iCount)
 {
-	CvPlot* pkPlot = (NULL != pPlot)? dynamic_cast<CvDllPlot*>(pPlot)->GetInstance() : NULL;
+	CvPlot* pkPlot = (NULL != pPlot)? static_cast<CvDllPlot*>(pPlot)->GetInstance() : NULL;
 	return m_pGame->cyclePlotUnits(pkPlot, bForward, bAuto, iCount);
 }
 //------------------------------------------------------------------------------
@@ -240,7 +240,7 @@ bool CvDllGame::GetPbemTurnSent() const
 //------------------------------------------------------------------------------
 ICvUnit1* CvDllGame::GetPlotUnit(ICvPlot1* pPlot, int iIndex)
 {
-	CvPlot* pkPlot = (NULL != pPlot)? dynamic_cast<CvDllPlot*>(pPlot)->GetInstance() : NULL;
+	CvPlot* pkPlot = (NULL != pPlot)? static_cast<CvDllPlot*>(pPlot)->GetInstance() : NULL;
 	CvUnit* pkUnit = m_pGame->getPlotUnit(pkPlot, iIndex);
 
 	return (NULL != pkUnit)? new CvDllUnit(pkUnit) : NULL;
@@ -390,13 +390,13 @@ void CvDllGame::ResetTurnTimer()
 //------------------------------------------------------------------------------
 void CvDllGame::SelectAll(ICvPlot1* pPlot)
 {
-	CvPlot* pkPlot = (NULL != pPlot)? dynamic_cast<CvDllPlot*>(pPlot)->GetInstance() : NULL;
+	CvPlot* pkPlot = (NULL != pPlot)? static_cast<CvDllPlot*>(pPlot)->GetInstance() : NULL;
 	m_pGame->selectAll(pkPlot);
 }
 //------------------------------------------------------------------------------
 void CvDllGame::SelectGroup(ICvUnit1* pUnit, bool bShift, bool bCtrl, bool bAlt)
 {
-	CvUnit* pkUnit = (NULL != pUnit)? dynamic_cast<CvDllUnit*>(pUnit)->GetInstance() : NULL;
+	CvUnit* pkUnit = (NULL != pUnit)? static_cast<CvDllUnit*>(pUnit)->GetInstance() : NULL;
 	m_pGame->selectGroup(pkUnit, bShift, bCtrl, bAlt);
 }
 //------------------------------------------------------------------------------
@@ -407,7 +407,7 @@ bool CvDllGame::SelectionListIgnoreBuildingDefense()
 //------------------------------------------------------------------------------
 void CvDllGame::SelectionListMove(ICvPlot1* pPlot, bool bShift)
 {
-	CvPlot* pkPlot = (NULL != pPlot)? dynamic_cast<CvDllPlot*>(pPlot)->GetInstance() : NULL;
+	CvPlot* pkPlot = (NULL != pPlot)? static_cast<CvDllPlot*>(pPlot)->GetInstance() : NULL;
 	m_pGame->selectionListMove(pkPlot, bShift);
 }
 //------------------------------------------------------------------------------
@@ -418,7 +418,7 @@ void CvDllGame::SelectSettler()
 //------------------------------------------------------------------------------
 void CvDllGame::SelectUnit(ICvUnit1* pUnit, bool bClear, bool bToggle, bool bSound)
 {
-	CvUnit* pkUnit = (NULL != pUnit)? dynamic_cast<CvDllUnit*>(pUnit)->GetInstance() : NULL;
+	CvUnit* pkUnit = (NULL != pUnit)? static_cast<CvDllUnit*>(pUnit)->GetInstance() : NULL;
 	m_pGame->selectUnit(pkUnit, bClear, bToggle, bSound);
 }
 //------------------------------------------------------------------------------

--- a/CvGameCoreDLL_Expansion2/CvDllGameDeals.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDllGameDeals.cpp
@@ -80,7 +80,7 @@ CvGameDeals* CvDllGameDeals::GetInstance()
 //------------------------------------------------------------------------------
 void CvDllGameDeals::AddProposedDeal(ICvDeal1* pDeal)
 {
-	CvDeal* pkDeal = (NULL != pDeal)? dynamic_cast<CvDllDeal*>(pDeal)->GetInstance() : NULL;
+	CvDeal* pkDeal = (NULL != pDeal)? static_cast<CvDllDeal*>(pDeal)->GetInstance() : NULL;
 	if(pkDeal != NULL)
 	{
 		m_pGameDeals->AddProposedDeal(*pkDeal);
@@ -110,7 +110,7 @@ ICvDeal1* CvDllGameDeals::GetTempDeal()
 //------------------------------------------------------------------------------
 void CvDllGameDeals::SetTempDeal(ICvDeal1* pDeal)
 {
-	CvDeal* pkDeal = (NULL != pDeal)? dynamic_cast<CvDllDeal*>(pDeal)->GetInstance() : NULL;
+	CvDeal* pkDeal = (NULL != pDeal)? static_cast<CvDllDeal*>(pDeal)->GetInstance() : NULL;
 	m_pGameDeals->SetTempDeal(pkDeal);
 }
 //------------------------------------------------------------------------------

--- a/CvGameCoreDLL_Expansion2/CvDllMap.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDllMap.cpp
@@ -117,7 +117,7 @@ ICvCity1* CvDllMap::FindCity(int iX,
 	CvCity* pkSkipCity = NULL;
 	if(pSkipCity)
 	{
-		pkSkipCity = dynamic_cast<CvDllCity*>(pSkipCity)->GetInstance();
+		pkSkipCity = static_cast<CvDllCity*>(pSkipCity)->GetInstance();
 	}
 
 	CvCity* pkCity = m_pMap->findCity(iX, iY, eOwner, eTeam, bSameArea, bCoastalOnly, eTeamAtWarWith, eDirection, pkSkipCity);

--- a/CvGameCoreDLL_Expansion2/CvDllPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDllPlayer.cpp
@@ -308,7 +308,7 @@ ICvUnit1* CvDllPlayer::NextUnit(int* pIterIdx, bool bRev)
 //------------------------------------------------------------------------------
 int CvDllPlayer::GetPlotDanger(ICvPlot1* pPlot) const
 {
-	CvDllPlot* pDllPlot = dynamic_cast<CvDllPlot*>(pPlot);
+	CvDllPlot* pDllPlot = static_cast<CvDllPlot*>(pPlot);
 	CvPlot& kPlot = (*pDllPlot->GetInstance());
 	return m_pPlayer->GetPlotDanger(kPlot, false);
 }

--- a/CvGameCoreDLL_Expansion2/CvDllPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDllPlot.cpp
@@ -97,7 +97,7 @@ void CvDllPlot::UpdateCenterUnit()
 //------------------------------------------------------------------------------
 bool CvDllPlot::IsAdjacent(ICvPlot1* pPlot) const
 {
-	CvPlot* pkPlot = (pPlot != NULL)? dynamic_cast<CvDllPlot*>(pPlot)->GetInstance() : NULL;
+	CvPlot* pkPlot = (pPlot != NULL)? static_cast<CvDllPlot*>(pPlot)->GetInstance() : NULL;
 	return m_pPlot->isAdjacent(pkPlot);
 }
 //------------------------------------------------------------------------------
@@ -129,7 +129,7 @@ bool CvDllPlot::IsCity() const
 //------------------------------------------------------------------------------
 bool CvDllPlot::IsEnemyCity(ICvUnit1* pUnit) const
 {
-	CvUnit* pkUnit = (NULL != pUnit)? dynamic_cast<CvDllUnit*>(pUnit)->GetInstance() : NULL;
+	CvUnit* pkUnit = (NULL != pUnit)? static_cast<CvDllUnit*>(pUnit)->GetInstance() : NULL;
 	if(pkUnit != NULL)
 		return m_pPlot->isEnemyCity(*pkUnit);
 	else
@@ -334,13 +334,13 @@ ICvUnit1* CvDllPlot::GetUnitByIndex(int iIndex) const
 //------------------------------------------------------------------------------
 void CvDllPlot::AddUnit(ICvUnit1* pUnit, bool bUpdate)
 {
-	CvUnit* pkUnit = (NULL != pUnit)? dynamic_cast<CvDllUnit*>(pUnit)->GetInstance() : NULL;
+	CvUnit* pkUnit = (NULL != pUnit)? static_cast<CvDllUnit*>(pUnit)->GetInstance() : NULL;
 	return m_pPlot->addUnit(pkUnit, bUpdate);
 }
 //------------------------------------------------------------------------------
 void CvDllPlot::RemoveUnit(ICvUnit1* pUnit, bool bUpdate)
 {
-	CvUnit* pkUnit = (NULL != pUnit)? dynamic_cast<CvDllUnit*>(pUnit)->GetInstance() : NULL;
+	CvUnit* pkUnit = (NULL != pUnit)? static_cast<CvDllUnit*>(pUnit)->GetInstance() : NULL;
 	return m_pPlot->removeUnit(pkUnit, bUpdate);
 }
 //------------------------------------------------------------------------------

--- a/CvGameCoreDLL_Expansion2/CvDllScriptSystemUtility.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDllScriptSystemUtility.cpp
@@ -67,7 +67,7 @@ void CvDllScriptSystemUtility::PushCvCityInstance(lua_State* L, ICvCity1* pkCity
 {
 	if(NULL != L && NULL != pkCity)
 	{
-		CvDllCity* pkDllCity = dynamic_cast<CvDllCity*>(pkCity);
+		CvDllCity* pkDllCity = static_cast<CvDllCity*>(pkCity);
 		CvLuaCity::Push(L, pkDllCity->GetInstance());
 	}
 	else
@@ -86,7 +86,7 @@ void CvDllScriptSystemUtility::PushCvDealInstance(lua_State* L, ICvDeal1* pkDeal
 {
 	if(NULL != L && NULL != pkDeal)
 	{
-		CvDllDeal* pkDllDeal = dynamic_cast<CvDllDeal*>(pkDeal);
+		CvDllDeal* pkDllDeal = static_cast<CvDllDeal*>(pkDeal);
 		CvLuaDeal::Push(L, pkDllDeal->GetInstance());
 	}
 	else
@@ -105,7 +105,7 @@ void CvDllScriptSystemUtility::PushCvPlotInstance(lua_State* L, ICvPlot1* pkPlot
 {
 	if(NULL != L && NULL != pkPlot)
 	{
-		CvDllPlot* pkDllPlot = dynamic_cast<CvDllPlot*>(pkPlot);
+		CvDllPlot* pkDllPlot = static_cast<CvDllPlot*>(pkPlot);
 		CvLuaPlot::Push(L, pkDllPlot->GetInstance());
 	}
 	else
@@ -124,7 +124,7 @@ void CvDllScriptSystemUtility::PushCvUnitInstance(lua_State* L, ICvUnit1* pkUnit
 {
 	if(NULL != L && NULL != pkUnit)
 	{
-		CvDllUnit* pkDllUnit = dynamic_cast<CvDllUnit*>(pkUnit);
+		CvDllUnit* pkDllUnit = static_cast<CvDllUnit*>(pkUnit);
 		CvLuaUnit::Push(L, pkDllUnit->GetInstance());
 	}
 	else

--- a/CvGameCoreDLL_Expansion2/CvGlobals.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGlobals.cpp
@@ -2723,7 +2723,7 @@ void CvGlobals::uninit()
 //------------------------------------------------------------------------------
 CvCity* CvGlobals::UnwrapCityPointer(ICvCity1* pCity)
 {
-	return (NULL != pCity)? dynamic_cast<CvDllCity*>(pCity)->GetInstance() : NULL;
+	return (NULL != pCity)? static_cast<CvDllCity*>(pCity)->GetInstance() : NULL;
 }
 //------------------------------------------------------------------------------
 CvInterfacePtr<ICvCity1> CvGlobals::WrapCityPointer(CvCity* pCity)
@@ -2733,7 +2733,7 @@ CvInterfacePtr<ICvCity1> CvGlobals::WrapCityPointer(CvCity* pCity)
 //------------------------------------------------------------------------------
 CvDeal* CvGlobals::UnwrapDealPointer(ICvDeal1* pDeal)
 {
-	return (NULL != pDeal)? dynamic_cast<CvDllDeal*>(pDeal)->GetInstance() : NULL;
+	return (NULL != pDeal)? static_cast<CvDllDeal*>(pDeal)->GetInstance() : NULL;
 }
 //------------------------------------------------------------------------------
 CvInterfacePtr<ICvDeal1> CvGlobals::WrapDealPointer(CvDeal* pDeal)
@@ -2743,7 +2743,7 @@ CvInterfacePtr<ICvDeal1> CvGlobals::WrapDealPointer(CvDeal* pDeal)
 //------------------------------------------------------------------------------
 CvPlot* CvGlobals::UnwrapPlotPointer(ICvPlot1* pPlot)
 {
-	return (NULL != pPlot)? dynamic_cast<CvDllPlot*>(pPlot)->GetInstance() : NULL;
+	return (NULL != pPlot)? static_cast<CvDllPlot*>(pPlot)->GetInstance() : NULL;
 }
 //------------------------------------------------------------------------------
 CvInterfacePtr<ICvPlot1> CvGlobals::WrapPlotPointer(CvPlot* pPlot)
@@ -2753,7 +2753,7 @@ CvInterfacePtr<ICvPlot1> CvGlobals::WrapPlotPointer(CvPlot* pPlot)
 //------------------------------------------------------------------------------
 CvRandom* CvGlobals::UnwrapRandomPointer(ICvRandom1* pRandom)
 {
-	return (NULL != pRandom)? dynamic_cast<CvDllRandom*>(pRandom)->GetInstance() : NULL;
+	return (NULL != pRandom)? static_cast<CvDllRandom*>(pRandom)->GetInstance() : NULL;
 }
 //------------------------------------------------------------------------------
 CvInterfacePtr<ICvRandom1> CvGlobals::WrapRandomPointer(CvRandom* pRandom)
@@ -2768,7 +2768,7 @@ CvInterfacePtr<ICvUnit1> CvGlobals::WrapUnitPointer(CvUnit* pUnit)
 //------------------------------------------------------------------------------
 CvUnit* CvGlobals::UnwrapUnitPointer(ICvUnit1* pUnit)
 {
-	return (NULL != pUnit)? dynamic_cast<CvDllUnit*>(pUnit)->GetInstance() : NULL;
+	return (NULL != pUnit)? static_cast<CvDllUnit*>(pUnit)->GetInstance() : NULL;
 }
 //------------------------------------------------------------------------------
 CvGlobals& CvGlobals::getInstance()


### PR DESCRIPTION
Revert dynamic_cast to static_cast and do not use (ignore) [cppcoreguidelines-pro-type-static-cast-downcast](https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/pro-type-static-cast-downcast.html). Reference https://github.com/Hello71/Community-Patch-DLL/commit/310e9626620866948a0c32f5782349ad4db58aed & https://github.com/LoneGazebo/Community-Patch-DLL/pull/10716.