### PR TITLE
Celts New Pantheon and minor balance changes

### DIFF
--- a/(2) Vox Populi/Database Changes/Beliefs/NewBeliefs.xml
+++ b/(2) Vox Populi/Database Changes/Beliefs/NewBeliefs.xml
@@ -72,6 +72,14 @@
 			<Pantheon>true</Pantheon>
 			<CivilizationType>CIVILIZATION_CELTS</CivilizationType>
 		</Row>
+		<!-- Congress 6 -->
+		<Row>
+			<Type>BELIEF_CAILLEACH</Type>
+			<Description>TXT_KEY_BELIEF_CAILLEACH</Description>
+			<ShortDescription>TXT_KEY_BELIEF_CAILLEACH_SHORT</ShortDescription>
+			<Pantheon>true</Pantheon>
+			<CivilizationType>CIVILIZATION_CELTS</CivilizationType>
+		</Row>
 		<!-- New follower beliefs -->
 		<Row>
 			<Type>BELIEF_GURDWARA</Type>

--- a/(2) Vox Populi/Database Changes/Beliefs/PantheonChanges.sql
+++ b/(2) Vox Populi/Database Changes/Beliefs/PantheonChanges.sql
@@ -465,7 +465,7 @@ VALUES
 	('BELIEF_CERNUNNOS', 'FEATURE_JUNGLE', 'YIELD_PRODUCTION', 1);
 
 -- Lugh, the Skilled One
-UPDATE Beliefs SET ProductionModifier = 10 WHERE Type = 'BELIEF_LUGH';
+UPDATE Beliefs SET WonderProductionModifier = 10 WHERE Type = 'BELIEF_LUGH';
 
 INSERT INTO Belief_YieldChangeAnySpecialist
 	(BeliefType, YieldType, Yield)

--- a/(2) Vox Populi/Database Changes/Beliefs/PantheonChanges.sql
+++ b/(2) Vox Populi/Database Changes/Beliefs/PantheonChanges.sql
@@ -389,7 +389,8 @@ VALUES
 	('BELIEF_RHIANNON', 'BUILDINGCLASS_CIRCUS', 'YIELD_GOLDEN_AGE_POINTS', 5),
 	('BELIEF_MANANNAN', 'BUILDINGCLASS_CIRCUS', 'YIELD_GREAT_ADMIRAL_POINTS', 2),
 	('BELIEF_OGMA', 'BUILDINGCLASS_CIRCUS', 'YIELD_SCIENCE', 5),
-	('BELIEF_BRAN', 'BUILDINGCLASS_CIRCUS', 'YIELD_FOOD', 5);
+	('BELIEF_BRAN', 'BUILDINGCLASS_CIRCUS', 'YIELD_FOOD', 5),
+	('BELIEF_CAILLEACH', 'BUILDINGCLASS_CIRCUS', 'YIELD_TOURISM', 5);
 
 INSERT INTO Belief_BuildingClassHappiness
 	(BeliefType, BuildingClassType, Happiness)
@@ -415,7 +416,7 @@ VALUES
 INSERT INTO Belief_CityYieldChanges
 	(BeliefType, YieldType, Yield)
 VALUES
-	('BELIEF_EPONA', 'YIELD_CULTURE_LOCAL', 3);
+	('BELIEF_EPONA', 'YIELD_CULTURE_LOCAL', 5);
 
 INSERT INTO Belief_YieldPerBorderGrowth
 	(BeliefType, YieldType, Yield, IsEraScaling)
@@ -463,7 +464,7 @@ VALUES
 	('BELIEF_CERNUNNOS', 'FEATURE_JUNGLE', 'YIELD_PRODUCTION', 1);
 
 -- Lugh, the Skilled One
-UPDATE Beliefs SET WonderProductionModifier = 10 WHERE Type = 'BELIEF_LUGH';
+UPDATE Beliefs SET WonderProductionModifier = 15 WHERE Type = 'BELIEF_LUGH';
 
 INSERT INTO Belief_YieldChangeAnySpecialist
 	(BeliefType, YieldType, Yield)
@@ -512,13 +513,16 @@ VALUES
 	('BELIEF_MANANNAN', 'YIELD_PRODUCTION', 3),
 	('BELIEF_MANANNAN', 'YIELD_GOLD', 3);
 
-INSERT INTO Belief_CityYieldPerXTerrainTimes100
+INSERT INTO Belief_TerrainYieldChanges
 	(BeliefType, TerrainType, YieldType, Yield)
 VALUES
