### PR TITLE
cppcheck

### DIFF
--- a/CvGameCoreDLLUtil/include/LinkedList.h
+++ b/CvGameCoreDLLUtil/include/LinkedList.h
@@ -8,24 +8,20 @@
 
 template <class tVARTYPE> class CLinkList;
 
-
 template <class tVARTYPE> class CLLNode
 {
 
 friend class CLinkList<tVARTYPE>;
 
 public:
+    CLLNode(const tVARTYPE& val) 
+        : m_data(val), m_pNext(NULL), m_pPrev(NULL) 
+    {
+    }
 
-    CLLNode(const tVARTYPE& val)
-          {
-	          m_data = val;
+    virtual ~CLLNode() {}
 
-	          m_pNext = NULL;
-	          m_pPrev = NULL;
-          }
-	virtual ~CLLNode() {}
-
-	tVARTYPE	m_data;		//list of vartype
+    tVARTYPE m_data; // list of vartype
 
 protected:
 
@@ -33,7 +29,6 @@ protected:
 	CLLNode<tVARTYPE>*	m_pPrev;
 
 };
-
 
 template <class tVARTYPE> class CLinkList
 {

--- a/CvGameCoreDLL_Expansion2/TContainer.h
+++ b/CvGameCoreDLL_Expansion2/TContainer.h
@@ -70,9 +70,17 @@ public:
 	void Write( FDataStream* pStream ) const;
 
 private:
-	//hide copy constructor and assignment operator
-	TContainer(const TContainer& other) {}
-	const TContainer& operator=(const TContainer& rhs) {}
+    //hide copy constructor and assignment operator
+    TContainer(const TContainer& other) {}
+    const TContainer& operator=(const TContainer& rhs) 
+    {
+        if (this != &rhs) {
+            // Copy the contents
+            m_items = rhs.m_items;
+            m_order = rhs.m_order;
+        }
+        return *this;
+    }
 
 protected:
 	std::tr1::unordered_map<int,T*> m_items; //for lookup by id

--- a/FirePlace/include/FireWorks/FFastList.h
+++ b/FirePlace/include/FireWorks/FFastList.h
@@ -695,9 +695,12 @@ protected:
 	FCustomList_Tail_Member( const TYPE& rhs ) : m_kAllocator( rhs.m_kAllocator ) {};
 	~FCustomList_Tail_Member(){ m_kAllocator.clear(); };
 
-	const TYPE& operator = ( const TYPE& rhs ){
-		m_kAllocator = rhs.m_kAllocator;
-	};
+	const TYPE& operator=(const TYPE& rhs) {
+		if (this != &rhs) {  // Check for self-assignment
+			m_kAllocator = rhs.m_kAllocator;
+		}
+		return *this;  // Return a reference to the current object
+	}
 
 	T_ALLOCATOR m_kAllocator;
 
@@ -722,9 +725,12 @@ public:
 	FCustomList( const TYPE& rhs )
 		: CORE( rhs ) {};
 
-	const TYPE& operator=( const TYPE& rhs ){
-		CORE = rhs;
-	};
+	const TYPE& operator=(const TYPE& rhs) {
+		if (this != &rhs) {  // Check for self-assignment
+			CORE::operator=(rhs);  // Call the base class's assignment operator
+		}
+		return *this;  // Return a reference to the current object
+	}
 };
 
 ////////////////////////////////////////////////////////////////////////
@@ -766,9 +772,12 @@ public:
 	FCustomList( T_ALLOCATOR* pAlloc ) : CORE( pAlloc ) {};
 	FCustomList( const TYPE& rhs ) : CORE( rhs ) {};
 
-	const TYPE& operator=( const TYPE& rhs ){
-		CORE = rhs;
-	};
+	const TYPE& operator=(const TYPE& rhs) {
+		if (this != &rhs) {  // Check for self-assignment
+			CORE::operator=(rhs);  // Call the base class's assignment operator
+		}
+		return *this;  // Return a reference to the current object
+	}
 };
 
 
@@ -880,11 +889,13 @@ public:
 	~FMultiList(){};
 
 	//Copy operator
-	const TYPE& operator = ( const TYPE& rhs )
-	{
-		m_pAlloc = rhs.m_pAlloc;
-		m_kVector = rhs.m_kVector;
-	};
+	const TYPE& operator=(const TYPE& rhs) {
+		if (this != &rhs) {  // Check for self-assignment
+			m_pAlloc = rhs.m_pAlloc;
+			m_kVector = rhs.m_kVector;
+		}
+		return *this;  // Return a reference to the current object
+	}
 
 	////////////////////////////////////////////////////////////////////////
 	// Methods to insert/remove elements from the list


### PR DESCRIPTION
Just fixing a couple cppcheck issues.
```
Id: useInitializationList
CWE: 398
When an object of a class is created, the constructors of all member variables are called consecutively in the order the variables are declared, even if you don't explicitly write them to the initialization list. You could avoid assigning 'm_data' a value by passing the value to the constructor in the initialization list.
Id: missingReturn
CWE: 758
Found an exit path from function with non-void return type that has missing return statement
Id: operatorEqMissingReturnStatement
CWE: 398
No 'return' statement in non-void function causes undefined behavior.
```