### PR TITLE
(7-49) All Civs Gain City Connections Along Rivers

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvAStar.h
+++ b/CvGameCoreDLL_Expansion2/CvAStar.h
@@ -324,6 +324,7 @@ int StepCost(const CvAStarNode* parent, const CvAStarNode* node, const SPathFind
 
 int CityConnectionLandValid(const CvAStarNode* parent, const CvAStarNode* node, const SPathFinderUserData& data, const CvAStar* finder);
 int CityConnectionGetExtraChildren(const CvAStarNode* node, const CvAStar* finder, vector<pair<int,int>>& out);
+int CityConnectionLandGetExtraChildren(const CvAStarNode* node, const CvAStar* finder, vector<pair<int, int>>& out);
 int CityConnectionWaterValid(const CvAStarNode* parent, const CvAStarNode* node, const SPathFinderUserData& data, const CvAStar* finder);
 
 int AreaValid(const CvAStarNode* parent, const CvAStarNode* node, const SPathFinderUserData& data, const CvAStar* finder);

--- a/CvGameCoreDLL_Expansion2/CvAStarNode.h
+++ b/CvGameCoreDLL_Expansion2/CvAStarNode.h
@@ -141,7 +141,7 @@ struct SPathFinderUserData
 	SPathFinderUserData(PlayerTypes ePlayer, PathType ePathType); // PT_TRADE_WATER, PT_TRADE_LAND, PT_LANDMASS_CONNECTION, PT_CITY_CONNECTION_WATER
 	SPathFinderUserData(PlayerTypes ePlayer, PathType ePathType, int iMaxTurns); // PT_AREA_CONNECTION (iMaxTurns is simple vs complex check (0/1)), PT_CITY_INFLUENCE
 	SPathFinderUserData(PlayerTypes ePlayer, PathType ePathType, PlayerTypes eEnemy, int iMaxTurns); // PT_GENERIC_SAME_AREA, PT_GENERIC_SAME_AREA_WIDE, PT_ARMY_LAND, PT_ARMY_WATER, PT_ARMY_MIXED
-	SPathFinderUserData(PlayerTypes ePlayer, PathType ePathType, BuildTypes eBuildType, RouteTypes eRouteType, RoutePurpose eRoutePurpose); // PT_BUILD_ROUTE, PT_BUILD_ROUTE_MIXED, PT_CITY_CONNECTION_LAND, PT_CITY_CONNECTION_MIXED
+	SPathFinderUserData(PlayerTypes ePlayer, PathType ePathType, BuildTypes eBuildType, RouteTypes eRouteType, RoutePurpose eRoutePurpose, bool bUseRivers); // PT_BUILD_ROUTE, PT_BUILD_ROUTE_MIXED, PT_CITY_CONNECTION_LAND, PT_CITY_CONNECTION_MIXED
 
 	//do not compare max turns and max cost ...
 	bool operator==(const SPathFinderUserData& rhs) const 
@@ -152,6 +152,7 @@ struct SPathFinderUserData
 	RouteTypes			eRoute;
 	BuildTypes			eBuild;             //BuildType related to the RouteType
 	RoutePurpose		eRoutePurpose;
+	bool                bUseRivers;
 	int					iFlags;				//see CvUnit::MOVEFLAG*
 	PlayerTypes			ePlayer;			//optional
 	PlayerTypes			eEnemy;

--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.h
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.h
@@ -139,7 +139,7 @@ public:
 protected:
 
 	typedef pair<int, int> PlotPair;
-	typedef pair<PlotPair, RouteTypes> PlannedRoute;
+	typedef pair<PlotPair, pair<RouteTypes, bool>> PlannedRoute;
 
 	void LogDirectives(vector<OptionWithScore<BuilderDirective>> directives);
 	void LogDirective(BuilderDirective directive, int iWeight, bool bChosen = false);
@@ -149,6 +149,8 @@ protected:
 	void ConnectCitiesForScenario(CvCity* pFirstCity, CvCity* pSecondCity, BuildTypes eBuild, RouteTypes eRoute);
 	void ConnectPointsForStrategy(CvCity* pOriginCity, CvPlot* pTargetPlot, BuildTypes eBuild, RouteTypes eRoute);
 
+	void ShortcutConnectionHelper(CvCity* pCity1, CvCity* pCity2, BuildTypes eBuild, RouteTypes eRoute, int iPlotDistance, bool bUseRivers);
+
 	vector<OptionWithScore<BuilderDirective>> GetRouteDirectives();
 	vector<OptionWithScore<BuilderDirective>> GetImprovementDirectives();
 
@@ -156,7 +158,7 @@ protected:
 	void UpdateProjectedPlotYields(CvPlot* pPlot, BuildTypes eBuild, bool bIgnoreCityConnection);
 
 	bool IsPlannedRouteForPurpose(const CvPlot* pPlot, RoutePurpose ePurpose) const;
-	void AddRoutePlots(CvPlot* pStartPlot, CvPlot* pTargetPlot, RouteTypes eRoute, int iValue, const SPath& path, RoutePurpose ePurpose);
+	void AddRoutePlots(CvPlot* pStartPlot, CvPlot* pTargetPlot, RouteTypes eRoute, int iValue, const SPath& path, RoutePurpose ePurpose, bool bUseRivers);
 	int GetMoveCostWithRoute(const CvPlot* pFromPlot, const CvPlot* pToPlot, RouteTypes eFromPlotRoute, RouteTypes eToPlotRoute);
 	int GetPlotYieldModifierTimes100(CvPlot* pPlot, YieldTypes eYield);
 	void GetPathValues(const SPath& path, RouteTypes eRoute, int& iVillageBonusesIfCityConnected, int& iTotalMoveCost, int& iNumRoadsNeededToBuild);

--- a/CvGameCoreDLL_Expansion2/CvCityConnections.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCityConnections.cpp
@@ -284,7 +284,7 @@ void CvCityConnections::UpdateRouteInfo(void)
 		ReachablePlots roadPlots;
 		ReachablePlots railroadPlots;
 		ReachablePlots waterPlots;
-		SPathFinderUserData data(m_pPlayer->GetID(),PT_CITY_CONNECTION_LAND,NO_BUILD,ROUTE_ROAD,NO_ROUTE_PURPOSE);
+		SPathFinderUserData data(m_pPlayer->GetID(),PT_CITY_CONNECTION_LAND,NO_BUILD,ROUTE_ROAD,NO_ROUTE_PURPOSE,true);
 		if (!pStartCity->IsBlockaded(DOMAIN_LAND))
 		{
 			roadPlots= GC.GetStepFinder().GetPlotsInReach( pStartCity->getX(),pStartCity->getY(), data);
@@ -505,7 +505,7 @@ void CvCityConnections::UpdateRouteInfo(void)
 
 		//Let's check for road first (railroad also counts as road)
 		//Very important to set up m_connectionState for direct connections first!
-		SPathFinderUserData data(m_pPlayer->GetID(), PT_CITY_CONNECTION_MIXED, NO_BUILD, ROUTE_ROAD, NO_ROUTE_PURPOSE);
+		SPathFinderUserData data(m_pPlayer->GetID(), PT_CITY_CONNECTION_MIXED, NO_BUILD, ROUTE_ROAD, NO_ROUTE_PURPOSE, true);
 		ReachablePlots capitalRoadConnectedPlots = GC.GetStepFinder().GetPlotsInReach( pCapital->getX(),pCapital->getY(), data);
 		for (ReachablePlots::iterator it = capitalRoadConnectedPlots.begin(); it != capitalRoadConnectedPlots.end(); ++it)
 		{
@@ -548,7 +548,13 @@ void CvCityConnections::UpdateRouteInfo(void)
 			for (size_t j = i + 1; j < vConnectedCities.size(); j++)
 			{
 				//find the shortest path between any two connected cities
+				data.bUseRivers = false;
 				SPath path = GC.GetStepFinder().GetPath(vConnectedCities[i]->plot(), vConnectedCities[j]->plot(), data);
+				if (!path)
+				{
+					data.bUseRivers = true;
+					path = GC.GetStepFinder().GetPath(vConnectedCities[i]->plot(), vConnectedCities[j]->plot(), data);
+				}
 				for (int k = 0; k < path.length(); k++)
 				{
 					CvPlot* pPlot = path.get(k);
@@ -558,6 +564,7 @@ void CvCityConnections::UpdateRouteInfo(void)
 			}
 		}
 		data.eRoute = ROUTE_RAILROAD;
+		data.bUseRivers = false;
 		for (size_t i = 0; i < vIndustrialConnectedCities.size(); i++)
 		{
 			for (size_t j = i + 1; j < vIndustrialConnectedCities.size(); j++)

--- a/CvGameCoreDLL_Expansion2/CvCityStrategyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCityStrategyAI.cpp
@@ -2782,7 +2782,7 @@ bool CityStrategyAIHelpers::IsTestCityStrategy_PocketCity(CvCity* pCity)
 	}
 
 	//could we build a route?
-	SPathFinderUserData data(pCity->getOwner(), PT_BUILD_ROUTE, NO_BUILD, ROUTE_ANY, NO_ROUTE_PURPOSE);
+	SPathFinderUserData data(pCity->getOwner(), PT_BUILD_ROUTE, NO_BUILD, ROUTE_ANY, NO_ROUTE_PURPOSE, true);
 	return !GC.GetStepFinder().DoesPathExist(pCapitalCity->getX(), pCapitalCity->getY(), pCity->getX(), pCity->getY(), data);
 }
 #endif

--- a/CvGameCoreDLL_Expansion2/CvMap.h
+++ b/CvGameCoreDLL_Expansion2/CvMap.h
@@ -90,6 +90,34 @@ protected:
 FDataStream& operator<<(FDataStream&, const CvLandmass&);
 FDataStream& operator>>(FDataStream&, CvLandmass&);
 
+class CvRiver
+{
+public:
+	CvRiver();
+	virtual ~CvRiver();
+
+	void init(int iID);
+	int GetID() const;
+	void SetID(int iID);
+
+	void AddPlot(CvPlot* pPlot);
+	vector<CvPlot*> GetPlots() const;
+
+	// for serialization
+	template<typename River, typename Visitor>
+	static void Serialize(River& landmass, Visitor& visitor);
+	virtual void read(FDataStream& kStream);
+	virtual void write(FDataStream& kStream) const;
+
+protected:
+
+	int m_iID;
+	vector<CvPlot*> m_vPlots;
+};
+
+FDataStream& operator<<(FDataStream&, const CvRiver&);
+FDataStream& operator>>(FDataStream&, CvRiver&);
+
 inline int coordRange(int iCoord, int iRange, bool bWrap)
 {
 	if(bWrap)
@@ -313,6 +341,18 @@ public:
 	void recalculateLandmasses();
 	void calculateLandmasses();
 
+	// Rivers
+	int GetNumRivers();
+	CvRiver* GetRiverById(int iID);
+	CvRiver* GetRiverByIndex(int iIndex);
+	CvRiver* AddRiver();
+	void DeleteRiver(int iID);
+	CvRiver* FirstRiver(int* pIterIdx, bool bRev = false);
+	CvRiver* NextRiver(int* pIterIdx, bool bRev = false);
+	void RecalculateRivers();
+	void CalculateRivers();
+	void CreateRiverFrom(CvPlot* pPlot, DirectionTypes eDirection, CvRiver* pRiver);
+
 	/// this is the default "continent stamper" a given lua map script can use it or not
 	void DefaultContinentStamper();
 
@@ -398,6 +438,7 @@ protected:
 
 	TContainer<CvArea> m_areas;
 	TContainer<CvLandmass> m_landmasses;
+	TContainer<CvRiver> m_rivers;
 
 	//store non-zero values outside of CvPlot because it will be zero almost all the time
 	typedef map<int, vector<unsigned char>> PlotInvisibleVisibilityLookup;

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -43317,11 +43317,6 @@ bool CvPlayer::GetSameRouteBenefitFromTrait(const CvPlot* pPlot, RouteTypes eRou
 		if ((pPlot->getFeatureType() == FEATURE_FOREST || pPlot->getFeatureType() == FEATURE_JUNGLE) && (MOD_BALANCE_VP || pPlot->getTeam() == getTeam()))
 			return true;
 	}
-	else if (GetPlayerTraits()->IsRiverTradeRoad())
-	{
-		if (pPlot->isRiver())
-			return true;
-	}
 
 	return false;
 }

--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -231,6 +231,12 @@ void CvPlot::reset()
 	m_owningCityOverride.reset();
 
 	m_vExtraYields.clear();
+	m_vRivers.clear();
+
+	for (int iI = 0; iI < NUM_DIRECTION_TYPES; iI++)
+	{
+		m_vRivers.push_back(-1);
+	}
 
 	m_bfRevealed.ClearAll();
 
@@ -1407,6 +1413,15 @@ bool CvPlot::IsRiverSide(DirectionTypes eDirection) const
 		default:
 			return false;
 	}
+}
+
+//	--------------------------------------------------------------------------------
+/// Is there a river on this side of the plot?
+bool CvPlot::IsLakeSide(DirectionTypes eDirection) const
+{
+	CvAssertMsg(eDirection != NO_DIRECTION, "eDirection is not assigned a valid value");
+	CvPlot* pAdjacentPlot = plotDirection(getX(), getY(), eDirection);
+	return pAdjacentPlot && pAdjacentPlot->isLake();
 }
 
 //	--------------------------------------------------------------------------------
