### PR TITLE
Squads modmod bugfixes

### DIFF
--- a/(3a) EUI Compatibility Files/LUA/UnitFlagManager.lua
+++ b/(3a) EUI Compatibility Files/LUA/UnitFlagManager.lua
@@ -668,8 +668,10 @@ local function CreateNewFlag( playerID, unitID, isSelected, isHiddenByFog, isInv
 		if g_isSquadsModEnabled and unit:GetSquadNumber() > -1 and b_ShowSquadNumberUnderFlag then
 			flag.SquadNumber:SetHide( false )
 			flag.SquadNumber:SetText( tostring(unit:GetSquadNumber()) )
+		else
+			flag.SquadNumber:SetHide( true )
+			flag.SquadNumber:SetText( "" )
 		end
-
 		---------------------------------------------------------
 		-- update all other info
 		flag.Anchor:SetHide( isHiddenByFog or isInvisibleToActiveTeam )

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -15974,6 +15974,11 @@ void CvUnit::DoSquadMovement(CvPlot* pDestPlot)
 	{
 		if (pLoopUnit->canMoveInto(*pDestPlot))
 		{
+			// If this unit is going to move later, clear its path cache. Otherwise, due to the 
+			// use of MOVEFLAG_CONTINUE_TO_CLOSEST_PLOT it can try to continue on its old path
+			// instead of calculating a new route to the destination plot
+			pLoopUnit->ClearMissionQueue(false);
+
 			if (!pLoopUnit->IsCombatUnit() || pLoopUnit->IsStackingUnit())
 			{
 				stackingUnits.push_back(pLoopUnit);


### PR DESCRIPTION
 * Fix a bug where EUI unit flags could incorrectly show squad numbers for units created shortly after a unit in a squad dies
 * Fix a bug where issuing squad move orders to a unit that just had a squad movement mission interrupted (either by user or by seeing enemy unit) would result in them continuing on their previous path