### PR TITLE
CvDllContext copy constructor

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvDllContext.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDllContext.cpp
@@ -54,16 +54,109 @@ CvDllGameContext* CvDllGameContext::s_pSingleton = NULL;
 HANDLE CvDllGameContext::s_hHeap = INVALID_HANDLE_VALUE;
 
 //------------------------------------------------------------------------------
-//------------------------------------------------------------------------------
-CvDllGameContext::CvDllGameContext()
-	: m_uiRngCounter(0)
-	, m_uiNetInitInfoCounter(0)
-	, m_uiNetLoadGameInfoCounter(0)
+// Constructor
+CvDllGameContext::CvDllGameContext() :
+	m_uiRngCounter(0),
+	m_uiNetInitInfoCounter(0),
+	m_uiNetLoadGameInfoCounter(0)
 {
 	m_pNetworkSyncronizer = new CvDllNetworkSyncronization();
 	m_pNetMessageHandler = new CvDllNetMessageHandler();
 	m_pScriptSystemUtility = new CvDllScriptSystemUtility();
 	m_pWorldBuilderMapLoader = new CvDllWorldBuilderMapLoader();
+}
+//------------------------------------------------------------------------------
+// Copy constructor
+CvDllGameContext::CvDllGameContext(const CvDllGameContext& other) :
+	m_uiRngCounter(other.m_uiRngCounter),
+	m_uiNetInitInfoCounter(other.m_uiNetInitInfoCounter),
+	m_uiNetLoadGameInfoCounter(other.m_uiNetLoadGameInfoCounter)
+{
+	m_pNetworkSyncronizer = new CvDllNetworkSyncronization(*other.m_pNetworkSyncronizer);
+	m_pNetMessageHandler = new CvDllNetMessageHandler(*other.m_pNetMessageHandler);
+	m_pScriptSystemUtility = new CvDllScriptSystemUtility(*other.m_pScriptSystemUtility);
+	m_pWorldBuilderMapLoader = new CvDllWorldBuilderMapLoader(*other.m_pWorldBuilderMapLoader);
+
+	for (std::vector<std::pair<uint, CvRandom*> >::const_iterator it = other.m_RandomNumberGenerators.begin();
+		it != other.m_RandomNumberGenerators.end(); ++it)
+	{
+		m_RandomNumberGenerators.push_back(std::make_pair(it->first, it->second->Clone()));
+	}
+
+	for (std::vector<std::pair<uint, CvDllNetInitInfo*> >::const_iterator it = other.m_NetInitInfos.begin();
+		it != other.m_NetInitInfos.end(); ++it)
+	{
+		m_NetInitInfos.push_back(std::make_pair(it->first, new CvDllNetInitInfo(*it->second)));
+	}
+
+	for (std::vector<std::pair<uint, CvDllNetLoadGameInfo*> >::const_iterator it = other.m_NetLoadGameInfos.begin();
+		it != other.m_NetLoadGameInfos.end(); ++it)
+	{
+		m_NetLoadGameInfos.push_back(std::make_pair(it->first, new CvDllNetLoadGameInfo(*it->second)));
+	}
+}
+//------------------------------------------------------------------------------
+// Assignment operator
+CvDllGameContext& CvDllGameContext::operator=(const CvDllGameContext& other)
+{
+	if (this != &other)
+	{
+		// Free existing resources
+		delete m_pNetworkSyncronizer;
+		delete m_pNetMessageHandler;
+		delete m_pScriptSystemUtility;
+		delete m_pWorldBuilderMapLoader;
+
+		for (std::vector<std::pair<uint, CvRandom*> >::iterator it = m_RandomNumberGenerators.begin();
+			it != m_RandomNumberGenerators.end(); ++it)
+		{
+			delete it->second;
+		}
+		m_RandomNumberGenerators.clear();
+
+		for (std::vector<std::pair<uint, CvDllNetInitInfo*> >::iterator it = m_NetInitInfos.begin();
+			it != m_NetInitInfos.end(); ++it)
+		{
+			delete it->second;
+		}
+		m_NetInitInfos.clear();
+
+		for (std::vector<std::pair<uint, CvDllNetLoadGameInfo*> >::iterator it = m_NetLoadGameInfos.begin();
+			it != m_NetLoadGameInfos.end(); ++it)
+		{
+			delete it->second;
+		}
+		m_NetLoadGameInfos.clear();
+
+		// Copy new resources
+		m_uiRngCounter = other.m_uiRngCounter;
+		m_uiNetInitInfoCounter = other.m_uiNetInitInfoCounter;
+		m_uiNetLoadGameInfoCounter = other.m_uiNetLoadGameInfoCounter;
+
+		m_pNetworkSyncronizer = new CvDllNetworkSyncronization(*other.m_pNetworkSyncronizer);
+		m_pNetMessageHandler = new CvDllNetMessageHandler(*other.m_pNetMessageHandler);
+		m_pScriptSystemUtility = new CvDllScriptSystemUtility(*other.m_pScriptSystemUtility);
+		m_pWorldBuilderMapLoader = new CvDllWorldBuilderMapLoader(*other.m_pWorldBuilderMapLoader);
+
+		for (std::vector<std::pair<uint, CvRandom*> >::const_iterator it = other.m_RandomNumberGenerators.begin();
+			it != other.m_RandomNumberGenerators.end(); ++it)
+		{
+			m_RandomNumberGenerators.push_back(std::make_pair(it->first, it->second->Clone()));
+		}
+
+		for (std::vector<std::pair<uint, CvDllNetInitInfo*> >::const_iterator it = other.m_NetInitInfos.begin();
+			it != other.m_NetInitInfos.end(); ++it)
+		{
+			m_NetInitInfos.push_back(std::make_pair(it->first, new CvDllNetInitInfo(*it->second)));
+		}
+
+		for (std::vector<std::pair<uint, CvDllNetLoadGameInfo*> >::const_iterator it = other.m_NetLoadGameInfos.begin();
+			it != other.m_NetLoadGameInfos.end(); ++it)
+		{
+			m_NetLoadGameInfos.push_back(std::make_pair(it->first, new CvDllNetLoadGameInfo(*it->second)));
+		}
+	}
+	return *this;
 }
 //------------------------------------------------------------------------------
 CvDllGameContext::~CvDllGameContext()

