### PR TITLE
useInitializationList

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvAIOperation.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAIOperation.cpp
@@ -33,13 +33,13 @@
 
 /// Constructor
 CvAIOperation::CvAIOperation(int iID, PlayerTypes eOwner, PlayerTypes eEnemy, AIOperationTypes eType, ArmyType eMoveType)
+    : m_iID(iID),
+      m_eOwner(eOwner),
+      m_eEnemy(eEnemy),
+      m_eType(eType),
+      m_eArmyType(eMoveType)
 {
-	m_iID = iID;
-	m_eOwner = eOwner;
-	m_eEnemy = eEnemy;
-	m_eType = eType;
-	m_eArmyType = eMoveType;
-	Reset();
+    Reset();
 }
 
 /// Destructor

--- a/CvGameCoreDLL_Expansion2/CvAStar.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAStar.cpp
@@ -90,41 +90,35 @@ int SMovePlot::effectivePathLength(int iMovesPerTurn) const
 //	--------------------------------------------------------------------------------
 /// Constructor
 CvAStar::CvAStar()
+    : m_iColumns(0),
+      m_iRows(0),
+      m_iXstart(0),
+      m_iYstart(0),
+      m_iXdest(0),
+      m_iYdest(0),
+      m_iDestHitCount(0),
+      m_bWrapX(false),
+      m_bWrapY(false),
+      m_bHeapDirty(false),
+      udDestValid(NULL),
+      udHeuristic(NULL),
+      udCost(NULL),
+      udValid(NULL),
+      udGetExtraChildrenFunc(NULL),
+      udInitializeFunc(NULL),
+      udUninitializeFunc(NULL),
+      m_pBest(NULL),
+      m_ppaaNodes(NULL),
+      m_ppaaNeighbors(NULL),
+      m_iCurrentGenerationID(0),
+      m_iProcessedNodes(0),
+      m_iTestedNodes(0),
+      m_iRounds(0),
+      m_iBasicPlotCost(1),
+      m_iMovesCached(0),
+      m_iTurnsCached(0),
+      m_strName("AStar") // for debugging
 {
-	m_iColumns = 0;
-	m_iRows = 0;
-	m_iXstart = 0;
-	m_iYstart = 0;
-	m_iXdest = 0;
-	m_iYdest = 0;
-	m_iDestHitCount = 0;
-
-	m_bWrapX = false;
-	m_bWrapY = false;
-	m_bHeapDirty = false;
-
-	udDestValid = NULL;
-	udHeuristic = NULL;
-	udCost = NULL;
-	udValid = NULL;
-	udGetExtraChildrenFunc = NULL;
-	udInitializeFunc = NULL;
-	udUninitializeFunc = NULL;
-
-	m_pBest = NULL;
-	m_ppaaNodes = NULL;
-	m_ppaaNeighbors = NULL;
-
-	m_iCurrentGenerationID = 0;
-	m_iProcessedNodes = 0;
-	m_iTestedNodes = 0;
-	m_iRounds = 0;
-	m_iBasicPlotCost = 1;
-	m_iMovesCached = 0;
-	m_iTurnsCached = 0;
-
-	//for debugging
-	m_strName = "AStar";
 }
 
 //	--------------------------------------------------------------------------------
@@ -3774,22 +3768,22 @@ SPathFinderUserData::SPathFinderUserData(const CvUnit* pUnit, int _iFlags, int _
 }
 
 //	---------------------------------------------------------------------------
-//convenience constructor
+// Convenience constructor
 SPathFinderUserData::SPathFinderUserData(PlayerTypes _ePlayer, PathType _ePathType)
