### PR TITLE
Fix Villa resources spawning rules

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvPlot.h
+++ b/CvGameCoreDLL_Expansion2/CvPlot.h
@@ -171,6 +171,8 @@ public:
 	bool canHaveImprovement(ImprovementTypes eImprovement, PlayerTypes ePlayer = NO_PLAYER, bool bOnlyTestVisible = false, bool bCheckAdjacency = false, bool bTestXAdjacent = false) const;
 	BuildTypes GetBuildTypeFromImprovement(ImprovementTypes eImprovement) const;
 
+	bool CanSpawnResource(PlayerTypes ePlayer, bool bIgnoreTech = true, bool bIsLand=true) const;
+
 	bool canBuild(BuildTypes eBuild, PlayerTypes ePlayer = NO_PLAYER, bool bTestVisible = false, bool bTestPlotOwner = true, bool bTestXAdjacent = false) const;
 	int getBuildTime(BuildTypes eBuild, PlayerTypes ePlayer) const;
 	int getBuildTurnsTotal(BuildTypes eBuild, PlayerTypes ePlayer) const;

--- a/CvGameCoreDLL_Expansion2/CvTraitClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTraitClasses.cpp
@@ -6552,19 +6552,16 @@ bool CvPlayerTraits::AddUniqueLuxuriesAround(CvCity *pCity, int iNumResourceToGi
 	for(int iCityPlotLoop = 0; iCityPlotLoop < pCity->GetNumWorkablePlots(); iCityPlotLoop++)
 	{
 		pLoopPlot = iterateRingPlots(pCity->getX(), pCity->getY(), iCityPlotLoop);
-		if( pLoopPlot != NULL && pLoopPlot->getOwner() == m_pPlayer->GetID() && !pLoopPlot->isCity() && 
-			pLoopPlot->isValidMovePlot(pCity->getOwner()) && !pLoopPlot->isWater() && !pLoopPlot->IsNaturalWonder() && !pLoopPlot->isMountain() && (pLoopPlot->getFeatureType() == NO_FEATURE))
+		if (pLoopPlot != NULL && pLoopPlot->getOwner() == m_pPlayer->GetID() && pLoopPlot->CanSpawnResource(pCity->getOwner())
+			&& pLoopPlot->getFeatureType() == NO_FEATURE && pLoopPlot->getImprovementType() == NO_IMPROVEMENT)
 		{
-			if(pLoopPlot->getResourceType() == NO_RESOURCE && pLoopPlot->getImprovementType() == NO_IMPROVEMENT)
-			{
-				pLoopPlot->setResourceType(eResourceToGive, 1, false);
-				iNumResourceGiven++;
+			pLoopPlot->setResourceType(eResourceToGive, 1, false);
+			iNumResourceGiven++;
 
-				if(iNumResourceGiven >= iNumResourceToGive)
-				{
-					bResult = true;
-					break;
-				}
+			if (iNumResourceGiven >= iNumResourceToGive)
+			{
+				bResult = true;
+				break;
 			}
 		}
 	}
@@ -6575,22 +6572,18 @@ bool CvPlayerTraits::AddUniqueLuxuriesAround(CvCity *pCity, int iNumResourceToGi
 		for(int iCityPlotLoop = 0; iCityPlotLoop < pCity->GetNumWorkablePlots(); iCityPlotLoop++)
 		{
 			pLoopPlot = iterateRingPlots(pCity->getX(), pCity->getY(), iCityPlotLoop);
-			if( pLoopPlot != NULL && (pLoopPlot->getOwner() == NO_PLAYER) && pLoopPlot->isValidMovePlot(pCity->getOwner()) && 
-				!pLoopPlot->isWater() && !pLoopPlot->IsNaturalWonder() && pLoopPlot->getFeatureType() != FEATURE_OASIS)
+			if (pLoopPlot != NULL && pLoopPlot->getOwner() == NO_PLAYER && pLoopPlot->CanSpawnResource(pCity->getOwner()))
 			{
-				if(pLoopPlot->getResourceType() == NO_RESOURCE)
+				if (pLoopPlot->getImprovementType() != NO_IMPROVEMENT)
+					pLoopPlot->setImprovementType(NO_IMPROVEMENT);
+
+				pLoopPlot->setResourceType(eResourceToGive, 1, false);
+				iNumResourceGiven++;
+
+				if(iNumResourceGiven >= iNumResourceToGive)
 				{
-					if (pLoopPlot->getImprovementType() != NO_IMPROVEMENT)
-						pLoopPlot->setImprovementType(NO_IMPROVEMENT);
-
-					pLoopPlot->setResourceType(eResourceToGive, 1, false);
-					iNumResourceGiven++;
-
-					if(iNumResourceGiven >= iNumResourceToGive)
-					{
-						bResult = true;
-						break;
-					}
+					bResult = true;
+					break;
 				}
 			}
 		}


### PR DESCRIPTION
Resources can now spawn in enemy territory.

Resources now have no preference for owned or unowned tiles.

Resource can no longer spawn on oasis.

Consolidate resource spawning validity logic.