### PR TITLE
Add support for SpawnsAdjacentResource

### DIFF
--- a/(1) Community Patch/Core Files/Core Tables/CoreTableEntries.sql
+++ b/(1) Community Patch/Core Files/Core Tables/CoreTableEntries.sql
@@ -1116,6 +1116,9 @@ ALTER TABLE Improvements ADD COLUMN 'CoastMakesValid' BOOLEAN DEFAULT 0;
 -- Improvements can generate vision for builder x tiles away (radially)
 ALTER TABLE Improvements ADD COLUMN 'GrantsVisionXTiles' INTEGER DEFAULT 0;
 
+-- Improvement spawns a resource in an adjacent tile on completion
+ALTER TABLE Improvements ADD COLUMN 'SpawnsAdjacentResource' TEXT DEFAULT NULL;
+
 -- New Goody Hut Additions
 ALTER TABLE GoodyHuts ADD COLUMN 'Production' INTEGER DEFAULT 0;
 ALTER TABLE GoodyHuts ADD COLUMN 'GoldenAge' INTEGER DEFAULT 0;

--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.h
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.h
@@ -152,6 +152,8 @@ public:
 	bool IsShortcutRoutePlot(const CvPlot* pPlot) const;
 	bool IsStrategicRoutePlot(const CvPlot* pPlot) const;
 
+	int GetResourceSpawnWorkableChance(CvPlot* pPlot, int& iTileClaimChance);
+
 	//---------------------------------------PROTECTED MEMBER VARIABLES---------------------------------
 protected:
 

--- a/CvGameCoreDLL_Expansion2/CvImprovementClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvImprovementClasses.cpp
@@ -184,7 +184,8 @@ CvImprovementEntry::CvImprovementEntry(void):
 	m_ppiTechNoFreshWaterYieldChanges(NULL),
 	m_ppiTechFreshWaterYieldChanges(NULL),
 	m_ppiRouteYieldChanges(NULL),
-	m_paImprovementResource(NULL)
+	m_paImprovementResource(NULL),
+	m_eSpawnsAdjacentResource(NO_RESOURCE)
 {
 }
 
@@ -385,6 +386,9 @@ bool CvImprovementEntry::CacheResults(Database::Results& kResults, CvDatabaseUti
 
 	const char* szImprovementUpgrade = kResults.GetText("ImprovementUpgrade");
 	m_iImprovementUpgrade = GC.getInfoTypeForString(szImprovementUpgrade, true);
+
+	const char* szSpawnsAdjacentResource = kResults.GetText("SpawnsAdjacentResource");
+	m_eSpawnsAdjacentResource = (ResourceTypes)GC.getInfoTypeForString(szSpawnsAdjacentResource, true);
 
 	//Arrays
 	const char* szImprovementType = GetType();
@@ -1624,6 +1628,12 @@ bool CvImprovementEntry::IsConnectsResource(int i) const
 		return false;
 
 	return ConnectsAllResources();
+}
+
+// Spawns a resource in one of the available adjacent tiles (if possible)
+ResourceTypes CvImprovementEntry::SpawnsAdjacentResource() const
+{
+	return m_eSpawnsAdjacentResource;
 }
 
 /// the chance of the specified Resource appearing randomly when the Improvement is present with no current Resource

--- a/CvGameCoreDLL_Expansion2/CvImprovementClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvImprovementClasses.h
@@ -226,6 +226,8 @@ public:
 	bool IsImprovementResourceTrade(int i) const;
 	bool IsConnectsResource(int i) const;
 
+	ResourceTypes SpawnsAdjacentResource() const;
+
 	int  GetImprovementResourceDiscoverRand(int i) const;
 	int  GetFlavorValue(int i) const;
 
@@ -368,6 +370,8 @@ protected:
 	int** m_ppiRouteYieldChanges;
 
 	CvImprovementResourceInfo* m_paImprovementResource;