+    : ePath(_ePathType),
+      iFlags(0),
+      iMaxTurns(INT_MAX),
+      ePlayer(_ePlayer),
+      eEnemy(NO_PLAYER),
+      iUnitID(0),
+      eBuild(NO_BUILD),
+      eRoute(NO_ROUTE),
+      iMaxNormalizedDistance(INT_MAX),
+      iMinMovesLeft(0),
+      iStartMoves(0),
+      eRoutePurpose(NO_ROUTE_PURPOSE),
+      bUseRivers(false)
 {
-	ePath = _ePathType;
-	iFlags = 0;
-	iMaxTurns = INT_MAX;
-	ePlayer = _ePlayer;
-	eEnemy = NO_PLAYER;
-	iUnitID = 0;
-	eBuild = NO_BUILD;
-	eRoute = NO_ROUTE;
-	iMaxNormalizedDistance = INT_MAX;
-	iMinMovesLeft = 0;
-	iStartMoves = 0;
-	eRoutePurpose = NO_ROUTE_PURPOSE;
-	bUseRivers = false;
 }
 
 //	---------------------------------------------------------------------------

--- a/CvGameCoreDLL_Expansion2/CvDealClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDealClasses.cpp
@@ -45,18 +45,18 @@ FDataStream& operator<<(FDataStream& saveTo, const TradeableItems& readFrom)
 
 /// Constructor
 CvTradedItem::CvTradedItem()
+    : m_eItemType(TRADE_ITEM_NONE),
+      m_iDuration(0),
+      m_iFinalTurn(0),
+      m_iData1(0),
+      m_iData2(0),
+      m_iData3(0),
+      m_bFlag1(false),
+      m_eFromPlayer(NO_PLAYER),
+      m_iValue(INT_MAX),
+      m_bValueIsEven(false),
+      m_bDoNotRemove(false)
 {
-	m_eItemType = TRADE_ITEM_NONE;
-	m_iDuration = 0;
-	m_iFinalTurn = 0;
-	m_iData1 = 0;
-	m_iData2 = 0;
-	m_iData3 = 0;
-	m_bFlag1 = false;
-	m_eFromPlayer = NO_PLAYER;
-	m_iValue = INT_MAX;
-	m_bValueIsEven = false;
-	m_bDoNotRemove = false;
 }
 
 /// Equals operator
@@ -122,44 +122,41 @@ FDataStream& operator<<(FDataStream& saveTo, const CvTradedItem& readFrom)
 
 /// Constructor with typical parameters
 CvDeal::CvDeal(PlayerTypes eFromPlayer, PlayerTypes eToPlayer)
+    : m_eFromPlayer(eFromPlayer),
+      m_eToPlayer(eToPlayer),
+      m_ePeaceTreatyType(NO_PEACE_TREATY_TYPE),
+      m_eSurrenderingPlayer(NO_PLAYER),
+      m_eDemandingPlayer(NO_PLAYER),
+      m_eRequestingPlayer(NO_PLAYER),
+      m_iStartTurn(0),
+      m_iFinalTurn(0),
+      m_iDuration(0),
+      m_bConsideringForRenewal(false),
+      m_bCheckedForRenewal(false),
+      m_bIsGift(false),
+      m_iFromPlayerValue(-1),
+      m_iToPlayerValue(-1)
 {
-	m_eFromPlayer = eFromPlayer;
-	m_eToPlayer = eToPlayer;
-
-	m_ePeaceTreatyType = NO_PEACE_TREATY_TYPE;
-	m_eSurrenderingPlayer = NO_PLAYER;
-	m_eDemandingPlayer = NO_PLAYER;
-	m_eRequestingPlayer = NO_PLAYER;
-	m_iStartTurn = 0;
-	m_iFinalTurn = 0;
-	m_iDuration = 0;
-
-	m_bConsideringForRenewal = false;
-	m_bCheckedForRenewal = false;
-
-	m_bIsGift = false;
-	m_iFromPlayerValue = -1;
-	m_iToPlayerValue = -1;
 }
 
 /// Copy Constructor with typical parameters
 CvDeal::CvDeal(const CvDeal& source)
