### PR TITLE
readability-inconsistent-declaration-parameter-name

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvGameCoreUtils.h
+++ b/CvGameCoreDLL_Expansion2/CvGameCoreUtils.h
@@ -489,7 +489,7 @@ public:
 	inline bool operator>=(const fraction &rhs) const { return !operator<(rhs); };
 	inline bool operator>(const fraction &rhs) const { return !operator<(rhs) && !operator==(rhs); };
 	
-	friend fraction abs(const fraction &rhs);
+	friend fraction abs(const fraction &lhs);
 	friend bool operator==(const int lhs, const fraction &rhs);
 	friend bool operator!=(const int lhs, const fraction &rhs);
 	


### PR DESCRIPTION
Linked to https://github.com/LoneGazebo/Community-Patch-DLL/pull/11210. For review, @LessRekkless. Builds work.

```
C:\Users\user\Documents\GitHub\Community-Patch-DLL\CvGameCoreDLL_Expansion2\CvGameCoreUtils.h:492:18: warning: function 'abs' has a definition with different parameter names [readability-inconsistent-declaration-parameter-name]
  492 |         friend fraction abs(const fraction &rhs);
      |                         ^
C:\Users\user\Documents\GitHub\Community-Patch-DLL\CvGameCoreDLL_Expansion2\CvGameCoreUtils.cpp:1580:10: note: the definition seen here
 1580 | fraction abs(const fraction &lhs)
      |          ^
C:\Users\user\Documents\GitHub\Community-Patch-DLL\CvGameCoreDLL_Expansion2\CvGameCoreUtils.h:492:18: note: differing parameters are named here: ('rhs'), in definition: ('lhs')
  492 |         friend fraction abs(const fraction &rhs);
      |                         ^                   ~~~
      |                                             lhs
```