### PR TITLE
Adjacent Improvements

### DIFF
--- a/(1) Community Patch/Core Files/Core Tables/CoreTableAdditions.xml
+++ b/(1) Community Patch/Core Files/Core Tables/CoreTableAdditions.xml
@@ -175,6 +175,7 @@
 		<Column name="Yield" type="integer"/>
 	</Table>
 	<!-- Improvement: allows an adjacent improvement of the same type to boost the base yield of this improvement -->
+	<!-- to be removed -->
 	<Table name="Improvement_YieldAdjacentSameType">
 		<!-- Refer to Improvements.CultureAdjacentSameType -->
 		<Column name="ImprovementType" type="text" reference="Improvements(Type)"/>
@@ -182,6 +183,7 @@
 		<Column name="Yield" type="integer" default="0"/>
 	</Table>
 	<!-- Improvement: allows two adjacent improvements of the same type to boost the base yield of this improvement -->
+	<!-- to be removed -->
 	<Table name="Improvement_YieldAdjacentTwoSameType">
 		<!-- Refer to Improvements.CultureAdjacentSameType -->
 		<Column name="ImprovementType" type="text" reference="Improvements(Type)"/>
@@ -1993,7 +1995,17 @@
 		<Column name="BeliefType" type="text" reference="Beliefs(Type)"/>
 		<Column name="UnitType" type="text" reference="Units(Type)"/>
 	</Table>
+	<Table name="Improvement_YieldPerXAdjacentImprovement">
+	<!-- Improvement: allows an adjacent improvement to boost the yield of this improvement -->
+	<!-- will replace Improvement_AdjacentImprovementYieldChanges, Improvement_YieldAdjacentSameType, Improvement_YieldAdjacentTwoSameType -->
+		<Column name="ImprovementType" type="text" reference="Improvements(Type)"/>
+		<Column name="OtherImprovementType" type="text" reference="Improvements(Type)"/>
+		<Column name="YieldType" type="text" reference="Yields(Type)"/>
+		<Column name="Yield" type="integer" default="0"/>
+		<Column name="NumRequired" type="integer" default="1"/>
+	</Table>
 	<!-- Improvement: allows this improvement to boost the base yield of another adjacent improvement -->
+	<!-- to be removed -->
 	<Table name="Improvement_AdjacentImprovementYieldChanges">
 		<Column name="ImprovementType" type="text" reference="Improvements(Type)"/>
 		<Column name="OtherImprovementType" type="text" reference="Improvements(Type)"/>
@@ -2007,7 +2019,7 @@
 		<Column name="YieldType" type="text" reference="Yields(Type)"/>
 		<Column name="Yield" type="integer"/>
 	</Table>
-	<!-- Improvement: allows a terrain to boost the base yield of this improvement when adjacent-->
+	<!-- Improvement: allows this improvement to boost the base yield of another plot with the corresponding terrain -->
 	<Table name="Improvement_AdjacentTerrainYieldChanges">
 		<Column name="ImprovementType" type="text" reference="Improvements(Type)"/>
 		<Column name="TerrainType" type="text" reference="Terrains(Type)"/>