+    : m_eFromPlayer(source.m_eFromPlayer),
+      m_eToPlayer(source.m_eToPlayer),
+      m_iDuration(source.m_iDuration),
+      m_iFinalTurn(source.m_iFinalTurn),
+      m_iStartTurn(source.m_iStartTurn),
+      m_ePeaceTreatyType(source.m_ePeaceTreatyType),
+      m_eSurrenderingPlayer(source.m_eSurrenderingPlayer),
+      m_eDemandingPlayer(source.m_eDemandingPlayer),
+      m_eRequestingPlayer(source.m_eRequestingPlayer),
+      m_bConsideringForRenewal(source.m_bConsideringForRenewal),
+      m_bCheckedForRenewal(source.m_bCheckedForRenewal),
+      m_bIsGift(source.m_bIsGift),
+      m_iFromPlayerValue(source.m_iFromPlayerValue),
+      m_iToPlayerValue(source.m_iToPlayerValue),
+      m_TradedItems(source.m_TradedItems)
 {
-	m_eFromPlayer = source.m_eFromPlayer;
-	m_eToPlayer = source.m_eToPlayer;
-	m_iDuration = source.m_iDuration;
-	m_iFinalTurn = source.m_iFinalTurn;
-	m_iStartTurn = source.m_iStartTurn;
-	m_ePeaceTreatyType = source.m_ePeaceTreatyType;
-	m_eSurrenderingPlayer = source.m_eSurrenderingPlayer;
-	m_eDemandingPlayer = source.m_eDemandingPlayer;
-	m_eRequestingPlayer = source.m_eRequestingPlayer;
-	m_bConsideringForRenewal = source.m_bConsideringForRenewal;
-	m_bCheckedForRenewal = source.m_bCheckedForRenewal;
-	m_bIsGift = source.m_bIsGift;
-	m_iFromPlayerValue = source.m_iFromPlayerValue;
-	m_iToPlayerValue = source.m_iToPlayerValue;
-	m_TradedItems = source.m_TradedItems;
 }
 
 /// Destructor

--- a/CvGameCoreDLL_Expansion2/CvDllNetLoadGameInfo.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDllNetLoadGameInfo.cpp
@@ -11,9 +11,9 @@
 #include "CvDllContext.h"
 
 CvDllNetLoadGameInfo::CvDllNetLoadGameInfo()
-	: m_slotStatus(), m_uiRefCount(1)
+    : m_slotStatus(CvPreGame::GetSlotStatus()), 
+      m_uiRefCount(1)
 {
-	m_slotStatus = CvPreGame::GetSlotStatus();
 }
 //------------------------------------------------------------------------------
 CvDllNetLoadGameInfo::~CvDllNetLoadGameInfo()

--- a/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
@@ -29,64 +29,64 @@
 
 /// Default Constructor
 CvMinorCivQuest::CvMinorCivQuest()
+    : m_eMinor(NO_PLAYER),
+      m_eAssignedPlayer(NO_PLAYER),
+      m_eType(NO_MINOR_CIV_QUEST_TYPE),
+      m_iStartTurn(NO_TURN),
+      m_iData1(NO_QUEST_DATA),
+      m_iData2(NO_QUEST_DATA),
+      m_iData3(NO_QUEST_DATA),
+      m_iInfluence(0),
+      m_iDisabledInfluence(0),
+      m_iGold(0),
+      m_iScience(0),
+      m_iCulture(0),
+      m_iFaith(0),
+      m_iGoldenAgePoints(0),
+      m_iFood(0),
+      m_iProduction(0),
+      m_iTourism(0),
+      m_iHappiness(0),
+      m_iGP(0),
+      m_iGPGlobal(0),
+      m_iGeneralPoints(0),
+      m_iAdmiralPoints(0),
+      m_iExperience(0),
+      m_iJuggernauts(0),
+      m_bPartialQuest(false),
+      m_bHandled(false)
 {
-	m_eMinor = NO_PLAYER;
-	m_eAssignedPlayer = NO_PLAYER;
-	m_eType = NO_MINOR_CIV_QUEST_TYPE;
-	m_iStartTurn = NO_TURN; /* -1 */
-	m_iData1 = NO_QUEST_DATA; /* -1 */
-	m_iData2 = NO_QUEST_DATA; /* -1 */
-	m_iData3 = NO_QUEST_DATA; /* -1 */
-	m_iInfluence = 0;
-	m_iDisabledInfluence = 0;
-	m_iGold = 0;
-	m_iScience = 0;
-	m_iCulture = 0;
-	m_iFaith = 0;
-	m_iGoldenAgePoints = 0;
-	m_iFood = 0;
-	m_iProduction = 0;
-	m_iTourism = 0;
-	m_iHappiness = 0;
-	m_iGP = 0;
-	m_iGPGlobal = 0;
-	m_iGeneralPoints = 0;
-	m_iAdmiralPoints = 0;
-	m_iExperience = 0;
-	m_iJuggernauts = 0;
-	m_bPartialQuest = false;
-	m_bHandled = false;
 }
 
 /// Constructor
 CvMinorCivQuest::CvMinorCivQuest(PlayerTypes eMinor, PlayerTypes eAssignedPlayer, MinorCivQuestTypes eType)
