### PR TITLE
Tooltip fix: Great Artist GA mission scaling from themed sets at a +20% rate, not 10%

### DIFF
--- a/(2) Vox Populi/Database Changes/Text/en_US/Units/MissionTextChanges.sql
+++ b/(2) Vox Populi/Database Changes/Text/en_US/Units/MissionTextChanges.sql
@@ -15,7 +15,7 @@ WHERE Tag = 'TXT_KEY_MISSION_GIVE_POLICIES_HELP';
 
 -- Start a Golden Age
 UPDATE Language_en_US
-SET Text = '+{1_Num} [ICON_GOLDEN_AGE] Golden Age Points[NEWLINE][NEWLINE]This order will consume the Great Artist and create Golden Age Points, which may trigger a [ICON_GOLDEN_AGE] Golden Age (extra [ICON_PRODUCTION] Production, [ICON_GOLD] Gold, and [ICON_CULTURE] Culture). Scales based on the [ICON_TOURISM] Tourism and [ICON_GOLDEN_AGE] Golden Age Point output of the past 10 turns, and is increased by 10% for every owned [COLOR_POSITIVE_TEXT]themed[ENDCOLOR] Great Work set.'
+SET Text = '+{1_Num} [ICON_GOLDEN_AGE] Golden Age Points[NEWLINE][NEWLINE]This order will consume the Great Artist and create Golden Age Points, which may trigger a [ICON_GOLDEN_AGE] Golden Age (extra [ICON_PRODUCTION] Production, [ICON_GOLD] Gold, and [ICON_CULTURE] Culture). Scales based on the [ICON_TOURISM] Tourism and [ICON_GOLDEN_AGE] Golden Age Point output of the past 10 turns, and is increased by 20% for every owned [COLOR_POSITIVE_TEXT]themed[ENDCOLOR] Great Work set.'
 WHERE Tag = 'TXT_KEY_MISSION_START_GOLDENAGE_HELP';
 
 -- Perform Concert Tour


### PR DESCRIPTION
Great Artist's GA mission increases by +20% per themed set, not 10%. The current tooltip states that it increases by +10%, and was likely made in anticipation of a vetoed proposal in the fifth Congress. This commit just changes the tooltip back to 20%, no functional changes.

(https://forums.civfanatics.com/threads/5-vt-golden-age-removal-series-great-artist-bulb-reduction-proposals.684457/)

For reference, the Units/UnitChanges.sql still has it at 20%:

-- Great Artist
UPDATE Units
SET
	GoldenAgeTurns = 0,
	BaseTurnsForGAPToCount = 10,
	ScaleFromNumThemes = 20
WHERE Class = 'UNITCLASS_ARTIST';