### PR TITLE
Builder AI fixes and tweaks

### DIFF
--- a/CvGameCoreDLLUtil/include/CvLuaMethodWrapper.h
+++ b/CvGameCoreDLLUtil/include/CvLuaMethodWrapper.h
@@ -22,6 +22,8 @@ protected:
 	static int BasicLuaMethod(lua_State* L, ret (FnInstanceType::*func)(arg1, arg2, arg3) const);
 	template<typename ret, typename arg1, typename arg2, typename arg3, typename arg4, typename FnInstanceType>
 	static int BasicLuaMethod(lua_State* L, ret (FnInstanceType::*func)(arg1, arg2, arg3, arg4) const);
+	template<typename ret, typename arg1, typename arg2, typename arg3, typename arg4, typename arg5, typename FnInstanceType>
+	static int BasicLuaMethod(lua_State* L, ret(FnInstanceType::* func)(arg1, arg2, arg3, arg4, arg5) const);
 
 	//regular variations (non const)
 	template<typename ret, typename FnInstanceType>
@@ -34,6 +36,8 @@ protected:
 	static int BasicLuaMethod(lua_State* L, ret (FnInstanceType::*func)(arg1, arg2, arg3));
 	template<typename ret, typename arg1, typename arg2, typename arg3, typename arg4, typename FnInstanceType>
 	static int BasicLuaMethod(lua_State* L, ret (FnInstanceType::*func)(arg1, arg2, arg3, arg4));
+	template<typename ret, typename arg1, typename arg2, typename arg3, typename arg4, typename arg5, typename FnInstanceType>
+	static int BasicLuaMethod(lua_State* L, ret(FnInstanceType::* func)(arg1, arg2, arg3, arg4, arg5));
 
 	//void variations (const)
 	template<typename FnInstanceType>
@@ -115,6 +119,16 @@ int CvLuaMethodWrapper<Derived, InstanceType>::BasicLuaMethod(lua_State* L, ret 
 
 	return 1;
 }
+//------------------------------------------------------------------------------
+template<class Derived, class InstanceType> template<typename ret, typename arg1, typename arg2, typename arg3, typename arg4, typename arg5, typename FnInstanceType>
+int CvLuaMethodWrapper<Derived, InstanceType>::BasicLuaMethod(lua_State* L, ret(FnInstanceType::* func)(arg1, arg2, arg3, arg4, arg5) const)
+{
+	const int idx = Derived::GetStartingArgIndex();
+	InstanceType* pkType = Derived::GetInstance(L);
+	CvLuaArgs::pushValue<ret>(L, (pkType->*func)(CvLuaArgs::toValue<arg1>(L, idx), CvLuaArgs::toValue<arg2>(L, idx + 1), CvLuaArgs::toValue<arg3>(L, idx + 2), CvLuaArgs::toValue<arg4>(L, idx + 3), CvLuaArgs::toValue<arg5>(L, idx + 4)));
+
+	return 1;
+}
 
 //------------------------------------------------------------------------------
 // regular variations (non const)
@@ -164,6 +178,16 @@ int CvLuaMethodWrapper<Derived, InstanceType>::BasicLuaMethod(lua_State* L, ret 
 	const int idx = Derived::GetStartingArgIndex();
 	InstanceType* pkType = Derived::GetInstance(L);
 	CvLuaArgs::pushValue<ret>(L, (pkType->*func)(CvLuaArgs::toValue<arg1>(L, idx), CvLuaArgs::toValue<arg2>(L, idx + 1), CvLuaArgs::toValue<arg3>(L, idx + 2), CvLuaArgs::toValue<arg4>(L, idx + 3)));
+
+	return 1;
+}
+//------------------------------------------------------------------------------
+template<class Derived, class InstanceType> template<typename ret, typename arg1, typename arg2, typename arg3, typename arg4, typename arg5, typename FnInstanceType>
+int CvLuaMethodWrapper<Derived, InstanceType>::BasicLuaMethod(lua_State* L, ret(FnInstanceType::* func)(arg1, arg2, arg3, arg4, arg5))
+{
+	const int idx = Derived::GetStartingArgIndex();
+	InstanceType* pkType = Derived::GetInstance(L);
+	CvLuaArgs::pushValue<ret>(L, (pkType->*func)(CvLuaArgs::toValue<arg1>(L, idx), CvLuaArgs::toValue<arg2>(L, idx + 1), CvLuaArgs::toValue<arg3>(L, idx + 2), CvLuaArgs::toValue<arg4>(L, idx + 3), CvLuaArgs::toValue<arg5>(L, idx + 4)));
 
 	return 1;
 }