+    : m_eMinor(eMinor),
+      m_eAssignedPlayer(eAssignedPlayer),
+      m_eType(eType),
+      m_iStartTurn(NO_TURN),
+      m_iData1(NO_QUEST_DATA),
+      m_iData2(NO_QUEST_DATA),
+      m_iData3(NO_QUEST_DATA),
+      m_iInfluence(0),
+      m_iDisabledInfluence(0),
+      m_iGold(0),
+      m_iScience(0),
+      m_iCulture(0),
+      m_iFaith(0),
+      m_iGoldenAgePoints(0),
+      m_iFood(0),
+      m_iProduction(0),
+      m_iTourism(0),
+      m_iHappiness(0),
+      m_iGP(0),
+      m_iGPGlobal(0),
+      m_iGeneralPoints(0),
+      m_iAdmiralPoints(0),
+      m_iExperience(0),
+      m_iJuggernauts(0),
+      m_bPartialQuest(false),
+      m_bHandled(false)
 {
-	m_eMinor = eMinor;
-	m_eAssignedPlayer = eAssignedPlayer;
-	m_eType = eType;
-	m_iStartTurn = NO_TURN; /* -1 */
-	m_iData1 = NO_QUEST_DATA; /* -1 */
-	m_iData2 = NO_QUEST_DATA; /* -1 */
-	m_iData3 = NO_QUEST_DATA; /* -1 */
-	m_iInfluence = 0;
-	m_iDisabledInfluence = 0;
-	m_iGold = 0;
-	m_iScience = 0;
-	m_iCulture = 0;
-	m_iFaith = 0;
-	m_iGoldenAgePoints = 0;
-	m_iFood = 0;
-	m_iProduction = 0;
-	m_iTourism = 0;
-	m_iHappiness = 0;
-	m_iGP = 0;
-	m_iGPGlobal = 0;
-	m_iGeneralPoints = 0;
-	m_iAdmiralPoints = 0;
-	m_iExperience = 0;
-	m_iJuggernauts = 0;
-	m_bPartialQuest = false;
-	m_bHandled = false;
 }
 
 CvMinorCivQuest::~CvMinorCivQuest()

--- a/CvGameCoreDLL_Expansion2/CvNotificationClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvNotificationClasses.cpp
@@ -14,9 +14,9 @@
 #include "LintFree.h"
 
 /// Constructor
-CvNotificationEntry::CvNotificationEntry(void)
+CvNotificationEntry::CvNotificationEntry()
+    : m_strNotificationType("")
 {
-	m_strNotificationType = "";
 }
 
 /// Destructor

--- a/CvGameCoreDLL_Expansion2/CvReligionClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvReligionClasses.cpp
@@ -212,19 +212,19 @@ CvCity * CvReligion::GetHolyCity() const
 //=====================================
 /// Default Constructor
 CvReligionInCity::CvReligionInCity()
