### PR TITLE
(7-49) All Civs Gain City Connections Along Rivers

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvAStar.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAStar.cpp
@@ -2046,30 +2046,24 @@ int InfluenceValid(const CvAStarNode* parent, const CvAStarNode* node, const SPa
 	return TRUE;
 }
 
-//	--------------------------------------------------------------------------------
-int CityConnectionGetExtraChildren(const CvAStarNode* node, const CvAStar* finder, vector<pair<int,int>>& out)
+static void AddCityConnectionHarborConnections(const CvPlot* pPlot, const CvAStar* finder, vector<pair<int, int>>& out)
 {
-	out.clear();
-
 	CvPlayerAI& kPlayer = GET_PLAYER(finder->GetData().ePlayer);
 	TeamTypes eTeam = kPlayer.getTeam();
-	CvPlot* pPlot = GC.getMap().plotCheckInvalid(node->m_iX, node->m_iY);
-	if (!pPlot)
-		return 0;
 
 	CvCity* pFirstCity = pPlot->getPlotCity();
 
 	// if there isn't a city there or the city isn't on our team
 	if (!pFirstCity || pFirstCity->getTeam() != eTeam)
-		return 0;
+		return;
 
 	// if the city is being razed
 	if (pFirstCity->IsRazing())
-		return 0;
+		return;
 
 	RouteTypes eRoute = finder->GetData().eRoute;
 	if (eRoute == NO_ROUTE)
-		return 0;
+		return;
 
 	int iCityConnectionMask = CvCityConnections::CONNECTION_HARBOR;
 	if (MOD_BALANCE_VP)
@@ -2085,7 +2079,7 @@ int CityConnectionGetExtraChildren(const CvAStarNode* node, const CvAStar* finde
 	}
 
 	const CvCityConnections::SingleCityConnectionStore& cityConnections = kPlayer.GetCityConnections()->GetDirectConnectionsFromCity(pFirstCity);
-	for (CvCityConnections::SingleCityConnectionStore::const_iterator it=cityConnections.begin(); it!=cityConnections.end(); ++it)
+	for (CvCityConnections::SingleCityConnectionStore::const_iterator it = cityConnections.begin(); it != cityConnections.end(); ++it)
 	{
 		//we only care about water and air connections here because they are not normal routes
 		if (it->second & iCityConnectionMask)
@@ -2095,6 +2089,74 @@ int CityConnectionGetExtraChildren(const CvAStarNode* node, const CvAStar* finde
 				out.push_back(make_pair(pSecondCity->getX(), pSecondCity->getY()));
 		}
 	}
+}
+
+static void AddCityConnectionRiverConnections(CvPlot* pPlot, const CvAStar* finder, vector<pair<int, int>>& out)
+{
+	if (!MOD_BALANCE_VP)
+		return;
+
+	RouteTypes eRoute = finder->GetData().eRoute;
+	if (eRoute != ROUTE_ROAD && eRoute != ROUTE_ANY)
+		return;
+
+	if (!pPlot->isFreshWater())
+		return;
+
+	bool bIsForRoadBuilding = finder->GetData().ePath == PT_BUILD_ROUTE || finder->GetData().ePath == PT_BUILD_ROUTE_MIXED;
+
+	if (!bIsForRoadBuilding && (pPlot->getRouteType() == NO_ROUTE || pPlot->IsRoutePillaged()))
+		return;
+
+	for (int iI = 0; iI < NUM_DIRECTION_TYPES; iI++)
+	{
+		int iRiverID = pPlot->GetRiverID((DirectionTypes)iI);
+		if (iRiverID == -1)
+			continue;
+
+		CvRiver* pRiver = GC.getMap().GetRiverById(iRiverID);
+		if (!pRiver)
+			continue;
+
+		std::vector<CvPlot*> pRiverPlots = pRiver->GetPlots();
+		for (std::vector<CvPlot*>::const_iterator it = pRiverPlots.begin(); it != pRiverPlots.end(); ++it)
+		{
+			CvPlot* pRiverPlot = *it;
+
+			if (!bIsForRoadBuilding && (pPlot->getRouteType() == NO_ROUTE || pPlot->IsRoutePillaged()))
+				continue;
+
+			if (pRiverPlot != pPlot && plotDistance(*pPlot, *pRiverPlot) >= 2)
+				out.push_back(make_pair(pRiverPlot->getX(), pRiverPlot->getY()));
+		}
+	}
+}
+
+//	--------------------------------------------------------------------------------
+int CityConnectionGetExtraChildren(const CvAStarNode* node, const CvAStar* finder, vector<pair<int,int>>& out)
+{
+	out.clear();
+
+	CvPlot* pPlot = GC.getMap().plotCheckInvalid(node->m_iX, node->m_iY);
+	if (!pPlot)
+		return 0;
+
+	AddCityConnectionHarborConnections(pPlot, finder, out);
+	AddCityConnectionRiverConnections(pPlot, finder, out);
+
+	return (int)out.size();
+}
+
+//	--------------------------------------------------------------------------------
+int CityConnectionLandGetExtraChildren(const CvAStarNode* node, const CvAStar* finder, vector<pair<int, int>>& out)
+{
+	out.clear();
+
+	CvPlot* pPlot = GC.getMap().plotCheckInvalid(node->m_iX, node->m_iY);
+	if (!pPlot)
+		return 0;
+
+	AddCityConnectionRiverConnections(pPlot, finder, out);
 
 	return (int)out.size();
 }
