### PR TITLE
Use python clang build in Visual Studio

### DIFF
--- a/CvGameCoreDLL_Expansion2/VoxPopuli.vcxproj
+++ b/CvGameCoreDLL_Expansion2/VoxPopuli.vcxproj
@@ -9,6 +9,14 @@
       <Configuration>Release</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Clang-Debug|Win32">
+      <Configuration>Clang-Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Clang-Release|Win32">
+      <Configuration>Clang-Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{2D4B6CDC-0887-4EE1-97B9-0865CC82FAF3}</ProjectGuid>
@@ -28,6 +36,18 @@
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v90</PlatformToolset>
     <WholeProgramOptimization>false</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Clang-Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Utility</ConfigurationType>
+    <PlatformToolset>v90</PlatformToolset>
+    <OutDir>$(SolutionDir)clang-output\Debug\</OutDir>
+    <IntDir>$(SolutionDir)clang-build\Debug\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Clang-Release|Win32'" Label="Configuration">
+    <ConfigurationType>Utility</ConfigurationType>
+    <PlatformToolset>v90</PlatformToolset>
+    <OutDir>$(SolutionDir)clang-output\Release\</OutDir>
+    <IntDir>$(SolutionDir)clang-build\Release\</IntDir>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -102,6 +122,16 @@
     </Link>
     <PreBuildEvent>
       <Command>..\update_commit_id.bat</Command>
+    </PreBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Clang-Debug|Win32'">
+    <PreBuildEvent>
+      <Command>cd "$(SolutionDir)" &amp; python build_vp_clang.py --config debug &amp; type clang-output\Debug\build.log</Command>
+    </PreBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Clang-Release|Win32'">
+    <PreBuildEvent>
+      <Command>cd "$(SolutionDir)" &amp; python build_vp_clang.py --config release &amp; type clang-output\Release\build.log</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/VoxPopuli_vs2013.sln
+++ b/VoxPopuli_vs2013.sln
@@ -9,12 +9,18 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Win32 = Debug|Win32
 		Release|Win32 = Release|Win32
+		Clang-Debug|Win32 = Clang-Debug|Win32
+		Clang-Release|Win32 = Clang-Release|Win32
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{2D4B6CDC-0887-4EE1-97B9-0865CC82FAF3}.Debug|Win32.ActiveCfg = Debug|Win32
 		{2D4B6CDC-0887-4EE1-97B9-0865CC82FAF3}.Debug|Win32.Build.0 = Debug|Win32
 		{2D4B6CDC-0887-4EE1-97B9-0865CC82FAF3}.Release|Win32.ActiveCfg = Release|Win32
 		{2D4B6CDC-0887-4EE1-97B9-0865CC82FAF3}.Release|Win32.Build.0 = Release|Win32
+		{2D4B6CDC-0887-4EE1-97B9-0865CC82FAF3}.Clang-Debug|Win32.ActiveCfg = Clang-Debug|Win32
+		{2D4B6CDC-0887-4EE1-97B9-0865CC82FAF3}.Clang-Debug|Win32.Build.0 = Clang-Debug|Win32
+		{2D4B6CDC-0887-4EE1-97B9-0865CC82FAF3}.Clang-Release|Win32.ActiveCfg = Clang-Release|Win32
+		{2D4B6CDC-0887-4EE1-97B9-0865CC82FAF3}.Clang-Release|Win32.Build.0 = Clang-Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Add visual studio config to call the python script. I'm sure we can eventually figure out how to add the clang solution completely to vcxproj to not use the python script.