### PR TITLE
Fix multiplayer desync in m_iCycleOrder

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvUnit.h
+++ b/CvGameCoreDLL_Expansion2/CvUnit.h
@@ -2499,7 +2499,7 @@ SYNC_ARCHIVE_VAR(int, m_iBaseRangedCombat)
 SYNC_ARCHIVE_VAR(int, m_iHotKeyNumber)
 SYNC_ARCHIVE_VAR(int, m_iDeployFromOperationTurn)
 SYNC_ARCHIVE_VAR(int, m_iLastMoveTurn)
-SYNC_ARCHIVE_VAR(int, m_iCycleOrder)
+//SYNC_ARCHIVE_VAR(int, m_iCycleOrder) don't sync this, it's used for the UI only
 SYNC_ARCHIVE_VAR(int, m_iReconX)
 SYNC_ARCHIVE_VAR(int, m_iReconY)
 SYNC_ARCHIVE_VAR(int, m_iReconCount)


### PR DESCRIPTION
that variable doesn't need to be synced. (actually, it doesn't need to be serialized either, but I don't want to cause a savegame incompatibility so quickly after a new version came out. will remove the serialization later)