### PR TITLE
Espionage Building Scaler Rescaled

### DIFF
--- a/(1) Community Patch/Core Files/Core Values/CoreDefines.sql
+++ b/(1) Community Patch/Core Files/Core Values/CoreDefines.sql
@@ -861,7 +861,7 @@ INSERT INTO Defines (Name, Value) SELECT 'ESPIONAGE_SECURITY_BASE', 10; -- Base 
 INSERT INTO Defines (Name, Value) SELECT 'ESPIONAGE_SECURITY_NOT_ALL_HAVE_SPIES', 1000; -- Security if not all players have a Spy
 INSERT INTO Defines (Name, Value) SELECT 'ESPIONAGE_SECURITY_PREVIOUS_CITY_MISSIONS', 2; -- Security for each previous Spy Mission completed in the City
 INSERT INTO Defines (Name, Value) SELECT 'ESPIONAGE_SECURITY_PER_POPULATION', -2; -- Security per Population in City
-INSERT INTO Defines (Name, Value) SELECT 'ESPIONAGE_SECURITY_PER_POPULATION_BUILDING_SCALER', 2; -- +1 Security per X Population in city for each SpySecurityModifierPerXPop provided by buildings
+INSERT INTO Defines (Name, Value) SELECT 'ESPIONAGE_SECURITY_PER_POPULATION_BUILDING_SCALER', 360; -- +1 Security per X Population in city for each SpySecurityModifierPerXPop provided by buildings
 INSERT INTO Defines (Name, Value) SELECT 'ESPIONAGE_SECURITY_PER_TRADE_ROUTE', -1; -- Security per Trade Route to/from City
 INSERT INTO Defines (Name, Value) SELECT 'ESPIONAGE_SECURITY_PER_EXCESS_UNHAPPINESS', -4; -- Security per Excess Unhappiness in City
 

--- a/(2) Vox Populi/Database Changes/City/Buildings/BuildingChanges.sql
+++ b/(2) Vox Populi/Database Changes/City/Buildings/BuildingChanges.sql
@@ -1176,7 +1176,7 @@ UPDATE Buildings
 SET
 	EspionageModifier = 0,
 	SpySecurityModifier = 20,
-	SpySecurityModifierPerXPop = 1,
+	SpySecurityModifierPerXPop = 180, -- ESPIONAGE_SECURITY_PER_POPULATION_BUILDING_SCALER = 360, so 180/360 gives 1 per 2 population in city
 	DistressFlatReduction = 1
 WHERE BuildingClass = 'BUILDINGCLASS_CONSTABLE';
 
@@ -1186,7 +1186,7 @@ SET
 	PrereqTech = 'TECH_ELECTRONICS',
 	EspionageModifier = 0,
 	SpySecurityModifier = 10,
-	SpySecurityModifierPerXPop = 1,
+	SpySecurityModifierPerXPop = 180, -- ESPIONAGE_SECURITY_PER_POPULATION_BUILDING_SCALER = 360, so 180/360 gives 1 per 2 population in city
 	DistressFlatReduction = 1,
 	PovertyFlatReduction = 1,
 	IlliteracyFlatReduction = 1,


### PR DESCRIPTION
Changes scaler in core defines to use base 360 instead of base 2. As coded, if modders want to set any value other than 2, the core defines needs to be re-set every time. This change sets the base core define to 360, which has many factors, so that security values can be manipulated more flexibly via SpySecurityModifierPerXPop.