@@ -5563,6 +5578,44 @@ void CvPlot::setLandmass(int iNewValue)
 CvLandmass * CvPlot::landmass() const
 {
 	return GC.getMap().getLandmassById(m_iLandmass);
+}
+
+//	--------------------------------------------------------------------------------
+int CvPlot::GetRiverID(DirectionTypes eDirection) const
+{
+	return m_vRivers[eDirection];
+}
+
+//	--------------------------------------------------------------------------------
+void CvPlot::SetRiverID(DirectionTypes eDirection, int iRiverID)
+{
+	m_vRivers[eDirection] = iRiverID;
+}
+
+//	--------------------------------------------------------------------------------
+CvRiver* CvPlot::GetRiver(DirectionTypes eDirection) const
+{
+	return GC.getMap().GetRiverById(m_vRivers[eDirection]);
+}
+
+//	--------------------------------------------------------------------------------
+bool CvPlot::HasSharedRiver(const CvPlot* pOther) const
+{
+	for (int iI = 0; iI < NUM_DIRECTION_TYPES; iI++)
+	{
+		int iRiverID = GetRiverID((DirectionTypes)iI);
+		if (iRiverID != -1)
+		{
+			for (int iJ = 0; iJ < NUM_DIRECTION_TYPES; iJ++)
+			{
+				if (pOther->GetRiverID((DirectionTypes)iJ) == iRiverID)
+				{
+					return true;
+				}
+			}
+		}
+	}
+	return false;
 }
 
 //	--------------------------------------------------------------------------------