-	('BELIEF_MANANNAN', 'TERRAIN_COAST', 'YIELD_PRODUCTION', 50),
-	('BELIEF_MANANNAN', 'TERRAIN_COAST', 'YIELD_GOLD', 50),
-	('BELIEF_MANANNAN', 'TERRAIN_OCEAN', 'YIELD_PRODUCTION', 50),
-	('BELIEF_MANANNAN', 'TERRAIN_OCEAN', 'YIELD_GOLD', 50);
+	('BELIEF_MANANNAN', 'TERRAIN_COAST', 'YIELD_PRODUCTION', 1),
+	('BELIEF_MANANNAN', 'TERRAIN_OCEAN', 'YIELD_PRODUCTION', 1);
+
+INSERT INTO Belief_ImprovementYieldChanges
+	(BeliefType, ImprovementType, YieldType, Yield)
+VALUES
+	('BELIEF_MANANNAN', 'IMPROVEMENT_FISHING_BOATS', 'YIELD_GOLD', 1);
 
 -- Ogma, the Learned
 INSERT INTO Belief_YieldPerPop
@@ -535,6 +539,7 @@ VALUES
 INSERT INTO Belief_GreatWorkYieldChanges
 	(BeliefType, YieldType, Yield)
 VALUES
+	('BELIEF_OGMA', 'YIELD_SCIENCE', 1),
 	('BELIEF_OGMA', 'YIELD_PRODUCTION', 1);
 
 INSERT INTO Belief_GreatPersonPoints
@@ -546,7 +551,6 @@ VALUES
 -- Bran, the Sleeping Guardian
 UPDATE Beliefs
 SET
-	CityRangeStrikeModifier = 25,
 	CityGrowthModifier = 25,
 	HappinessPerCity = 1
 WHERE Type = 'BELIEF_BRAN';
@@ -554,11 +558,16 @@ WHERE Type = 'BELIEF_BRAN';
 INSERT INTO Belief_YieldPerBirth
 	(BeliefType, YieldType, Yield)
 VALUES
-	('BELIEF_BRAN', 'YIELD_GOLD', 15),
-	('BELIEF_BRAN', 'YIELD_CULTURE', 15);
+	('BELIEF_BRAN', 'YIELD_GOLD', 10),
+	('BELIEF_BRAN', 'YIELD_PRODUCTION', 10),
+	('BELIEF_BRAN', 'YIELD_CULTURE', 10);
 
 -- Dagda, the All-Father
-UPDATE Beliefs SET FriendlyHealChange = 5 WHERE Type = 'BELIEF_DAGDA';
+UPDATE Beliefs 
+SET 
+	FriendlyHealChange = 10,
+	CityRangeStrikeModifier = 25
+WHERE Type = 'BELIEF_DAGDA';
 
 INSERT INTO Belief_BuildingClassYieldChanges
 	(BeliefType, BuildingClassType, YieldType, YieldChange)
@@ -575,3 +584,32 @@ VALUES
 	('BELIEF_DAGDA', 'YIELD_GOLD', 4),
 	('BELIEF_DAGDA', 'YIELD_SCIENCE', 4),
 	('BELIEF_DAGDA', 'YIELD_CULTURE', 4);
+
+-- Cailleach, the Winter Queen (congress 6)
+UPDATE Beliefs SET RequiresResource = 1 WHERE Type = 'BELIEF_CAILLEACH';
+-- Note: if you have the RequiresResources flag set, the Times100 table ignores it for tundra, but the YieldChanges table obeys it
+INSERT INTO Belief_CityYieldPerXTerrainTimes100
+	(BeliefType, TerrainType, YieldType, Yield)
+VALUES
+	('BELIEF_CAILLEACH', 'TERRAIN_TUNDRA', 'YIELD_PRODUCTION', 50),
+	('BELIEF_CAILLEACH', 'TERRAIN_TUNDRA', 'YIELD_FOOD', 50);
+
+INSERT INTO Belief_TerrainYieldChanges
+	(BeliefType, TerrainType, YieldType, Yield)
+VALUES
+	('BELIEF_CAILLEACH', 'TERRAIN_SNOW', 'YIELD_FOOD', 1),	
+	('BELIEF_CAILLEACH', 'TERRAIN_SNOW', 'YIELD_PRODUCTION', 1),		
+	('BELIEF_CAILLEACH', 'TERRAIN_SNOW', 'YIELD_SCIENCE', 1),
+	('BELIEF_CAILLEACH', 'TERRAIN_SNOW', 'YIELD_CULTURE', 1);
+
+
+INSERT INTO Belief_ImprovementYieldChanges
+	(BeliefType, ImprovementType, YieldType, Yield)
+VALUES
+	('BELIEF_CAILLEACH', 'IMPROVEMENT_QUARRY', 'YIELD_GOLD', 1),
+	('BELIEF_CAILLEACH', 'IMPROVEMENT_QUARRY', 'YIELD_CULTURE', 1),
+	('BELIEF_CAILLEACH', 'IMPROVEMENT_MINE', 'YIELD_GOLD', 1),
+	('BELIEF_CAILLEACH', 'IMPROVEMENT_MINE', 'YIELD_CULTURE', 1);
+
+
+

