### PR TITLE
(8-35) Rome 4UC

### DIFF
--- a/(1) Community Patch/Core Files/Core Tables/CoreTableEntries.sql
+++ b/(1) Community Patch/Core Files/Core Tables/CoreTableEntries.sql
@@ -1107,6 +1107,9 @@ ALTER TABLE Improvements ADD COLUMN 'Lakeside' BOOLEAN DEFAULT 0;
 -- Improvements can be made valid by being adjacent to a city
 ALTER TABLE Improvements ADD COLUMN 'Cityside' BOOLEAN DEFAULT 0;
 
+-- Improvements cannot be built adjacent to a city
+ALTER TABLE Improvements ADD COLUMN 'NoCityside' BOOLEAN DEFAULT 0;
+
 -- Improvements can be made valid by being adjacent to X of the same improvement
 ALTER TABLE Improvements ADD COLUMN 'XSameAdjacentMakesValid' INTEGER DEFAULT 0;
 
@@ -1115,6 +1118,9 @@ ALTER TABLE Improvements ADD COLUMN 'CoastMakesValid' BOOLEAN DEFAULT 0;
 
 -- Improvements can generate vision for builder x tiles away (radially)
 ALTER TABLE Improvements ADD COLUMN 'GrantsVisionXTiles' INTEGER DEFAULT 0;
+
+-- Improvement spawns a resource in an adjacent tile on completion
+ALTER TABLE Improvements ADD COLUMN 'SpawnsAdjacentResource' TEXT DEFAULT NULL;
 
 -- New Goody Hut Additions
 ALTER TABLE GoodyHuts ADD COLUMN 'Production' INTEGER DEFAULT 0;

--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.h
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.h
@@ -152,6 +152,8 @@ public:
 	bool IsShortcutRoutePlot(const CvPlot* pPlot) const;
 	bool IsStrategicRoutePlot(const CvPlot* pPlot) const;
 
+	int GetResourceSpawnWorkableChance(CvPlot* pPlot, int& iTileClaimChance);
+
 	//---------------------------------------PROTECTED MEMBER VARIABLES---------------------------------
 protected:
 

--- a/CvGameCoreDLL_Expansion2/CvImprovementClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvImprovementClasses.cpp
@@ -143,6 +143,7 @@ CvImprovementEntry::CvImprovementEntry(void):
 	m_iGetObsoleteTech(NO_TECH),
 	m_bAdjacentLake(false),
 	m_bAdjacentCity(false),
+	m_bNoAdjacentCity(false),
 	m_iGrantsVision(0),
 	m_iMovesChange(0),
 	m_bRestoreMoves(false),
@@ -184,7 +185,8 @@ CvImprovementEntry::CvImprovementEntry(void):
 	m_ppiTechNoFreshWaterYieldChanges(NULL),
 	m_ppiTechFreshWaterYieldChanges(NULL),
 	m_ppiRouteYieldChanges(NULL),
-	m_paImprovementResource(NULL)
+	m_paImprovementResource(NULL),
+	m_eSpawnsAdjacentResource(NO_RESOURCE)
 {
 }
 