--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.h
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.h
@@ -125,7 +125,7 @@ public:
 	bool IsRoutePlanned(CvPlot* pPlot, RouteTypes eRoute, RoutePurpose ePurpose) const;
 	bool WantCanalAtPlot(const CvPlot* pPlot) const; //build it and keep it
 	bool WillNeverBuildVillageOnPlot(CvPlot* pPlot, RouteTypes eRoute, bool bIgnoreUnowned) const;
-	ImprovementTypes SavePlotForUniqueImprovement(CvPlot* pPlot) const;
+	ImprovementTypes SavePlotForUniqueImprovement(const CvPlot* pPlot) const;
 
 	int ScorePlotBuild(CvPlot* pPlot, ImprovementTypes eImprovement, BuildTypes eBuild, const SBuilderState& sState = SBuilderState::DefaultInstance());
 	int GetTotalRouteBuildTime(const CvUnit* pUnit, const CvPlot* pPlot) const;
@@ -177,6 +177,9 @@ protected:
 	int GetRouteBuildTime(PlannedRoute plannedRoute, const CvUnit* pUnit = (CvUnit*)NULL) const;
 	int GetRouteMissingTiles(PlannedRoute plannedRoute) const;
 
+	void SetupExtraXAdjacentPlots();
+	bool SetupExtraXAdjacentBuildPlot(const CvPlot* pPlot, BuildTypes eBuild, ImprovementTypes eImprovement, int iAdjacencyRequirement, std::tr1::unordered_set<const CvPlot*> sIgnoredPlots = std::tr1::unordered_set<const CvPlot*>());
+
 	void UpdateCanalPlots();
 
 	PlotPair GetPlotPair(int iPlotId1, int iPlotId2);
@@ -208,6 +211,8 @@ protected:
 
 	//some player dependent flags for unique improvements
 	vector<ImprovementTypes> m_uniqueImprovements; // serialized
+
+	std::tr1::unordered_map<ImprovementTypes, std::tr1::unordered_set<const CvPlot*>> m_extraPlotsForXAdjacentImprovements;
 };
 
 FDataStream& operator>>(FDataStream&, CvBuilderTaskingAI&);