--- a/(2) Vox Populi/Database Changes/Beliefs/PantheonChanges.sql
+++ b/(2) Vox Populi/Database Changes/Beliefs/PantheonChanges.sql
@@ -389,13 +389,13 @@ VALUES
 	('BELIEF_RHIANNON', 'BUILDINGCLASS_CIRCUS', 'YIELD_GOLDEN_AGE_POINTS', 5),
 	('BELIEF_MANANNAN', 'BUILDINGCLASS_CIRCUS', 'YIELD_GREAT_ADMIRAL_POINTS', 2),
 	('BELIEF_OGMA', 'BUILDINGCLASS_CIRCUS', 'YIELD_SCIENCE', 5),
-	('BELIEF_BRAN', 'BUILDINGCLASS_CIRCUS', 'YIELD_FOOD', 5),
+	('BELIEF_DAGDA', 'BUILDINGCLASS_CIRCUS', 'YIELD_FOOD', 5),
 	('BELIEF_CAILLEACH', 'BUILDINGCLASS_CIRCUS', 'YIELD_TOURISM', 5);
 
 INSERT INTO Belief_BuildingClassHappiness
 	(BeliefType, BuildingClassType, Happiness)
 VALUES
-	('BELIEF_DAGDA', 'BUILDINGCLASS_CIRCUS', 2);
+	('BELIEF_BRAN', 'BUILDINGCLASS_CIRCUS', 2);
 
 -- Morrigan, the Harbinger
 INSERT INTO Belief_YieldFromKills
@@ -421,9 +421,10 @@ VALUES
 INSERT INTO Belief_YieldPerBorderGrowth
 	(BeliefType, YieldType, Yield, IsEraScaling)
 VALUES
-	('BELIEF_EPONA', 'YIELD_FOOD', 10, 1),
-	('BELIEF_EPONA', 'YIELD_SCIENCE', 10, 1),
-	('BELIEF_EPONA', 'YIELD_CULTURE', 10, 1);
+	('BELIEF_EPONA', 'YIELD_FOOD', 8, 1),	
+	('BELIEF_EPONA', 'YIELD_PRODUCTION', 8, 1),
+	('BELIEF_EPONA', 'YIELD_SCIENCE', 8, 1),
+	('BELIEF_EPONA', 'YIELD_CULTURE', 8, 1);
 
 -- Nuada, the Silver-Handed
 INSERT INTO Belief_YieldFromWLTKD
@@ -464,7 +465,7 @@ VALUES
 	('BELIEF_CERNUNNOS', 'FEATURE_JUNGLE', 'YIELD_PRODUCTION', 1);
 
 -- Lugh, the Skilled One
-UPDATE Beliefs SET WonderProductionModifier = 15 WHERE Type = 'BELIEF_LUGH';
+UPDATE Beliefs SET ProductionModifier = 10 WHERE Type = 'BELIEF_LUGH';
 
 INSERT INTO Belief_YieldChangeAnySpecialist
 	(BeliefType, YieldType, Yield)
@@ -473,6 +474,13 @@ VALUES
 	('BELIEF_LUGH', 'YIELD_GOLD', 2),
 	('BELIEF_LUGH', 'YIELD_SCIENCE', 2),
 	('BELIEF_LUGH', 'YIELD_CULTURE', 2);
+
+INSERT INTO Belief_YieldChangeWorldWonder
+	(BeliefType, YieldType, Yield)
+VALUES
+	('BELIEF_LUGH', 'YIELD_CULTURE', 2),
+	('BELIEF_LUGH', 'YIELD_TOURISM', 2);
+
 
 -- Rhiannon, the Sovereign
 INSERT INTO Belief_YieldPerFollowingCity
