### PR TITLE
(7-45a) Khan Replace Heal from Unique Promotion with Medic I and II Promotions

### DIFF
--- a/(2) Vox Populi/Database Changes/Civilizations/Mongolia.sql
+++ b/(2) Vox Populi/Database Changes/Civilizations/Mongolia.sql
@@ -34,7 +34,9 @@ WHERE Type = 'UNIT_MONGOLIAN_KHAN';
 INSERT INTO Unit_FreePromotions
 	(UnitType, PromotionType)
 VALUES
-	('UNIT_MONGOLIAN_KHAN', 'PROMOTION_MEDIC_GENERAL');
+	('UNIT_MONGOLIAN_KHAN', 'PROMOTION_MEDIC_GENERAL'),
+	('UNIT_MONGOLIAN_KHAN', 'PROMOTION_MEDIC'),
+	('UNIT_MONGOLIAN_KHAN', 'PROMOTION_MEDIC_II');
 
 ----------------------------------------------------------
 -- Unique Improvement: Ordo

--- a/(2) Vox Populi/Database Changes/Text/en_US/Civilizations/CivilizationTextChanges.sql
+++ b/(2) Vox Populi/Database Changes/Text/en_US/Civilizations/CivilizationTextChanges.sql
@@ -640,7 +640,7 @@ SET Text = 'Skirmisher Units have an extra Attack. Gain All Yields equal to 20% 
 WHERE Tag = 'TXT_KEY_TRAIT_TERROR';
 
 UPDATE Language_en_US
-SET Text = 'Unique Mongolian {TXT_KEY_UNIT_GREAT_GENERAL} that specializes in mobile leadership. The same {TXT_KEY_PROMOTION_GREAT_GENERAL} bonuses apply, but the {TXT_KEY_UNIT_MONGOL_KHAN} moves much faster, boosts healing of adjacent friendly Units by +10, and deals 10 damage to enemy Units if they end their turn next to it.[NEWLINE][NEWLINE]Can be expended to construct an [COLOR_POSITIVE_TEXT]{TXT_KEY_IMPROVEMENT_MONGOLIA_ORDO}[ENDCOLOR], the unique Mongolian {TXT_KEY_IMPROVEMENT_CITADEL}.'
+SET Text = 'Unique Mongolian {TXT_KEY_UNIT_GREAT_GENERAL} that specializes in mobile leadership. The same {TXT_KEY_PROMOTION_GREAT_GENERAL} bonuses apply, but the {TXT_KEY_UNIT_MONGOL_KHAN} moves much faster, starts with [COLOR_POSITIVE_TEXT]{TXT_KEY_PROMOTION_MEDIC}[ENDCOLOR] and [COLOR_POSITIVE_TEXT]{TXT_KEY_PROMOTION_MEDIC_II}[ENDCOLOR], and deals 10 damage to enemy Units if they end their turn next to it.[NEWLINE][NEWLINE]Can be expended to construct an [COLOR_POSITIVE_TEXT]{TXT_KEY_IMPROVEMENT_MONGOLIA_ORDO}[ENDCOLOR], the unique Mongolian {TXT_KEY_IMPROVEMENT_CITADEL}.'
 WHERE Tag = 'TXT_KEY_CIV5_MONGOLIA_KHAN_HELP';
 
 UPDATE Language_en_US

--- a/(2) Vox Populi/Database Changes/Text/en_US/UnitPromotions/PromotionTextChanges.sql
+++ b/(2) Vox Populi/Database Changes/Text/en_US/UnitPromotions/PromotionTextChanges.sql
@@ -666,7 +666,7 @@ WHERE Tag = 'TXT_KEY_PROMOTION_HAKA_WAR_DANCE_HELP';
 
 -- Enhanced Medic
 UPDATE Language_en_US
-SET Text = '+10 HP when [COLOR_POSITIVE_TEXT]Healing[ENDCOLOR] for Units [COLOR_POSITIVE_TEXT]on or adjacent to this tile[ENDCOLOR].[NEWLINE]Deal 10 Damage to Enemy Units ending their turn adjacent to this Unit.[NEWLINE]This Damage ignores damage reduction, but does not affect Units in [COLOR_NEGATIVE_TEXT]Cities[ENDCOLOR] and [COLOR_NEGATIVE_TEXT]Fortifications[ENDCOLOR].'
+SET Text = 'Deal 10 Damage to Enemy Units ending their turn adjacent to this Unit.[NEWLINE]This Damage ignores damage reduction, but does not affect Units in [COLOR_NEGATIVE_TEXT]Cities[ENDCOLOR] and [COLOR_NEGATIVE_TEXT]Fortifications[ENDCOLOR].'
 WHERE Tag = 'TXT_KEY_PROMOTION_MEDIC_GENERAL_HELP';
 
 -- Quick Study

--- a/(2) Vox Populi/Database Changes/UnitPromotions/PromotionChanges.sql
+++ b/(2) Vox Populi/Database Changes/UnitPromotions/PromotionChanges.sql
@@ -875,7 +875,7 @@ UPDATE UnitPromotions SET NearbyEnemyCombatMod = -10, NearbyEnemyCombatRange = 1
 UPDATE UnitPromotions SET NearbyEnemyCombatMod = -15, NearbyEnemyCombatRange = 1 WHERE Type = 'PROMOTION_HAKA_WAR_DANCE';
 
 -- Khan: Enhanced Medic
-UPDATE UnitPromotions SET SameTileHealChange = 10, AdjacentTileHealChange = 10, NearbyEnemyDamage = 10 WHERE Type = 'PROMOTION_MEDIC_GENERAL';
+UPDATE UnitPromotions SET NearbyEnemyDamage = 10 WHERE Type = 'PROMOTION_MEDIC_GENERAL';
 
 -- Samurai: Quick Study
 UPDATE UnitPromotions SET ExperiencePercent = 50 WHERE Type = 'PROMOTION_GAIN_EXPERIENCE';


### PR DESCRIPTION
https://forums.civfanatics.com/threads/7-45a-khan-replace-heal-from-unique-promotion-with-medic-i-and-ii-promotions.689226/

So... the proposal itself specifies that only adjacent healing (AdjacentTileHealChange) should be removed, but it's clear from the title and rationale that the proposer (Anarcomu) wanted to have both SameTileHealChange and AdjacentTileHealChange removed from Khan's promotion.

I'm implementing as Anarcomu intended, but, if Recursive and the magi decide that I should stick strictly with what was proposed, I'll commit a later change adding back the SameTileHealChange.