### PR TITLE
fixed Religious Settlement/God of the Expanse pantheon not giving 25% border growth

### DIFF
--- a/(2) Vox Populi/Database Changes/Beliefs/PantheonChanges.sql
+++ b/(2) Vox Populi/Database Changes/Beliefs/PantheonChanges.sql
@@ -61,7 +61,7 @@ VALUES
 -- Religious Settlements (now God of the Expanse)
 UPDATE Beliefs
 SET
-	PlotCultureCostModifier = 0,
+	PlotCultureCostModifier = -25,
 	BorderGrowthRateIncreaseGlobal = 25
 WHERE Type = 'BELIEF_RELIGIOUS_SETTLEMENTS';
 


### PR DESCRIPTION
The description of the pantheon:
> UPDATE Language_en_US
SET Text = '+25% [ICON_CULTURE_LOCAL] Border Growth. Gain 25 [ICON_PEACE] Faith and 15 [ICON_PRODUCTION] Production every time the City expands its borders naturally.'
WHERE Tag = 'TXT_KEY_BELIEF_RELIGIOUS_SETTLEMENTS';

Fixing #11348