@@ -540,7 +548,7 @@ INSERT INTO Belief_GreatWorkYieldChanges
 	(BeliefType, YieldType, Yield)
 VALUES
 	('BELIEF_OGMA', 'YIELD_SCIENCE', 1),
-	('BELIEF_OGMA', 'YIELD_PRODUCTION', 1);
+	('BELIEF_OGMA', 'YIELD_CULTURE', 1);
 
 INSERT INTO Belief_GreatPersonPoints
 	(BeliefType, GreatPersonType, Value)
@@ -548,42 +556,42 @@ VALUES
 	('BELIEF_OGMA', 'GREATPERSON_ARTIST', 3),
 	('BELIEF_OGMA', 'GREATPERSON_SCIENTIST', 3);
 
--- Bran, the Sleeping Guardian
+-- Dagda, the All-Father
 UPDATE Beliefs
 SET
 	CityGrowthModifier = 25,
 	HappinessPerCity = 1
-WHERE Type = 'BELIEF_BRAN';
+WHERE Type = 'BELIEF_DAGDA';
 
 INSERT INTO Belief_YieldPerBirth
 	(BeliefType, YieldType, Yield)
 VALUES
-	('BELIEF_BRAN', 'YIELD_GOLD', 10),
-	('BELIEF_BRAN', 'YIELD_PRODUCTION', 10),
-	('BELIEF_BRAN', 'YIELD_CULTURE', 10);
+	('BELIEF_DAGDA', 'YIELD_GOLD', 12),
+	('BELIEF_DAGDA', 'YIELD_PRODUCTION', 12),
+	('BELIEF_DAGDA', 'YIELD_CULTURE', 12);
 
--- Dagda, the All-Father
+-- Bran, the Sleeping Guardian
 UPDATE Beliefs 
 SET 
 	FriendlyHealChange = 10,
 	CityRangeStrikeModifier = 25
-WHERE Type = 'BELIEF_DAGDA';
+WHERE Type = 'BELIEF_BRAN';
 
 INSERT INTO Belief_BuildingClassYieldChanges
 	(BeliefType, BuildingClassType, YieldType, YieldChange)
 VALUES
-	('BELIEF_DAGDA', 'BUILDINGCLASS_PALACE', 'YIELD_PRODUCTION', 1),
-	('BELIEF_DAGDA', 'BUILDINGCLASS_PALACE', 'YIELD_GOLD', 1),
-	('BELIEF_DAGDA', 'BUILDINGCLASS_PALACE', 'YIELD_SCIENCE', 1),
-	('BELIEF_DAGDA', 'BUILDINGCLASS_PALACE', 'YIELD_CULTURE', 1);
+	('BELIEF_BRAN', 'BUILDINGCLASS_PALACE', 'YIELD_PRODUCTION', 1),
+	('BELIEF_BRAN', 'BUILDINGCLASS_PALACE', 'YIELD_GOLD', 1),
+	('BELIEF_BRAN', 'BUILDINGCLASS_PALACE', 'YIELD_SCIENCE', 1),
+	('BELIEF_BRAN', 'BUILDINGCLASS_PALACE', 'YIELD_CULTURE', 1);
 
 INSERT INTO Belief_YieldPerXFollowers
 	(BeliefType, YieldType, PerXFollowers)
 VALUES
-	('BELIEF_DAGDA', 'YIELD_PRODUCTION', 4),
-	('BELIEF_DAGDA', 'YIELD_GOLD', 4),
-	('BELIEF_DAGDA', 'YIELD_SCIENCE', 4),
-	('BELIEF_DAGDA', 'YIELD_CULTURE', 4);
+	('BELIEF_BRAN', 'YIELD_PRODUCTION', 4),
+	('BELIEF_BRAN', 'YIELD_GOLD', 4),
+	('BELIEF_BRAN', 'YIELD_SCIENCE', 4),
+	('BELIEF_BRAN', 'YIELD_CULTURE', 4);
 
 -- Cailleach, the Winter Queen (congress 6)
 UPDATE Beliefs SET RequiresResource = 1 WHERE Type = 'BELIEF_CAILLEACH';

--- a/(2) Vox Populi/Database Changes/Beliefs/PantheonChanges.sql
+++ b/(2) Vox Populi/Database Changes/Beliefs/PantheonChanges.sql
@@ -416,7 +416,7 @@ VALUES
 INSERT INTO Belief_CityYieldChanges
 	(BeliefType, YieldType, Yield)
 VALUES