+
+	ResourceTypes m_eSpawnsAdjacentResource;
 };
 
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -232,6 +232,9 @@ void CvPlot::reset()
 	m_owningCity.reset();
 	m_owningCityOverride.reset();
 
+	m_sSpawnedResourceX = -1;
+	m_sSpawnedResourceY = -1;
+
 	m_vExtraYields.clear();
 	m_vRivers.clear();
 
@@ -8564,6 +8567,57 @@ void CvPlot::setImprovementType(ImprovementTypes eNewValue, PlayerTypes eBuilder
 					GET_PLAYER(eBuilder).doInstantYield(INSTANT_YIELD_TYPE_IMPROVEMENT_BUILD, false, NO_GREATPERSON, NO_BUILDING, 0, false, NO_PLAYER, NULL, false, pTargetCity);
 				}
 			}
+
+			ResourceTypes eSpawnedResource = newImprovementEntry.SpawnsAdjacentResource();
+			if (eSpawnedResource != NO_RESOURCE)
+			{
+				CvPlot* pSpawnPlot = GetAdjacentResourceSpawnPlot(eBuilder);
+				if (pSpawnPlot)
+				{
+					pSpawnPlot->setResourceType(eSpawnedResource, 1);
+					SetSpawnedResourcePlot(pSpawnPlot);
+
+					if (pSpawnPlot->getOwner() == NO_PLAYER)
+					{
+						int iBestCityID = -1;
+						int iBestCityDistance = -1;
+						int iDistance = 0;
+						CvCity* pLoopCity = NULL;
+						int iLoop = 0;
+						for (pLoopCity = GET_PLAYER(eBuilder).firstCity(&iLoop); pLoopCity != NULL; pLoopCity = GET_PLAYER(eBuilder).nextCity(&iLoop))
+						{
+							CvPlot* pPlot = pLoopCity->plot();
+							if (pPlot)
+							{
+								iDistance = plotDistance(getX(), getY(), pLoopCity->getX(), pLoopCity->getY());
+								if (iBestCityDistance == -1 || iDistance < iBestCityDistance)
+								{
+									iBestCityID = pLoopCity->GetID();
+									iBestCityDistance = iDistance;
+								}
+							}
+						}
+						pSpawnPlot->setOwner(eBuilder, iBestCityID);
+					}
+				}
+			}
+		}
+
+		if (eOldImprovement != NO_IMPROVEMENT)
+		{
+			ResourceTypes eSpawnedResource = GC.getImprovementInfo(eOldImprovement)->SpawnsAdjacentResource();
+			if (eSpawnedResource != NO_RESOURCE)
+			{
+				CvPlot* pSpawnedPlot = GetSpawnedResourcePlot();
+				if (pSpawnedPlot)
+				{
+					pSpawnedPlot->setResourceType(NO_RESOURCE, 0);
+					CvImprovementEntry* pkOldImprovementInfo = GC.getImprovementInfo(eOldImprovement);
+					if (pkOldImprovementInfo && pkOldImprovementInfo->IsImprovementResourceMakesValid(eSpawnedResource))
+						pSpawnedPlot->setImprovementType(NO_IMPROVEMENT);
+					SetSpawnedResourcePlot(NULL);
+				}
+			}
 		}
 
 		// If we're removing an Improvement that hooked up a resource then we need to take away the bonus
@@ -8877,6 +8931,72 @@ void CvPlot::setImprovementType(ImprovementTypes eNewValue, PlayerTypes eBuilder
 			}
 		}
 	}
