### PR TITLE
CvPlotManger copy constructor

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvPlotManager.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlotManager.cpp
@@ -14,6 +14,7 @@
 //////////////////////////////////////////////////////////////////////////
 
 //	---------------------------------------------------------------------------
+/// Constructor
 CvSparseIDInfoGrid::CvSparseIDInfoGrid(uint uiWidth, uint uiHeight, CvIDInfoFixedVectorAllocator* pkAllocator)
 {
 	m_uiWidth = uiWidth;
@@ -25,6 +26,73 @@ CvSparseIDInfoGrid::CvSparseIDInfoGrid(uint uiWidth, uint uiHeight, CvIDInfoFixe
 	memset( &m_paEntries[0], 0, sizeof(CvIDInfoFixedVector*) * m_uiMaxIndex);
 
 	m_pkAllocator = pkAllocator;
+}
+
+//	---------------------------------------------------------------------------
+/// Copy constructor
+CvSparseIDInfoGrid::CvSparseIDInfoGrid(const CvSparseIDInfoGrid& other) :
+	m_uiWidth(other.m_uiWidth),
+	m_uiHeight(other.m_uiHeight),
+	m_uiMaxIndex(other.m_uiMaxIndex),
+	m_uiNumAllocated(other.m_uiNumAllocated),
+	m_pkAllocator(other.m_pkAllocator)
+{
+	m_paEntries = FNEW(CvIDInfoFixedVector*[m_uiMaxIndex], c_eCiv5GameplayDLL, 0);
+	for (uint i = 0; i < m_uiMaxIndex; ++i)
+	{
+		if (other.m_paEntries[i])
+		{
+			m_paEntries[i] = m_pkAllocator->GetFreeObject();
+			*m_paEntries[i] = *other.m_paEntries[i];
+		}
+		else
+		{
+			m_paEntries[i] = NULL;
+		}
+	}
+}
+
+//	---------------------------------------------------------------------------
+/// Assignment operator
+CvSparseIDInfoGrid& CvSparseIDInfoGrid::operator=(const CvSparseIDInfoGrid& other)
+{
+	if (this != &other)
+	{
+		// Release existing resources
+		if (m_paEntries)
+		{
+			for (uint i = 0; i < m_uiMaxIndex; ++i)
+			{
+				if (m_paEntries[i])
+				{
+					m_pkAllocator->Release(m_paEntries[i]);
+				}
+			}
+			delete[] m_paEntries;
+		}
+
+		// Copy new resources
+		m_uiWidth = other.m_uiWidth;
+		m_uiHeight = other.m_uiHeight;
+		m_uiMaxIndex = other.m_uiMaxIndex;
+		m_uiNumAllocated = other.m_uiNumAllocated;
+		m_pkAllocator = other.m_pkAllocator;
+
+		m_paEntries = FNEW(CvIDInfoFixedVector*[m_uiMaxIndex], c_eCiv5GameplayDLL, 0);
+		for (uint i = 0; i < m_uiMaxIndex; ++i)
+		{
+			if (other.m_paEntries[i])
+			{
+				m_paEntries[i] = m_pkAllocator->GetFreeObject();
+				*m_paEntries[i] = *other.m_paEntries[i];
+			}
+			else
+			{
+				m_paEntries[i] = NULL;
+			}
+		}
+	}
+	return *this;
 }
 
 //	---------------------------------------------------------------------------

--- a/CvGameCoreDLL_Expansion2/CvPlotManager.h
+++ b/CvGameCoreDLL_Expansion2/CvPlotManager.h
@@ -67,6 +67,8 @@ class CvSparseIDInfoGrid
 public:
 
 	CvSparseIDInfoGrid(uint uiWidth, uint uiHeight, CvIDInfoFixedVectorAllocator* pkAllocator);
+	CvSparseIDInfoGrid(const CvSparseIDInfoGrid& other); // Copy constructor
+	CvSparseIDInfoGrid& operator=(const CvSparseIDInfoGrid& other); // Assignment operator
 	~CvSparseIDInfoGrid();
 
 	const CvIDInfoFixedVector *Get(int iX, int iY) const;


### PR DESCRIPTION
Add copy constructor to fix cppcheck warnings. Both builds work.

The other ones that need review:
https://github.com/LoneGazebo/Community-Patch-DLL/blob/d897d8e37714544360357c21630ac5166ee0927b/CvGameCoreDLL_Expansion2/CvDllContext.cpp#L63
```
Id: noCopyConstructor
CWE: 398
Class 'CvDllGameContext' does not have a copy constructor which is recommended since it has dynamic memory/resource allocation(s).
Id: noOperatorEq
CWE: 398
Class 'CvDllGameContext' does not have a operator= which is recommended since it has dynamic memory/resource allocation(s).
```
https://github.com/LoneGazebo/Community-Patch-DLL/blob/d897d8e37714544360357c21630ac5166ee0927b/CvGameCoreDLL_Expansion2/CvCity.cpp#L324
```
Id: noCopyConstructor
CWE: 398
Class 'CvCity' does not have a copy constructor which is recommended since it has dynamic memory/resource allocation(s).
Id: noOperatorEq
CWE: 398
Class 'CvCity' does not have a operator= which is recommended since it has dynamic memory/resource allocation(s).
```