-	('BELIEF_EPONA', 'YIELD_CULTURE_LOCAL', 5);
+	('BELIEF_EPONA', 'YIELD_CULTURE_LOCAL', 3);
 
 INSERT INTO Belief_YieldPerBorderGrowth
 	(BeliefType, YieldType, Yield, IsEraScaling)

--- a/(2) Vox Populi/Database Changes/Text/en_US/Beliefs/NewBeliefText.xml
+++ b/(2) Vox Populi/Database Changes/Text/en_US/Beliefs/NewBeliefText.xml
@@ -8,7 +8,7 @@
 			<Text>Morrigan, the Harbinger</Text>
 		</Row>
 		<Row Tag="TXT_KEY_BELIEF_EPONA">
-			<Text>+5 [ICON_CULTURE_LOCAL] Border Growth in every City. Receive +10 [ICON_RESEARCH] Science, [ICON_CULTURE] Culture, and [ICON_FOOD] Food when your Borders expand, scaling with Era. +5 [ICON_CULTURE_LOCAL] Border Growth from Ceilidh Hall.</Text>
+			<Text>+3 [ICON_CULTURE_LOCAL] Border Growth in every City. Receive +8 [ICON_FOOD] Food, [ICON_PRODUCTION] Production, [ICON_RESEARCH] Science, and [ICON_CULTURE] Culture when your Borders expand, scaling with Era. +5 [ICON_CULTURE_LOCAL] Border Growth from Ceilidh Hall.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_BELIEF_EPONA_SHORT">
 			<Text>Epona, the Great Mare</Text>
@@ -26,7 +26,7 @@
 			<Text>Cernunnos, the Horned Stag</Text>
 		</Row>
 		<Row Tag="TXT_KEY_BELIEF_LUGH">
-			<Text>+2 [ICON_CULTURE] Culture, [ICON_RESEARCH] Science, [ICON_FOOD] Food, and [ICON_GOLD] Gold in Cities with a Specialist. +15% [ICON_PRODUCTION] Production towards [ICON_WONDER] Wonders. +3 [ICON_PRODUCTION] Production from Ceilidh Hall.</Text>
+			<Text>+2 [ICON_CULTURE] Culture, [ICON_RESEARCH] Science, [ICON_FOOD] Food, and [ICON_GOLD] Gold in Cities with a Specialist. +10% [ICON_PRODUCTION] Production towards [ICON_WONDER] Wonders, and +2 [ICON_CULTURE] Culture and [ICON_TOURISM] Tourism from each. +3 [ICON_PRODUCTION] Production from Ceilidh Hall.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_BELIEF_LUGH_SHORT">
 			<Text>Lugh, the Skilled One</Text>
@@ -44,21 +44,21 @@
 			<Text>Manannan, Son of the Sea</Text>
 		</Row>
 		<Row Tag="TXT_KEY_BELIEF_OGMA">
-			<Text>+1 [ICON_RESEARCH] Science for every 4 [ICON_CITIZEN] Citizens. +1 [ICON_PRODUCTION] Production and [ICON_RESEARCH] Science from [ICON_GREAT_WORK] Great Works. +3 [ICON_RESEARCH] Science, [ICON_CULTURE] Culture, and [ICON_GREAT_SCIENTIST] Great Scientist Points, and [ICON_GREAT_ARTIST] Great Artist Points in [ICON_CAPITAL] Capital. +5 [ICON_RESEARCH] Science from Ceilidh Hall.</Text>
+			<Text>+1 [ICON_RESEARCH] Science for every 4 [ICON_CITIZEN] Citizens. +1 [ICON_CULTURE] Culture and [ICON_RESEARCH] Science from [ICON_GREAT_WORK] Great Works. +3 [ICON_RESEARCH] Science, [ICON_CULTURE] Culture, and [ICON_GREAT_SCIENTIST] Great Scientist Points, and [ICON_GREAT_ARTIST] Great Artist Points in [ICON_CAPITAL] Capital. +5 [ICON_RESEARCH] Science from Ceilidh Hall.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_BELIEF_OGMA_SHORT">
 			<Text>Ogma, the Learned</Text>
 		</Row>
