### PR TITLE
Add interface option for disabling city view highlighting of plots buffed by hovered building

### DIFF
--- a/(3a) EUI Compatibility Files/LUA/CityView.lua
+++ b/(3a) EUI Compatibility Files/LUA/CityView.lua
@@ -128,6 +128,8 @@ local YieldTypes = YieldTypes
 local g_options = Modding.OpenUserData( "Enhanced User Interface Options", 1)
 local g_isAdvisor = true
 
+local g_isDisableBuildingBonusHighlights = g_options.GetValue( "DisableBuildingBonusHighlights" ) == 1
+
 local g_isSeparateCityProductionEUI = g_options.GetValue( "SeparateCityProduction" ) == 1
 --print("Separate City Production: "..tostring(g_isSeparateCityProductionEUI))
 
@@ -1251,6 +1253,7 @@ local function handleBuildOrder( city, orderID, itemID )
 end
 
 local function ChangeHoverBuildingDisplay(city, itemID)
+	if g_isDisableBuildingBonusHighlights then return end
 	Events.ClearHexHighlightStyle("BoostedResourcePlot")
 	g_HoverBuildingID = itemID
 

--- a/Vox Populi Installer Files/UI_bc1/Options/OptionsMenu.lua
+++ b/Vox Populi Installer Files/UI_bc1/Options/OptionsMenu.lua
@@ -116,6 +116,7 @@ function OnOK()
 	EUI_options.SetValue( "SeparateMilitaryDomain", Controls.SeparateMilitaryDomainCheckbox:IsChecked() )
 	EUI_options.SetValue( "SeparateProjectWonders", Controls.SeparateProjectWondersCheckbox:IsChecked() )
 --
+	EUI_options.SetValue( "DisableBuildingBonusHighlights", Controls.DisableBonusHighlightsCheckbox:IsChecked() )
 	OptionsManager.CommitGameOptions();
 	OptionsManager.CommitGraphicsOptions();
 	SaveAudioOptions();
@@ -667,6 +668,7 @@ function UpdateGameOptionsDisplay()
 		Controls.SeparateProjectWondersCheckbox:SetAlpha( 0.5 );
 	end
 --
+	Controls.DisableBonusHighlightsCheckbox:SetCheck( EUI_options.GetValue( "DisableBuildingBonusHighlights" ) == 1 )
 	Controls.NoCitizenWarningCheckbox:SetCheck( OptionsManager.IsNoCitizenWarning_Cached() );
 	Controls.AutoWorkersDontReplaceCB:SetCheck( OptionsManager.IsAutoWorkersDontReplace_Cached() );
 	Controls.AutoWorkersDontRemoveFeaturesCB:SetCheck( OptionsManager.IsAutoWorkersDontRemoveFeatures_Cached() );

--- a/Vox Populi Installer Files/UI_bc1/Options/OptionsMenu.xml
+++ b/Vox Populi Installer Files/UI_bc1/Options/OptionsMenu.xml
@@ -131,7 +131,7 @@
 
 		<!-- Interface Options -->
 		<Container ID="IFacePanel" Size="971,500" Offset="0,44" Hidden="1">
-			<Stack Anchor="R,T" Offset="550,50" Padding="4" >
+			<Stack Anchor="R,T" Offset="550,50" Padding="2" >
 				<CheckBox ID="PolicyInfo" Anchor="R,C" String="TXT_KEY_OPSCREEN_SHOW_ALL_POLICY_INFO" IsChecked="0" ToolTip="TXT_KEY_OPSCREEN_SHOW_ALL_POLICY_INFO_TT" />
 				<CheckBox ID="ScoreListCheck" Anchor="R,C" String="TXT_KEY_OPSCREEN_SCORE_LIST" IsChecked="0" ToolTip="TXT_KEY_OPSCREEN_SCORE_LIST_TT" />
 				<CheckBox ID="MPScoreListCheck" Anchor="R,C" String="TXT_KEY_OPSCREEN_MP_SCORE_LIST" IsChecked="0" ToolTip="TXT_KEY_OPSCREEN_MP_SCORE_LIST_TT" />