--- a/CvGameCoreDLL_Expansion2/CvDllContext.h
+++ b/CvGameCoreDLL_Expansion2/CvDllContext.h
@@ -19,7 +19,10 @@ class CvDllWorldBuilderMapLoader;
 class CvDllGameContext : public ICvGameContext3
 {
 public:
-	virtual ~CvDllGameContext();
+    CvDllGameContext(); // Constructor
+    CvDllGameContext(const CvDllGameContext& other); // Copy constructor
+    CvDllGameContext& operator=(const CvDllGameContext& other); // Assignment operator
+    virtual ~CvDllGameContext(); // Destructor
 
 	void* DLLCALL QueryInterface(GUID guidInterface);
 
@@ -202,8 +205,6 @@ public:
 
 protected:
 	void DLLCALL Destroy();
-
-	CvDllGameContext();
 
 
 private:

--- a/CvGameCoreDLL_Expansion2/CvRandom.cpp
+++ b/CvGameCoreDLL_Expansion2/CvRandom.cpp
@@ -30,6 +30,15 @@ CvRandom::CvRandom(const std::string& name) :
 	reset();
 }
 
+CvRandom* CvRandom::Clone() const {
+    CvRandom* newRandom = new CvRandom(m_name);
+    newRandom->m_ullRandomSeed = m_ullRandomSeed;
+    newRandom->m_ulCallCount = m_ulCallCount;
+    newRandom->m_ulResetCount = m_ulResetCount;
+    newRandom->m_bSynchronous = m_bSynchronous;
+    return newRandom;
+}
+
 /*
 // private
 CvRandom::CvRandom(const CvRandom& source) :

--- a/CvGameCoreDLL_Expansion2/CvRandom.h
+++ b/CvGameCoreDLL_Expansion2/CvRandom.h
@@ -95,6 +95,7 @@ class CvRandom
 
 public:
 	CvRandom(const std::string& name);
+	CvRandom* Clone() const;
 	virtual ~CvRandom();
 
 	void init(unsigned long long ullSeed);


### PR DESCRIPTION
Add copy constructor to fix cppcheck warnings. Both builds work.

The last one that needs to be fixed:
https://github.com/LoneGazebo/Community-Patch-DLL/blob/8eb70893988a9a1dfed45804800543a383a6e081/CvGameCoreDLL_Expansion2/CvCity.cpp#L324
```
Id: noCopyConstructor
CWE: 398
Class 'CvCity' does not have a copy constructor which is recommended since it has dynamic memory/resource allocation(s).
Id: noOperatorEq
CWE: 398
Class 'CvCity' does not have a operator= which is recommended since it has dynamic memory/resource allocation(s).
```