-		<Row Tag="TXT_KEY_BELIEF_BRAN">
-			<Text>+25% [ICON_FOOD] Growth. +10 [ICON_CULTURE] Culture, [ICON_PRODUCTION] Production, and [ICON_GOLD] Gold when a [ICON_CITIZEN] Citizen is born, scaling with Era. +1 [ICON_HAPPINESS_1] Happiness per following City. +5 [ICON_FOOD] Food from Ceilidh Hall.</Text>
-		</Row>
-		<Row Tag="TXT_KEY_BELIEF_BRAN_SHORT">
-			<Text>Dagda, the All-Father</Text>
-		</Row>
 		<Row Tag="TXT_KEY_BELIEF_DAGDA">
-			<Text>+1 [ICON_CULTURE] Culture, [ICON_GOLD] Gold, [ICON_PRODUCTION] Production, and [ICON_RESEARCH] Science in the [ICON_CAPITAL] Capital, and for every 4 Followers of your Pantheon in owned Cities. +10 HP healed per turn in Friendly Territory and +25% increase in City [ICON_RANGE_STRENGTH] Ranged Combat Strength. +2 [ICON_HAPPINESS_1] Happiness from Ceilidh Hall.</Text>
+			<Text>+25% [ICON_FOOD] Growth. +12 [ICON_CULTURE] Culture, [ICON_PRODUCTION] Production, and [ICON_GOLD] Gold when a [ICON_CITIZEN] Citizen is born, scaling with Era. +1 [ICON_HAPPINESS_1] Happiness per following City. +5 [ICON_FOOD] Food from Ceilidh Hall.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_BELIEF_DAGDA_SHORT">
+			<Text>Dagda, the All-Father</Text>
+		</Row>
+		<Row Tag="TXT_KEY_BELIEF_BRAN">
+			<Text>+1 [ICON_CULTURE] Culture, [ICON_GOLD] Gold, [ICON_PRODUCTION] Production, and [ICON_RESEARCH] Science in the [ICON_CAPITAL] Capital, and for every 4 Followers of your Pantheon in owned Cities. +10 HP healed per turn in Friendly Territory and +25% increase in City [ICON_RANGE_STRENGTH] Ranged Combat Strength. +2 [ICON_HAPPINESS_1] Happiness from Ceilidh Hall.</Text>
+		</Row>
+		<Row Tag="TXT_KEY_BELIEF_BRAN_SHORT">
 			<Text>Bran, the Sleeping Guardian</Text>
 		</Row>
 		<Row Tag="TXT_KEY_BELIEF_CAILLEACH">
@@ -121,5 +121,4 @@
 			<Text>+2 [ICON_PEACE] Faith[NEWLINE][NEWLINE]{TXT_KEY_BUILDING_TEOCALLI_HELP}</Text>
 		</Row>
 	</Language_en_US>
-</GameData>uage_en_US>
 </GameData>

--- a/(2) Vox Populi/Database Changes/Text/en_US/Beliefs/NewBeliefText.xml
+++ b/(2) Vox Populi/Database Changes/Text/en_US/Beliefs/NewBeliefText.xml
@@ -8,7 +8,7 @@
 			<Text>Morrigan, the Harbinger</Text>
 		</Row>
 		<Row Tag="TXT_KEY_BELIEF_EPONA">
-			<Text>+3 [ICON_CULTURE_LOCAL] Border Growth in every City. Receive +10 [ICON_RESEARCH] Science, [ICON_CULTURE] Culture, and [ICON_FOOD] Food when your Borders expand, scaling with Era. +5 [ICON_CULTURE_LOCAL] Border Growth from Ceilidh Hall.</Text>
+			<Text>+5 [ICON_CULTURE_LOCAL] Border Growth in every City. Receive +10 [ICON_RESEARCH] Science, [ICON_CULTURE] Culture, and [ICON_FOOD] Food when your Borders expand, scaling with Era. +5 [ICON_CULTURE_LOCAL] Border Growth from Ceilidh Hall.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_BELIEF_EPONA_SHORT">
 			<Text>Epona, the Great Mare</Text>
@@ -26,40 +26,46 @@
 			<Text>Cernunnos, the Horned Stag</Text>
 		</Row>
 		<Row Tag="TXT_KEY_BELIEF_LUGH">
-			<Text>+2 [ICON_CULTURE] Culture, [ICON_RESEARCH] Science, [ICON_FOOD] Food, and [ICON_GOLD] Gold in Cities with a Specialist. +10% [ICON_PRODUCTION] Production towards [ICON_WONDER] Wonders. +3 [ICON_PRODUCTION] Production from Ceilidh Hall.</Text>
+			<Text>+2 [ICON_CULTURE] Culture, [ICON_RESEARCH] Science, [ICON_FOOD] Food, and [ICON_GOLD] Gold in Cities with a Specialist. +15% [ICON_PRODUCTION] Production towards [ICON_WONDER] Wonders. +3 [ICON_PRODUCTION] Production from Ceilidh Hall.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_BELIEF_LUGH_SHORT">
 			<Text>Lugh, the Skilled One</Text>
 		</Row>
 		<Row Tag="TXT_KEY_BELIEF_RHIANNON">