@@ -13206,6 +13259,7 @@ void CvPlot::Serialize(Plot& plot, Visitor& visitor)
 	visitor(plot.m_iRiverCrossingCount);
 	visitor(plot.m_iResourceNum);
 	visitor(plot.m_iLandmass);
+	visitor(plot.m_vRivers);
 
 	// Bit fields
 	{

--- a/CvGameCoreDLL_Expansion2/CvPlot.h
+++ b/CvGameCoreDLL_Expansion2/CvPlot.h
@@ -34,6 +34,7 @@
 
 class CvArea;
 class CvLandmass;
+class CvRiver;
 class CvRoute;
 
 typedef bool (*ConstPlotUnitFunc)(const CvUnit* pUnit, int iData1, int iData2);
@@ -148,6 +149,7 @@ public:
 	bool isRiverConnection(DirectionTypes eDirection) const;
 
 	bool IsRiverSide(DirectionTypes eDirection) const;
+	bool IsLakeSide(DirectionTypes eDirection) const;
 	bool IsAlongSameRiver(const CvPlot* pToPlot) const;
 
 	CvPlot* getNeighboringPlot(DirectionTypes eDirection) const;
@@ -341,6 +343,11 @@ public:
 	CvLandmass* landmass() const;
 	std::vector<int> getAllAdjacentLandmasses() const;
 	bool hasSharedAdjacentLandmass(const CvPlot* pOther, bool bAllowLand, bool bAllowWater) const;
+
+	int GetRiverID(DirectionTypes eDirection) const;
+	void SetRiverID(DirectionTypes eDirection, int iRiverID);
+	CvRiver* GetRiver(DirectionTypes eDirection) const;
+	bool HasSharedRiver(const CvPlot* pOther) const;
 
 	int getOwnershipDuration() const;
 	bool isOwnershipScore() const;
@@ -976,6 +983,8 @@ protected:
 	short m_iOwnershipDuration;
 	short m_iImprovementDuration;
 	short m_iUpgradeProgress;
+
+	std::vector<int> m_vRivers;
 
 	SYNC_ARCHIVE_MEMBER(CvPlot)
 	char /*FeatureTypes*/ m_eFeatureType; 

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -30559,7 +30559,7 @@ bool CvUnit::UnitRoadTo(int iX, int iY, int iFlags)
 
 	//ok apparently we both can move and need to move
 	//do not use the path cache here, the step finder tells us where to put the route
-	SPathFinderUserData data(getOwner(),PT_BUILD_ROUTE,NO_BUILD,eBestRoute,NO_ROUTE_PURPOSE);
+	SPathFinderUserData data(getOwner(),PT_BUILD_ROUTE,NO_BUILD,eBestRoute,NO_ROUTE_PURPOSE,false);
 	SPath path = GC.GetStepFinder().GetPath(getX(), getY(), iX, iY, data);
 
 	//index zero is the current plot!

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaGame.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaGame.cpp
@@ -3498,7 +3498,7 @@ int CvLuaGame::lGetLongestCityConnectionPlots(lua_State* L)
 		int iLoop1;
 		int iLoop2;
 
-		SPathFinderUserData data(ePlayer, PT_CITY_CONNECTION_LAND, NO_BUILD, ROUTE_RAILROAD, NO_ROUTE_PURPOSE);
+		SPathFinderUserData data(ePlayer, PT_CITY_CONNECTION_LAND, NO_BUILD, ROUTE_RAILROAD, NO_ROUTE_PURPOSE, true);
 
 		for (pFirstCity = GET_PLAYER(ePlayer).firstCity(&iLoop1); pFirstCity != NULL; pFirstCity = GET_PLAYER(ePlayer).nextCity(&iLoop1))
 		{

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlot.cpp
@@ -74,6 +74,7 @@ void CvLuaPlot::PushMethods(lua_State* L, int t)
 	Method(IsRiverSide);
 	Method(IsRiverConnection);
 	Method(IsRiverCrossingFlowClockwise);
+	Method(GetRiverID);
 
 	Method(GetNearestLandArea);
 	Method(SeeFromLevel);
@@ -631,6 +632,13 @@ int CvLuaPlot::lIsRiverCrossingFlowClockwise(lua_State* L)
 	lua_pushboolean(L, bResult);
 	return 1;
 }
+//------------------------------------------------------------------------------
+//int GetRiverID();
+int CvLuaPlot::lGetRiverID(lua_State* L)
+{
+	return BasicLuaMethod(L, &CvPlot::GetRiverID);
+}
+
 //------------------------------------------------------------------------------
 //int getNearestLandArea();
 int CvLuaPlot::lGetNearestLandArea(lua_State* L)

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlot.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlot.h
@@ -84,6 +84,7 @@ protected:
 	static int lIsRiverSide(lua_State* L);
 	static int lIsRiverConnection(lua_State* L);
 	static int lIsRiverCrossingFlowClockwise(lua_State* L);
+	static int lGetRiverID(lua_State* L);
 
 	static int lGetInlandCorner(lua_State* L);
 	static int lGetNearestLandArea(lua_State* L);


### PR DESCRIPTION
Also, river connection rework. City connection along rivers now functions more sensibly.

Lakes now also count as rivers for city connection purposes.

AI taught how to plan route both with and without rivers.

Add connection value from policies/traits in connection evaluation.