### PR TITLE
Builder AI fixes and tweaks

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.h
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.h
@@ -76,7 +76,7 @@ struct BuilderDirective
 
 	int GetPotentialScore() const
 	{
-		return m_iScore + m_iPotentialBonusScore - m_iScorePenalty;
+		return m_iScore + m_iPotentialBonusScore;
 	}
 };
 FDataStream& operator<<(FDataStream&, const BuilderDirective&);
@@ -108,7 +108,6 @@ public:
 	void UpdateImprovementPlots(void);
 
 	bool CanUnitPerformDirective(CvUnit* pUnit, BuilderDirective eDirective, bool bTestEra = false);
-	int GetBuilderNumTurnsAway(CvUnit* pUnit, BuilderDirective eDirective, int iMaxDistance=INT_MAX);
 	int GetTurnsToBuild(const CvUnit* pUnit, BuildTypes eBuild, const CvPlot* pPlot) const;
 	vector<BuilderDirective> GetDirectives();
 	bool ExecuteWorkerMove(CvUnit* pUnit, BuilderDirective aDirective);
@@ -178,7 +177,6 @@ protected:
 	bool IsPlannedRouteForPurpose(const CvPlot* pPlot, RoutePurpose ePurpose) const;
 	void AddRoutePlots(CvPlot* pStartPlot, CvPlot* pTargetPlot, RouteTypes eRoute, int iValue, const SPath& path, RoutePurpose ePurpose, bool bUseRivers);
 	int GetMoveCostWithRoute(const CvPlot* pFromPlot, const CvPlot* pToPlot, RouteTypes eFromPlotRoute, RouteTypes eToPlotRoute);
-	int GetPlotYieldModifierTimes100(CvPlot* pPlot, YieldTypes eYield);
 	void GetPathValues(const SPath& path, RouteTypes eRoute, int& iVillageBonusesIfCityConnected, int& iMovementBonus, int& iNumRoadsNeededToBuild);
 
 	int GetRouteBuildTime(PlannedRoute plannedRoute, const CvUnit* pUnit = (CvUnit*)NULL) const;

--- a/CvGameCoreDLL_Expansion2/CvHomelandAI.h
+++ b/CvGameCoreDLL_Expansion2/CvHomelandAI.h
@@ -13,6 +13,8 @@
 #define UPGRADE_THIS_TURN_PRIORITY_BOOST 5000
 #define UPGRADE_IN_TERRITORY_PRIORITY_BOOST 2000
 
+struct BuilderDirective;
+
 enum AIHomelandTargetType
 {
     AI_HOMELAND_TARGET_NONE,
@@ -310,6 +312,8 @@ private:
 	bool MoveToTargetButDontEndTurn(CvUnit* pUnit, CvPlot* pTargetPlot, int iFlags);
 
 	CvPlot* FindArchaeologistTarget(CvUnit *pUnit);
+	vector<OptionWithScore<pair<CvUnit*, BuilderDirective>>> GetWeightedDirectives(const vector<BuilderDirective> aDirectives, const set<BuilderDirective> ignoredDirectives, const list<int> allWorkers, const set<int> ignoredWorkers, map<pair<int, int>, int>& plotDistanceCache);
+	int GetBuilderNumTurnsAway(CvUnit* pUnit, BuilderDirective eDirective, int iMaxDistance = INT_MAX);
 
 	void UnitProcessed(int iID);
 	bool ExecuteCultureBlast(CvUnit* pUnit);
@@ -358,8 +362,6 @@ struct SBuilderState {
 	map<ResourceTypes, int> mExtraResources;
 	map<int, FeatureTypes> mChangedPlotFeatures;
 	map<int, ImprovementTypes> mChangedPlotImprovements;
-	map<int, int> mExtraDefense;
-	map<int, int> mExtraDamageToAdjacent;
 
 	SBuilderState(){};
 	static const SBuilderState& DefaultInstance() {

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -47804,6 +47804,10 @@ void CvPlayer::updatePlotFoundValues()
 		{
 			ignoreYieldPlots[iI] = 1;
 		}
+		else if (!pPlot->isRevealed(getTeam()))
+		{
+			ignoreYieldPlots[iI] = 1;
+		}
 	}
 
 	//calculate new values and apply our threshold

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -24065,7 +24065,7 @@ void CvUnit::DoConvertReligiousUnitsToMilitary(const CvPlot* pPlot)
 //finish improvements (mostly roads) at the beginning of the turn so we can use them immediately
 void CvUnit::DoFinishBuildIfSafe()
 {
-	if (isHuman())
+	if (isHuman() && !IsAutomated())
 		return;
 
 	BuildTypes eBuild = getBuildType();


### PR DESCRIPTION
## Improvement planning AI:

Take puppet status into account when evaluating plot yields.

Make AI much better at planning out potential monopolies from tile improvements. And make them more aggressively pursue them.

Simplify and cleanup defensive build evaluation function.

Flesh out culture bomb logic in improvement evaluation function (for human citadel recommendations, and any future non-citadel culture bomb improvements.

Make encampment buff evaluation properly take other encampments into account. AI should be better at spreading them out early in order to get the buff in all of their territory.

Increase value of existing improvements.

## Worker AI:

Give a harser penalty for moving (should make workers much more prone to working in their vicinity again, without making them avoid improvements which take a long time to build).

Fix some cases where AI workers would do nothing when in danger.

Automated workers perform all actions on turn start, instead of waiting to turn end when building improvements.

Fix AI not wanting to build GP improvements when they weren't much better than the existing improvement.

Fix AI GPs just standing around when they can't build anything.

## Road planning AI:

Stop assuming puppets give unhappiness from isolation.

Should be better at building strategic routes.

## Recommendations and AI:

Plot picker for settling locations no longer ignores fog of war when evaluating nearby plots.