-			<Text>+2 [ICON_CULTURE] Culture in every City, +1 [ICON_GOLD] Gold and [ICON_PRODUCTION] Production from every [COLOR_POSITIVE_TEXT]connected[ENDCOLOR] Resource tile. +5 [ICON_GOLDEN_AGE] Golden Age Points from Ceilidh Hall.</Text>
+			<Text>+2 [ICON_CULTURE] Culture in every City, +1 [ICON_GOLD] Gold and [ICON_PRODUCTION] Production from [COLOR_POSITIVE_TEXT]improved[ENDCOLOR] Resource tile. +5 [ICON_GOLDEN_AGE] Golden Age Points from Ceilidh Hall.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_BELIEF_RHIANNON_SHORT">
 			<Text>Rhiannon, the Sovereign</Text>
 		</Row>
 		<Row Tag="TXT_KEY_BELIEF_MANANNAN">
-			<Text>+3 [ICON_FOOD] Food, [ICON_PRODUCTION] Production, and [ICON_GOLD] Gold in Coastal Cities. +1 [ICON_PRODUCTION] Production and [ICON_GOLD] Gold for every 2 [ICON_CITIZEN] Citizens working Water tiles in your Cities. +2 [ICON_GREAT_ADMIRAL] Great Admiral Points from Ceilidh Hall.</Text>
+			<Text>+3 [ICON_FOOD] Food, [ICON_PRODUCTION] Production, and [ICON_GOLD] Gold in Coastal Cities. +1 [ICON_PRODUCTION] Production from Water tiles in your Cities and +1 [ICON_GOLD] Gold from Fishing Boats. +2 [ICON_GREAT_ADMIRAL] Great Admiral Points from Ceilidh Hall.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_BELIEF_MANANNAN_SHORT">
 			<Text>Manannan, Son of the Sea</Text>
 		</Row>
 		<Row Tag="TXT_KEY_BELIEF_OGMA">
-			<Text>+1 [ICON_RESEARCH] Science for every 4 [ICON_CITIZEN] Citizens and +1 [ICON_PRODUCTION] Production from [ICON_GREAT_WORK] Great Works in a City. +3 [ICON_RESEARCH] Science, [ICON_CULTURE] Culture, and [ICON_GREAT_SCIENTIST] Great Scientist Points, and [ICON_GREAT_ARTIST] Great Artist Points in [ICON_CAPITAL] Capital. +5 [ICON_RESEARCH] Science from Ceilidh Hall.</Text>
+			<Text>+1 [ICON_RESEARCH] Science for every 4 [ICON_CITIZEN] Citizens. +1 [ICON_PRODUCTION] Production and [ICON_RESEARCH] Science from [ICON_GREAT_WORK] Great Works. +3 [ICON_RESEARCH] Science, [ICON_CULTURE] Culture, and [ICON_GREAT_SCIENTIST] Great Scientist Points, and [ICON_GREAT_ARTIST] Great Artist Points in [ICON_CAPITAL] Capital. +5 [ICON_RESEARCH] Science from Ceilidh Hall.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_BELIEF_OGMA_SHORT">
 			<Text>Ogma, the Learned</Text>
 		</Row>
 		<Row Tag="TXT_KEY_BELIEF_BRAN">
-			<Text>+25% increase in City [ICON_RANGE_STRENGTH] Ranged Combat Strength and +25% [ICON_FOOD] Growth. +15 [ICON_CULTURE] Culture and [ICON_GOLD] Gold when a [ICON_CITIZEN] Citizen is born, scaling with Era. +1 [ICON_HAPPINESS_1] Happiness per following City. +5 [ICON_FOOD] Food from Ceilidh Hall.</Text>
+			<Text>+25% [ICON_FOOD] Growth. +10 [ICON_CULTURE] Culture, [ICON_PRODUCTION] Production, and [ICON_GOLD] Gold when a [ICON_CITIZEN] Citizen is born, scaling with Era. +1 [ICON_HAPPINESS_1] Happiness per following City. +5 [ICON_FOOD] Food from Ceilidh Hall.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_BELIEF_BRAN_SHORT">
-			<Text>Bran, the Sleeping Guardian</Text>
+			<Text>Dagda, the All-Father</Text>
 		</Row>
 		<Row Tag="TXT_KEY_BELIEF_DAGDA">
