### PR TITLE
modernize-use-bool-literals

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
@@ -4070,7 +4070,7 @@ void CvHomelandAI::ExecuteMerchantMoves()
 			CvPlot* pTargetPlot = bIsVenice ? GET_PLAYER(m_pPlayer->GetID()).FindBestCultureBombPlot(pUnit, eColonia, vDummy, true) : NULL;
 			if (pTargetPlot) //venetian merchant
 			{
-				ExecuteMoveToTarget(pUnit, pTargetPlot, 0, 0);
+				ExecuteMoveToTarget(pUnit, pTargetPlot, 0, false);
 				if (pUnit->atPlot(*pTargetPlot) && pUnit->canMove())
 					pUnit->PushMission(CvTypes::getMISSION_BUILD(), eColonia);
 			}

--- a/CvGameCoreDLL_Expansion2/CvImprovementClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvImprovementClasses.cpp
@@ -146,7 +146,7 @@ CvImprovementEntry::CvImprovementEntry(void):
 	m_bAdjacentCity(false),
 	m_iGrantsVision(0),
 	m_iMovesChange(0),
-	m_bRestoreMoves(0),
+	m_bRestoreMoves(false),
 #endif
 	m_bNoTwoAdjacent(false),
 	m_iXSameAdjacentMakesValid(0),

--- a/CvGameCoreDLL_Expansion2/CvTacticalAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTacticalAI.cpp
@@ -3713,7 +3713,7 @@ bool CvTacticalAI::ExecuteAttackWithCitiesAndGarrisons(CvUnit* pDefender)
 
 		if (pCity->canRangeStrikeAt(pDefender->getX(), pDefender->getY()) && !pCity->isMadeAttack())
 		{
-			pCity->doTask(TASK_RANGED_ATTACK, pDefender->getX(), pDefender->getY(), 0);
+			pCity->doTask(TASK_RANGED_ATTACK, pDefender->getX(), pDefender->getY(), false);
 			if (pDefender->GetCurrHitPoints() < 1)
 				return true;
 		}


### PR DESCRIPTION
Ran [modernize-use-bool-literals](https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-bool-literals.html). Minor change. Build works.