### PR TITLE
Builder AI tweaks

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
@@ -1643,8 +1643,6 @@ vector<OptionWithScore<BuilderDirective>> CvBuilderTaskingAI::GetRouteDirectives
 		if (!ShouldAnyBuilderConsiderPlot(pPlot))
 			continue;
 
-		iValue /= 10;
-
 		AddRouteOrRepairDirective(aDirectives, pPlot, eRoute, iValue, plotPurposes[pPlot]);
 	}
 
@@ -2015,8 +2013,6 @@ void CvBuilderTaskingAI::AddImprovingPlotsDirective(vector<OptionWithScore<Build
 		{
 			continue;
 		}
-
-		iScore /= 10;
 		
 		if (iScore > iMinScore)
 		{
@@ -2105,8 +2101,6 @@ void CvBuilderTaskingAI::AddRemoveRouteDirective(vector<OptionWithScore<BuilderD
 	//if we are losing gold, be more aggressive
 	if (iNetGoldTimes100 < -1000)
 		iWeight *= 10;
-
-	iWeight /= 10;
 
 	BuilderDirective directive(BuilderDirective::REMOVE_ROAD, m_eRemoveRouteBuild, NO_RESOURCE, false, pPlot->getX(), pPlot->getY(), iWeight);
 
@@ -2389,8 +2383,6 @@ void CvBuilderTaskingAI::AddRepairImprovementDirective(vector<OptionWithScore<Bu
 
 	int iWeight = ScorePlotBuild(pPlot, pPlot->getImprovementType(), m_eRepairBuild);
 
-	iWeight /= 10;
-
 	if (iWeight > 0)
 	{
 		BuilderDirective directive(BuilderDirective::REPAIR, m_eRepairBuild, NO_RESOURCE, false, pPlot->getX(), pPlot->getY(), iWeight);
@@ -2440,8 +2432,6 @@ void CvBuilderTaskingAI::AddScrubFalloutDirectives(vector<OptionWithScore<Builde
 	if(pPlot->getFeatureType() == m_eFalloutFeature && m_pPlayer->canBuild(pPlot, m_eFalloutRemove))
 	{
 		int iWeight =/*20000*/ GD_INT_GET(BUILDER_TASKING_BASELINE_SCRUB_FALLOUT);
-
-		iWeight /= 10;
 
 		BuilderDirective directive(BuilderDirective::CHOP, m_eFalloutRemove, NO_RESOURCE, false, pPlot->getX(), pPlot->getY(), iWeight);
 		aDirectives.push_back(OptionWithScore<BuilderDirective>(directive, iWeight));
@@ -2555,10 +2545,10 @@ int CvBuilderTaskingAI::GetResourceWeight(ResourceTypes eResource, int iQuantity
 
 		// We have plenty to spare
 		if (iNumResourceAvailable > 1)
-			iValue /= 10;
+			iValue /= 2;
 		// We have one already
 		else if (iNumResourceAvailable > 0)
-			iValue /= 2;
+			iValue = (iValue * 3) / 4;
 
 		return iValue;
 	}
@@ -2570,11 +2560,11 @@ int CvBuilderTaskingAI::GetResourceWeight(ResourceTypes eResource, int iQuantity
 		int iNumResourceAvailable = m_pPlayer->getNumResourceAvailable(eResource) + iAdditionalOwned;
 
 		// We have plenty to spare
-		if (iNumResourceAvailable > 5)
-			iValue /= 10;
-		// We have some already
-		else if (iNumResourceAvailable > 0)
+		if (iNumResourceAvailable > 4)
 			iValue /= 2;
+		// We have some already
+		else if (iNumResourceAvailable > 1)
+			iValue = (iValue * 3) / 4;
 
 		return iValue;
 	}
@@ -3054,26 +3044,72 @@ int CvBuilderTaskingAI::ScorePlotBuild(CvPlot* pPlot, ImprovementTypes eImprovem
 
 	//Improvement grants or connects resource
 	//Don't give any bonus if we are creating a resource on top of an existing one
-	if (pOwningCity && ((eResourceFromImprovement != NO_RESOURCE && eResource == NO_RESOURCE) || (eResource != NO_RESOURCE && pkImprovementInfo && pkImprovementInfo->IsConnectsResource(eResource))))
+	bool bOldCreatedResource = eResourceFromOldImprovement != NO_RESOURCE;
+	bool bOldConnectedResource = eNaturalResource != NO_RESOURCE && pkOldImprovementInfo && pkOldImprovementInfo->IsConnectsResource(eNaturalResource);
+	bool bNewCreatesResource = eResourceFromImprovement != NO_RESOURCE;
+	bool bNewConnectsResource = eNaturalResource != NO_RESOURCE && pkImprovementInfo && pkImprovementInfo->IsConnectsResource(eNaturalResource);
+	if (pOwningCity)
 	{
-		ResourceTypes eConnectedResource = eResourceFromImprovement != NO_RESOURCE ? eResourceFromImprovement : eResource;
-		int iResourceAmount = eResourceFromImprovement != NO_RESOURCE ? pkImprovementInfo->GetResourceQuantityFromImprovement() : pPlot->getNumResource();
-		int iResourceWeight = GetResourceWeight(eConnectedResource, iResourceAmount, iExtraResource);
-		iSecondaryScore += iResourceWeight;
-
-		CvResourceInfo* pkConnectedResource = GC.getResourceInfo(eConnectedResource);
-		//amp up monopoly alloc!
-		if (pkConnectedResource && pkConnectedResource->isMonopoly())
+		ResourceTypes eRemovedResource = NO_RESOURCE;
+		ResourceTypes eCreatedResource = NO_RESOURCE;
+		if (bOldCreatedResource)
 		{
-			if (pkConnectedResource->getResourceUsage() == RESOURCEUSAGE_LUXURY)
+			eRemovedResource = eResourceFromOldImprovement;
+		}
+		if (bOldConnectedResource && !bNewConnectsResource)
+		{
+			eRemovedResource = eNaturalResource;
+		}
+		if (!bOldConnectedResource && bNewConnectsResource)
+		{
+			eCreatedResource = eNaturalResource;
+		}
+		if (bNewCreatesResource)
+		{
+			eCreatedResource = eResourceFromImprovement;
+		}
+
+		if (eCreatedResource)
+		{
+			int iResourceAmount = eResourceFromImprovement != NO_RESOURCE ? pkImprovementInfo->GetResourceQuantityFromImprovement() : pPlot->getNumResource();
+			int iResourceWeight = GetResourceWeight(eCreatedResource, iResourceAmount, iExtraResource);
+			iSecondaryScore += iResourceWeight;
+
+			CvResourceInfo* pkConnectedResource = GC.getResourceInfo(eCreatedResource);
+			//amp up monopoly alloc!
+			if (pkConnectedResource && pkConnectedResource->isMonopoly())
 			{
-				if (m_pPlayer->GetMonopolyPercent(eConnectedResource) > 0 && m_pPlayer->GetMonopolyPercent(eConnectedResource) <= /*50*/ GD_INT_GET(GLOBAL_RESOURCE_MONOPOLY_THRESHOLD))
-					iSecondaryScore += (iResourceWeight * m_pPlayer->GetMonopolyPercent(eConnectedResource)) / 25;
+				if (pkConnectedResource->getResourceUsage() == RESOURCEUSAGE_LUXURY)
+				{
+					if (m_pPlayer->GetMonopolyPercent(eCreatedResource) > 0 && m_pPlayer->GetMonopolyPercent(eCreatedResource) <= /*50*/ GD_INT_GET(GLOBAL_RESOURCE_MONOPOLY_THRESHOLD))
+						iSecondaryScore += (iResourceWeight * m_pPlayer->GetMonopolyPercent(eCreatedResource)) / 25;
+				}
+				else if (pkConnectedResource->getResourceUsage() == RESOURCEUSAGE_STRATEGIC)
+				{
+					if (m_pPlayer->GetMonopolyPercent(eCreatedResource) > 0 && m_pPlayer->GetMonopolyPercent(eCreatedResource) <= /*50*/ GD_INT_GET(GLOBAL_RESOURCE_MONOPOLY_THRESHOLD))
+						iSecondaryScore += (iResourceWeight * m_pPlayer->GetMonopolyPercent(eCreatedResource)) / 25;
+				}
 			}
-			else if (pkConnectedResource->getResourceUsage() == RESOURCEUSAGE_STRATEGIC)
+		}
+		if (eRemovedResource)
+		{
+			int iResourceAmount = eResourceFromOldImprovement != NO_RESOURCE ? pkOldImprovementInfo->GetResourceQuantityFromImprovement() : pPlot->getNumResource();
+			int iResourceWeight = GetResourceWeight(eRemovedResource, iResourceAmount, iExtraResource);
+			iSecondaryScore -= iResourceWeight;
+
+			CvResourceInfo* pkConnectedResource = GC.getResourceInfo(eRemovedResource);
+			if (pkConnectedResource && pkConnectedResource->isMonopoly())
 			{
-				if (m_pPlayer->GetMonopolyPercent(eConnectedResource) > 0 && m_pPlayer->GetMonopolyPercent(eConnectedResource) <= /*50*/ GD_INT_GET(GLOBAL_RESOURCE_MONOPOLY_THRESHOLD))
-					iSecondaryScore += (iResourceWeight * m_pPlayer->GetMonopolyPercent(eConnectedResource)) / 25;
+				if (pkConnectedResource->getResourceUsage() == RESOURCEUSAGE_LUXURY)
+				{
+					if (m_pPlayer->GetMonopolyPercent(eRemovedResource) > 0 && m_pPlayer->GetMonopolyPercent(eRemovedResource) <= /*50*/ GD_INT_GET(GLOBAL_RESOURCE_MONOPOLY_THRESHOLD))
+						iSecondaryScore -= (iResourceWeight * m_pPlayer->GetMonopolyPercent(eRemovedResource)) / 25;
+				}
+				else if (pkConnectedResource->getResourceUsage() == RESOURCEUSAGE_STRATEGIC)
+				{
+					if (m_pPlayer->GetMonopolyPercent(eRemovedResource) > 0 && m_pPlayer->GetMonopolyPercent(eRemovedResource) <= /*50*/ GD_INT_GET(GLOBAL_RESOURCE_MONOPOLY_THRESHOLD))
+						iSecondaryScore -= (iResourceWeight * m_pPlayer->GetMonopolyPercent(eRemovedResource)) / 25;
+				}
 			}
 		}
 	}
@@ -3129,8 +3165,13 @@ int CvBuilderTaskingAI::ScorePlotBuild(CvPlot* pPlot, ImprovementTypes eImprovem
 	}
 
 	// Do we want a canal here?
-	if ((pOwningCity || (bIsCultureBomb && pPlot->isAdjacentPlayer(m_pPlayer->GetID()))) && MOD_GLOBAL_PASSABLE_FORTS && pkImprovementInfo && pkImprovementInfo->IsMakesPassable() && WantCanalAtPlot(pPlot) && pkImprovementInfo->GetNearbyEnemyDamage() == 0)
-		iSecondaryScore += 3000;
+	if ((pOwningCity || (bIsCultureBomb && pPlot->isAdjacentPlayer(m_pPlayer->GetID()))) && MOD_GLOBAL_PASSABLE_FORTS && WantCanalAtPlot(pPlot))
+	{
+		if (pkImprovementInfo && pkImprovementInfo->IsMakesPassable() && (pkImprovementInfo->GetNearbyEnemyDamage() == 0 || eBuild == NO_BUILD))
+			iSecondaryScore += 3000;
+		if (pkOldImprovementInfo && pkOldImprovementInfo->IsMakesPassable())
+			iSecondaryScore -= 3000;
+	}
 
 	// TODO flesh out culture bomb logic and move it from TacticalAI?
 	// Currently this is only for human player recommendations.

--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
@@ -3094,7 +3094,7 @@ int CvBuilderTaskingAI::ScorePlotBuild(CvPlot* pPlot, ImprovementTypes eImprovem
 		if (eRemovedResource)
 		{
 			int iResourceAmount = eResourceFromOldImprovement != NO_RESOURCE ? pkOldImprovementInfo->GetResourceQuantityFromImprovement() : pPlot->getNumResource();
-			int iResourceWeight = GetResourceWeight(eRemovedResource, iResourceAmount, iExtraResource);
+			int iResourceWeight = GetResourceWeight(eRemovedResource, iResourceAmount, iExtraResource - iResourceAmount);
 			iSecondaryScore -= iResourceWeight;
 
 			CvResourceInfo* pkConnectedResource = GC.getResourceInfo(eRemovedResource);

--- a/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
@@ -2520,7 +2520,7 @@ static int GetDirectiveWeight(BuilderDirective eDirective, int iBuildTurns, int 
 
 	// Try to avoid moving around too much with workers
 	if (!eDirective.m_bIsGreatPerson)
-		iMoveTurns *= 2;
+		iMoveTurns += iMoveTurns / 2;
 
 	int iBuildTime = iBuildTurns + iMoveTurns;
 
@@ -2534,7 +2534,7 @@ static int GetDirectiveWeight(BuilderDirective eDirective, int iBuildTurns, int 
 		return iScore * iScore;
 
 	const int iScoreWeightSquared = 1;
-	int iBuildTimeWeightSquared = eDirective.m_bIsGreatPerson ? 16 : 100;
+	int iBuildTimeWeightSquared = eDirective.m_bIsGreatPerson ? 1600 : 10000;
 
 	return (iScore * iScore) * iScoreWeightSquared - (iBuildTime * iBuildTime) * iBuildTimeWeightSquared;
 }
@@ -3024,7 +3024,6 @@ void CvHomelandAI::ExecuteWorkerMoves()
 						{
 							int iScore = pBuilderTaskingAI->ScorePlotBuild(pDirectivePlot, eOtherImprovement, eOtherDirective.m_eBuild, sState);
 
-							iScore /= 10;
 							// If we are planning to build something else here in the future, downscale the priority of this by 1/3
 							eOtherDirective.m_iScore = iScore;
 							eOtherDirective.m_iScorePenalty += iScore / 3;
@@ -3051,8 +3050,6 @@ void CvHomelandAI::ExecuteWorkerMoves()
 					{
 						int iScore = pBuilderTaskingAI->ScorePlotBuild(pOtherPlot, eOtherImprovement, eOtherDirective.m_eBuild, sState);
 
-						iScore /= 10;
-
 						if (iScore != eOtherDirective.m_iScore)
 						{
 							eOtherDirective.m_iScore = iScore;
@@ -3075,8 +3072,6 @@ void CvHomelandAI::ExecuteWorkerMoves()
 						if (eOtherFeature != pOtherPlot->getFeatureType())
 						{
 							int iScore = pBuilderTaskingAI->ScorePlotBuild(pOtherPlot, eOtherImprovement, eOtherDirective.m_eBuild, sState);
-
-							iScore /= 10;
 
 							if (iScore != eOtherDirective.m_iScore)
 							{
@@ -3106,8 +3101,6 @@ void CvHomelandAI::ExecuteWorkerMoves()
 						{
 							int iScore = pBuilderTaskingAI->ScorePlotBuild(pOtherPlot, eOtherImprovement, eOtherDirective.m_eBuild, sState);
 
-							iScore /= 10;
-
 							if (iScore != eOtherDirective.m_iScore)
 							{
 								eOtherDirective.m_iScore = iScore;
@@ -3126,8 +3119,6 @@ void CvHomelandAI::ExecuteWorkerMoves()
 						if (eOtherImprovement != NO_IMPROVEMENT)
 						{
 							int iScore = pBuilderTaskingAI->ScorePlotBuild(pOtherPlot, eOtherImprovement, eOtherDirective.m_eBuild, sState);
-
-							iScore /= 10;
 
 							if (iScore != eOtherDirective.m_iScore)
 							{


### PR DESCRIPTION
Make workers less focused on local improvements.

Fix some issues causing the AI to love removing some existing improvements, especially related to resources.

Increase value of already owned resources by a bit.

Stop dividing all builder scores by 10.