+    : m_eReligion(NO_RELIGION),
+      m_iFollowers(0),
+      m_iPressure(0),
+      m_iNumTradeRoutesApplyingPressure(0)
 {
-	m_eReligion = NO_RELIGION;
-	m_iFollowers = 0;
-	m_iPressure = 0;
-	m_iNumTradeRoutesApplyingPressure = 0;
 }
 
 /// Constructor
-CvReligionInCity::CvReligionInCity(ReligionTypes eReligion, int iFollowers, int iPressure) :
-	m_eReligion(eReligion),
-	m_iFollowers(iFollowers),
-	m_iPressure(iPressure),
-	m_iNumTradeRoutesApplyingPressure(0)
+CvReligionInCity::CvReligionInCity(ReligionTypes eReligion, int iFollowers, int iPressure)
+    : m_eReligion(eReligion),
+      m_iFollowers(iFollowers),
+      m_iPressure(iPressure),
+      m_iNumTradeRoutesApplyingPressure(0)
 {
 }
 

--- a/CvGameCoreDLL_Expansion2/CvStartPositioner.cpp
+++ b/CvGameCoreDLL_Expansion2/CvStartPositioner.cpp
@@ -846,10 +846,10 @@ struct SStartRegion
 	int iTotalWorth;
 
 	SStartRegion(int iIndex = 0, int iPlotWorth = 0)
+		: iID(iIndex),
+		  iTotalWorth(iPlotWorth),
+		  vPlots(1, iIndex)
 	{  
-		iID = iIndex;
-		vPlots = vector<int>(1, iIndex);
-		iTotalWorth = iPlotWorth;
 	}
 
 	void mergeWith(SStartRegion& other) 

--- a/CvGameCoreDLL_Expansion2/CvVotingClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvVotingClasses.cpp
@@ -1037,12 +1037,12 @@ FDataStream& operator<<(FDataStream& saveTo, const CvVoterDecision& readFrom)
 // ================================================================================
 //			CvResolution
 // ================================================================================
-CvResolution::CvResolution(void)
+CvResolution::CvResolution()
+    : m_iID(-1),
+      m_eType(NO_RESOLUTION),
+      m_eLeague(NO_LEAGUE),
+      m_sEffects()
 {
-	m_iID = -1;
-	m_eType = NO_RESOLUTION;
-	m_eLeague = NO_LEAGUE;
-	m_sEffects = CvResolutionEffects();
 }
 
 CvResolution::CvResolution(int iID, ResolutionTypes eType, LeagueTypes eLeague)
@@ -1137,14 +1137,14 @@ FDataStream& operator<<(FDataStream& saveTo, const CvResolution& readFrom)
 // ================================================================================
 //			CvProposal
 // ================================================================================
-CvProposal::CvProposal(void)
+CvProposal::CvProposal() : m_eProposalPlayer(NO_PLAYER)
 {
-	m_eProposalPlayer = NO_PLAYER;
 }
 
-CvProposal::CvProposal(int iID, ResolutionTypes eType, LeagueTypes eLeague, PlayerTypes eProposalPlayer) : CvResolution(iID, eType, eLeague)
+CvProposal::CvProposal(int iID, ResolutionTypes eType, LeagueTypes eLeague, PlayerTypes eProposalPlayer)
+    : CvResolution(iID, eType, eLeague),
+      m_eProposalPlayer(eProposalPlayer)
 {
-	m_eProposalPlayer = eProposalPlayer;
 }
 
 CvProposal::~CvProposal(void)


### PR DESCRIPTION
Fix some cppcheck useInitializationList issues.
```
Id: useInitializationList
CWE: 398
When an object of a class is created, the constructors of all member variables are called consecutively in the order the variables are declared, even if you don't explicitly write them to the initialization list. You could avoid assigning a value by passing the value to the constructor in the initialization list.
```