+}
+
+CvPlot* CvPlot::GetAdjacentResourceSpawnPlot(PlayerTypes ePlayer) const
+{
+	vector<OptionWithScore<CvPlot*>> sortedPlots;
+
+	int iBestCost = INT_MAX;
+	int iPossibleSpawnPlots = 0;
+
+	for (int iI = 0; iI < NUM_DIRECTION_TYPES; iI++)
+	{
+		CvPlot* pAdjacentPlot = plotDirection(getX(), getY(), (DirectionTypes)iI);
+		if (!pAdjacentPlot)
+			continue;
+
+		if (pAdjacentPlot->isCity() || !pAdjacentPlot->isValidMovePlot(ePlayer) || pAdjacentPlot->isWater()
+			|| pAdjacentPlot->IsNaturalWonder() || pAdjacentPlot->isMountain() || pAdjacentPlot->getResourceType() != NO_RESOURCE)
+			continue;
+
+		if (pAdjacentPlot->getOwner() != ePlayer && pAdjacentPlot->getOwner() != NO_PLAYER)
+			continue;
+
+		int iCost = pAdjacentPlot->getOwner() != ePlayer && pAdjacentPlot->getOwner() != NO_PLAYER ? 1 : 0;
+
+		sortedPlots.push_back(OptionWithScore<CvPlot*>(pAdjacentPlot, -iCost));
+		if (iCost < iBestCost)
+		{
+			iBestCost = iCost;
+			iPossibleSpawnPlots = 1;
+		}
+		else if (iCost == iBestCost)
+		{
+			iPossibleSpawnPlots++;
+		}
+	}
+
+	if (sortedPlots.empty())
+		return NULL;
+
+	std::stable_sort(sortedPlots.begin(), sortedPlots.end());
+
+	int iRandomIndex = GC.getGame().urandLimitExclusive(iPossibleSpawnPlots, GET_PLAYER(getOwner()).GetPseudoRandomSeed().mix(GetPseudoRandomSeed()));
+
+	return sortedPlots[iRandomIndex].option;
+}
+
+void CvPlot::SetSpawnedResourcePlot(const CvPlot* pPlot)
+{
+	if (pPlot)
+	{
+		m_sSpawnedResourceX = pPlot->getX();
+		m_sSpawnedResourceY = pPlot->getY();
+	}
+	else
+	{
+		m_sSpawnedResourceX = -1;
+		m_sSpawnedResourceY = -1;
+	}
+}
+
+CvPlot* CvPlot::GetSpawnedResourcePlot() const
+{
+	if (m_sSpawnedResourceX != -1 && m_sSpawnedResourceY != -1)
+		return GC.getMap().plot(m_sSpawnedResourceX, m_sSpawnedResourceY);
+
+	return NULL;
 }
 
 //	--------------------------------------------------------------------------------
@@ -13475,6 +13595,9 @@ void CvPlot::Serialize(Plot& plot, Visitor& visitor)
 	visitor(plot.m_kArchaeologyData);
 	visitor(plot.m_bIsTradeUnitRoute);
 	visitor(plot.m_iLastTurnBuildChanged);
+
+	visitor(plot.m_sSpawnedResourceX);
+	visitor(plot.m_sSpawnedResourceY);
 }
 
 //	--------------------------------------------------------------------------------

--- a/CvGameCoreDLL_Expansion2/CvPlot.h
+++ b/CvGameCoreDLL_Expansion2/CvPlot.h
@@ -626,6 +626,10 @@ public:
 	void updateRiverCrossing(DirectionTypes eIndex);
 	void updateRiverCrossing();
 
+	CvPlot* GetAdjacentResourceSpawnPlot(PlayerTypes ePlayer) const;
+	void SetSpawnedResourcePlot(const CvPlot* pPlot);
+	CvPlot* GetSpawnedResourcePlot() const;
+
 	bool isRevealed(TeamTypes eTeam, bool bDebug) const
 	{
 		if(bDebug && GC.getGame().isDebugMode())
@@ -913,6 +917,9 @@ protected:
 	char /*PlotTypes*/    m_ePlotType;
 	char /*TerrainTypes*/ m_eTerrainType;
 	bool m_bIsCity;
+
+	short m_sSpawnedResourceX;
+	short m_sSpawnedResourceY;
 
 	PlotBoolField m_bfRevealed;
 


### PR DESCRIPTION
Includes AI support.

Resource is spawned in a random adjacent passable land tile which doesn't have an existing resource. The tile is claimed if it is unowned. Resource will only spawn within another civ's borders if there is no other viable plot.