### PR TITLE
Fix route-to mode not working for railroads

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvAStar.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAStar.cpp
@@ -3730,12 +3730,12 @@ FDataStream& operator<<(FDataStream& kStream, const CvPathNodeArray& readFrom)
 }
 
 //	---------------------------------------------------------------------------
-bool IsPlotConnectedToPlot(PlayerTypes ePlayer, CvPlot* pFromPlot, CvPlot* pToPlot, RouteTypes eRestrictRoute, bool bAllowHarbors, bool bAssumeOpenBorders, SPath* pPathOut)
+bool IsPlotConnectedToPlot(PlayerTypes ePlayer, CvPlot* pFromPlot, CvPlot* pToPlot, RouteTypes eRestrictRoute, bool bAllowHarbors, bool bUseRivers, bool bAssumeOpenBorders, SPath* pPathOut)
 {
 	if (ePlayer==NO_PLAYER || pFromPlot==NULL || pToPlot==NULL)
 		return false;
 
-	SPathFinderUserData data(ePlayer, bAllowHarbors ? PT_CITY_CONNECTION_MIXED : PT_CITY_CONNECTION_LAND, NO_BUILD, eRestrictRoute, NO_ROUTE_PURPOSE, true);
+	SPathFinderUserData data(ePlayer, bAllowHarbors ? PT_CITY_CONNECTION_MIXED : PT_CITY_CONNECTION_LAND, NO_BUILD, eRestrictRoute, NO_ROUTE_PURPOSE, bUseRivers);
 	data.iFlags = bAssumeOpenBorders ? CvUnit::MOVEFLAG_IGNORE_RIGHT_OF_PASSAGE : 0; //slight misuse but who cares
 
 	SPath result;

--- a/CvGameCoreDLL_Expansion2/CvAStar.h
+++ b/CvGameCoreDLL_Expansion2/CvAStar.h
@@ -356,7 +356,7 @@ int ArmyStepValidWater(const CvAStarNode* parent, const CvAStarNode* node, const
 int ArmyStepValidMixed(const CvAStarNode* parent, const CvAStarNode* node, const SPathFinderUserData& data, const CvAStar* finder);
 
 //helper functions
-bool IsPlotConnectedToPlot(PlayerTypes ePlayer, CvPlot* pFromPlot, CvPlot* pToPlot, RouteTypes eRestrictRoute = ROUTE_ANY, bool bAllowHarbors = true, bool bAssumeOpenBorders = false, SPath* pPathOut = NULL);
+bool IsPlotConnectedToPlot(PlayerTypes ePlayer, CvPlot* pFromPlot, CvPlot* pToPlot, RouteTypes eRestrictRoute = ROUTE_ANY, bool bAllowHarbors = true, bool bUseRivers = true, bool bAssumeOpenBorders = false, SPath* pPathOut = NULL);
 
 namespace PathHelpers
 {

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -11323,7 +11323,7 @@ bool CvPlayer::IsCityConnectedToCity(CvCity* pCity1, CvCity* pCity2, RouteTypes 
 	if (!pCity1 || !pCity2)
 		return false;
 
-	return IsPlotConnectedToPlot(m_eID, pCity1->plot(), pCity2->plot(), eRestrictRoute, !bIgnoreHarbors, false, pPathOut);
+	return IsPlotConnectedToPlot(m_eID, pCity1->plot(), pCity2->plot(), eRestrictRoute, !bIgnoreHarbors, true, false, pPathOut);
 }
 
 bool CvPlayer::IsCapitalConnectedToPlayer(PlayerTypes ePlayer)

--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -3098,6 +3098,10 @@ bool CvPlot::canBuild(BuildTypes eBuild, PlayerTypes ePlayer, bool bTestVisible,
 	// Route
 	if(eRoute != NO_ROUTE)
 	{
+		// can't build roads in cities
+		if (isCity())
+			return false;
+
 		if(getRouteType() != NO_ROUTE)
 		{
 			if (isWater() && !thisBuildInfo.IsWater())

--- a/CvGameCoreDLL_Expansion2/CvUnit.h
+++ b/CvGameCoreDLL_Expansion2/CvUnit.h
@@ -284,7 +284,7 @@ public:
 
 	bool CanDoInterfaceMode(InterfaceModeTypes eInterfaceMode, bool bTestVisibility = false);
 
-	RouteTypes GetBestBuildRoute(CvPlot* pPlot, BuildTypes* peBestBuild = NULL) const;
+	RouteTypes GetBestBuildRouteForRoadTo(CvPlot* pPlot, BuildTypes* peBestBuild = NULL) const;
 	void PlayActionSound();
 
 	TeamTypes GetDeclareWarMove(const CvPlot& pPlot) const;
@@ -1847,7 +1847,7 @@ public:
 	void PopMission();
 	void AutoMission();
 	void UpdateMission();
-	CvPlot* LastMissionPlot();
+	CvPlot* LastMissionPlot() const;
 	bool CanStartMission(int iMission, int iData1, int iData2, CvPlot* pPlot = NULL, bool bTestVisible = false);
 	int GetMissionTimer() const;
 	void SetMissionTimer(int iNewValue);

--- a/CvGameCoreDLL_Expansion2/CvUnitMission.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnitMission.cpp
@@ -770,7 +770,7 @@ void CvUnitMission::ContinueMission(CvUnit* hUnit, int iSteps)
 			{
 				if(hUnit->at(kMissionData.iData1, kMissionData.iData2))
 				{
-					if(hUnit->GetBestBuildRoute(hUnit->plot()) == NO_ROUTE)
+					if(hUnit->GetBestBuildRouteForRoadTo(hUnit->plot()) == NO_ROUTE)
 					{
 						bDone = true;
 					}
@@ -1042,7 +1042,7 @@ bool CvUnitMission::CanStartMission(CvUnit* hUnit, int iMission, int iData1, int
 	}
 	else if(iMission == CvTypes::getMISSION_ROUTE_TO())
 	{
-		if(!(pPlot->at(iData1, iData2)) || (hUnit->GetBestBuildRoute(pPlot) != NO_ROUTE))
+		if(!(pPlot->at(iData1, iData2)) || (hUnit->GetBestBuildRouteForRoadTo(pPlot) != NO_ROUTE))
 		{
 			return true;
 		}
@@ -1968,7 +1968,7 @@ void CvUnitMission::StartMission(CvUnit* hUnit)
 
 //	---------------------------------------------------------------------------
 /// Where does this mission end?
-CvPlot* CvUnitMission::LastMissionPlot(CvUnit* hUnit)
+CvPlot* CvUnitMission::LastMissionPlot(const CvUnit* hUnit)
 {
 	const MissionData* pMissionNode = TailMissionData(hUnit->m_missionQueue);
 

--- a/CvGameCoreDLL_Expansion2/CvUnitMission.h
+++ b/CvGameCoreDLL_Expansion2/CvUnitMission.h
@@ -24,7 +24,7 @@ public:
 	static void ContinueMission(CvUnit* hUnit, int iSteps = 0);
 	static void AutoMission(CvUnit* hUnit);
 	static void UpdateMission(CvUnit* hUnit);
-	static CvPlot* LastMissionPlot(CvUnit* hUnit);
+	static CvPlot* LastMissionPlot(const CvUnit* hUnit);
 	static void PushMission(CvUnit* hUnit, MissionTypes eMission, int iData1 = -1, int iData2 = -1, int iFlags = 0, bool bAppend = false, bool bManual = false, MissionAITypes eMissionAI = NO_MISSIONAI, CvPlot* pMissionAIPlot = NULL, CvUnit* pMissionAIUnit = NULL);
 	static void PopMission(CvUnit* hUnit);
 	static void ClearMissionQueue(CvUnit* hUnit, bool bKeepPathCache, int iUnitCycleTimerOverride);


### PR DESCRIPTION
Should also fix the MOD_GLOBAL_QUICK_ROUTES mod option, which seems to not have been functioning.

Route-to will now ignore rivers.

Can no longer build roads in cities.

Fix #10780
Fix #10797 
Fix #10922