### PR TITLE
QoL Addition: Add the ability to set citizen focus for all cities with shift modifier

### DIFF
--- a/(2) Vox Populi/Database Changes/Text/en_US/Concepts/NewConceptText.xml
+++ b/(2) Vox Populi/Database Changes/Text/en_US/Concepts/NewConceptText.xml
@@ -189,6 +189,9 @@
 				[ICON_BULLET][COLOR_CYAN]Insert Bottom All[ENDCOLOR]: [COLOR_YELLOW]SHIFT+ALT+LCLICK[ENDCOLOR] an item to add it to the bottom of every eligible cities construction queues.[NEWLINE]
 				[ICON_BULLET][COLOR_CYAN]Insert Top All[ENDCOLOR]: [COLOR_YELLOW]SHIFT+CTRL+LCLICK[ENDCOLOR] an item to add it to the top of every eligible owned cities construction queues.[NEWLINE]
 				[ICON_BULLET][COLOR_CYAN]Invest All[ENDCOLOR]: [COLOR_YELLOW]SHIFT+LCLICK[ENDCOLOR] a buildings invest button to invest in every copy of this building in any cities active construction queue.[NEWLINE]
+				
+				[NEWLINE][COLOR_POSITIVE_TEXT]Citizen Management Modifiers:[ENDCOLOR][NEWLINE]
+				[ICON_BULLET][COLOR_CYAN]Set Yield Focus All[ENDCOLOR]: [COLOR_YELLOW]SHIFT+LCLICK[ENDCOLOR] a focus type to have all cities emphasize the production of that yield type.
 			</Text>
 		</Row>
 		<Row Tag="TXT_KEY_TOPIC_SHORTCUT_WORLD_VIEW">

--- a/(3a) EUI Compatibility Files/LUA/CityView.lua
+++ b/(3a) EUI Compatibility Files/LUA/CityView.lua
@@ -2842,10 +2842,21 @@ end
 -- Citizen Focus
 local FocusButtonBehavior = {
 	[Mouse.eLClick] = function( focus )
-		local city = GetSelectedModifiableCity()
-		if city then
-			Network.SendSetCityAIFocus( city:GetID(), focus )
-			return Network.SendUpdateCityCitizens( city:GetID() )
+		if UI.ShiftKeyDown() then
+			-- Set focus for all cities
+			for cityX in g_activePlayer:Cities() do
+				if ( not cityX:IsPuppet() or ( bnw_mode and g_activePlayer:MayNotAnnex() )) then
+					Network.SendSetCityAIFocus( cityX:GetID(), focus )
+					Network.SendUpdateCityCitizens( cityX:GetID() )
+				end
+			end
+		else
+			-- Set focus for local city only
+			local city = GetSelectedModifiableCity()
+			if city then
+				Network.SendSetCityAIFocus( city:GetID(), focus )
+				return Network.SendUpdateCityCitizens( city:GetID() )
+			end
 		end
 	end,
 }


### PR DESCRIPTION
* Adds a shift modifier to setting citizen focus in the citizen management menu that applies the selected focus to all owned cities
* Update Civilopedia input shortcuts section to include it