### PR TITLE
Fix unit cycling selecting only some of the available units

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvGame.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGame.cpp
@@ -983,6 +983,8 @@ void CvGame::DoGameStarted()
 			pBuilding->UpdateUnitTypesUnlocked();
 	}
 
+	GET_PLAYER(getActivePlayer()).GetUnitCycler().Rebuild();
+
 #if defined(MOD_BALANCE_CORE)
 	CvPlayerManager::Refresh(false);
 #endif

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -470,6 +470,7 @@ CvPlayer::CvPlayer() :
 #pragma warning(push)
 #pragma warning(disable:4355 )
 , m_kPlayerAchievements(*this)
+, m_kUnitCycle(*this)
 #pragma warning(pop)
 , m_neededUnitAITypes()
 , m_aiCityYieldModFromMonopoly()
@@ -35485,6 +35486,7 @@ void CvPlayer::setTurnActive(bool bNewValue, bool bDoTurn) // R: bDoTurn default
 
 			if(GetID() == kGame.getActivePlayer())
 			{
+				GetUnitCycler().Rebuild();
 				if(DLLUI->GetLengthSelectionList() == 0)
 				{
 					DLLUI->setCycleSelectionCounter(1);
@@ -48836,6 +48838,7 @@ void CvPlayer::Serialize(Player& player, Visitor& visitor)
 
 	visitor(player.m_strEmbarkedGraphicOverride);
 	visitor(player.m_kPlayerAchievements);
+	visitor(player.m_kUnitCycle);
 
 	// Diplomacy requests
 	if (player.GetID() < MAX_MAJOR_CIVS)

--- a/CvGameCoreDLL_Expansion2/CvPlayer.h
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.h
@@ -2418,7 +2418,7 @@ public:
 	int getImprovementYieldChange(ImprovementTypes eIndex1, YieldTypes eIndex2) const;
 	void changeImprovementYieldChange(ImprovementTypes eIndex1, YieldTypes eIndex2, int iChange);
 
-	CvUnitCycler& GetUnitCycler() { return m_UnitCycle; };
+	CvUnitCycler& GetUnitCycler() { return m_kUnitCycle; };
 
 	bool removeFromArmy(int iArmyID, int iID);
 
@@ -3752,7 +3752,7 @@ protected:
 	std::map<GreatPersonTypes, std::map<MonopolyTypes, int>> m_ppiSpecificGreatPersonRateChangeFromMonopoly;
 #endif
 
-	CvUnitCycler	m_UnitCycle;	
+	CvUnitCycler	m_kUnitCycle;	
 
 	// slewis's tutorial variables!
 	bool m_bEverPoppedGoody;

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -134,6 +134,7 @@ CvUnit::CvUnit() :
 	, m_iX()
 	, m_iY()
 	, m_iLastMoveTurn()
+	, m_iCycleOrder()
 	, m_iDeployFromOperationTurn()
 	, m_iReconX()
 	, m_iReconY()
@@ -1230,6 +1231,7 @@ void CvUnit::initWithNameOffset(int iID, UnitTypes eUnit, int iNameOffset, UnitA
 	if(getOwner() == GC.getGame().getActivePlayer())
 	{
 		DLLUI->setDirty(GameData_DIRTY_BIT, true);
+		kPlayer.GetUnitCycler().AddUnit(GetID());
 	}
 
 	// Message for World Unit being born
@@ -1389,6 +1391,7 @@ void CvUnit::reset(int iID, UnitTypes eUnit, PlayerTypes eOwner, bool bConstruct
 	m_iX = INVALID_PLOT_COORD;
 	m_iY = INVALID_PLOT_COORD;
 	m_iLastMoveTurn = 0;
+	m_iCycleOrder = -1;
 	m_iDeployFromOperationTurn = -100;
 	m_iReconX = INVALID_PLOT_COORD;
 	m_iReconY = INVALID_PLOT_COORD;
@@ -2693,6 +2696,7 @@ void CvUnit::kill(bool bDelay, PlayerTypes ePlayer /*= NO_PLAYER*/)
 	}
 
 	DLLUI->RemoveFromSelectionList(pDllThisUnit.get());
+	GET_PLAYER(getOwner()).GetUnitCycler().RemoveUnit(GetID());
 
 	// Killing a unit while in combat is not something we really expect to happen.
 	// It is *mostly* safe for it to happen, but combat systems must be able to gracefully handle the disapperance of a unit.
@@ -21632,6 +21636,21 @@ void CvUnit::setLastMoveTurn(int iNewValue)
 	CvAssert(getLastMoveTurn() >= 0);
 }
 
+//	--------------------------------------------------------------------------------
+int CvUnit::GetCycleOrder() const
+{
+	VALIDATE_OBJECT
+	return m_iCycleOrder;
+}
+
+
+//	--------------------------------------------------------------------------------
+void CvUnit::SetCycleOrder(int iNewValue)
+{
+	VALIDATE_OBJECT
+	m_iCycleOrder = iNewValue;
+}
+
 
 //	--------------------------------------------------------------------------------
 bool CvUnit::IsRecentlyDeployedFromOperation() const
@@ -28528,6 +28547,7 @@ void CvUnit::Serialize(Unit& unit, Visitor& visitor)
 	visitor(unit.m_iHotKeyNumber);
 	visitor(unit.m_iDeployFromOperationTurn);
 	visitor(unit.m_iLastMoveTurn);
+	visitor(unit.m_iCycleOrder);
 	visitor(unit.m_iReconX);
 	visitor(unit.m_iReconY);
 	visitor(unit.m_iReconCount);

--- a/CvGameCoreDLL_Expansion2/CvUnit.h
+++ b/CvGameCoreDLL_Expansion2/CvUnit.h
@@ -1094,6 +1094,9 @@ public:
 	int getLastMoveTurn() const;
 	void setLastMoveTurn(int iNewValue);
 
+	int GetCycleOrder() const;
+	void SetCycleOrder(int iNewValue);
+
 	bool IsRecentlyDeployedFromOperation() const;
 	void SetDeployFromOperationTurn(int iTurn)
 	{
@@ -2076,6 +2079,7 @@ protected:
 	int m_iHotKeyNumber;
 	int m_iDeployFromOperationTurn;
 	int m_iLastMoveTurn;
+	int m_iCycleOrder;
 	int m_iReconX;
 	int m_iReconY;
 	int m_iReconCount;
@@ -2533,6 +2537,7 @@ SYNC_ARCHIVE_VAR(int, m_iBaseRangedCombat)
 SYNC_ARCHIVE_VAR(int, m_iHotKeyNumber)
 SYNC_ARCHIVE_VAR(int, m_iDeployFromOperationTurn)
 SYNC_ARCHIVE_VAR(int, m_iLastMoveTurn)
+SYNC_ARCHIVE_VAR(int, m_iCycleOrder)
 SYNC_ARCHIVE_VAR(int, m_iReconX)
 SYNC_ARCHIVE_VAR(int, m_iReconY)
 SYNC_ARCHIVE_VAR(int, m_iReconCount)

--- a/CvGameCoreDLL_Expansion2/CvUnitCycler.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnitCycler.cpp
@@ -1,9 +1,9 @@
 /*	-------------------------------------------------------------------------------------------------------
-	© 1991-2012 Take-Two Interactive Software and its subsidiaries.  Developed by Firaxis Games.  
-	Sid Meier's Civilization V, Civ, Civilization, 2K Games, Firaxis Games, Take-Two Interactive Software 
-	and their respective logos are all trademarks of Take-Two interactive Software, Inc.  
-	All other marks and trademarks are the property of their respective owners.  
-	All rights reserved. 
+	© 1991-2012 Take-Two Interactive Software and its subsidiaries.  Developed by Firaxis Games.
+	Sid Meier's Civilization V, Civ, Civilization, 2K Games, Firaxis Games, Take-Two Interactive Software
+	and their respective logos are all trademarks of Take-Two interactive Software, Inc.
+	All other marks and trademarks are the property of their respective owners.
+	All rights reserved.
 	------------------------------------------------------------------------------------------------------- */
 #include "CvGameCoreDLLPCH.h"
 #include "CvUnitCycler.h"
@@ -11,49 +11,308 @@
 #include "CvUnit.h"
 #include "CvGameCoreUtils.h"
 
-//	---------------------------------------------------------------------------
-CvUnitCycler::CvUnitCycler()
+	//	---------------------------------------------------------------------------
+CvUnitCycler::CvUnitCycler(CvPlayer& kPlayer)
 {
+	m_pkPlayer = &kPlayer;
+}
+
+//	---------------------------------------------------------------------------
+void CvUnitCycler::Clear()
+{
+	m_kNodeList.clear();
+}
+
+//	---------------------------------------------------------------------------
+void CvUnitCycler::Rebuild(CvUnit* pkStartUnit /* = NULL */)
+{
+	// Delete contents of old list
+	Node* pUnitNode = HeadNode();
+	while (pUnitNode != NULL)
+	{
+		DeleteNode(pUnitNode);
+		pUnitNode = HeadNode();
+	}
+
+	if (pkStartUnit == NULL)
+	{
+		// If no unit supplied, use the selected unit.
+		auto_ptr<ICvUnit1> pSelectedUnit(DLLUI->GetHeadSelectedUnit());
+		pkStartUnit = GC.UnwrapUnitPointer(pSelectedUnit.get());
+
+		if (pkStartUnit && pkStartUnit->getOwner() != m_pkPlayer->GetID())
+		{
+			// Not ours, fall back to just selecting a worker
+			pkStartUnit = NULL;
+		}
+	}
+
+	CvUnit* pLoopUnit;
+	int iLoop;
+	CvUnit* pkFirstUnit = m_pkPlayer->firstUnit(&iLoop);
+	for (pLoopUnit = pkFirstUnit; pLoopUnit != NULL; pLoopUnit = m_pkPlayer->nextUnit(&iLoop))
+	{
+		// Reset cycle order (will be used later in this function)
+		pLoopUnit->SetCycleOrder(0);
+
+		if (!pkStartUnit)
+		{
+			// Workers first
+			if (pLoopUnit->workRate(true) > 0)
+				pkStartUnit = pLoopUnit;
+		}
+	}
+
+	if (!pkStartUnit)
+		pkStartUnit = pkFirstUnit;
+
+	// Add first unit to list
+	if (pkStartUnit)
+	{
+		m_kNodeList.insertAtEnd(pkStartUnit->GetID());
+
+		// Current unit is the first one
+		CvUnit* pCurrentUnit = pkStartUnit;
+		pCurrentUnit->SetCycleOrder(1);
+
+		// Loop through units until everyone is accounted for
+		int iNumUnits = m_pkPlayer->getNumUnits();
+		while (m_kNodeList.getLength() < iNumUnits)
+		{
+			int iBestUnitScore = MAX_INT;
+			CvUnit* pBestUnit = NULL;
+
+			int iX = pCurrentUnit->getX();
+			int iY = pCurrentUnit->getY();
+			for (pLoopUnit = m_pkPlayer->firstUnit(&iLoop); pLoopUnit != NULL; pLoopUnit = m_pkPlayer->nextUnit(&iLoop))
+			{
+				// If we've already added this unit to the cycle list, skip it
+				if (pLoopUnit->GetCycleOrder() == 1)
+					continue;
+
+				int iScore = plotDistance(iX, iY, pLoopUnit->getX(), pLoopUnit->getY());
+
+				// Closest unit yet
+				if (iScore < iBestUnitScore)
+				{
+					iBestUnitScore = iScore;
+					pBestUnit = pLoopUnit;
+				}
+			}
+
+			CvAssertMsg(pBestUnit, "Didn't find a unit to add to cycle list.");
+
+			if (pBestUnit)
+			{
+				m_kNodeList.insertAtEnd(pBestUnit->GetID());
+
+				// Now have a new current unit
+				pCurrentUnit = pBestUnit;
+				pCurrentUnit->SetCycleOrder(1);
+			}
+			else
+				break;
+		}
+	}
+}
+
+//	---------------------------------------------------------------------------
+void CvUnitCycler::AddUnit(int iID)
+{
+	Rebuild();
+}
+//	---------------------------------------------------------------------------
+void CvUnitCycler::RemoveUnit(int iID)
+{
+	CLLNode<int>* pUnitNode;
+
+	pUnitNode = HeadNode();
+
+	while (pUnitNode != NULL)
+	{
+		if (pUnitNode->m_data == iID)
+		{
+			pUnitNode = DeleteNode(pUnitNode);
+			break;
+		}
+		else
+		{
+			pUnitNode = NextNode(pUnitNode);
+		}
+	}
 }
 
 //	-----------------------------------------------------------------------------------------------
 // Returns the next unit in the cycle...
-CvUnit *CvUnitCycler::Cycle(CvUnit* pUnit, bool bForward, bool bWorkers, bool* pbWrap)
+CvUnit* CvUnitCycler::Cycle(CvUnit* pUnit, bool bForward, bool bWorkers, bool* pbWrap)
 {
-	if (!pUnit)
-		return NULL;
+	const CLLNode<int>* pUnitNode;
+	const CLLNode<int>* pFirstUnitNode;
+	CvUnit* pLoopUnit;
 
 	if (pbWrap != NULL)
-		*pbWrap = false;
-
-	//---------------------------------------------------------------------------------------------
-	// just return the closest suitable unit, no bookkeeping required
-	//---------------------------------------------------------------------------------------------
-	int iUnitLoop = 0;
-	int iMinDist = INT_MAX;
-	CvUnit* pClosestUnit = NULL;
-	for (CvUnit* pLoopUnit = GET_PLAYER(pUnit->getOwner()).firstUnit(&iUnitLoop); pLoopUnit; pLoopUnit = GET_PLAYER(pUnit->getOwner()).nextUnit(&iUnitLoop))
 	{
-		if (pLoopUnit == pUnit || !pLoopUnit->ReadyToSelect())
-			continue;
+		*pbWrap = false;
+	}
 
-		if (bWorkers && pLoopUnit->AI_getUnitAIType() != UNITAI_WORKER && pLoopUnit->AI_getUnitAIType() != UNITAI_WORKER_SEA)
-			continue;
+	pUnitNode = HeadNode();
 
-		int iDist = plotDistance(*pUnit->plot(),*pLoopUnit->plot());
-
-		//use forward/backward flag to introduce a slight bias
-		if (bForward && pUnit->GetID() > pLoopUnit->GetID())
-			iDist++;
-		if (!bForward && pUnit->GetID() < pLoopUnit->GetID())
-			iDist++;
-
-		if ( iDist<iMinDist )
+	if (pUnit != NULL)
+	{
+		while (pUnitNode != NULL)
 		{
-			iMinDist = iDist;
-			pClosestUnit = pLoopUnit;
+			if (m_pkPlayer->getUnit(pUnitNode->m_data) == pUnit)
+			{
+				if (bForward)
+				{
+					pUnitNode = NextNode(pUnitNode);
+				}
+				else
+				{
+					pUnitNode = PreviousNode(pUnitNode);
+				}
+				break;
+			}
+
+			pUnitNode = NextNode(pUnitNode);
 		}
 	}
 
-	return pClosestUnit;
+	if (pUnitNode == NULL)
+	{
+		if (bForward)
+		{
+			pUnitNode = HeadNode();
+		}
+		else
+		{
+			pUnitNode = TailNode();
+		}
+
+		if (pbWrap != NULL)
+		{
+			*pbWrap = true;
+		}
+	}
+
+	if (pUnitNode != NULL)
+	{
+		pFirstUnitNode = pUnitNode;
+
+		while (true)
+		{
+			pLoopUnit = m_pkPlayer->getUnit(pUnitNode->m_data);
+			CvAssertMsg(pLoopUnit, "LoopUnit is not assigned a valid value");
+
+			if (pLoopUnit && pLoopUnit->ReadyToSelect())
+			{
+				if (!bWorkers || pLoopUnit->AI_getUnitAIType() == UNITAI_WORKER || pLoopUnit->AI_getUnitAIType() == UNITAI_WORKER_SEA)
+				{
+					if (pUnit && pLoopUnit == pUnit)
+					{
+						if (pbWrap != NULL)
+						{
+							*pbWrap = true;
+						}
+					}
+
+					return pLoopUnit;
+				}
+			}
+
+			if (bForward)
+			{
+				pUnitNode = NextNode(pUnitNode);
+
+				if (pUnitNode == NULL)
+				{
+					pUnitNode = HeadNode();
+
+					if (pbWrap != NULL)
+					{
+						*pbWrap = true;
+					}
+				}
+			}
+			else
+			{
+				pUnitNode = PreviousNode(pUnitNode);
+
+				if (pUnitNode == NULL)
+				{
+					pUnitNode = TailNode();
+
+					if (pbWrap != NULL)
+					{
+						*pbWrap = true;
+					}
+				}
+			}
+
+			if (pUnitNode == pFirstUnitNode)
+			{
+				break;
+			}
+		}
+	}
+
+	return NULL;
+}
+
+
+//	---------------------------------------------------------------------------
+CvUnitCycler::Node* CvUnitCycler::DeleteNode(CvUnitCycler::Node* pNode)
+{
+	return m_kNodeList.deleteNode(pNode);
+}
+
+//	---------------------------------------------------------------------------
+const CvUnitCycler::Node* CvUnitCycler::NextNode(const CvUnitCycler::Node* pNode) const
+{
+	return m_kNodeList.next(pNode);
+}
+
+//	---------------------------------------------------------------------------
+CvUnitCycler::Node* CvUnitCycler::NextNode(CvUnitCycler::Node* pNode)
+{
+	return m_kNodeList.next(pNode);
+}
+
+//	---------------------------------------------------------------------------
+const CvUnitCycler::Node* CvUnitCycler::PreviousNode(const CvUnitCycler::Node* pNode) const
+{
+	return m_kNodeList.prev(pNode);
+}
+
+//	---------------------------------------------------------------------------
+const CvUnitCycler::Node* CvUnitCycler::HeadNode() const
+{
+	return m_kNodeList.head();
+}
+
+//	---------------------------------------------------------------------------
+CvUnitCycler::Node* CvUnitCycler::HeadNode()
+{
+	return m_kNodeList.head();
+}
+
+//	---------------------------------------------------------------------------
+const CvUnitCycler::Node* CvUnitCycler::TailNode() const
+{
+	return m_kNodeList.tail();
+}
+
+//	---------------------------------------------------------------------------
+FDataStream& operator>>(FDataStream& loadFrom, CvUnitCycler& writeTo)
+{
+	writeTo.Clear();
+	loadFrom >> writeTo.m_kNodeList;
+	return loadFrom;
+}
+
+//	---------------------------------------------------------------------------
+FDataStream& operator<<(FDataStream& saveTo, const CvUnitCycler& readFrom)
+{
+	saveTo << readFrom.m_kNodeList;
+	return saveTo;
 }

--- a/CvGameCoreDLL_Expansion2/CvUnitCycler.h
+++ b/CvGameCoreDLL_Expansion2/CvUnitCycler.h
@@ -1,22 +1,48 @@
 /*	-------------------------------------------------------------------------------------------------------
-	© 1991-2012 Take-Two Interactive Software and its subsidiaries.  Developed by Firaxis Games.  
-	Sid Meier's Civilization V, Civ, Civilization, 2K Games, Firaxis Games, Take-Two Interactive Software 
-	and their respective logos are all trademarks of Take-Two interactive Software, Inc.  
-	All other marks and trademarks are the property of their respective owners.  
-	All rights reserved. 
+	© 1991-2012 Take-Two Interactive Software and its subsidiaries.  Developed by Firaxis Games.
+	Sid Meier's Civilization V, Civ, Civilization, 2K Games, Firaxis Games, Take-Two Interactive Software
+	and their respective logos are all trademarks of Take-Two interactive Software, Inc.
+	All other marks and trademarks are the property of their respective owners.
+	All rights reserved.
 	------------------------------------------------------------------------------------------------------- */
 
 #ifndef CVUNITCYCLER_H
 #define CVUNITCYCLER_H
 #pragma once
 #include "LinkedList.h"
+class CvPlayer;
 
 class CvUnitCycler
 {
 public:
 
-	CvUnitCycler();
-	static CvUnit*	Cycle(CvUnit* pUnit, bool bForward, bool bWorkers, bool* pbWrap);
+	CvUnitCycler(CvPlayer& kPlayer);
+	typedef CLLNode<int> Node;
+	typedef CLinkList<int> NodeList;
+
+	void		Clear();
+	void		Rebuild(CvUnit* pkStartUnit = NULL);
+	CvUnit* Cycle(CvUnit* pUnit, bool bForward, bool bWorkers, bool* pbWrap);
+
+	void		RemoveUnit(int iID);
+	void		AddUnit(int iID);
+	Node* DeleteNode(Node* pNode);
+	Node* NextNode(Node* pNode);
+	const Node* NextNode(const Node* pNode) const;
+	const Node* PreviousNode(const Node* pNode) const;
+	const Node* HeadNode() const;
+	Node* HeadNode();
+	const Node* TailNode() const;
+
+protected:
+	NodeList	m_kNodeList;
+	CvPlayer* m_pkPlayer;
+
+	friend FDataStream& operator>>(FDataStream& loadFrom, CvUnitCycler& writeTo);
+	friend FDataStream& operator<<(FDataStream& saveTo, const CvUnitCycler& readFrom);
 };
+
+FDataStream& operator>>(FDataStream& loadFrom, CvUnitCycler& writeTo);
+FDataStream& operator<<(FDataStream& saveTo, const CvUnitCycler& readFrom);
 
 #endif


### PR DESCRIPTION
- Fix #10841
- Reverted to the BNW method of storing a list of units which is updated each turn or when a unit is created/removed
- Units are sorted by distance to each other

not savegame compatible