@@ -2119,9 +2181,6 @@ int CityConnectionLandValid(const CvAStarNode* parent, const CvAStarNode* node, 
 
 	if(ePlotRoute == NO_ROUTE)
 	{
-		//what else can count as road depends on the player type
-		if(kPlayer.GetPlayerTraits()->IsRiverTradeRoad() && pNewPlot->isRiver())
-			ePlotRoute = ROUTE_ROAD;
 		if (kPlayer.GetPlayerTraits()->IsWoodlandMovementBonus() && (pNewPlot->getFeatureType() == FEATURE_FOREST || pNewPlot->getFeatureType() == FEATURE_JUNGLE))
 		{
 			//balance patch does not require plot ownership
@@ -2304,7 +2363,7 @@ int BuildRouteCost(const CvAStarNode* /*parent*/, const CvAStarNode* node, const
 	else if (pPlot->getRouteType() >= ROUTE_ROAD || pPlayer->GetSameRouteBenefitFromTrait(pPlot, ROUTE_ROAD) || pPlot->IsRoutePillaged())
 	{
 		// if there is already any kind of road here, provide a smaller discount
-		iCost = PATH_BASE_COST - 1;
+		iCost = (PATH_BASE_COST * 10) / 12;
 	}
 	else
 	{
@@ -2350,7 +2409,7 @@ int BuildRouteValid(const CvAStarNode* parent, const CvAStarNode* node, const SP
 	if(pNewPlot->isWater())
 		return FALSE;
 
-	if(!pNewPlot->isValidMovePlot(ePlayer))
+	if(!pNewPlot->isValidMovePlot(ePlayer) && (!pNewPlot->isMountain() || !kPlayer.IsWorkersIgnoreImpassable()))
 		return FALSE;
 
 	if (pNewPlot->GetPlannedRouteState(ePlayer) == ROAD_PLANNING_EXCLUDE && !pNewPlot->isCity())
@@ -2754,7 +2813,7 @@ bool CvStepFinder::Configure(const SPathFinderUserData& config)
 		m_iBasicPlotCost = PATH_BASE_COST;
 		break;
 	case PT_BUILD_ROUTE:
-		SetFunctionPointers(NULL, NULL, BuildRouteCost, BuildRouteValid, NULL, NULL, NULL);
+		SetFunctionPointers(NULL, NULL, BuildRouteCost, BuildRouteValid, config.bUseRivers ? CityConnectionLandGetExtraChildren : NULL, NULL, NULL);
 		m_iBasicPlotCost = PATH_BASE_COST;
 		break;
 	case PT_BUILD_ROUTE_MIXED:
@@ -2774,7 +2833,7 @@ bool CvStepFinder::Configure(const SPathFinderUserData& config)
 		m_iBasicPlotCost = PATH_BASE_COST;
 		break;
 	case PT_CITY_CONNECTION_LAND:
-		SetFunctionPointers(NULL, StepHeuristic, NULL, CityConnectionLandValid, NULL, NULL, NULL);
+		SetFunctionPointers(NULL, StepHeuristic, NULL, CityConnectionLandValid, config.bUseRivers ? CityConnectionLandGetExtraChildren : NULL, NULL, NULL);
 		m_iBasicPlotCost = PATH_BASE_COST;
 		break;
 	case PT_CITY_CONNECTION_WATER:
@@ -3684,7 +3743,7 @@ bool IsPlotConnectedToPlot(PlayerTypes ePlayer, CvPlot* pFromPlot, CvPlot* pToPl
 	if (ePlayer==NO_PLAYER || pFromPlot==NULL || pToPlot==NULL)
 		return false;
 
-	SPathFinderUserData data(ePlayer, bAllowHarbors ? PT_CITY_CONNECTION_MIXED : PT_CITY_CONNECTION_LAND, NO_BUILD, eRestrictRoute, NO_ROUTE_PURPOSE);
+	SPathFinderUserData data(ePlayer, bAllowHarbors ? PT_CITY_CONNECTION_MIXED : PT_CITY_CONNECTION_LAND, NO_BUILD, eRestrictRoute, NO_ROUTE_PURPOSE, true);
 	data.iFlags = bAssumeOpenBorders ? CvUnit::MOVEFLAG_IGNORE_RIGHT_OF_PASSAGE : 0; //slight misuse but who cares
 
 	SPath result;
@@ -3711,6 +3770,7 @@ SPathFinderUserData::SPathFinderUserData(const CvUnit* pUnit, int _iFlags, int _
 	iMinMovesLeft = 0;
 	iStartMoves = pUnit ? pUnit->getMoves() : 0;
 	eRoutePurpose = NO_ROUTE_PURPOSE;
+	bUseRivers = false;
 }
 
 //	---------------------------------------------------------------------------
@@ -3729,6 +3789,7 @@ SPathFinderUserData::SPathFinderUserData(PlayerTypes _ePlayer, PathType _ePathTy
 	iMinMovesLeft = 0;
 	iStartMoves = 0;
 	eRoutePurpose = NO_ROUTE_PURPOSE;
+	bUseRivers = false;
 }
 
 //	---------------------------------------------------------------------------
@@ -3747,6 +3808,7 @@ SPathFinderUserData::SPathFinderUserData(PlayerTypes _ePlayer, PathType _ePathTy
 	iMinMovesLeft = 0;
 	iStartMoves = 0;
 	eRoutePurpose = NO_ROUTE_PURPOSE;
+	bUseRivers = false;
 }
 
 //	---------------------------------------------------------------------------
@@ -3765,11 +3827,12 @@ SPathFinderUserData::SPathFinderUserData(PlayerTypes _ePlayer, PathType _ePathTy
 	iMinMovesLeft = 0;
 	iStartMoves = 0;
 	eRoutePurpose = NO_ROUTE_PURPOSE;
+	bUseRivers = false;
 }
 
 //	---------------------------------------------------------------------------
 //convenience constructor
-SPathFinderUserData::SPathFinderUserData(PlayerTypes _ePlayer, PathType _ePathType, BuildTypes _eBuildType, RouteTypes _eRouteType, RoutePurpose _eRoutePurpose)
+SPathFinderUserData::SPathFinderUserData(PlayerTypes _ePlayer, PathType _ePathType, BuildTypes _eBuildType, RouteTypes _eRouteType, RoutePurpose _eRoutePurpose, bool _bUseRivers)
 {
 	ePath = _ePathType;
 	iFlags = 0;
@@ -3783,6 +3846,7 @@ SPathFinderUserData::SPathFinderUserData(PlayerTypes _ePlayer, PathType _ePathTy
 	iMinMovesLeft = 0;
 	iStartMoves = 0;
 	eRoutePurpose = _eRoutePurpose;
+	bUseRivers = _bUseRivers;
 }
 
 CvPlot * SPath::get(int i) const

--- a/CvGameCoreDLL_Expansion2/CvAStar.h
+++ b/CvGameCoreDLL_Expansion2/CvAStar.h
@@ -324,6 +324,7 @@ int StepCost(const CvAStarNode* parent, const CvAStarNode* node, const SPathFind
 
 int CityConnectionLandValid(const CvAStarNode* parent, const CvAStarNode* node, const SPathFinderUserData& data, const CvAStar* finder);
 int CityConnectionGetExtraChildren(const CvAStarNode* node, const CvAStar* finder, vector<pair<int,int>>& out);
+int CityConnectionLandGetExtraChildren(const CvAStarNode* node, const CvAStar* finder, vector<pair<int, int>>& out);
 int CityConnectionWaterValid(const CvAStarNode* parent, const CvAStarNode* node, const SPathFinderUserData& data, const CvAStar* finder);
 
 int AreaValid(const CvAStarNode* parent, const CvAStarNode* node, const SPathFinderUserData& data, const CvAStar* finder);

--- a/CvGameCoreDLL_Expansion2/CvAStarNode.h
+++ b/CvGameCoreDLL_Expansion2/CvAStarNode.h
@@ -141,7 +141,7 @@ struct SPathFinderUserData
 	SPathFinderUserData(PlayerTypes ePlayer, PathType ePathType); // PT_TRADE_WATER, PT_TRADE_LAND, PT_LANDMASS_CONNECTION, PT_CITY_CONNECTION_WATER
 	SPathFinderUserData(PlayerTypes ePlayer, PathType ePathType, int iMaxTurns); // PT_AREA_CONNECTION (iMaxTurns is simple vs complex check (0/1)), PT_CITY_INFLUENCE
 	SPathFinderUserData(PlayerTypes ePlayer, PathType ePathType, PlayerTypes eEnemy, int iMaxTurns); // PT_GENERIC_SAME_AREA, PT_GENERIC_SAME_AREA_WIDE, PT_ARMY_LAND, PT_ARMY_WATER, PT_ARMY_MIXED
-	SPathFinderUserData(PlayerTypes ePlayer, PathType ePathType, BuildTypes eBuildType, RouteTypes eRouteType, RoutePurpose eRoutePurpose); // PT_BUILD_ROUTE, PT_BUILD_ROUTE_MIXED, PT_CITY_CONNECTION_LAND, PT_CITY_CONNECTION_MIXED
+	SPathFinderUserData(PlayerTypes ePlayer, PathType ePathType, BuildTypes eBuildType, RouteTypes eRouteType, RoutePurpose eRoutePurpose, bool bUseRivers); // PT_BUILD_ROUTE, PT_BUILD_ROUTE_MIXED, PT_CITY_CONNECTION_LAND, PT_CITY_CONNECTION_MIXED
 
 	//do not compare max turns and max cost ...
 	bool operator==(const SPathFinderUserData& rhs) const 
@@ -152,6 +152,7 @@ struct SPathFinderUserData
 	RouteTypes			eRoute;
 	BuildTypes			eBuild;             //BuildType related to the RouteType
 	RoutePurpose		eRoutePurpose;
+	bool                bUseRivers;
 	int					iFlags;				//see CvUnit::MOVEFLAG*
 	PlayerTypes			ePlayer;			//optional
 	PlayerTypes			eEnemy;

--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
@@ -490,7 +490,7 @@ void CvBuilderTaskingAI::GetPathValues(const SPath& path, RouteTypes eRoute, int
 		iMovementUsedBackwardsWithoutRoute += min(iMoveDenominator * 2, aiMovingBackwardCostsWithoutRoute[iI]);
 	}
 
-	iMovementBonus = ((iMovementUsedForwardsWithoutRoute + iMovementUsedBackwardsWithoutRoute) / (iMovementUsedForwardsWithRoute + iMovementUsedBackwardsWithRoute)) * 300;
+	iMovementBonus = ((iMovementUsedForwardsWithoutRoute + iMovementUsedBackwardsWithoutRoute + 1) / (iMovementUsedForwardsWithRoute + iMovementUsedBackwardsWithRoute + 1)) * 300;
 }
 
 pair<int, int> CvBuilderTaskingAI::GetPlotPair(int iPlotId1, int iPlotId2)
@@ -501,7 +501,7 @@ pair<int, int> CvBuilderTaskingAI::GetPlotPair(int iPlotId1, int iPlotId2)
 		return make_pair(iPlotId2, iPlotId1);
 }
 
-void CvBuilderTaskingAI::AddRoutePlots(CvPlot* pStartPlot, CvPlot* pTargetPlot, RouteTypes eRoute, int iValue, const SPath& path, RoutePurpose ePurpose)
+void CvBuilderTaskingAI::AddRoutePlots(CvPlot* pStartPlot, CvPlot* pTargetPlot, RouteTypes eRoute, int iValue, const SPath& path, RoutePurpose ePurpose, bool bUseRivers)
 {
 	vector<int> routePlots;
 
@@ -542,7 +542,7 @@ void CvBuilderTaskingAI::AddRoutePlots(CvPlot* pStartPlot, CvPlot* pTargetPlot, 
 				if (routePlots.size() != 0)
 				{
 					plotPair = GetPlotPair(pStartPlot->GetPlotIndex(), pPlot->GetPlotIndex());
-					plannedRoute = make_pair(plotPair, eRoute);
+					plannedRoute = make_pair(plotPair, make_pair(eRoute, bUseRivers));
 
 					if (ePurpose == PURPOSE_CONNECT_CAPITAL)
 						m_plannedRouteAdditiveValues[plannedRoute] += iValue;
@@ -565,7 +565,7 @@ void CvBuilderTaskingAI::AddRoutePlots(CvPlot* pStartPlot, CvPlot* pTargetPlot, 
 	if (routePlots.size() != 0)
 	{
 		plotPair = GetPlotPair(pStartPlot->GetPlotIndex(), pTargetPlot->GetPlotIndex());
-		plannedRoute = make_pair(plotPair, eRoute);
+		plannedRoute = make_pair(plotPair, make_pair(eRoute, bUseRivers));
 
 		if (ePurpose == PURPOSE_CONNECT_CAPITAL)
 			m_plannedRouteAdditiveValues[plannedRoute] += iValue;
@@ -596,6 +596,18 @@ static int GetCapitalConnectionValue(CvPlayer* pPlayer, CvCity* pCity, RouteType
 	}
 	int iCityConnectionFlatValueTimes100 = pPlayer->GetTreasury()->GetCityConnectionRouteGoldTimes100(pCity);
 	iConnectionValue += iCityConnectionFlatValueTimes100;
+	int iGoldYieldBaseModifierTimes100 = GetYieldBaseModifierTimes100(YIELD_GOLD);
+
+	for (int iI = 0; iI <= YIELD_FAITH; iI++)
+	{
+		YieldTypes eYield = (YieldTypes)iI;
+		int iEra = pPlayer->GetCurrentEra();
+		if (iEra <= 0)
+			iEra = 1;
+		int iYieldModifier = GetYieldBaseModifierTimes100(eYield);
+		iConnectionValue += (100 * pPlayer->GetYieldChangeTradeRoute(eYield) * iYieldModifier) / iGoldYieldBaseModifierTimes100;
+		iConnectionValue += (100 * pPlayer->GetPlayerTraits()->GetYieldChangeTradeRoute(eYield) * iEra * iYieldModifier) / iGoldYieldBaseModifierTimes100;
+	}
 
 	if (GC.getGame().GetIndustrialRoute() == eRoute)
 	{
@@ -607,7 +619,6 @@ static int GetCapitalConnectionValue(CvPlayer* pPlayer, CvCity* pCity, RouteType
 
 		if (MOD_BALANCE_VP)
 		{
-			int iGoldYieldBaseModifierTimes100 = GetYieldBaseModifierTimes100(YIELD_GOLD);
 			int iGoldYieldTimes100 = pCity->getBasicYieldRateTimes100(YIELD_GOLD);
 			int iGoldYieldRateModifierTimes100 = 0;
 
@@ -655,8 +666,10 @@ void CvBuilderTaskingAI::ConnectCitiesToCapital(CvCity* pPlayerCapital, CvCity* 
 		return;
 	}
 
+	bool bUseRivers = eRoute == ROUTE_ROAD;
+
 	// build a path between the two cities using harbors (shortcut routes are handled in the shortcut function)
-	SPathFinderUserData data(m_pPlayer->GetID(),PT_BUILD_ROUTE_MIXED,eBuild,eRoute,PURPOSE_CONNECT_CAPITAL);
+	SPathFinderUserData data(m_pPlayer->GetID(), PT_BUILD_ROUTE_MIXED, eBuild, eRoute, PURPOSE_CONNECT_CAPITAL, bUseRivers);
 	SPath path = GC.GetStepFinder().GetPath(pPlayerCapital->getX(), pPlayerCapital->getY(), pTargetCity->getX(), pTargetCity->getY(), data);
 
 	if(!path)
@@ -701,7 +714,7 @@ void CvBuilderTaskingAI::ConnectCitiesToCapital(CvCity* pPlayerCapital, CvCity* 
 
 	iConnectionValue -= iNumRoadsNeededToBuild * 10;
 
-	AddRoutePlots(pPlayerCapital->plot(), pTargetCity->plot(), eRoute, iConnectionValue, path, PURPOSE_CONNECT_CAPITAL);
+	AddRoutePlots(pPlayerCapital->plot(), pTargetCity->plot(), eRoute, iConnectionValue, path, PURPOSE_CONNECT_CAPITAL, bUseRivers);
 }
 
 void CvBuilderTaskingAI::ConnectCitiesForShortcuts(CvCity* pCity1, CvCity* pCity2, BuildTypes eBuild, RouteTypes eRoute)
@@ -723,13 +736,21 @@ void CvBuilderTaskingAI::ConnectCitiesForShortcuts(CvCity* pCity1, CvCity* pCity
 	if (!pRouteInfo)
 		return;
 
+	ShortcutConnectionHelper(pCity1, pCity2, eBuild, eRoute, iPlotDistance, false);
+	if (MOD_BALANCE_VP && eRoute == ROUTE_ROAD)
+		ShortcutConnectionHelper(pCity1, pCity2, eBuild, eRoute, iPlotDistance, true);
+}
+
+void CvBuilderTaskingAI::ShortcutConnectionHelper(CvCity* pCity1, CvCity* pCity2, BuildTypes eBuild, RouteTypes eRoute, int iPlotDistance, bool bUseRivers)
+{
+
 	// build a path between the two cities - this will tend to re-use existing routes, unless the new path is much shorter
-	SPathFinderUserData data(m_pPlayer->GetID(),PT_BUILD_ROUTE,eBuild,eRoute,PURPOSE_SHORTCUT);
+	SPathFinderUserData data(m_pPlayer->GetID(), PT_BUILD_ROUTE, eBuild, eRoute, PURPOSE_SHORTCUT, bUseRivers);
 	data.iMaxTurns = iPlotDistance * 2;
 	SPath path = GC.GetStepFinder().GetPath(pCity1->getX(), pCity1->getY(), pCity2->getX(), pCity2->getY(), data);
 
 	// cities are not on the same landmass? then give up
-	if(!path)
+	if (!path)
 		return;
 
 	// go through the route to see how long it is and how many plots already have roads
@@ -752,7 +773,7 @@ void CvBuilderTaskingAI::ConnectCitiesForShortcuts(CvCity* pCity1, CvCity* pCity
 
 	iValue -= iNumRoadsNeededToBuild * 10;
 
-	AddRoutePlots(pCity1->plot(), pCity2->plot(), eRoute, iValue, path, PURPOSE_SHORTCUT);
+	AddRoutePlots(pCity1->plot(), pCity2->plot(), eRoute, iValue, path, PURPOSE_SHORTCUT, bUseRivers);
 }
 
 void CvBuilderTaskingAI::ConnectPointsForStrategy(CvCity* pOriginCity, CvPlot* pTargetPlot, BuildTypes eBuild, RouteTypes eRoute)
@@ -779,7 +800,7 @@ void CvBuilderTaskingAI::ConnectPointsForStrategy(CvCity* pOriginCity, CvPlot* p
 		return;
 
 	// build a path between the two cities
-	SPathFinderUserData data(m_pPlayer->GetID(), PT_BUILD_ROUTE, eBuild, eRoute, PURPOSE_STRATEGIC);
+	SPathFinderUserData data(m_pPlayer->GetID(), PT_BUILD_ROUTE, eBuild, eRoute, PURPOSE_STRATEGIC, false);
 	data.iMaxTurns = iPlotDistance * 2;
 	SPath path = GC.GetStepFinder().GetPath(pOriginCity->getX(), pOriginCity->getY(), pTargetPlot->getX(), pTargetPlot->getY(), data);
 
@@ -802,7 +823,7 @@ void CvBuilderTaskingAI::ConnectPointsForStrategy(CvCity* pOriginCity, CvPlot* p
 
 	iValue -= iNumRoadsNeededToBuild * 10;
 
-	AddRoutePlots(pOriginCity->plot(), pTargetPlot, eRoute, iValue, path, PURPOSE_STRATEGIC);
+	AddRoutePlots(pOriginCity->plot(), pTargetPlot, eRoute, iValue, path, PURPOSE_STRATEGIC, false);
 }
 
 void CvBuilderTaskingAI::ConnectCitiesForScenario(CvCity* pCity1, CvCity* pCity2, BuildTypes eBuild, RouteTypes eRoute)
@@ -816,14 +837,14 @@ void CvBuilderTaskingAI::ConnectCitiesForScenario(CvCity* pCity1, CvCity* pCity2
 		return;
 
 	// build a path between the two cities
-	SPathFinderUserData data(m_pPlayer->GetID(), PT_BUILD_ROUTE, eBuild, eRoute, PURPOSE_SHORTCUT);
+	SPathFinderUserData data(m_pPlayer->GetID(), PT_BUILD_ROUTE, eBuild, eRoute, PURPOSE_SHORTCUT, false);
 	SPath path = GC.GetStepFinder().GetPath(pCity1->getX(), pCity1->getY(), pCity2->getX(), pCity2->getY(), data);
 
 	//  if no path, then bail!
 	if (!path)
 		return;
 
-	AddRoutePlots(pCity1->plot(), pCity2->plot(), eRoute, 100, path, PURPOSE_SHORTCUT);
+	AddRoutePlots(pCity1->plot(), pCity2->plot(), eRoute, 100, path, PURPOSE_SHORTCUT, false);
 }
 
 pair<RouteTypes, int> CvBuilderTaskingAI::GetBestRouteTypeAndValue(const CvPlot* pPlot) const
@@ -887,7 +908,7 @@ bool CvBuilderTaskingAI::IsRoutePlanned(CvPlot* pPlot, RouteTypes eRoute, RouteP
 
 int CvBuilderTaskingAI::GetRouteBuildTime(PlannedRoute plannedRoute, const CvUnit* pUnit) const
 {
-	RouteTypes eRoute = plannedRoute.second;
+	RouteTypes eRoute = plannedRoute.second.first;
 	
 	map<PlannedRoute, vector<int>>::const_iterator it = m_plannedRoutePlots.find(plannedRoute);
 	if (it == m_plannedRoutePlots.end())
@@ -932,21 +953,19 @@ int CvBuilderTaskingAI::GetTotalRouteBuildTime(const CvUnit* pUnit, const CvPlot
 	return GetRouteBuildTime(it->second, pUnit);
 }
 
-int CvBuilderTaskingAI::GetRouteCompletionTimes100(PlannedRoute plannedRoute) const
+int CvBuilderTaskingAI::GetRouteMissingTiles(PlannedRoute plannedRoute) const
 {
-	RouteTypes eRoute = plannedRoute.second;
+	RouteTypes eRoute = plannedRoute.second.first;
 
 	map<PlannedRoute, vector<int>>::const_iterator it = m_plannedRoutePlots.find(plannedRoute);
 	if (it == m_plannedRoutePlots.end())
 		return 0;
 
-	int iLength = 0;
-	int iIncomplete = 0;
+	int iMissing = 0;
 
 	for (vector<int>::const_iterator it2 = it->second.begin(); it2 != it->second.end(); ++it2)
 	{
 		CvPlot* pPlot = GC.getMap().plotByIndexUnchecked(*it2);
-		iLength++;
 
 		if (!pPlot)
 			continue;
@@ -957,10 +976,10 @@ int CvBuilderTaskingAI::GetRouteCompletionTimes100(PlannedRoute plannedRoute) co
 		if (pPlot->getRouteType() >= eRoute && !pPlot->IsRoutePillaged())
 			continue;
 
-		iIncomplete++;
+		iMissing++;
 	}
 
-	return ((iLength - iIncomplete) * 100) / iLength;
+	return iMissing;
 }
 
 bool CvBuilderTaskingAI::WillNeverBuildVillageOnPlot(CvPlot* pPlot, RouteTypes eRoute, bool bIgnoreUnowned) const
@@ -1540,45 +1559,51 @@ vector<OptionWithScore<BuilderDirective>> CvBuilderTaskingAI::GetRouteDirectives
 {
 	vector<OptionWithScore<BuilderDirective>> aDirectives;
 
-	map<PlotPair, map<RouteTypes, pair<int, int>>> plannedRouteTypeValues;
+	map<PlotPair, map<pair<RouteTypes, bool>, pair<int, int>>> plannedRouteTypeValues;
 
 	// Loop through all planned routes and calculate the additive and non-additive values for them
 	for (map<PlannedRoute, RoutePurpose>::const_iterator it = m_plannedRoutePurposes.begin(); it != m_plannedRoutePurposes.end(); ++it)
 	{
 		PlannedRoute plannedRoute = it->first;
 		PlotPair plotPair = plannedRoute.first;
-		RouteTypes eRoute = plannedRoute.second;
+		RouteTypes eRoute = plannedRoute.second.first;
+		bool bUseRivers = plannedRoute.second.second;
 
 		int iAdditiveValue = m_plannedRouteAdditiveValues[plannedRoute];
 		int iNonAdditiveValue = m_plannedRouteNonAdditiveValues[plannedRoute];
 
 		if (iAdditiveValue > 0 || iNonAdditiveValue > 0)
 		{
-			pair<int, int> oldValues = plannedRouteTypeValues[plotPair][eRoute];
-			plannedRouteTypeValues[plotPair][eRoute] = make_pair(oldValues.first + iAdditiveValue, max(oldValues.second, iNonAdditiveValue));
+			pair<int, int> oldValues = plannedRouteTypeValues[plotPair][make_pair(eRoute, bUseRivers)];
+			plannedRouteTypeValues[plotPair][make_pair(eRoute, bUseRivers)] = make_pair(oldValues.first + iAdditiveValue, max(oldValues.second, iNonAdditiveValue));
 		}
 	}
 
 	map<PlotPair, pair<int, int>> bestRouteValues;
-	map<PlotPair, RouteTypes> bestRouteType;
+	map<PlotPair, pair<RouteTypes, bool>> bestRouteType;
 
 	// Loop through each pair of terminal plots and find the best route type and build value for this particular plot pair
-	for (map<PlotPair, map<RouteTypes, pair<int, int>>>::const_iterator it = plannedRouteTypeValues.begin(); it != plannedRouteTypeValues.end(); ++it)
+	for (map<PlotPair, map<pair<RouteTypes, bool>, pair<int, int>>>::const_iterator it = plannedRouteTypeValues.begin(); it != plannedRouteTypeValues.end(); ++it)
 	{
 		PlotPair plotPair = it->first;
 
-		int iRoadValue = plannedRouteTypeValues[plotPair][ROUTE_ROAD].first + plannedRouteTypeValues[plotPair][ROUTE_ROAD].second;
-		int iRailroadValue = plannedRouteTypeValues[plotPair][ROUTE_RAILROAD].first + plannedRouteTypeValues[plotPair][ROUTE_RAILROAD].second;
+		PlannedRoute plannedRouteRoadNoRivers = make_pair(plotPair, make_pair(ROUTE_ROAD, false));
+		PlannedRoute plannedRouteRoadWithRivers = make_pair(plotPair, make_pair(ROUTE_ROAD, true));
+		PlannedRoute plannedRouteRailroad = make_pair(plotPair, make_pair(ROUTE_RAILROAD, false));
+
+		int iRoadValueNoRivers = plannedRouteTypeValues[plotPair][plannedRouteRoadNoRivers.second].first + plannedRouteTypeValues[plotPair][plannedRouteRoadNoRivers.second].second;
+		int iRoadValueWithRivers = plannedRouteTypeValues[plotPair][plannedRouteRoadWithRivers.second].first + plannedRouteTypeValues[plotPair][plannedRouteRoadWithRivers.second].second;
+		int iRailroadValue = plannedRouteTypeValues[plotPair][plannedRouteRailroad.second].first + plannedRouteTypeValues[plotPair][plannedRouteRailroad.second].second;
 
 		int iRoadTotalMaintenance = 0;
-		if (iRoadValue > 0)
+		if (iRoadValueNoRivers > 0)
 		{
 			// If the road is completed, increase its value
-			iRoadValue += (iRoadValue * GetRouteCompletionTimes100(make_pair(plotPair, ROUTE_ROAD))) / 400;
+			iRoadValueNoRivers += iRoadValueNoRivers / (4 * (GetRouteMissingTiles(plannedRouteRoadNoRivers) + 1));
 
 			int iRoadMaintenance = GC.getRouteInfo(ROUTE_ROAD)->GetGoldMaintenance() * (100 + m_pPlayer->GetImprovementGoldMaintenanceMod());
 
-			vector<int> plannedRoadPlots = m_plannedRoutePlots[make_pair(plotPair, ROUTE_ROAD)];
+			vector<int> plannedRoadPlots = m_plannedRoutePlots[plannedRouteRoadNoRivers];
 
 			// Need to recompute road maintenance length because we don't store it
 			int iRoadMaintenanceTiles = 0;
@@ -1590,31 +1615,54 @@ vector<OptionWithScore<BuilderDirective>> CvBuilderTaskingAI::GetRouteDirectives
 			}
 
 			iRoadTotalMaintenance = iRoadMaintenanceTiles * iRoadMaintenance;
-			iRoadValue -= iRoadTotalMaintenance;
+			iRoadValueNoRivers -= iRoadTotalMaintenance;
+		}
+
+		if (iRoadValueWithRivers > 0)
+		{
+			// If the road is completed, increase its value
+			iRoadValueWithRivers += iRoadValueWithRivers / (4 * (GetRouteMissingTiles(plannedRouteRoadWithRivers) + 1));
+
+			int iRoadMaintenance = GC.getRouteInfo(ROUTE_ROAD)->GetGoldMaintenance() * (100 + m_pPlayer->GetImprovementGoldMaintenanceMod());
+
+			vector<int> plannedRoadPlots = m_plannedRoutePlots[plannedRouteRoadWithRivers];
+
+			// Need to recompute road maintenance length because we don't store it
+			int iRoadMaintenanceTiles = 0;
+			for (vector<int>::const_iterator it2 = plannedRoadPlots.begin(); it2 != plannedRoadPlots.end(); ++it2)
+			{
+				CvPlot* pPlot = GC.getMap().plotByIndexUnchecked(*it2);
+				if (!m_pPlayer->GetSameRouteBenefitFromTrait(pPlot, ROUTE_ROAD))
+					iRoadMaintenanceTiles++;
+			}
+
+			iRoadTotalMaintenance = iRoadMaintenanceTiles * iRoadMaintenance;
+			iRoadValueWithRivers -= iRoadTotalMaintenance;
 		}
 
 		int iRailroadTotalMaintenance = 0;
 		if (iRailroadValue > 0)
 		{
 			// If the railroad is completed, increase its value
-			iRailroadValue += (iRailroadValue * GetRouteCompletionTimes100(make_pair(plotPair, ROUTE_RAILROAD))) / 400;
+			iRailroadValue += iRailroadValue / (4 * (GetRouteMissingTiles(plannedRouteRailroad) + 1));
 
 			int iRailroadMaintenance = GC.getRouteInfo(ROUTE_RAILROAD)->GetGoldMaintenance() * (100 + m_pPlayer->GetImprovementGoldMaintenanceMod());
-			iRailroadTotalMaintenance = m_plannedRoutePlots[make_pair(plotPair, ROUTE_RAILROAD)].size() * iRailroadMaintenance;
+			iRailroadTotalMaintenance = m_plannedRoutePlots[plannedRouteRailroad].size() * iRailroadMaintenance;
 			iRailroadValue -= iRailroadTotalMaintenance;
 		}
 
-		if (iRoadValue > 0 || iRailroadValue > 0)
+		if (iRoadValueNoRivers > 0 || iRoadValueWithRivers > 0 || iRailroadValue > 0)
 		{
-			if (iRoadValue > iRailroadValue)
+			if (iRoadValueNoRivers > iRailroadValue || iRoadValueWithRivers > iRailroadValue)
 			{
-				bestRouteType[plotPair] = ROUTE_ROAD;
-				bestRouteValues[plotPair] = plannedRouteTypeValues[plotPair][ROUTE_ROAD];
+				bool bUseRivers = iRoadValueWithRivers >= iRoadValueNoRivers;
+				bestRouteType[plotPair] = make_pair(ROUTE_ROAD, bUseRivers);
+				bestRouteValues[plotPair] = plannedRouteTypeValues[plotPair][make_pair(ROUTE_ROAD, bUseRivers)];
 			}
 			else
 			{
-				bestRouteType[plotPair] = ROUTE_RAILROAD;
-				bestRouteValues[plotPair] = plannedRouteTypeValues[plotPair][ROUTE_RAILROAD];
+				bestRouteType[plotPair] = make_pair(ROUTE_RAILROAD, false);
+				bestRouteValues[plotPair] = plannedRouteTypeValues[plotPair][make_pair(ROUTE_RAILROAD, false)];
 			}
 		}
 	}
@@ -1629,8 +1677,9 @@ vector<OptionWithScore<BuilderDirective>> CvBuilderTaskingAI::GetRouteDirectives
 	{
 		PlotPair plotPair = it->first;
 		pair<int, int> newValues = it->second;
-		RouteTypes eRoute = bestRouteType[plotPair];
-		PlannedRoute plannedRoute = make_pair(plotPair, eRoute);
+		pair<RouteTypes, bool> routeTypeAndRiver = bestRouteType[plotPair];
+		RouteTypes eRoute = routeTypeAndRiver.first;
+		PlannedRoute plannedRoute = make_pair(plotPair, routeTypeAndRiver);
 
 		vector<int> plots = m_plannedRoutePlots.find(plannedRoute)->second;
 		RoutePurpose ePurpose = m_plannedRoutePurposes.find(plannedRoute)->second;
@@ -2649,11 +2698,6 @@ int CvBuilderTaskingAI::ScorePlotBuild(CvPlot* pPlot, ImprovementTypes eImprovem
 	if (!IsRoutePlanned(pPlot, eRouteNeeded, PURPOSE_SHORTCUT) && !IsRoutePlanned(pPlot, eRouteNeeded, PURPOSE_CONNECT_CAPITAL))
 	{
 		bWillBeCityConnectingRoad = false;
-	}
-	if (eRouteNeeded == NO_ROUTE && m_pPlayer->GetPlayerTraits()->IsRiverTradeRoad())
-	{
-		if (pPlot->IsCityConnection(m_pPlayer->GetID()) && pPlot->isRiver())
-			bWillBeCityConnectingRoad = true;
 	}
 
 	const bool bIsWithinWorkRange = pOwningCity && pOwningCity->IsWithinWorkRange(pPlot);

--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.h
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.h
@@ -139,7 +139,7 @@ public:
 protected:
 
 	typedef pair<int, int> PlotPair;
-	typedef pair<PlotPair, RouteTypes> PlannedRoute;
+	typedef pair<PlotPair, pair<RouteTypes, bool>> PlannedRoute;
 
 	void LogDirectives(vector<OptionWithScore<BuilderDirective>> directives);
 	void LogDirective(BuilderDirective directive, int iWeight, bool bChosen = false);
@@ -149,6 +149,8 @@ protected:
 	void ConnectCitiesForScenario(CvCity* pFirstCity, CvCity* pSecondCity, BuildTypes eBuild, RouteTypes eRoute);
 	void ConnectPointsForStrategy(CvCity* pOriginCity, CvPlot* pTargetPlot, BuildTypes eBuild, RouteTypes eRoute);
 
+	void ShortcutConnectionHelper(CvCity* pCity1, CvCity* pCity2, BuildTypes eBuild, RouteTypes eRoute, int iPlotDistance, bool bUseRivers);
+
 	vector<OptionWithScore<BuilderDirective>> GetRouteDirectives();
 	vector<OptionWithScore<BuilderDirective>> GetImprovementDirectives();
 
@@ -156,13 +158,13 @@ protected:
 	void UpdateProjectedPlotYields(CvPlot* pPlot, BuildTypes eBuild, bool bIgnoreCityConnection);
 
 	bool IsPlannedRouteForPurpose(const CvPlot* pPlot, RoutePurpose ePurpose) const;
-	void AddRoutePlots(CvPlot* pStartPlot, CvPlot* pTargetPlot, RouteTypes eRoute, int iValue, const SPath& path, RoutePurpose ePurpose);
+	void AddRoutePlots(CvPlot* pStartPlot, CvPlot* pTargetPlot, RouteTypes eRoute, int iValue, const SPath& path, RoutePurpose ePurpose, bool bUseRivers);
 	int GetMoveCostWithRoute(const CvPlot* pFromPlot, const CvPlot* pToPlot, RouteTypes eFromPlotRoute, RouteTypes eToPlotRoute);
 	int GetPlotYieldModifierTimes100(CvPlot* pPlot, YieldTypes eYield);
 	void GetPathValues(const SPath& path, RouteTypes eRoute, int& iVillageBonusesIfCityConnected, int& iTotalMoveCost, int& iNumRoadsNeededToBuild);
 
 	int GetRouteBuildTime(PlannedRoute plannedRoute, const CvUnit* pUnit = (CvUnit*)NULL) const;
-	int CvBuilderTaskingAI::GetRouteCompletionTimes100(PlannedRoute plannedRoute) const;
+	int CvBuilderTaskingAI::GetRouteMissingTiles(PlannedRoute plannedRoute) const;
 
 	void UpdateCanalPlots();
 

--- a/CvGameCoreDLL_Expansion2/CvCityConnections.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCityConnections.cpp
@@ -284,7 +284,7 @@ void CvCityConnections::UpdateRouteInfo(void)
 		ReachablePlots roadPlots;
 		ReachablePlots railroadPlots;
 		ReachablePlots waterPlots;
-		SPathFinderUserData data(m_pPlayer->GetID(),PT_CITY_CONNECTION_LAND,NO_BUILD,ROUTE_ROAD,NO_ROUTE_PURPOSE);
+		SPathFinderUserData data(m_pPlayer->GetID(),PT_CITY_CONNECTION_LAND,NO_BUILD,ROUTE_ROAD,NO_ROUTE_PURPOSE,true);
 		if (!pStartCity->IsBlockaded(DOMAIN_LAND))
 		{
 			roadPlots= GC.GetStepFinder().GetPlotsInReach( pStartCity->getX(),pStartCity->getY(), data);
@@ -505,7 +505,7 @@ void CvCityConnections::UpdateRouteInfo(void)
 
 		//Let's check for road first (railroad also counts as road)
 		//Very important to set up m_connectionState for direct connections first!
-		SPathFinderUserData data(m_pPlayer->GetID(), PT_CITY_CONNECTION_MIXED, NO_BUILD, ROUTE_ROAD, NO_ROUTE_PURPOSE);
+		SPathFinderUserData data(m_pPlayer->GetID(), PT_CITY_CONNECTION_MIXED, NO_BUILD, ROUTE_ROAD, NO_ROUTE_PURPOSE, true);
 		ReachablePlots capitalRoadConnectedPlots = GC.GetStepFinder().GetPlotsInReach( pCapital->getX(),pCapital->getY(), data);
 		for (ReachablePlots::iterator it = capitalRoadConnectedPlots.begin(); it != capitalRoadConnectedPlots.end(); ++it)
 		{
@@ -548,7 +548,13 @@ void CvCityConnections::UpdateRouteInfo(void)
 			for (size_t j = i + 1; j < vConnectedCities.size(); j++)
 			{
 				//find the shortest path between any two connected cities
+				data.bUseRivers = false;
 				SPath path = GC.GetStepFinder().GetPath(vConnectedCities[i]->plot(), vConnectedCities[j]->plot(), data);
+				if (!path)
+				{
+					data.bUseRivers = true;
+					path = GC.GetStepFinder().GetPath(vConnectedCities[i]->plot(), vConnectedCities[j]->plot(), data);
+				}
 				for (int k = 0; k < path.length(); k++)
 				{
 					CvPlot* pPlot = path.get(k);
@@ -558,6 +564,7 @@ void CvCityConnections::UpdateRouteInfo(void)
 			}
 		}
 		data.eRoute = ROUTE_RAILROAD;
+		data.bUseRivers = false;
 		for (size_t i = 0; i < vIndustrialConnectedCities.size(); i++)
 		{
 			for (size_t j = i + 1; j < vIndustrialConnectedCities.size(); j++)

--- a/CvGameCoreDLL_Expansion2/CvCityStrategyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCityStrategyAI.cpp
@@ -2782,7 +2782,7 @@ bool CityStrategyAIHelpers::IsTestCityStrategy_PocketCity(CvCity* pCity)
 	}
 
 	//could we build a route?
-	SPathFinderUserData data(pCity->getOwner(), PT_BUILD_ROUTE, NO_BUILD, ROUTE_ANY, NO_ROUTE_PURPOSE);
+	SPathFinderUserData data(pCity->getOwner(), PT_BUILD_ROUTE, NO_BUILD, ROUTE_ANY, NO_ROUTE_PURPOSE, true);
 	return !GC.GetStepFinder().DoesPathExist(pCapitalCity->getX(), pCapitalCity->getY(), pCity->getX(), pCity->getY(), data);
 }
 #endif

--- a/CvGameCoreDLL_Expansion2/CvMap.h
+++ b/CvGameCoreDLL_Expansion2/CvMap.h
@@ -90,6 +90,34 @@ protected:
 FDataStream& operator<<(FDataStream&, const CvLandmass&);
 FDataStream& operator>>(FDataStream&, CvLandmass&);
 
+class CvRiver
+{
+public:
+	CvRiver();
+	virtual ~CvRiver();
+
+	void init(int iID);
+	int GetID() const;
+	void SetID(int iID);
+
+	void AddPlot(CvPlot* pPlot);
+	vector<CvPlot*> GetPlots() const;
+
+	// for serialization
+	template<typename River, typename Visitor>
+	static void Serialize(River& landmass, Visitor& visitor);
+	virtual void read(FDataStream& kStream);
+	virtual void write(FDataStream& kStream) const;
+
+protected:
+
+	int m_iID;
+	vector<CvPlot*> m_vPlots;
+};
+
+FDataStream& operator<<(FDataStream&, const CvRiver&);
+FDataStream& operator>>(FDataStream&, CvRiver&);
+
 inline int coordRange(int iCoord, int iRange, bool bWrap)
 {
 	if(bWrap)
@@ -313,6 +341,18 @@ public:
 	void recalculateLandmasses();
 	void calculateLandmasses();
 
+	// Rivers
+	int GetNumRivers();
+	CvRiver* GetRiverById(int iID);
+	CvRiver* GetRiverByIndex(int iIndex);
+	CvRiver* AddRiver();
+	void DeleteRiver(int iID);
+	CvRiver* FirstRiver(int* pIterIdx, bool bRev = false);
+	CvRiver* NextRiver(int* pIterIdx, bool bRev = false);
+	void RecalculateRivers();
+	void CalculateRivers();
+	void CreateRiverFrom(CvPlot* pPlot, DirectionTypes eDirection, CvRiver* pRiver);
+
 	/// this is the default "continent stamper" a given lua map script can use it or not
 	void DefaultContinentStamper();
 
@@ -398,6 +438,7 @@ protected:
 
 	TContainer<CvArea> m_areas;
 	TContainer<CvLandmass> m_landmasses;
+	TContainer<CvRiver> m_rivers;
 
 	//store non-zero values outside of CvPlot because it will be zero almost all the time
 	typedef map<int, vector<unsigned char>> PlotInvisibleVisibilityLookup;

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -377,6 +377,7 @@ CvPlayer::CvPlayer() :
 	, m_bLostHolyCity()
 	, m_eHolyCityConqueror(NO_PLAYER)
 	, m_bHasAdoptedStateReligion()
+	, m_bWorkersIgnoreImpassable()
 	, m_eID()
 	, m_ePersonalityType()
 	, m_abInstantYieldNotificationsDisabled()
@@ -1736,6 +1737,7 @@ void CvPlayer::uninit()
 	m_bLostHolyCity = false;
 	m_eHolyCityConqueror = NO_PLAYER;
 	m_bHasAdoptedStateReligion = false;
+	m_bWorkersIgnoreImpassable = false;
 	m_lastGameTurnInitialAIProcessed = -1;
 	m_bVassalLevy = false;
 	m_iVassalGoldMaintenanceMod = 0;
@@ -43317,11 +43319,6 @@ bool CvPlayer::GetSameRouteBenefitFromTrait(const CvPlot* pPlot, RouteTypes eRou
 		if ((pPlot->getFeatureType() == FEATURE_FOREST || pPlot->getFeatureType() == FEATURE_JUNGLE) && (MOD_BALANCE_VP || pPlot->getTeam() == getTeam()))
 			return true;
 	}
-	else if (GetPlayerTraits()->IsRiverTradeRoad())
-	{
-		if (pPlot->isRiver())
-			return true;
-	}
 
 	return false;
 }
@@ -48704,6 +48701,7 @@ void CvPlayer::Serialize(Player& player, Visitor& visitor)
 	visitor(player.m_bLostHolyCity);
 	visitor(player.m_eHolyCityConqueror);
 	visitor(player.m_bHasAdoptedStateReligion);
+	visitor(player.m_bWorkersIgnoreImpassable);
 	visitor(player.m_abInstantYieldNotificationsDisabled);
 	visitor(player.m_aiCityYieldChange);
 	visitor(player.m_aiCoastalCityYieldChange);
@@ -51646,6 +51644,21 @@ void CvPlayer::SetHasAdoptedStateReligion(bool bValue)
 	if(m_bHasAdoptedStateReligion != bValue)
 	{
 		m_bHasAdoptedStateReligion = bValue;
+	}
+}
+
+//	--------------------------------------------------------------------------------
+bool CvPlayer::IsWorkersIgnoreImpassable() const
+{
+	return m_bWorkersIgnoreImpassable;
+}
+
+//	--------------------------------------------------------------------------------
+void CvPlayer::SetWorkersIgnoreImpassable(bool bValue)
+{
+	if (m_bWorkersIgnoreImpassable != bValue)
+	{
+		m_bWorkersIgnoreImpassable = bValue;
 	}
 }
 

--- a/CvGameCoreDLL_Expansion2/CvPlayer.h
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.h
@@ -2718,6 +2718,9 @@ public:
 	bool IsHasAdoptedStateReligion() const;
 	void SetHasAdoptedStateReligion(bool bValue);
 
+	bool IsWorkersIgnoreImpassable() const;
+	void SetWorkersIgnoreImpassable(bool bValue);
+
 	int GetNumCitiesWithStateReligion();
 
 	CvCity* GetHolyCity();
@@ -3578,6 +3581,7 @@ protected:
 	bool m_bLostHolyCity;
 	PlayerTypes m_eHolyCityConqueror;
 	bool m_bHasAdoptedStateReligion;
+	bool m_bWorkersIgnoreImpassable;
 
 	std::vector<int> m_aiCityYieldChange;
 	std::vector<int> m_aiCoastalCityYieldChange;

--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -231,6 +231,12 @@ void CvPlot::reset()
 	m_owningCityOverride.reset();
 
 	m_vExtraYields.clear();
+	m_vRivers.clear();
+
+	for (int iI = 0; iI < NUM_DIRECTION_TYPES; iI++)
+	{
+		m_vRivers.push_back(-1);
+	}
 
 	m_bfRevealed.ClearAll();
 
@@ -1407,6 +1413,15 @@ bool CvPlot::IsRiverSide(DirectionTypes eDirection) const
 		default:
 			return false;
 	}
+}
+
+//	--------------------------------------------------------------------------------
+/// Is there a river on this side of the plot?
+bool CvPlot::IsLakeSide(DirectionTypes eDirection) const
+{
+	CvAssertMsg(eDirection != NO_DIRECTION, "eDirection is not assigned a valid value");
+	CvPlot* pAdjacentPlot = plotDirection(getX(), getY(), eDirection);
+	return pAdjacentPlot && pAdjacentPlot->isLake();
 }
 
 //	--------------------------------------------------------------------------------
@@ -5563,6 +5578,44 @@ void CvPlot::setLandmass(int iNewValue)
 CvLandmass * CvPlot::landmass() const
 {
 	return GC.getMap().getLandmassById(m_iLandmass);
+}
+
+//	--------------------------------------------------------------------------------
+int CvPlot::GetRiverID(DirectionTypes eDirection) const
+{
+	return m_vRivers[eDirection];
+}
+
+//	--------------------------------------------------------------------------------
+void CvPlot::SetRiverID(DirectionTypes eDirection, int iRiverID)
+{
+	m_vRivers[eDirection] = iRiverID;
+}
+
+//	--------------------------------------------------------------------------------
+CvRiver* CvPlot::GetRiver(DirectionTypes eDirection) const
+{
+	return GC.getMap().GetRiverById(m_vRivers[eDirection]);
+}
+
+//	--------------------------------------------------------------------------------
+bool CvPlot::HasSharedRiver(const CvPlot* pOther) const
+{
+	for (int iI = 0; iI < NUM_DIRECTION_TYPES; iI++)
+	{
+		int iRiverID = GetRiverID((DirectionTypes)iI);
+		if (iRiverID != -1)
+		{
+			for (int iJ = 0; iJ < NUM_DIRECTION_TYPES; iJ++)
+			{
+				if (pOther->GetRiverID((DirectionTypes)iJ) == iRiverID)
+				{
+					return true;
+				}
+			}
+		}
+	}
+	return false;
 }
 
 //	--------------------------------------------------------------------------------
@@ -13206,6 +13259,7 @@ void CvPlot::Serialize(Plot& plot, Visitor& visitor)
 	visitor(plot.m_iRiverCrossingCount);
 	visitor(plot.m_iResourceNum);
 	visitor(plot.m_iLandmass);
+	visitor(plot.m_vRivers);
 
 	// Bit fields
 	{

--- a/CvGameCoreDLL_Expansion2/CvPlot.h
+++ b/CvGameCoreDLL_Expansion2/CvPlot.h
@@ -34,6 +34,7 @@
 
 class CvArea;
 class CvLandmass;
+class CvRiver;
 class CvRoute;
 
 typedef bool (*ConstPlotUnitFunc)(const CvUnit* pUnit, int iData1, int iData2);
@@ -148,6 +149,7 @@ public:
 	bool isRiverConnection(DirectionTypes eDirection) const;
 
 	bool IsRiverSide(DirectionTypes eDirection) const;
+	bool IsLakeSide(DirectionTypes eDirection) const;
 	bool IsAlongSameRiver(const CvPlot* pToPlot) const;
 
 	CvPlot* getNeighboringPlot(DirectionTypes eDirection) const;
@@ -341,6 +343,11 @@ public:
 	CvLandmass* landmass() const;
 	std::vector<int> getAllAdjacentLandmasses() const;
 	bool hasSharedAdjacentLandmass(const CvPlot* pOther, bool bAllowLand, bool bAllowWater) const;
+
+	int GetRiverID(DirectionTypes eDirection) const;
+	void SetRiverID(DirectionTypes eDirection, int iRiverID);
+	CvRiver* GetRiver(DirectionTypes eDirection) const;
+	bool HasSharedRiver(const CvPlot* pOther) const;
 
 	int getOwnershipDuration() const;
 	bool isOwnershipScore() const;
@@ -976,6 +983,8 @@ protected:
 	short m_iOwnershipDuration;
 	short m_iImprovementDuration;
 	short m_iUpgradeProgress;
+
+	std::vector<int> m_vRivers;
 
 	SYNC_ARCHIVE_MEMBER(CvPlot)
 	char /*FeatureTypes*/ m_eFeatureType; 

--- a/CvGameCoreDLL_Expansion2/CvTeam.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTeam.cpp
@@ -8049,6 +8049,12 @@ void CvTeam::processTech(TechTypes eTech, int iChange, bool bNoBonus)
 							}
 						}
 					}
+
+					CvPromotionEntry* pkPromotionInfo = GC.getPromotionInfo(ePromotion);
+					if (pkPromotionInfo && pkPromotionInfo->IsCanMoveImpassable())
+					{
+						kPlayer.SetWorkersIgnoreImpassable(true);
+					}
 				}
 #else
 				if(pTech->IsFreePromotion(ePromotion))

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -30559,7 +30559,7 @@ bool CvUnit::UnitRoadTo(int iX, int iY, int iFlags)
 
 	//ok apparently we both can move and need to move
 	//do not use the path cache here, the step finder tells us where to put the route
-	SPathFinderUserData data(getOwner(),PT_BUILD_ROUTE,NO_BUILD,eBestRoute,NO_ROUTE_PURPOSE);
+	SPathFinderUserData data(getOwner(),PT_BUILD_ROUTE,NO_BUILD,eBestRoute,NO_ROUTE_PURPOSE,false);
 	SPath path = GC.GetStepFinder().GetPath(getX(), getY(), iX, iY, data);
 
 	//index zero is the current plot!

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaGame.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaGame.cpp
@@ -3498,7 +3498,7 @@ int CvLuaGame::lGetLongestCityConnectionPlots(lua_State* L)
 		int iLoop1;
 		int iLoop2;
 
-		SPathFinderUserData data(ePlayer, PT_CITY_CONNECTION_LAND, NO_BUILD, ROUTE_RAILROAD, NO_ROUTE_PURPOSE);
+		SPathFinderUserData data(ePlayer, PT_CITY_CONNECTION_LAND, NO_BUILD, ROUTE_RAILROAD, NO_ROUTE_PURPOSE, false);
 
 		for (pFirstCity = GET_PLAYER(ePlayer).firstCity(&iLoop1); pFirstCity != NULL; pFirstCity = GET_PLAYER(ePlayer).nextCity(&iLoop1))
 		{

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlot.cpp
@@ -74,6 +74,7 @@ void CvLuaPlot::PushMethods(lua_State* L, int t)
 	Method(IsRiverSide);
 	Method(IsRiverConnection);
 	Method(IsRiverCrossingFlowClockwise);
+	Method(GetRiverID);
 
 	Method(GetNearestLandArea);
 	Method(SeeFromLevel);
@@ -631,6 +632,13 @@ int CvLuaPlot::lIsRiverCrossingFlowClockwise(lua_State* L)
 	lua_pushboolean(L, bResult);
 	return 1;
 }
+//------------------------------------------------------------------------------
+//int GetRiverID();
+int CvLuaPlot::lGetRiverID(lua_State* L)
+{
+	return BasicLuaMethod(L, &CvPlot::GetRiverID);
+}
+
 //------------------------------------------------------------------------------
 //int getNearestLandArea();
 int CvLuaPlot::lGetNearestLandArea(lua_State* L)

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlot.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlot.h
@@ -84,6 +84,7 @@ protected:
 	static int lIsRiverSide(lua_State* L);
 	static int lIsRiverConnection(lua_State* L);
 	static int lIsRiverCrossingFlowClockwise(lua_State* L);
+	static int lGetRiverID(lua_State* L);
 
 	static int lGetInlandCorner(lua_State* L);
 	static int lGetNearestLandArea(lua_State* L);


### PR DESCRIPTION
Also, river connection rework. City connection along rivers now functions more sensibly.

Lakes now also count as rivers for city connection purposes.

AI taught how to plan routes both with and without rivers.

Add connection value from policies/traits in connection evaluation.

Teach AI to build roads across mountains when prerequisite tech is researched.