@@ -330,6 +332,7 @@ bool CvImprovementEntry::CacheResults(Database::Results& kResults, CvDatabaseUti
 	m_iGetObsoleteTech = GC.getInfoTypeForString(szObsoleteTech, true);
 	m_bAdjacentLake = kResults.GetBool("Lakeside");
 	m_bAdjacentCity = kResults.GetBool("Cityside");
+	m_bNoAdjacentCity = kResults.GetBool("NoCityside");
 	m_iGrantsVision = kResults.GetInt("GrantsVisionXTiles");
 	m_iUnitPlotExperience = kResults.GetInt("UnitPlotExperience");
 	m_iGAUnitPlotExperience = kResults.GetInt("GAUnitPlotExperience");
@@ -385,6 +388,9 @@ bool CvImprovementEntry::CacheResults(Database::Results& kResults, CvDatabaseUti
 
 	const char* szImprovementUpgrade = kResults.GetText("ImprovementUpgrade");
 	m_iImprovementUpgrade = GC.getInfoTypeForString(szImprovementUpgrade, true);
+
+	const char* szSpawnsAdjacentResource = kResults.GetText("SpawnsAdjacentResource");
+	m_eSpawnsAdjacentResource = (ResourceTypes)GC.getInfoTypeForString(szSpawnsAdjacentResource, true);
 
 	//Arrays
 	const char* szImprovementType = GetType();
@@ -1178,6 +1184,10 @@ bool CvImprovementEntry::IsAdjacentCity() const
 {
 	return m_bAdjacentCity;
 }
+bool CvImprovementEntry::IsNoAdjacentCity() const
+{
+	return m_bNoAdjacentCity;
+}
 int CvImprovementEntry::GetGrantsVision() const
 {
 	return m_iGrantsVision;
@@ -1624,6 +1634,12 @@ bool CvImprovementEntry::IsConnectsResource(int i) const
 		return false;
 
 	return ConnectsAllResources();
+}
+
+// Spawns a resource in one of the available adjacent tiles (if possible)
+ResourceTypes CvImprovementEntry::SpawnsAdjacentResource() const
+{
+	return m_eSpawnsAdjacentResource;
 }
 
 /// the chance of the specified Resource appearing randomly when the Improvement is present with no current Resource

--- a/CvGameCoreDLL_Expansion2/CvImprovementClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvImprovementClasses.h
@@ -144,6 +144,7 @@ public:
 	int GetObsoleteTech() const;
 	bool IsAdjacentLake() const;
 	bool IsAdjacentCity() const;
+	bool IsNoAdjacentCity() const;
 	int GetGrantsVision() const;
 #endif
 	bool IsNoTwoAdjacent() const;
@@ -225,6 +226,8 @@ public:
 	bool IsImprovementResourceMakesValid(int i) const;
 	bool IsImprovementResourceTrade(int i) const;
 	bool IsConnectsResource(int i) const;
+
+	ResourceTypes SpawnsAdjacentResource() const;
 
 	int  GetImprovementResourceDiscoverRand(int i) const;
 	int  GetFlavorValue(int i) const;
@@ -318,6 +321,7 @@ protected:
 	int m_iGetObsoleteTech;
 	bool m_bAdjacentLake;
 	bool m_bAdjacentCity;
+	bool m_bNoAdjacentCity;
 	int m_iGrantsVision;
 #endif
 	bool m_bNoTwoAdjacent;
@@ -368,6 +372,8 @@ protected:
 	int** m_ppiRouteYieldChanges;
 
 	CvImprovementResourceInfo* m_paImprovementResource;
+
+	ResourceTypes m_eSpawnsAdjacentResource;
 };
 
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/CvGameCoreDLL_Expansion2/CvPlot.h
+++ b/CvGameCoreDLL_Expansion2/CvPlot.h
@@ -626,6 +626,10 @@ public:
 	void updateRiverCrossing(DirectionTypes eIndex);
 	void updateRiverCrossing();
 
+	CvPlot* GetAdjacentResourceSpawnPlot(PlayerTypes ePlayer) const;
+	void SetSpawnedResourcePlot(const CvPlot* pPlot);
+	CvPlot* GetSpawnedResourcePlot() const;
+
 	bool isRevealed(TeamTypes eTeam, bool bDebug) const
 	{
 		if(bDebug && GC.getGame().isDebugMode())
@@ -913,6 +917,9 @@ protected:
 	char /*PlotTypes*/    m_ePlotType;
 	char /*TerrainTypes*/ m_eTerrainType;
 	bool m_bIsCity;
+
+	short m_sSpawnedResourceX;
+	short m_sSpawnedResourceY;
 
 	PlotBoolField m_bfRevealed;
 


### PR DESCRIPTION
Add support for NoCityside and SpawnsAdjacentResource

Includes extra AI support for SpawnsAdjacentResource.

Resource is spawned in a random adjacent passable land tile which doesn't have an existing resource. The tile is claimed if it is unowned. Resource will only spawn within another civ's borders if there is no other viable plot.