### PR TITLE
Use default player color if no color set in pregame

### DIFF
--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
@@ -9769,8 +9769,12 @@ int CvLuaPlayer::lGetPlayerColor(lua_State* L)
 int CvLuaPlayer::lGetPlayerColors(lua_State* L)
 {
 	CvPlayerAI* pkPlayer = GetInstance(L);
-	const PlayerColorTypes eColor = CvPreGame::playerColor(pkPlayer->GetID());
-
+	PlayerColorTypes eColor = CvPreGame::playerColor(pkPlayer->GetID());
+	if (eColor == NO_PLAYERCOLOR)
+	{
+		CvCivilizationInfo* pkCivilizationInfo = GC.getCivilizationInfo(pkPlayer->getCivilizationType());
+		eColor = (PlayerColorTypes)pkCivilizationInfo->getDefaultPlayerColor();
+	}
 	CvPlayerColorInfo* pkPlayerColor = GC.GetPlayerColorInfo(eColor);
 
 	if(pkPlayerColor == NULL)


### PR DESCRIPTION
Fix for the UI issue in #10784 

It can happen that no player color is set in the pregame if two AI players of the same civ are in the game. To prevent lua errors, we should use the default color in those cases.