--- a/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
@@ -2516,11 +2516,11 @@ bool CvHomelandAI::ExecuteExplorerMoves(CvUnit* pUnit)
 // Higher weight means better directive
 static int GetDirectiveWeight(BuilderDirective eDirective, int iBuildTurns, int iMoveTurns)
 {
-	int iScore = eDirective.GetScore();
+	int iScore = eDirective.GetScore() / 10;
 
 	// Try to avoid moving around too much with workers
 	if (!eDirective.m_bIsGreatPerson)
-		iMoveTurns *= 2;
+		iMoveTurns *= 4;
 
 	int iBuildTime = iBuildTurns + iMoveTurns;
 
@@ -2534,7 +2534,7 @@ static int GetDirectiveWeight(BuilderDirective eDirective, int iBuildTurns, int 
 		return iScore * iScore;
 
 	const int iScoreWeightSquared = 1;
-	int iBuildTimeWeightSquared = eDirective.m_bIsGreatPerson ? 16 : 100;
+	int iBuildTimeWeightSquared = 100;
 
 	return (iScore * iScore) * iScoreWeightSquared - (iBuildTime * iBuildTime) * iBuildTimeWeightSquared;
 }
@@ -3024,7 +3024,6 @@ void CvHomelandAI::ExecuteWorkerMoves()
 						{
 							int iScore = pBuilderTaskingAI->ScorePlotBuild(pDirectivePlot, eOtherImprovement, eOtherDirective.m_eBuild, sState);
 
-							iScore /= 10;
 							// If we are planning to build something else here in the future, downscale the priority of this by 1/3
 							eOtherDirective.m_iScore = iScore;
 							eOtherDirective.m_iScorePenalty += iScore / 3;
@@ -3051,8 +3050,6 @@ void CvHomelandAI::ExecuteWorkerMoves()
 					{
 						int iScore = pBuilderTaskingAI->ScorePlotBuild(pOtherPlot, eOtherImprovement, eOtherDirective.m_eBuild, sState);
 
-						iScore /= 10;
-
 						if (iScore != eOtherDirective.m_iScore)
 						{
 							eOtherDirective.m_iScore = iScore;
@@ -3075,8 +3072,6 @@ void CvHomelandAI::ExecuteWorkerMoves()
 						if (eOtherFeature != pOtherPlot->getFeatureType())
 						{
 							int iScore = pBuilderTaskingAI->ScorePlotBuild(pOtherPlot, eOtherImprovement, eOtherDirective.m_eBuild, sState);
-
-							iScore /= 10;
 
 							if (iScore != eOtherDirective.m_iScore)
 							{
@@ -3106,8 +3101,6 @@ void CvHomelandAI::ExecuteWorkerMoves()
 						{
 							int iScore = pBuilderTaskingAI->ScorePlotBuild(pOtherPlot, eOtherImprovement, eOtherDirective.m_eBuild, sState);
 
-							iScore /= 10;
-
 							if (iScore != eOtherDirective.m_iScore)
 							{
 								eOtherDirective.m_iScore = iScore;
@@ -3126,8 +3119,6 @@ void CvHomelandAI::ExecuteWorkerMoves()
 						if (eOtherImprovement != NO_IMPROVEMENT)
 						{
 							int iScore = pBuilderTaskingAI->ScorePlotBuild(pOtherPlot, eOtherImprovement, eOtherDirective.m_eBuild, sState);
-
-							iScore /= 10;
 
 							if (iScore != eOtherDirective.m_iScore)
 							{

--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -2471,7 +2471,7 @@ bool CvPlot::canHaveResource(ResourceTypes eResource, bool bIgnoreLatitude, bool
 
 
 //	--------------------------------------------------------------------------------
-bool CvPlot::canHaveImprovement(ImprovementTypes eImprovement, PlayerTypes ePlayer, bool, bool bCheckAdjacency) const
+bool CvPlot::canHaveImprovement(ImprovementTypes eImprovement, PlayerTypes ePlayer, bool, bool bCheckAdjacency, bool bTestXAdjacent) const
 {
 	CvPlot* pLoopPlot = NULL;
 	bool bValid = false;
@@ -2670,18 +2670,25 @@ bool CvPlot::canHaveImprovement(ImprovementTypes eImprovement, PlayerTypes ePlay
 	{
 		int iAdjacentSameImprovement = 0;
 
-		for (iI = 0; iI < NUM_DIRECTION_TYPES; ++iI)
+		if (bTestXAdjacent)
 		{
-			pLoopPlot = plotDirection(getX(), getY(), ((DirectionTypes)iI));
-
-			if (pLoopPlot && pLoopPlot->getImprovementType() == eImprovement)
+			bValid = true;
+		}
+		else
+		{
+			for (iI = 0; iI < NUM_DIRECTION_TYPES; ++iI)
 			{
-				iAdjacentSameImprovement++;
+				pLoopPlot = plotDirection(getX(), getY(), ((DirectionTypes)iI));
 
-				if (iAdjacentSameImprovement >= iAdjacentSameImprovementMakesValid)
+				if (pLoopPlot && pLoopPlot->getImprovementType() == eImprovement)
 				{
-					bValid = true;
-					break;
+					iAdjacentSameImprovement++;
+
+					if (iAdjacentSameImprovement >= iAdjacentSameImprovementMakesValid)
+					{
+						bValid = true;
+						break;
+					}
 				}
 			}
 		}
@@ -2857,7 +2864,7 @@ BuildTypes CvPlot::GetBuildTypeFromImprovement(ImprovementTypes eImprovement) co
 
 
 //	--------------------------------------------------------------------------------
-bool CvPlot::canBuild(BuildTypes eBuild, PlayerTypes ePlayer, bool bTestVisible, bool bTestPlotOwner) const
+bool CvPlot::canBuild(BuildTypes eBuild, PlayerTypes ePlayer, bool bTestVisible, bool bTestPlotOwner, bool bTestXAdjacent) const
 {
 	static const ImprovementTypes eFeitoria = (ImprovementTypes)GC.getInfoTypeForString("IMPROVEMENT_FEITORIA");
 	TeamTypes eTeam = GET_PLAYER(ePlayer).getTeam();
@@ -2944,7 +2951,7 @@ bool CvPlot::canBuild(BuildTypes eBuild, PlayerTypes ePlayer, bool bTestVisible,
 	if(eImprovement != NO_IMPROVEMENT)
 	{
 		// Player must be able to build this Improvement
-		if(!canHaveImprovement(eImprovement, ePlayer, bTestVisible))
+		if(!canHaveImprovement(eImprovement, ePlayer, bTestVisible, false, bTestXAdjacent))
 		{
 			return false;
 		}

--- a/CvGameCoreDLL_Expansion2/CvPlot.h
+++ b/CvGameCoreDLL_Expansion2/CvPlot.h
@@ -168,10 +168,10 @@ public:
 	void updateSeeFromSight(bool bIncrement, bool bRecalculate);
 
 	bool canHaveResource(ResourceTypes eResource, bool bIgnoreLatitude = false, bool bIgnoreCiv = false) const;
-	bool canHaveImprovement(ImprovementTypes eImprovement, PlayerTypes ePlayer = NO_PLAYER, bool bOnlyTestVisible = false, bool bCheckAdjacency = false) const;
+	bool canHaveImprovement(ImprovementTypes eImprovement, PlayerTypes ePlayer = NO_PLAYER, bool bOnlyTestVisible = false, bool bCheckAdjacency = false, bool bTestXAdjacent = false) const;
 	BuildTypes GetBuildTypeFromImprovement(ImprovementTypes eImprovement) const;
 
-	bool canBuild(BuildTypes eBuild, PlayerTypes ePlayer = NO_PLAYER, bool bTestVisible = false, bool bTestPlotOwner = true) const;
+	bool canBuild(BuildTypes eBuild, PlayerTypes ePlayer = NO_PLAYER, bool bTestVisible = false, bool bTestPlotOwner = true, bool bTestXAdjacent = false) const;
 	int getBuildTime(BuildTypes eBuild, PlayerTypes ePlayer) const;
 	int getBuildTurnsTotal(BuildTypes eBuild, PlayerTypes ePlayer) const;
 	int getBuildTurnsLeft(BuildTypes eBuild, PlayerTypes ePlayer, int iNowExtra, int iThenExtra) const;


### PR DESCRIPTION
Fix some issues causing the AI to love removing some existing improvements, especially on resources.

Increase value of already owned resources by a bit.

Add handling for GetXSameAdjacentMakesValid improvements, should help China to better plan their improvements.

Fix AI (way) overvaluing yields for X worked features from buildings and beliefs.

Make workers less focused on local improvements.