@@ -172,6 +172,7 @@
 						<Label Anchor="L,C" String="TXT_KEY_CLOSE" />
 					</Stack>
 				</CheckBox>
+				<CheckBox ID="DisableBonusHighlightsCheckbox" Anchor="R,C" String="TXT_KEY_EUI_DISABLE_BUILDING_BONUS_HIGHLIGHTS_DISPLAY" LeadingOffset="-10" WrapWidth="450" ToolTip="TXT_KEY_EUI_DISABLE_BUILDING_BONUS_HIGHLIGHTS_BODY" />
 				<CheckBox ID="SeparateCityProductionCheckbox" Anchor="R,C" String="TXT_KEY_EUI_SEPARATE_CITY_PRODUCTION_DISPLAY" IsChecked="1" LeadingOffset="-10" WrapWidth="450" ToolTip="TXT_KEY_EUI_SEPARATE_CITY_PRODUCTION_BODY"/>
 				<CheckBox ID="SeparateGPReligiousCheckbox" Anchor="R,T" Offset="24,-6" String="TXT_KEY_EUI_SEPARATE_GP_RELIGIOUS_DISPLAY" Font="TwCenMT16" IsChecked="1" NoStateChange="1" Disabled="0"/>
 				<CheckBox ID="SeparateMilitaryDomainCheckbox" Anchor="R,T" Offset="24,-16" String="TXT_KEY_EUI_SEPARATE_MILITARY_DOMAIN_DISPLAY" Font="TwCenMT16" IsChecked="1" NoStateChange="1" Disabled="0"/>

--- a/Vox Populi Installer Files/VPUI Text/VPUI_tips_en_us.xml
+++ b/Vox Populi Installer Files/VPUI Text/VPUI_tips_en_us.xml
@@ -17,6 +17,12 @@
 		<Replace Tag="TXT_KEY_EUI_SEPARATE_CITY_PRODUCTION_BODY">
 			<Text>Separate city production items into specific categories. (e.g. Great Person Units, Religious Units, Military Units, Projects, National Wonders, World Wonders.)[NEWLINE][COLOR_NEGATIVE_TEXT]{TXT_KEY_EUI_REQUIRES_RELOAD}[ENDCOLOR]</Text>
 		</Replace>
+		<Replace Tag="TXT_KEY_EUI_DISABLE_BUILDING_BONUS_HIGHLIGHTS_DISPLAY">
+			<Text>Disable City Screen Bonus Highlights</Text>
+		</Replace>
+		<Replace Tag="TXT_KEY_EUI_DISABLE_BUILDING_BONUS_HIGHLIGHTS_BODY">
+			<Text>Disable highlighting of plots that would be buffed by a building when hovering over it in the city view production menu.[NEWLINE][COLOR_NEGATIVE_TEXT]{TXT_KEY_EUI_REQUIRES_RELOAD}[ENDCOLOR]</Text>
+		</Replace>
 		<Replace Tag="TXT_KEY_EUI_SEPARATE_GP_RELIGIOUS_DISPLAY">
 			<Text>Separate Great Person and Religious Units</Text>
 		</Replace>


### PR DESCRIPTION
Adds an option for disabling highlighting of plots that would be buffed by a building when hovered over in the construction menu
![image](https://github.com/LoneGazebo/Community-Patch-DLL/assets/8049171/eedf3d23-d799-47d2-b087-da9521efe4c8)

This change should provide a workaround for people experiencing some city view CTDs as it appears that `SerialEventHexHighlight` may cause memory problems

* https://github.com/LoneGazebo/Community-Patch-DLL/issues/10534
* https://github.com/LoneGazebo/Community-Patch-DLL/issues/10574
* https://github.com/LoneGazebo/Community-Patch-DLL/issues/10848
* https://forums.civfanatics.com/threads/new-version-4-7-3-april-28-2024.689478/page-2#post-16598238