--- a/(2) Vox Populi/Core Files/Overrides/CivilopediaScreen.lua
+++ b/(2) Vox Populi/Core Files/Overrides/CivilopediaScreen.lua
@@ -6398,6 +6398,7 @@ CivilopediaCategory[CategoryImprovements].SelectArticle = function( improvementI
 			improvementString = "";
 			fullstring = "";
 			baseImprovement = "";
+			-- TO BE REMOVED IN FAVOR OF Improvement_YieldPerXAdjacentImprovement
 			for row in GameInfo.Improvement_AdjacentImprovementYieldChanges( condition ) do
 				numYields = numYields + 1;
 				local OtherImprovement = GameInfo.Improvements[row.OtherImprovementType];
@@ -6427,6 +6428,7 @@ CivilopediaCategory[CategoryImprovements].SelectArticle = function( improvementI
 			improvementString = "";
 			fullstring = "";
 			baseImprovement = "";
+			-- TO BE REMOVED IN FAVOR OF Improvement_YieldPerXAdjacentImprovement
 			for row in GameInfo.Improvement_YieldAdjacentTwoSameType( condition ) do
 				numYields = numYields + 1;
 				local OtherImprovement = GameInfo.Improvements[row.ImprovementType];
@@ -6456,6 +6458,7 @@ CivilopediaCategory[CategoryImprovements].SelectArticle = function( improvementI
 			improvementString = "";
 			fullstring = "";
 			baseImprovement = "";
+			-- TO BE REMOVED IN FAVOR OF Improvement_YieldPerXAdjacentImprovement
 			for row in GameInfo.Improvement_YieldAdjacentSameType( condition ) do
 				numYields = numYields + 1;
 				local OtherImprovement = GameInfo.Improvements[row.ImprovementType];
@@ -6473,11 +6476,44 @@ CivilopediaCategory[CategoryImprovements].SelectArticle = function( improvementI
 					fullstring = fullstring .. Locale.ConvertTextKey( yieldString );
 				end
 			end
+			for row in GameInfo.Improvement_YieldPerXAdjacentImprovement ( condition ) do
+				numYields = numYields + 1;
+				local OtherImprovement = GameInfo.Improvements[row.OtherImprovementType];
+				if OtherImprovement then
+					improvementString = Locale.ConvertTextKey(OtherImprovement.Description)..": ";
+					if (OtherImprovement ~= baseImprovement) then
+						baseImprovement = OtherImprovement;
+						if(fullstring == "") then
+							fullstring = fullstring .. improvementString;
+						else
+							fullstring = fullstring .. "[NEWLINE]" .. improvementString;
+						end
+					end
+					if row.NumRequired > 1 then
+						-- round up to hundredth decimal place and remove trailing zeros
+						local decimalYield = tostring(math.ceil(100*row.Yield/row.NumRequired)/100);
+						yieldString = decimalYield:gsub('%.?0*$', '');
+						-- should give X.17, X.2, X.34, X.5, X.67, X.84, X
+					else
+						yieldString = row.Yield;
+					end
+					yieldString = " +" .. yieldString .. GameInfo.Yields[row.YieldType].IconString;
+					local teststring = fullstring .. Locale.ConvertTextKey( yieldString );
+					-- SetText will extract x and y dimensions of the label; use this to determine if we need to wrap
+					Controls.AdjacentImprovYieldLabel:SetText( teststring );
+					contentSize = Controls.AdjacentImprovYieldLabel:GetSize();
+					if contentSize.x > narrowInnerFrameWidth then
+						fullstring = fullstring .. "[NEWLINE]  " .. Locale.ConvertTextKey( yieldString );
+					else
+						fullstring = teststring;
+					end
+				end
+			end
 			if numYields == 0 then
 				Controls.AdjacentImprovYieldFrame:SetHide( true );
 			else
-				Controls.AdjacentImprovYieldLabel:SetText( fullstring );
 				Controls.AdjacentImprovYieldFrame:SetHide( false );
+				UpdateNarrowTextBlock( fullstring, Controls.AdjacentImprovYieldLabel, Controls.AdjacentImprovYieldInnerFrame, Controls.AdjacentImprovYieldFrame );
 			end
 
 			local numYields = 0;

--- a/(2) Vox Populi/Core Files/Overrides/CivilopediaScreen.xml
+++ b/(2) Vox Populi/Core Files/Overrides/CivilopediaScreen.xml
@@ -979,7 +979,7 @@
 					
 					<!-- Adjacent Improvement Yield-->
 					<Grid Anchor="L,T" Offset="0,24" Size="204,76" Padding="0,0" Style="GridBlackIndent8" Hidden="0" ID="AdjacentImprovYieldFrame">
-						<Grid Anchor="C,C" Offset="0,0" Size="208,80" Padding="0,0" Style="Grid9Frame" Hidden="0">
+						<Grid Anchor="C,C" Offset="0,0" Size="208,80" Padding="0,0" Style="Grid9Frame" Hidden="0" ID="AdjacentImprovYieldInnerFrame">
 							<Label Anchor="L,T" Offset="4,-16" Anchorside="I.O" WrapWidth="600" LeadingOffset="0" Font="TwCenMT20" FontStyle="Shadow" Color0="Beige" Color1="0.0.0.160" String="TXT_KEY_PEDIA_ADJIMPROVYIELD_LABEL"/>
 							<Label Anchor="L,C" Offset="8,-2" Anchorside="I.O" WrapWidth="600" LeadingOffset="0" Font="TwCenMT20" FontStyle="Shadow" Color0="Beige" Color1="0.0.0.160" ID="AdjacentImprovYieldLabel"/>
 						</Grid>

--- a/(2) Vox Populi/Database Changes/Civilizations/Huns.sql
+++ b/(2) Vox Populi/Database Changes/Civilizations/Huns.sql
@@ -92,11 +92,18 @@ VALUES
 	('IMPROVEMENT_EKI', 'YIELD_PRODUCTION', 1),
 	('IMPROVEMENT_EKI', 'YIELD_CULTURE', 1);
 
+/*
 INSERT INTO Improvement_YieldAdjacentTwoSameType
 	(ImprovementType, YieldType, Yield)
 VALUES
 	('IMPROVEMENT_EKI', 'YIELD_PRODUCTION', 1),
 	('IMPROVEMENT_EKI', 'YIELD_GOLD', 1);
+*/
+INSERT INTO Improvement_YieldPerXAdjacentImprovement
+	(ImprovementType, OtherImprovementType, YieldType, Yield, NumRequired)
+VALUES
+	('IMPROVEMENT_EKI', 'IMPROVEMENT_EKI', 'YIELD_PRODUCTION', 1, 2),
+	('IMPROVEMENT_EKI', 'IMPROVEMENT_EKI', 'YIELD_GOLD', 1, 2);
 
 INSERT INTO Improvement_TechYieldChanges
 	(ImprovementType, TechType, YieldType, Yield)

--- a/(2) Vox Populi/Database Changes/Civilizations/Inca.sql
+++ b/(2) Vox Populi/Database Changes/Civilizations/Inca.sql
@@ -54,6 +54,7 @@ VALUES
 --	('IMPROVEMENT_TERRACE_FARM', 'YIELD_FOOD', 1),
 	('IMPROVEMENT_TERRACE_FARM', 'YIELD_PRODUCTION', 2);
 
+/*
 INSERT INTO Improvement_YieldAdjacentSameType
 	(ImprovementType, YieldType, Yield)
 VALUES
@@ -63,6 +64,12 @@ INSERT INTO Improvement_AdjacentImprovementYieldChanges
 	(ImprovementType, OtherImprovementType, YieldType, Yield)
 VALUES
 	('IMPROVEMENT_TERRACE_FARM', 'IMPROVEMENT_FARM', 'YIELD_FOOD', 1);
+*/
+INSERT INTO Improvement_YieldPerXAdjacentImprovement
+	(ImprovementType, OtherImprovementType, YieldType, Yield, NumRequired)
+VALUES
+	('IMPROVEMENT_FARM', 'IMPROVEMENT_TERRACE_FARM', 'YIELD_FOOD', 1, 1),
+	('IMPROVEMENT_TERRACE_FARM', 'IMPROVEMENT_TERRACE_FARM', 'YIELD_FOOD', 1, 1);
 
 INSERT INTO Improvement_TechYieldChanges
 	(ImprovementType, TechType, YieldType, Yield)

--- a/(2) Vox Populi/Database Changes/Civilizations/Morocco.sql
+++ b/(2) Vox Populi/Database Changes/Civilizations/Morocco.sql
@@ -82,10 +82,16 @@ VALUES
 	('IMPROVEMENT_KASBAH', 'TECH_ARCHITECTURE', 'YIELD_CULTURE', 1),
 	('IMPROVEMENT_KASBAH', 'TECH_RADIO', 'YIELD_CULTURE', 1);
 
+/*
 INSERT INTO Improvement_AdjacentImprovementYieldChanges
 	(ImprovementType, OtherImprovementType, YieldType, Yield)
 VALUES
 	('IMPROVEMENT_KASBAH', 'IMPROVEMENT_FISHING_BOATS', 'YIELD_GOLD', 2);
+*/
+INSERT INTO Improvement_YieldPerXAdjacentImprovement
+	(ImprovementType, OtherImprovementType, YieldType, Yield, NumRequired)
+VALUES
+	('IMPROVEMENT_FISHING_BOATS', 'IMPROVEMENT_KASBAH', 'YIELD_GOLD', 2, 1);
 
 INSERT INTO Improvement_AdjacentTerrainYieldChanges
 	(ImprovementType, TerrainType, YieldType, Yield)

--- a/(2) Vox Populi/Database Changes/Civilizations/Polynesia.sql
+++ b/(2) Vox Populi/Database Changes/Civilizations/Polynesia.sql
@@ -56,7 +56,7 @@ UPDATE Builds
 SET PrereqTech = 'TECH_MASONRY' -- Construction
 WHERE Type = 'BUILD_MOAI';
 
--- Use Improvement_YieldAdjacentSameType instead
+-- Use Improvement_YieldPerXAdjacentImprovement instead
 UPDATE Improvements
 SET CultureAdjacentSameType = 0
 WHERE Type = 'IMPROVEMENT_MOAI';
@@ -73,10 +73,16 @@ INSERT INTO Improvement_AdjacentCityYields
 VALUES
 	('IMPROVEMENT_MOAI', 'YIELD_CULTURE', 1);
 
+/*
 INSERT INTO Improvement_YieldAdjacentSameType
 	(ImprovementType, YieldType, Yield)
 VALUES
 	('IMPROVEMENT_MOAI', 'YIELD_CULTURE', 1);
+*/
+INSERT INTO Improvement_YieldPerXAdjacentImprovement
+	(ImprovementType, OtherImprovementType, YieldType, Yield, NumRequired)
+VALUES
+	('IMPROVEMENT_MOAI', 'IMPROVEMENT_MOAI', 'YIELD_CULTURE', 1, 1);
 
 INSERT INTO Improvement_TechYieldChanges
 	(ImprovementType, TechType, YieldType, Yield)

--- a/(2) Vox Populi/Database Changes/WorldMap/Improvements/ImprovementChanges.sql
+++ b/(2) Vox Populi/Database Changes/WorldMap/Improvements/ImprovementChanges.sql
@@ -13,10 +13,16 @@ DELETE FROM Improvement_ValidTerrains
 WHERE ImprovementType = 'IMPROVEMENT_FARM' AND TerrainType = 'TERRAIN_DESERT';
 
 -- +1 Food per 2 adjacent farms
+/*
 INSERT INTO Improvement_YieldAdjacentTwoSameType
 	(ImprovementType, YieldType, Yield)
 VALUES
 	('IMPROVEMENT_FARM', 'YIELD_FOOD', 1);
+*/
+INSERT INTO Improvement_YieldPerXAdjacentImprovement
+	(ImprovementType, OtherImprovementType, YieldType, Yield, NumRequired)
+VALUES
+	('IMPROVEMENT_FARM', 'IMPROVEMENT_FARM', 'YIELD_FOOD', 1, 2);
 
 -- +1 Food on fresh water
 INSERT INTO Improvement_FreshWaterYields
@@ -49,11 +55,18 @@ VALUES
 
 -- Lumber Mill
 -- +1 Prod/Gold per 2 adjacent lumber mills
+/*
 INSERT INTO Improvement_YieldAdjacentTwoSameType
 	(ImprovementType, YieldType, Yield)
 VALUES
 	('IMPROVEMENT_LUMBERMILL', 'YIELD_GOLD', 1),
 	('IMPROVEMENT_LUMBERMILL', 'YIELD_PRODUCTION', 1);
+*/
+INSERT INTO Improvement_YieldPerXAdjacentImprovement
+	(ImprovementType, OtherImprovementType, YieldType, Yield, NumRequired)
+VALUES
+	('IMPROVEMENT_LUMBERMILL', 'IMPROVEMENT_LUMBERMILL', 'YIELD_GOLD', 1, 2),
+	('IMPROVEMENT_LUMBERMILL', 'IMPROVEMENT_LUMBERMILL', 'YIELD_PRODUCTION', 1, 2);
 
 INSERT INTO Improvement_ValidFeatures
 	(ImprovementType, FeatureType)

--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -2710,7 +2710,7 @@ void CvCity::UpdateAllNonPlotYields(bool bIncludePlayerHappiness)
 			continue;
 
 		//Simplification - errata yields not worth considering.
-		if ((YieldTypes)iI > YIELD_GOLDEN_AGE_POINTS && !MOD_BALANCE_CORE_JFD)
+		if ((YieldTypes)iI > YIELD_CULTURE_LOCAL && !MOD_BALANCE_CORE_JFD)
 			break;
 
 		UpdateCityYields(eYield);

--- a/CvGameCoreDLL_Expansion2/CvImprovementClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvImprovementClasses.cpp
@@ -173,6 +173,7 @@ CvImprovementEntry::CvImprovementEntry(void):
 	m_pbTerrainMakesValid(NULL),
 	m_pbFeatureMakesValid(NULL),
 	m_pbImprovementMakesValid(NULL),
+	m_YieldPerXAdjacentImprovement(),
 	m_piAdjacentSameTypeYield(NULL),
 	m_piAdjacentTwoSameTypeYield(NULL),
 	m_ppiAdjacentImprovementYieldChanges(NULL),
@@ -207,6 +208,7 @@ CvImprovementEntry::~CvImprovementEntry(void)
 	SAFE_DELETE_ARRAY(m_pbTerrainMakesValid);
 	SAFE_DELETE_ARRAY(m_pbFeatureMakesValid);
 	SAFE_DELETE_ARRAY(m_pbImprovementMakesValid);
+	m_YieldPerXAdjacentImprovement.clear();
 	SAFE_DELETE_ARRAY(m_piAdjacentSameTypeYield);
 	SAFE_DELETE_ARRAY(m_piAdjacentTwoSameTypeYield);
 	if(m_ppiAdjacentImprovementYieldChanges != NULL)
@@ -483,10 +485,40 @@ bool CvImprovementEntry::CacheResults(Database::Results& kResults, CvDatabaseUti
 
 	const int iNumYields = kUtility.MaxRows("Yields");
 #if defined(MOD_BALANCE_CORE)
+	const int iNumImprovements = kUtility.MaxRows("Improvements");
+	CvAssertMsg(iNumImprovements > 0, "Num Improvement Infos <= 0");
+	//YieldPerXAdjacentImprovement
+	{
+		std::string strKey("Improvements - YieldPerXAdjacentImprovement");
+		Database::Results* pResults = kUtility.GetResults(strKey);
+		if (pResults == NULL)
+		{
+			pResults = kUtility.PrepareResults(strKey, "select Yields.ID as YieldID, Improvements.ID as ImprovementID, Yield, NumRequired from Improvement_YieldPerXAdjacentImprovement inner join Yields on YieldType = Yields.Type inner join Improvements on OtherImprovementType = Improvements.Type where ImprovementType = ?");
+		}
+
+		pResults->Bind(1, szImprovementType);
+
+		while (pResults->Step())
+		{
+			const YieldTypes yield_idx = YieldTypes(pResults->GetInt(0));
+			CvAssert(yield_idx > -1);
+
+			const ImprovementTypes improvement_idx = ImprovementTypes(pResults->GetInt(1));
+			CvAssert(improvement_idx > -1);
+
+			const int yield = pResults->GetInt(2);
+			
+			const int nRequired = pResults->GetInt(3);
+			CvAssert(nRequired > 0);
+
+			m_YieldPerXAdjacentImprovement[yield_idx][improvement_idx] = fraction(yield, nRequired);
+		}
+
+		//Trim extra memory off container since this is mostly read-only.
+		map<YieldTypes, map<ImprovementTypes, fraction>>(m_YieldPerXAdjacentImprovement).swap(m_YieldPerXAdjacentImprovement);
+	}
 	//AdjacentImprovementYieldChanges
 	{
-		const int iNumImprovements = kUtility.MaxRows("Improvements");
-		CvAssertMsg(iNumImprovements > 0, "Num Improvement Infos <= 0");
 		kUtility.Initialize2DArray(m_ppiAdjacentImprovementYieldChanges, iNumImprovements, iNumYields);
 
 		std::string strKey = "Improvements - AdjacentImprovementYieldChanges";
@@ -801,6 +833,47 @@ int CvImprovementEntry::GetAdditionalUnits() const
 }
 #endif
 
+/// Bonus yield if another improvement is adjacent
+fraction CvImprovementEntry::GetYieldPerXAdjacentImprovement(YieldTypes eYield, ImprovementTypes eImprovement) const
+{
+	CvAssertMsg(eImprovement < GC.getNumImprovementInfos(), "Index out of bounds");
+	CvAssertMsg(eImprovement > -1, "Index out of Bounds");
+	CvAssertMsg(eYield < NUM_YIELD_TYPES, "Index out of bounds");
+	CvAssertMsg(eYield > -1, "Index out of bounds");
+
+	fraction fYield = 0;
+	map<YieldTypes, map<ImprovementTypes, fraction>>::const_iterator itImprovement = m_YieldPerXAdjacentImprovement.find(eYield);
+	if (itImprovement != m_YieldPerXAdjacentImprovement.end())
+	{
+		map<ImprovementTypes, fraction>::const_iterator itYield = itImprovement->second.find(eImprovement);
+		if (itYield != itImprovement->second.end())
+		{
+			fYield = itYield->second;
+		}
+	}
+
+	// Special case for culture
+	if (eYield == YIELD_CULTURE)
+	{
+		fYield += m_iCultureAdjacentSameType;
+	}
+
+	return fYield;
+}
+bool CvImprovementEntry::IsYieldPerXAdjacentImprovement(YieldTypes eYield) const
+{
+	CvAssertMsg(eYield < NUM_YIELD_TYPES, "Index out of bounds");
+	CvAssertMsg(eYield >= -1, "Index out of bounds");
+	
+	if (eYield == NO_YIELD)
+		return (!m_YieldPerXAdjacentImprovement.empty() || m_iCultureAdjacentSameType != 0);
+
+	map<YieldTypes, map<ImprovementTypes, fraction>>::const_iterator itImprovement = m_YieldPerXAdjacentImprovement.find(eYield);
+	if (eYield == YIELD_CULTURE)
+		return (itImprovement != m_YieldPerXAdjacentImprovement.end() || m_iCultureAdjacentSameType != 0);
+	else
+		return (itImprovement != m_YieldPerXAdjacentImprovement.end());
+}
 /// Bonus yield if another Improvement of same type is adjacent
 int CvImprovementEntry::GetYieldAdjacentSameType(YieldTypes eYield) const
 {
@@ -1452,7 +1525,8 @@ int* CvImprovementEntry::GetAdjacentTwoSameTypeYieldArray()
 {
 	return m_piAdjacentTwoSameTypeYield;
 }
-/// How much a tech improves the yield of this improvement if it has fresh water
+
+/// How this improvement changes the yields of an adjacent improvement
 int CvImprovementEntry::GetAdjacentImprovementYieldChanges(int i, int j) const
 {
 	CvAssertMsg(i < GC.getNumImprovementInfos(), "Index out of bounds");
@@ -1461,7 +1535,6 @@ int CvImprovementEntry::GetAdjacentImprovementYieldChanges(int i, int j) const
 	CvAssertMsg(j > -1, "Index out of bounds");
 	return m_ppiAdjacentImprovementYieldChanges[i][j];
 }
-
 int* CvImprovementEntry::GetAdjacentImprovementYieldChangesArray(int i)
 {
 	return m_ppiAdjacentImprovementYieldChanges[i];

--- a/CvGameCoreDLL_Expansion2/CvImprovementClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvImprovementClasses.h
@@ -55,8 +55,8 @@ public:
 	int GetGoldMaintenance() const;
 	int GetCultureBombRadius() const;
 
-	int GetYieldAdjacentSameType(YieldTypes eYield) const;
-	int GetYieldAdjacentTwoSameType(YieldTypes eYield) const;
+	int GetYieldAdjacentSameType(YieldTypes eYield) const; // to be removed
+	int GetYieldAdjacentTwoSameType(YieldTypes eYield) const; // to be removed
 
 #if defined(MOD_GLOBAL_STACKING_RULES)
 	int GetAdditionalUnits() const;
@@ -196,12 +196,14 @@ public:
 	bool GetFeatureMakesValid(int i) const;
 	bool GetImprovementMakesValid(int i) const;
 
-	int GetAdjacentSameTypeYield(int i) const;
-	int* GetAdjacentSameTypeYieldArray();
-	int GetAdjacentTwoSameTypeYield(int i) const;
-	int* GetAdjacentTwoSameTypeYieldArray();
-	int GetAdjacentImprovementYieldChanges(int i, int j) const;
-	int* GetAdjacentImprovementYieldChangesArray(int i);
+	fraction GetYieldPerXAdjacentImprovement(YieldTypes eYield, ImprovementTypes eImprovement) const;
+	bool IsYieldPerXAdjacentImprovement(YieldTypes eYield = NO_YIELD) const;
+	int GetAdjacentSameTypeYield(int i) const; // to be removed
+	int* GetAdjacentSameTypeYieldArray(); // to be removed
+	int GetAdjacentTwoSameTypeYield(int i) const; // to be removed
+	int* GetAdjacentTwoSameTypeYieldArray(); // to be removed
+	int GetAdjacentImprovementYieldChanges(int i, int j) const; // to be removed
+	int* GetAdjacentImprovementYieldChangesArray(int i); // to be removed
 	int GetAdjacentResourceYieldChanges(int i, int j) const;
 	int* GetAdjacentResourceYieldChangesArray (int i);
 	int GetAdjacentTerrainYieldChanges(int i, int j) const;
@@ -353,10 +355,10 @@ protected:
 	bool* m_pbTerrainMakesValid;
 	bool* m_pbFeatureMakesValid;
 	bool* m_pbImprovementMakesValid;
-
-	int* m_piAdjacentSameTypeYield;
-	int* m_piAdjacentTwoSameTypeYield;
-	int** m_ppiAdjacentImprovementYieldChanges;
+	map<YieldTypes, map<ImprovementTypes, fraction>> m_YieldPerXAdjacentImprovement;
+	int* m_piAdjacentSameTypeYield; // to be removed
+	int* m_piAdjacentTwoSameTypeYield; // to be removed
+	int** m_ppiAdjacentImprovementYieldChanges; // to be removed
 	int** m_ppiAdjacentTerrainYieldChanges;
 	int** m_ppiAdjacentResourceYieldChanges;
 	int** m_ppiAdjacentFeatureYieldChanges;

--- a/CvGameCoreDLL_Expansion2/CvPlot.h
+++ b/CvGameCoreDLL_Expansion2/CvPlot.h
@@ -363,9 +363,10 @@ public:
 	void setUpgradeProgress(int iNewValue);
 	void changeUpgradeProgress(int iChange);
 
-	int ComputeYieldFromAdjacentImprovement(CvImprovementEntry& kImprovement, ImprovementTypes eValue, YieldTypes eYield) const;
-	int ComputeYieldFromTwoAdjacentImprovement(CvImprovementEntry& kImprovement, ImprovementTypes eValue, YieldTypes eYield) const;
-	int ComputeYieldFromOtherAdjacentImprovement(CvImprovementEntry& kImprovement, YieldTypes eYield) const;
+	fraction ComputeFractionalYieldFromAdjacentImprovement(CvImprovementEntry& kImprovement, YieldTypes eYield) const;
+	int ComputeYieldFromAdjacentImprovement(CvImprovementEntry& kImprovement, ImprovementTypes eValue, YieldTypes eYield) const; // to be removed
+	int ComputeYieldFromTwoAdjacentImprovement(CvImprovementEntry& kImprovement, ImprovementTypes eValue, YieldTypes eYield) const; // to be removed
+	int ComputeYieldFromOtherAdjacentImprovement(CvImprovementEntry& kImprovement, YieldTypes eYield) const; // to be removed
 	int ComputeYieldFromAdjacentTerrain(CvImprovementEntry& kImprovement, YieldTypes eYield) const;
 	int ComputeYieldFromAdjacentResource(CvImprovementEntry& kImprovement, YieldTypes eYield, TeamTypes eTeam) const;
 	int ComputeYieldFromAdjacentFeature(CvImprovementEntry& kImprovement, YieldTypes eYield) const;


### PR DESCRIPTION
New table **Improvement_YieldPerXAdjacentImprovement** to replace the following VP-created tables:
- Improvement_AdjacentImprovementYieldChanges
- Improvement_YieldAdjacentSameType
- Improvement_YieldAdjacentSameTwoType

Everything now gains yields from adjacent improvements, based on the number required improvements.  Fractional Yields from different Improvement Types are added together (truncated down to the nearest whole number).

These tables and the corresponding (commented) SQL will be deleted during the implementation phase of next Congress, so modmods have time to switch over.

@KungCheops I didn't touch AI evaluation of this, as you asked.