### PR TITLE
Add improvement golden age extra yields table

### DIFF
--- a/(1) Community Patch/Core Files/Core Tables/CoreTableAdditions.xml
+++ b/(1) Community Patch/Core Files/Core Tables/CoreTableAdditions.xml
@@ -194,6 +194,12 @@
 		<Column name="YieldType" type="text" reference="Yields(Type)"/>
 		<Column name="Yield" type="integer"/>
 	</Table>
+	<!-- Improvement: allows a players Golden Age to boost the base yield of this improvement -->
+	<Table name="Improvement_GoldenAgeYields">
+		<Column name="ImprovementType" type="text" reference="Improvements(Type)"/>
+		<Column name="YieldType" type="text" reference="Yields(Type)"/>
+		<Column name="Yield" type="integer"/>
+	</Table>
 
 	<Table name="Policy_CityYieldFromUnimprovedFeature">
 		<!-- Refer to Traits.FaithFromUnimprovedForest -->

--- a/CvGameCoreDLL_Expansion2/CvImprovementClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvImprovementClasses.cpp
@@ -161,6 +161,7 @@ CvImprovementEntry::CvImprovementEntry(void):
 	m_piYieldChange(NULL),
 	m_piYieldPerEra(NULL),
 	m_piWLTKDYieldChange(NULL),
+	m_piGoldenAgeYieldChange(NULL),
 	m_piRiverSideYieldChange(NULL),
 	m_piCoastalLandYieldChange(NULL),
 	m_piHillsYieldChange(NULL),
@@ -194,6 +195,7 @@ CvImprovementEntry::~CvImprovementEntry(void)
 	SAFE_DELETE_ARRAY(m_piYieldChange);
 	SAFE_DELETE_ARRAY(m_piYieldPerEra);
 	SAFE_DELETE_ARRAY(m_piWLTKDYieldChange);
+	SAFE_DELETE_ARRAY(m_piGoldenAgeYieldChange);
 	SAFE_DELETE_ARRAY(m_piRiverSideYieldChange);
 	SAFE_DELETE_ARRAY(m_piCoastalLandYieldChange);
 	SAFE_DELETE_ARRAY(m_piHillsYieldChange);
@@ -418,6 +420,7 @@ bool CvImprovementEntry::CacheResults(Database::Results& kResults, CvDatabaseUti
 	kUtility.SetYields(m_piFreshWaterChange, "Improvement_FreshWaterYields", "ImprovementType", szImprovementType);
 	kUtility.SetYields(m_piHillsYieldChange, "Improvement_HillsYields", "ImprovementType", szImprovementType);
 	kUtility.SetYields(m_piWLTKDYieldChange, "Improvement_WLTKDYields", "ImprovementType", szImprovementType);
+	kUtility.SetYields(m_piGoldenAgeYieldChange, "Improvement_GoldenAgeYields", "ImprovementType", szImprovementType);
 	kUtility.SetYields(m_piRiverSideYieldChange, "Improvement_RiverSideYields", "ImprovementType", szImprovementType);
 	kUtility.SetYields(m_piPrereqNatureYield, "Improvement_PrereqNatureYields", "ImprovementType", szImprovementType);
 
@@ -1303,6 +1306,19 @@ int CvImprovementEntry::GetWLTKDYieldChange(int i) const
 int* CvImprovementEntry::GetWLTKDYieldChangeArray()
 {
 	return m_piWLTKDYieldChange;
+}
+
+// How much the city having a Golden Age improves the yield of this improvement
+int CvImprovementEntry::GetGoldenAgeYieldChange(int i) const
+{
+	CvAssertMsg(i < NUM_YIELD_TYPES, "Index out of bounds");
+	CvAssertMsg(i > -1, "Index out of bounds");
+	return m_piGoldenAgeYieldChange ? m_piGoldenAgeYieldChange[i] : 0;
+}
+
+int* CvImprovementEntry::GetGoldenAgeYieldChangeArray()
+{
+	return m_piGoldenAgeYieldChange;
 }
 
 /// How much being next to a river improves the yield of this improvement

--- a/CvGameCoreDLL_Expansion2/CvImprovementClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvImprovementClasses.h
@@ -174,6 +174,8 @@ public:
 	int GetYieldChangePerEra(int i) const;
 	int GetWLTKDYieldChange(int i) const;
 	int* GetWLTKDYieldChangeArray();
+	int GetGoldenAgeYieldChange(int i) const;
+	int* GetGoldenAgeYieldChangeArray();
 	int GetRiverSideYieldChange(int i) const;
 	int* GetRiverSideYieldChangeArray();
 	int GetCoastalLandYieldChange(int i) const;
@@ -337,6 +339,7 @@ protected:
 	int* m_piYieldChange;
 	int* m_piYieldPerEra;
 	int* m_piWLTKDYieldChange;
+	int* m_piGoldenAgeYieldChange;
 	int* m_piRiverSideYieldChange;
 	int* m_piCoastalLandYieldChange;
 	int* m_piHillsYieldChange;

--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -10450,6 +10450,11 @@ int CvPlot::calculateImprovementYield(YieldTypes eYield, PlayerTypes ePlayer, Im
 		{
 			iYield += pkImprovementInfo->GetImprovementResourceYield(eResource, eYield);
 		}
+
+		if (kPlayer.getGoldenAgeTurns() > 0)
+		{
+			iYield += pkImprovementInfo->GetGoldenAgeYieldChange(eYield);
+		}
 	}
 
 	if (pOwningCity != NULL)


### PR DESCRIPTION
Add improvement golden age extra yields table for 4UC Persia.

Fix some bugs with improvement planning yield calculations.

Normalize golden age yield calculations for improvement planning.

Fix two bugs with vanilla Celts UA improvement planning.