### PR TITLE
Fix ancient ruin population not being added when founding a city

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -1107,10 +1107,6 @@ void CvCity::init(int iID, PlayerTypes eOwner, int iX, int iY, bool bBumpUnits, 
 	// Stuff for Pioneers and Colonists
 	if (MOD_BALANCE_CORE_SETTLER_ADVANCED && bInitialFounding && pkSettlerUnitEntry != NULL)
 	{
-		if (pkSettlerUnitEntry->IsFound())
-		{
-			kPlayer.cityBoost(getX(), getY(), pkSettlerUnitEntry, 0, 1, 1);
-		}
 		if (pkSettlerUnitEntry->GetNumColonyFound() > 0)
 		{
 			kPlayer.cityBoost(getX(), getY(), pkSettlerUnitEntry, /*3*/ GD_INT_GET(PIONEER_EXTRA_PLOTS), /*3*/ GD_INT_GET(PIONEER_POPULATION_CHANGE), 1);

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -14955,9 +14955,9 @@ void CvPlayer::cityBoost(int iX, int iY, CvUnitEntry* pkUnitEntry, int iExtraPlo
 			}
 		}
 
-		pCity->setPopulation(GetNewCityExtraPopulation() + iPopChange, true, true);
+		pCity->changePopulation(iPopChange, true, true);
 
-		//25% food, to prevent instant-starvation
+		//additional food to prevent instant-starvation
 		pCity->changeFood((pCity->growthThreshold() * iFoodPercent / 100));
 
 		//And a little territory to boot


### PR DESCRIPTION
Fix #10628 , and also fix pioneers and colonists giving one population less than intended. 