### PR TITLE
More city governor updates 

### DIFF
--- a/(2) Vox Populi/LUA/CityView.lua
+++ b/(2) Vox Populi/LUA/CityView.lua
@@ -2281,7 +2281,7 @@ function OnEnterCityScreen()
 	
 	local pCity = UI.GetHeadSelectedCity();
 	
-	if (pCity ~= nil) then
+	if (pCity ~= nil and not pCity:IsPuppet()) then
 		Network.SendUpdateCityCitizens(pCity:GetID());
 	end
 

--- a/(3a) EUI Compatibility Files/LUA/CityView.lua
+++ b/(3a) EUI Compatibility Files/LUA/CityView.lua
@@ -2990,10 +2990,10 @@ UpdateOptionsAndCityView()
 Events.SerialEventEnterCityScreen.Add(
 function()
 
---	local city = UI_GetHeadSelectedCity()
---	if city then
---		Network.SendUpdateCityCitizens( city:GetID() )
---	end
+	local city = UI_GetHeadSelectedCity()
+	if city and not city:IsPuppet() then
+		Network.SendUpdateCityCitizens( city:GetID() )
+	end
 
 	LuaEvents.TryQueueTutorial("CITY_SCREEN", true)
 

--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -2354,11 +2354,20 @@ void CvCity::doTurn()
 	setMadeAttack(false);
 	GetCityBuildings()->SetSoldBuildingThisTurn(false);
 
-	//not a full re-allocation but see if we can shift some citizens around
-	//DoReallocateCitizens() will be called less frequently when a building is added, a plot is claimed, population changes etc
-	GetCityCitizens()->DoVerifyWorkingPlots();
-	GetCityCitizens()->OptimizeWorkedPlots(false);
-	updateNetHappiness();
+	
+	if (foodDifferenceTimes100(true) < 0)
+	{
+		// avoid starvation if possible
+		GetCityCitizens()->DoReallocateCitizens(true);
+	}
+	else
+	{
+		//not a full re-allocation but see if we can shift some citizens around
+		//DoReallocateCitizens() will be called less frequently when a building is added, a plot is claimed, population changes etc
+		GetCityCitizens()->DoVerifyWorkingPlots();
+		GetCityCitizens()->OptimizeWorkedPlots(false);
+		updateNetHappiness();
+	}
 	UpdateTerrainImprovementNeed();
 
 	GetCityStrategyAI()->DoTurn();

--- a/CvGameCoreDLL_Expansion2/CvCityCitizens.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCityCitizens.cpp
@@ -2545,6 +2545,8 @@ void CvCityCitizens::DoAlterWorkingPlot(int iIndex)
 					return;
 
 				pPlot->setOwningCityOverride(GetCity());
+				// check if the city governor wants to work the new tile
+				DoReallocateCitizens(true);
 			}
 		}
 	}

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -4430,6 +4430,7 @@ CvCity* CvPlayer::acquireCity(CvCity* pCity, bool bConquest, bool bGift, bool bO
 
 	// New owner should update city specializations
 	GetCitySpecializationAI()->SetSpecializationsDirty(SPECIALIZATION_UPDATE_ENEMY_CITY_CAPTURED);
+	pNewCity->GetCityCitizens()->DoReallocateCitizens(true);
 
 	// Display the notification for the spoils of plundering
 	if (GC.getGame().getActivePlayer() == GetID())


### PR DESCRIPTION
The city governor updates the worked tiles
- when a city is acquired from someone else (fixes #11252)
- when a player switches a tile from one city to another
- when a player opens the city screen of a non-puppet city
- at the beginning of each turn if the city is starving