### PR TITLE
clang warning

### DIFF
--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlot.cpp
@@ -31,7 +31,7 @@
 	lua_setfield(L, t, #Name);
 
 //safety measure against illegal pointers passed from lua
-#define CHECK_PLOT_VALID(p) if(!p||!GC.getMap().isPlot(p->getX(),p->getY())|(p<GC.getMap().plotByIndexUnchecked(0))|(p>GC.getMap().plotByIndexUnchecked(GC.getMap().numPlots()-1))) return 0;
+#define CHECK_PLOT_VALID(p) if (!p || !GC.getMap().isPlot(p->getX(), p->getY()) || (p < GC.getMap().plotByIndexUnchecked(0)) || (p > GC.getMap().plotByIndexUnchecked(GC.getMap().numPlots() - 1))) return 0;
 
 //------------------------------------------------------------------------------
 void CvLuaPlot::PushMethods(lua_State* L, int t)


### PR DESCRIPTION
Fixes Wbitwise-instead-of-logical (118 warnings). Clang and msvc builds. Mod runs.

Using the the logical OR operator (||) instead of the bitwise OR operator (|).

A few more to go...
```
118 [-Wbitwise-instead-of-logical]
44 [-Wdelete-non-abstract-non-virtual-dtor]
16 [-Woverloaded-virtual]
111 [-Wreorder-ctor]
66 [-Wunused-but-set-variable]
2 [-Wunused-const-variable]
6228 [-Wunused-function]
30 [-Wunused-variable]
```