### PR TITLE
readability-container-size-empty

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvCultureClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCultureClasses.cpp
@@ -6712,7 +6712,7 @@ CvString CvCityCulture::GetTourismTooltip()
 		int iFromNaturalWonders = GetCultureFromNaturalWonders();
 		int iFromImprovements = m_pCity->GetBaseYieldRateFromTerrain(YIELD_CULTURE);
 		iTileTourism = ((iFromWonders + iFromNaturalWonders + iFromImprovements) * iPercent / 100);
-		if (szRtnValue.length() > 0)
+		if (!szRtnValue.empty())
 		{
 			szRtnValue += "[NEWLINE][NEWLINE]";
 		}
@@ -6728,7 +6728,7 @@ CvString CvCityCulture::GetTourismTooltip()
 		{
 			int iCulture = m_pCity->getJONSCulturePerTurn();
 			iGATourism = ((iCulture * iPercent) / 100);
-			if (szRtnValue.length() > 0)
+			if (!szRtnValue.empty())
 			{
 				szRtnValue += "[NEWLINE][NEWLINE]";
 			}
@@ -6748,7 +6748,7 @@ CvString CvCityCulture::GetTourismTooltip()
 		{
 			iSacredSitesTourism = m_pCity->GetCityBuildings()->GetNumBuildingsFromFaith() * iFaithBuildingTourism;
 		}
-		if (szRtnValue.length() > 0)
+		if (!szRtnValue.empty())
 		{
 			szRtnValue += "[NEWLINE][NEWLINE]";
 		}
@@ -6769,7 +6769,7 @@ CvString CvCityCulture::GetTourismTooltip()
 		if(iReligiousArtTourism != 0)
 		{
 #endif
-		if (szRtnValue.length() > 0)
+		if (!szRtnValue.empty())
 		{
 			szRtnValue += "[NEWLINE][NEWLINE]";
 		}
@@ -6792,7 +6792,7 @@ CvString CvCityCulture::GetTourismTooltip()
 			{
 				iTechEnhancedTourism *= m_pCity->GetCityBuildings()->GetNumBuilding(eBuilding);
 
-				if (szRtnValue.length() > 0)
+				if (!szRtnValue.empty())
 				{
 					szRtnValue += "[NEWLINE][NEWLINE]";
 				}
@@ -6808,7 +6808,7 @@ CvString CvCityCulture::GetTourismTooltip()
 		iTourismFromWW *= m_pCity->getNumWorldWonders();
 		if(iTourismFromWW != 0)
 		{
-			if (szRtnValue.length() > 0)
+			if (!szRtnValue.empty())
 			{
 				szRtnValue += "[NEWLINE][NEWLINE]";
 			}
@@ -6818,7 +6818,7 @@ CvString CvCityCulture::GetTourismTooltip()
 	int iRemainder = (m_pCity->getYieldRate(YIELD_TOURISM, false) - iTraitBonuses - iTourismFromWW);
 	if(iRemainder != 0)
 	{
-		if (szRtnValue.length() > 0)
+		if (!szRtnValue.empty())
 		{
 			szRtnValue += "[NEWLINE][NEWLINE]";
 		}
@@ -6836,7 +6836,7 @@ CvString CvCityCulture::GetTourismTooltip()
 			{
 				iBuildingMod *= m_pCity->GetCityBuildings()->GetNumBuilding(allBuildings[iI]);
 
-				if (szRtnValue.length() > 0)
+				if (!szRtnValue.empty())
 				{
 					szRtnValue += "[NEWLINE][NEWLINE]";
 				}
@@ -6863,7 +6863,7 @@ CvString CvCityCulture::GetTourismTooltip()
 				// City shares religion with this player
 				if (kPlayer.GetReligions()->GetStateReligion() == ePlayerReligion)
 				{
-					if (sharedReligionCivs.length() > 0)
+					if (!sharedReligionCivs.empty())
 					{
 						sharedReligionCivs += ", ";
 					}
@@ -6875,7 +6875,7 @@ CvString CvCityCulture::GetTourismTooltip()
 				if ((MOD_BALANCE_FLIPPED_TOURISM_MODIFIER_OPEN_BORDERS && GET_TEAM(eTeam).IsAllowsOpenBordersToTeam(kTeam.GetID())) ||
 					(!MOD_BALANCE_FLIPPED_TOURISM_MODIFIER_OPEN_BORDERS && kTeam.IsAllowsOpenBordersToTeam(eTeam)))
 				{
-					if (openBordersCivs.length() > 0)
+					if (!openBordersCivs.empty())
 					{
 						openBordersCivs += ", ";
 					}
@@ -6885,7 +6885,7 @@ CvString CvCityCulture::GetTourismTooltip()
 				// Trade route with this player
 				if (GC.getGame().GetGameTrade()->IsPlayerConnectedToPlayer(m_pCity->getOwner(), (PlayerTypes)iLoopPlayer))
 				{
-					if (tradeRouteCivs.length() > 0)
+					if (!tradeRouteCivs.empty())
 					{
 						tradeRouteCivs += ", ";
 					}
@@ -6897,7 +6897,7 @@ CvString CvCityCulture::GetTourismTooltip()
 				{
 					if (kCityPlayer.GetExcessHappiness() > kPlayer.GetExcessHappiness())
 					{
-						if (lessHappyCivs.length() > 0)
+						if (!lessHappyCivs.empty())
 						{
 							lessHappyCivs += ", ";
 						}
@@ -6916,7 +6916,7 @@ CvString CvCityCulture::GetTourismTooltip()
 							// Are they at war with me too?
 							if (GET_TEAM(kCityPlayer.getTeam()).isAtWar(GET_PLAYER(eLoopPlayer).getTeam()) && GET_TEAM(kPlayer.getTeam()).isAtWar(GET_PLAYER(eLoopPlayer).getTeam()))
 							{
-								if (commonFoeCivs.length() > 0)
+								if (!commonFoeCivs.empty())
 								{
 									commonFoeCivs += ", ";
 								}
@@ -6931,7 +6931,7 @@ CvString CvCityCulture::GetTourismTooltip()
 				{
 					if (eMyIdeology != NO_POLICY_BRANCH_TYPE && eTheirIdeology != NO_POLICY_BRANCH_TYPE && eMyIdeology == eTheirIdeology)
 					{
-						if (sharedIdeologyCivs.length() > 0)
+						if (!sharedIdeologyCivs.empty())
 						{
 							sharedIdeologyCivs += ", ";
 						}
@@ -6942,7 +6942,7 @@ CvString CvCityCulture::GetTourismTooltip()
 				// Different ideology penalty (applies all the time)
 				if (eMyIdeology != NO_POLICY_BRANCH_TYPE && eTheirIdeology != NO_POLICY_BRANCH_TYPE && eMyIdeology != eTheirIdeology)
 				{
-					if (differentIdeologyCivs.length() > 0)
+					if (!differentIdeologyCivs.empty())
 					{
 						differentIdeologyCivs += ", ";
 					}
@@ -6952,27 +6952,27 @@ CvString CvCityCulture::GetTourismTooltip()
 		}
 
 		// Build the strings
-		if (sharedReligionCivs.length() > 0)
+		if (!sharedReligionCivs.empty())
 		{
-			if (szRtnValue.length() > 0)
+			if (!szRtnValue.empty())
 			{
 				szRtnValue += "[NEWLINE][NEWLINE]";
 			}
 			szTemp = GetLocalizedText("TXT_KEY_CO_CITY_TOURISM_RELIGION_BONUS", kCityPlayer.GetCulture()->GetTourismModifierSharedReligion());
 			szRtnValue += szTemp + sharedReligionCivs;
 		}
-		if (openBordersCivs.length() > 0)
+		if (!openBordersCivs.empty())
 		{
-			if (szRtnValue.length() > 0)
+			if (!szRtnValue.empty())
 			{
 				szRtnValue += "[NEWLINE][NEWLINE]";
 			}
 			szTemp = GetLocalizedText("TXT_KEY_CO_CITY_TOURISM_OPEN_BORDERS_BONUS", kCityPlayer.GetCulture()->GetTourismModifierOpenBorders());
 			szRtnValue += szTemp + openBordersCivs;
 		}
-		if (tradeRouteCivs.length() > 0)
+		if (!tradeRouteCivs.empty())
 		{
-			if (szRtnValue.length() > 0)
+			if (!szRtnValue.empty())
 			{
 				szRtnValue += "[NEWLINE][NEWLINE]";
 			}
@@ -6980,36 +6980,36 @@ CvString CvCityCulture::GetTourismTooltip()
 			szRtnValue += szTemp + tradeRouteCivs;
 		}
 		
-		if (lessHappyCivs.length() > 0)
+		if (!lessHappyCivs.empty())
 		{
-			if (szRtnValue.length() > 0)
+			if (!szRtnValue.empty())
 			{
 				szRtnValue += "[NEWLINE][NEWLINE]";
 			}
 			szTemp = GetLocalizedText("TXT_KEY_CO_CITY_TOURISM_LESS_HAPPY_BONUS", iLessHappyMod);
 			szRtnValue += szTemp + lessHappyCivs;
 		}
-		if (commonFoeCivs.length() > 0)
+		if (!commonFoeCivs.empty())
 		{
-			if (szRtnValue.length() > 0)
+			if (!szRtnValue.empty())
 			{
 				szRtnValue += "[NEWLINE][NEWLINE]";
 			}
 			szTemp = GetLocalizedText("TXT_KEY_CO_CITY_TOURISM_COMMON_FOE_BONUS", iCommonFoeMod);
 			szRtnValue += szTemp + commonFoeCivs;
 		}
-		if (sharedIdeologyCivs.length() > 0)
+		if (!sharedIdeologyCivs.empty())
 		{
-			if (szRtnValue.length() > 0)
+			if (!szRtnValue.empty())
 			{
 				szRtnValue += "[NEWLINE][NEWLINE]";
 			}
 			szTemp = GetLocalizedText("TXT_KEY_CO_CITY_TOURISM_SHARED_IDEOLOGY_BONUS", iSharedIdeologyMod);
 			szRtnValue += szTemp + sharedIdeologyCivs;
 		}
-		if (differentIdeologyCivs.length() > 0)
+		if (!differentIdeologyCivs.empty())
 		{
-			if (szRtnValue.length() > 0)
+			if (!szRtnValue.empty())
 			{
 				szRtnValue += "[NEWLINE][NEWLINE]";
 			}
@@ -7021,7 +7021,7 @@ CvString CvCityCulture::GetTourismTooltip()
 	int iTechSpreadModifier = kCityPlayer.GetInfluenceSpreadModifier();
 	if (iTechSpreadModifier != 0)
 	{
-		if (szRtnValue.length() > 0)
+		if (!szRtnValue.empty())
 		{
 			szRtnValue += "[NEWLINE][NEWLINE]";
 		}
@@ -7031,7 +7031,7 @@ CvString CvCityCulture::GetTourismTooltip()
 	int iLeagueCityModifier = GC.getGame().GetGameLeagues()->GetCityTourismModifier(m_pCity->getOwner(), m_pCity);
 	if (iLeagueCityModifier != 0)
 	{
-		if (szRtnValue.length() > 0)
+		if (!szRtnValue.empty())
 		{
 			szRtnValue += "[NEWLINE][NEWLINE]";
 		}
@@ -7041,7 +7041,7 @@ CvString CvCityCulture::GetTourismTooltip()
 
 	if (kCityPlayer.isGoldenAge() && kCityPlayer.GetPlayerTraits()->GetGoldenAgeTourismModifier())
 	{
-		if (szRtnValue.length() > 0)
+		if (!szRtnValue.empty())
 		{
 			szRtnValue += "[NEWLINE][NEWLINE]";
 		}
@@ -7057,7 +7057,7 @@ CvString CvCityCulture::GetTourismTooltip()
 	{
 		if (!bHasCityModTooltip)
 		{
-			if (szRtnValue.length() > 0)
+			if (!szRtnValue.empty())
 			{
 				szRtnValue += "[NEWLINE]";
 			}
@@ -7074,7 +7074,7 @@ CvString CvCityCulture::GetTourismTooltip()
 		{
 			if (!bHasCityModTooltip)
 			{
-				if (szRtnValue.length() > 0)
+				if (!szRtnValue.empty())
 				{
 					szRtnValue += "[NEWLINE]";
 				}
@@ -7089,7 +7089,7 @@ CvString CvCityCulture::GetTourismTooltip()
 	{
 		if (!bHasCityModTooltip)
 		{
-			if (szRtnValue.length() > 0)
+			if (!szRtnValue.empty())
 			{
 				szRtnValue += "[NEWLINE]";
 			}
@@ -7103,7 +7103,7 @@ CvString CvCityCulture::GetTourismTooltip()
 	{
 		if (!bHasCityModTooltip)
 		{
-			if (szRtnValue.length() > 0)
+			if (!szRtnValue.empty())
 			{
 				szRtnValue += "[NEWLINE]";
 			}
@@ -7120,7 +7120,7 @@ CvString CvCityCulture::GetTourismTooltip()
 		{
 			if (!bHasCityModTooltip)
 			{
-				if (szRtnValue.length() > 0)
+				if (!szRtnValue.empty())
 				{
 					szRtnValue += "[NEWLINE]";
 				}
@@ -7135,7 +7135,7 @@ CvString CvCityCulture::GetTourismTooltip()
 	{
 		if (!bHasCityModTooltip)
 		{
-			if (szRtnValue.length() > 0)
+			if (!szRtnValue.empty())
 			{
 				szRtnValue += "[NEWLINE]";
 			}
@@ -7151,7 +7151,7 @@ CvString CvCityCulture::GetTourismTooltip()
 		{
 			if (!bHasCityModTooltip)
 			{
-				if (szRtnValue.length() > 0)
+				if (!szRtnValue.empty())
 				{
 					szRtnValue += "[NEWLINE]";
 				}
@@ -7167,7 +7167,7 @@ CvString CvCityCulture::GetTourismTooltip()
 	{
 		if (!bHasCityModTooltip)
 		{
-			if (szRtnValue.length() > 0)
+			if (!szRtnValue.empty())
 			{
 				szRtnValue += "[NEWLINE]";
 			}
@@ -7181,7 +7181,7 @@ CvString CvCityCulture::GetTourismTooltip()
 	{
 		if (!bHasCityModTooltip)
 		{
-			if (szRtnValue.length() > 0)
+			if (!szRtnValue.empty())
 			{
 				szRtnValue += "[NEWLINE]";
 			}
@@ -7195,7 +7195,7 @@ CvString CvCityCulture::GetTourismTooltip()
 	{
 		if (!bHasCityModTooltip)
 		{
-			if (szRtnValue.length() > 0)
+			if (!szRtnValue.empty())
 			{
 				szRtnValue += "[NEWLINE]";
 			}
@@ -7209,7 +7209,7 @@ CvString CvCityCulture::GetTourismTooltip()
 	{
 		if (!bHasCityModTooltip)
 		{
-			if (szRtnValue.length() > 0)
+			if (!szRtnValue.empty())
 			{
 				szRtnValue += "[NEWLINE]";
 			}
@@ -7223,7 +7223,7 @@ CvString CvCityCulture::GetTourismTooltip()
 	{
 		if (!bHasCityModTooltip)
 		{
-			if (szRtnValue.length() > 0)
+			if (!szRtnValue.empty())
 			{
 				szRtnValue += "[NEWLINE]";
 			}
@@ -7237,7 +7237,7 @@ CvString CvCityCulture::GetTourismTooltip()
 	{
 		if (!bHasCityModTooltip)
 		{
-			if (szRtnValue.length() > 0)
+			if (!szRtnValue.empty())
 			{
 				szRtnValue += "[NEWLINE]";
 			}
@@ -7250,7 +7250,7 @@ CvString CvCityCulture::GetTourismTooltip()
 	{
 		if (!bHasCityModTooltip)
 		{
-			if (szRtnValue.length() > 0)
+			if (!szRtnValue.empty())
 			{
 				szRtnValue += "[NEWLINE]";
 			}
@@ -7271,7 +7271,7 @@ CvString CvCityCulture::GetTourismTooltip()
 			{
 				if (!bHasCityModTooltip)
 				{
-					if (szRtnValue.length() > 0)
+					if (!szRtnValue.empty())
 					{
 						szRtnValue += "[NEWLINE]";
 					}
@@ -7286,7 +7286,7 @@ CvString CvCityCulture::GetTourismTooltip()
 		{
 			if (!bHasCityModTooltip)
 			{
-				if (szRtnValue.length() > 0)
+				if (!szRtnValue.empty())
 				{
 					szRtnValue += "[NEWLINE]";
 				}
@@ -7300,7 +7300,7 @@ CvString CvCityCulture::GetTourismTooltip()
 		{
 			if (!bHasCityModTooltip)
 			{
-				if (szRtnValue.length() > 0)
+				if (!szRtnValue.empty())
 				{
 					szRtnValue += "[NEWLINE]";
 				}
@@ -7329,7 +7329,7 @@ CvString CvCityCulture::GetTourismTooltip()
 			{
 				if (!bHasCityModTooltip)
 				{
-					if (szRtnValue.length() > 0)
+					if (!szRtnValue.empty())
 					{
 						szRtnValue += "[NEWLINE]";
 					}
@@ -7349,7 +7349,7 @@ CvString CvCityCulture::GetTourismTooltip()
 				{
 					if (!bHasCityModTooltip)
 					{
-						if (szRtnValue.length() > 0)
+						if (!szRtnValue.empty())
 						{
 							szRtnValue += "[NEWLINE]";
 						}
@@ -7371,7 +7371,7 @@ CvString CvCityCulture::GetTourismTooltip()
 			iTempMod += GET_PLAYER(m_pCity->getOwner()).GetMonopolyModPercent();
 			if (!bHasCityModTooltip)
 			{
-				if (szRtnValue.length() > 0)
+				if (!szRtnValue.empty())
 				{
 					szRtnValue += "[NEWLINE]";
 				}
@@ -7398,7 +7398,7 @@ CvString CvCityCulture::GetTourismTooltip()
 					{
 						if (!bHasCityModTooltip)
 						{
-							if (szRtnValue.length() > 0)
+							if (!szRtnValue.empty())
 							{
 								szRtnValue += "[NEWLINE]";
 							}
@@ -7418,7 +7418,7 @@ CvString CvCityCulture::GetTourismTooltip()
 					{
 						if (!bHasCityModTooltip)
 						{
-							if (szRtnValue.length() > 0)
+							if (!szRtnValue.empty())
 							{
 								szRtnValue += "[NEWLINE]";
 							}
@@ -7437,7 +7437,7 @@ CvString CvCityCulture::GetTourismTooltip()
 		{
 			if (!bHasCityModTooltip)
 			{
-				if (szRtnValue.length() > 0)
+				if (!szRtnValue.empty())
 				{
 					szRtnValue += "[NEWLINE]";
 				}
@@ -7454,7 +7454,7 @@ CvString CvCityCulture::GetTourismTooltip()
 			iTempMod = 0;
 		if (!bHasCityModTooltip)
 		{
-			if (szRtnValue.length() > 0)
+			if (!szRtnValue.empty())
 			{
 				szRtnValue += "[NEWLINE]";
 			}

--- a/CvGameCoreDLL_Expansion2/CvPolicyClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPolicyClasses.cpp
@@ -4965,7 +4965,7 @@ CvString CvPlayerPolicies::GetWeLoveTheKingString()
 		{
 			// Does it have a string for us?
 			CvString str = m_pPolicies->GetPolicyEntry(i)->GetWeLoveTheKing();
-			if(str.length() > 0)
+			if(!str.empty())
 			{
 				rtnValue = str;
 				break;  // All done when find the first one

--- a/CvGameCoreDLL_Expansion2/CvPreGame.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPreGame.cpp
@@ -3081,7 +3081,7 @@ void setLeaderKey(PlayerTypes p, const CvString& szKey)
 		// Check to see if this is available, if not, set the index to NO_LEADER and the package ID to invalid
 		// The key will stay valid
 		bool bFailed = true;
-		if(szKey.length() > 0)
+		if(!szKey.empty())
 		{
 			// During the pre-game, we can't be sure the cached *Infos are current, so query the database
 			Database::Connection* pDB = GC.GetGameDatabase();
@@ -3107,7 +3107,7 @@ void setLeaderKey(PlayerTypes p, const CvString& szKey)
 		{
 			s_leaderHeads[p] = NO_LEADER;
 			ClearGUID(s_leaderPackageID[p]);
-			s_leaderKeysAvailable[p] = (szKey.length() == 0);	// If the key was empty, then it is the 'random' state so it is available
+			s_leaderKeysAvailable[p] = (szKey.empty());	// If the key was empty, then it is the 'random' state so it is available
 		}
 	}
 }
@@ -3827,7 +3827,7 @@ void setCivilizationKey(PlayerTypes p, const CvString& szKey)
 		// Check to see if this is available, if not, set the index to NO_CIVILIZATION and the package ID to invalid
 		// The key will stay valid
 		bool bFailed = true;
-		if(szKey.length() > 0)
+		if(!szKey.empty())
 		{
 			// During the pre-game, we can't be sure the cached *Infos are current, so query the database
 			Database::Results kResults;
@@ -3850,7 +3850,7 @@ void setCivilizationKey(PlayerTypes p, const CvString& szKey)
 		{
 			s_civilizations[p] = NO_CIVILIZATION;
 			ClearGUID(s_civilizationPackageID[p]);
-			s_civilizationKeysAvailable[p] = (szKey.length() == 0);	// If the key was empty, then it is the 'random' state so it is available
+			s_civilizationKeysAvailable[p] = (szKey.empty());	// If the key was empty, then it is the 'random' state so it is available
 			s_civilizationKeysPlayable[p] = s_civilizationKeysAvailable[p];
 		}
 	}


### PR DESCRIPTION
Ran [readability-container-size-empty](https://clang.llvm.org/extra/clang-tidy/checks/readability/container-size-empty.html). v90 build works after changing to /Zm260 similar to https://github.com/LoneGazebo/Community-Patch-DLL/commit/eab6a30633c6adb288283c9b9297b57ac69c2ed5#diff-2705f19fed026fce017b69e8eefea4a5df4610c4093feebe6e965e6057be40d4 and https://github.com/LoneGazebo/Community-Patch-DLL/pull/10739.