-			<Text>+1 [ICON_CULTURE] Culture, [ICON_GOLD] Gold, [ICON_PRODUCTION] Production, and [ICON_RESEARCH] Science in the [ICON_CAPITAL] Capital, and for every 4 Followers of your Pantheon in owned Cities. +5 HP healed per turn in Friendly Territory. +2 [ICON_HAPPINESS_1] Happiness from Ceilidh Hall.</Text>
+			<Text>+1 [ICON_CULTURE] Culture, [ICON_GOLD] Gold, [ICON_PRODUCTION] Production, and [ICON_RESEARCH] Science in the [ICON_CAPITAL] Capital, and for every 4 Followers of your Pantheon in owned Cities. +10 HP healed per turn in Friendly Territory and +25% increase in City [ICON_RANGE_STRENGTH] Ranged Combat Strength. +2 [ICON_HAPPINESS_1] Happiness from Ceilidh Hall.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_BELIEF_DAGDA_SHORT">
-			<Text>Dagda, the All-Father</Text>
+			<Text>Bran, the Sleeping Guardian</Text>
+		</Row>
+		<Row Tag="TXT_KEY_BELIEF_CAILLEACH">
+			<Text>+1 [ICON_FOOD] Food and [ICON_PRODUCTION] Production for every 2 Tundra tiles worked by a City. +1 [ICON_FOOD] Food, [ICON_PRODUCTION] Production, [ICON_RESEARCH] Science, and [ICON_CULTURE] Culture from Snow tiles with Resources. +1 [ICON_GOLD] Gold and [ICON_CULTURE] Culture from Quarries and Mines on Resources. +5 [ICON_TOURISM] Tourism from Ceilidh Hall.</Text>
+		</Row>
+		<Row Tag="TXT_KEY_BELIEF_CAILLEACH_SHORT">
+			<Text>Cailleach, the Queen of Winter</Text>
 		</Row>
 
 		<Row Tag="TXT_KEY_BELIEF_GURDWARA">
@@ -115,4 +121,5 @@
 			<Text>+2 [ICON_PEACE] Faith[NEWLINE][NEWLINE]{TXT_KEY_BUILDING_TEOCALLI_HELP}</Text>
 		</Row>
 	</Language_en_US>
+</GameData>uage_en_US>
 </GameData>


### PR DESCRIPTION
Actioned the following passed proposal that languished due to a weird DLL part:
https://forums.civfanatics.com/threads/6-66-revision-of-the-celtic-pantheons.686198/#post-16522823

Added the new belief in the xml, its changes in pantheonchanges sql, and the text in newbelieftext xml
Tested with IGE and checked no database errors.

Also made the changes to Dagda and Bran that changed their names and move all healing/defense onto one of them.

Additional balance changes, some in the proposal, some modified. I.e. it was clear the new snow pantheon's numbers were not balanced (+2 yields on every tundra totally insane, for example).

A changelog, readable version is:
New Celtic Pantheon:
**Cailleach, the Queen of Winter** +1 Food and Production for every 2 Tundra tiles worked by a City. +1 Food, Production, Science, and Culture from Snow tiles with Resources. +1 Gold and Culture from Quarries and Mines on Resources. +5 Tourism from Ceilidh Hall.
Dagda the All-Father now named Bran, the Sleeping Guardian and reads: +1 Culture, Gold, Production, and Science in the Capital, and for every 4 Followers of your Pantheon in owned Cities. **+10 HP** healed per turn in Friendly Territory and **+25% increase in City Ranged Combat Strength**. +2 Happiness from Ceilidh Hall.
Bran the Sleeping Guardian now named Dagda the All-Father and reads: +25% Growth. +**10** Culture, **Production**, and Gold when a Citizen is born, scaling with Era. +1 Happiness per following City. +5 Food from Ceilidh Hall.
Manannan, Son of the Sea: Instead of +1 prod/+1 gold per two coast and two ocean tiles, +1 prod flat to all sea tiles and +1 gold to fishing boats.
Ogma the Learned: Now has +1 Science on Great Works in addition to +1 Production.
Lugh, the Skilled One: +10% to wonders increased to +15%
Epona, the Great Mare: +5 border growth per city, up from +3