### PR TITLE
Fix stack overflow in Squads options panel

### DIFF
--- a/(4a) Squads for VP/UI/SquadsOptions.lua
+++ b/(4a) Squads for VP/UI/SquadsOptions.lua
@@ -1,3 +1,5 @@
+print('This is SquadsOptions.lua')
+
 local SquadsOptions = Modding.OpenUserData( "Squads Options", 1 );
 
 -- Defaults
@@ -9,14 +11,10 @@ local SquadsEndMovementType = 0;
 function OpenSquadsOptions()
     UpdateOptionsPanel();
     Controls.OptionsPanel:SetHide( false );
-    -- Controls.SideStack:CalculateSize();
-    -- Controls.SideStack:ReprocessAnchoring();
 end
 
 function CloseSquadsOptions()
     Controls.OptionsPanel:SetHide( true );
-    -- Controls.SideStack:CalculateSize();
-    -- Controls.SideStack:ReprocessAnchoring();
 end
 
 function ToggleSquadsOptions()
@@ -32,27 +30,23 @@ function UpdateOptionsPanel()
 end
 
 function HandleSquadsOptionsButton()
-    print("Squads Options Button Pressed");
     ToggleSquadsOptions()
 end
 Controls.SquadsOptionsButton:RegisterCallback(Mouse.eLClick, HandleSquadsOptionsButton);
 
 function HandleHighlightSquadUnitsCheckbox()
-    print("HandleHighlightSquadUnitsCheckbox")
     HighlightSquadUnits = not HighlightSquadUnits;
     LuaEvents.SQUADS_OPTIONS_CHANGED("HighlightSquadUnits", HighlightSquadUnits)
 end
 Controls.HighlightSquadUnitsCheckBox:RegisterCheckHandler(HandleHighlightSquadUnitsCheckbox);
 
 function HandleFlagsNumberCheckBox()
-    print("HandleFlagsNumberCheckBox")
     ShowSquadNumberUnderFlag = not ShowSquadNumberUnderFlag;
     LuaEvents.SQUADS_OPTIONS_CHANGED("ShowSquadNumberUnderFlag", ShowSquadNumberUnderFlag)
 end
 Controls.FlagsNumberCheckBox:RegisterCheckHandler(HandleFlagsNumberCheckBox);
 
 function HandleAlertOnArrivalRadioButton()
-    print("HandleAlertOnArrivalRadioButton")
     if SquadsEndMovementType ~= 0 then
         SquadsEndMovementType = 0;
         LuaEvents.SQUADS_OPTIONS_CHANGED("SquadsEndMovementType", SquadsEndMovementType);
@@ -61,7 +55,6 @@ end
 Controls.AlertOnArrivalRadioButton:RegisterCheckHandler(HandleAlertOnArrivalRadioButton);
 
 function HandleWakeOnUnitArrivalRadioButton()
-    print("HandleWakeOnUnitArrivalRadioButton")
     if SquadsEndMovementType ~= 1 then
         SquadsEndMovementType = 1;
         LuaEvents.SQUADS_OPTIONS_CHANGED("SquadsEndMovementType", SquadsEndMovementType);
@@ -70,7 +63,6 @@ end
 Controls.WakeOnUnitArrivalRadioButton:RegisterCheckHandler(HandleWakeOnUnitArrivalRadioButton);
 
 function HandleWakeOnSquadArrivalRadioButton()
-    print("HandleWakeOnSquadArrivalRadioButton")
     if SquadsEndMovementType ~= 2 then
         SquadsEndMovementType = 2;
         LuaEvents.SQUADS_OPTIONS_CHANGED("SquadsEndMovementType", SquadsEndMovementType);
@@ -80,25 +72,8 @@ Controls.WakeOnSquadArrivalRadioButton:RegisterCheckHandler(HandleWakeOnSquadArr
 
 -- Options Logic
 function SquadsOptionChanged(optionKey, newValue)
-    if optionKey == "HighlightSquadUnits" then
-        Controls.HighlightSquadUnitsCheckBox:SetCheck(newValue);
-        print("Setting highlight squad units checkbox to ", newValue);
-    elseif optionKey == "ShowSquadNumberUnderFlag" then
-        Controls.FlagsNumberCheckBox:SetCheck(newValue);
-        print("Setting FlagsNumberCheckBox checkbox to ", newValue);
-    elseif optionKey == "SquadsEndMovementType" then
-        print("Setting SquadsEndMovementType to ", newValue);
-        if newValue == 0 then
-            Controls.AlertOnArrivalRadioButton:SetCheck(true);
-        elseif newValue == 1 then
-            Controls.WakeOnUnitArrivalRadioButton:SetCheck(true);
-        elseif newValue == 2 then
-            Controls.WakeOnSquadArrivalRadioButton:SetCheck(true);
-        end
-    end
     SquadsOptions.SetValue(optionKey, newValue);
 end
-
 LuaEvents.SQUADS_OPTIONS_CHANGED.Add(SquadsOptionChanged);
 
 -- Load Saved Options
@@ -108,15 +83,27 @@ if _hsu ~= nil then
     HighlightSquadUnits = _hsu == 1;
 end
 LuaEvents.SQUADS_OPTIONS_CHANGED("HighlightSquadUnits", HighlightSquadUnits)
+Controls.HighlightSquadUnitsCheckBox:SetCheck(HighlightSquadUnits);
 
 local _ssnuf = SquadsOptions.GetValue("ShowSquadNumberUnderFlag");
 if _ssnuf ~= nil then
     ShowSquadNumberUnderFlag = _ssnuf == 1;
 end
 LuaEvents.SQUADS_OPTIONS_CHANGED("ShowSquadNumberUnderFlag", ShowSquadNumberUnderFlag)
+Controls.FlagsNumberCheckBox:SetCheck(ShowSquadNumberUnderFlag);
 
 local _semt = SquadsOptions.GetValue("SquadsEndMovementType");
 if _semt ~= nil then
     SquadsEndMovementType = _semt;
 end
 LuaEvents.SQUADS_OPTIONS_CHANGED("SquadsEndMovementType", SquadsEndMovementType)
+print("loaded the following value for SquadsEndMovementType: ", SquadsEndMovementType);
+if SquadsEndMovementType == 0 then
+    Controls.AlertOnArrivalRadioButton:SetCheck(true);
+elseif SquadsEndMovementType == 1 then
+    Controls.WakeOnUnitArrivalRadioButton:SetCheck(true);
+elseif SquadsEndMovementType == 2 then
+    Controls.WakeOnSquadArrivalRadioButton:SetCheck(true);
+end
+
+print('Loaded SquadsOptions.lua')


### PR DESCRIPTION
Fixes an infinite recursion that occured when a squad option was changed.

Note that the games error handling did handle this case in a way that the game didn't crash and the outcome was correct. The only visible outcomes of this fix are that changing options now happens faster and the "C Stack Overflow" error is no longer logged to `Lua.log`.

Also did some minor cleanup in that file