### PR TITLE
update cppcheck

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -4,45 +4,75 @@ on:
     branches: [ master ]
   workflow_dispatch:
 
+env:
+  CPPCHECK_VERSION: "2.16.0"
+
 jobs:
-  analysis:
+  build_cppcheck:
     runs-on: ubuntu-22.04
+    steps:
+      - name: Restore cached cppcheck
+        id: cache-cppcheck
+        uses: actions/cache@v4
+        with:
+          path: /tmp/cppcheck-build
+          key: cppcheck-${{ env.CPPCHECK_VERSION }}
+
+      - name: Build cppcheck
+        if: steps.cache-cppcheck.outputs.cache-hit != 'true'
+        run: |
+          cd /tmp
+          git clone https://github.com/danmar/cppcheck.git
+          cd cppcheck 
+          git checkout ${{ env.CPPCHECK_VERSION }}
+          make MATCHCOMPILER=yes FILESDIR=/usr/share/cppcheck HAVE_RULES=yes CXXFLAGS="-O2 -DNDEBUG -Wall -Wno-sign-compare -Wno-unused-function"
+          mkdir -p ../cppcheck-build
+          cp cppcheck ../cppcheck-build/
+          cp -r cfg ../cppcheck-build/
+          chmod +x ../cppcheck-build/cppcheck
+          ../cppcheck-build/cppcheck --version
+
+      - name: Upload cppcheck build
+        uses: actions/upload-artifact@v4
+        with:
+          name: cppcheck-build
+          path: /tmp/cppcheck-build/
+          retention-days: 1
+
+  analysis:
+    needs: build_cppcheck
+    runs-on: ubuntu-22.04
+    continue-on-error: true
+    outputs:
+      timed_out: ${{ steps.check-timeout.outputs.timed_out }}
     env:
-      TIMEOUT_EXIT_CODE: 124  # exit code for timeout command
+      TIMEOUT_EXIT_CODE: 124
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Debug TIMEOUT_EXIT_CODE
-        run: |
-          echo "Timeout exit code: $TIMEOUT_EXIT_CODE"
+      - name: Download cppcheck build
+        uses: actions/download-artifact@v4
+        with:
+          name: cppcheck-build
+          path: ./cppcheck-build
 
-      - name: Make build-dir # Cppcheck work folder
+      - name: Setup cppcheck
+        run: |
+          chmod +x ./cppcheck-build/cppcheck
+          echo "$PWD/cppcheck-build" >> $GITHUB_PATH
+
+      - name: Verify cppcheck
+        run: cppcheck --version
+
+      - name: Make build-dir
         run: mkdir build-dir
 
-      # - name: Install latest cppcheck for distro # cppcheck 2.7 is the latest for ubuntu-22.04 https://packages.ubuntu.com/search?keywords=cppcheck
-        # run: |
-          # sudo apt-get update
-          # sudo apt-get --yes install cppcheck
-          # cppcheck --version
-
-      - name: Build cppcheck 2.15.0 # https://stackoverflow.com/a/72307265
-        run: |
-          cd /tmp
-          git clone https://github.com/danmar/cppcheck.git
-          cd cppcheck 
-          git checkout 2.15.0
-          sudo make MATCHCOMPILER=yes FILESDIR=/usr/share/cppcheck HAVE_RULES=yes CXXFLAGS="-O2 -DNDEBUG -Wall -Wno-sign-compare -Wno-unused-function" install
-          cd /tmp
-          sudo rm -rf /tmp/cppcheck
-          sudo ldconfig
-          cppcheck --version
-
       - uses: actions/cache@v4
-        id: cache-build-dir  # Check if the cache hit-or-not
+        id: cache-build-dir
         with:
-          path: ./build-dir/  # Path of folder to cache, Cppcheck work folder
+          path: ./build-dir/
           key: build-dir-${{ hashFiles('**/*.*') }}
           restore-keys: |
             build-dir-
@@ -54,66 +84,98 @@ jobs:
       - name: Run cppcheck analysis
         id: cppcheck
         run: |
-          timeout --signal=SIGTERM 350m cppcheck -j ${{ steps.cpu-info.outputs.cpu_count }} --project=VoxPopuli_vs2013.sln --check-level=exhaustive --max-ctu-depth=9999 --cppcheck-build-dir=build-dir --enable=all --std=c++03 --verbose --xml 2> cppcheck.xml || exit_code=$?
-          echo "exit_code=$exit_code" >> $GITHUB_ENV
-          if [ $exit_code -eq $TIMEOUT_EXIT_CODE ]; then
-            echo "cppcheck timed out but continuing"
+          timeout --signal=SIGTERM 350m cppcheck -j ${{ steps.cpu-info.outputs.cpu_count }} \
+            --project=VoxPopuli_vs2013.sln \
+            --check-level=exhaustive \
+            --max-ctu-depth=10 \
+            --cppcheck-build-dir=build-dir \
+            --enable=all \
+            --std=c++03 \
+            --verbose \
+            --check-library \
+            --inline-suppr \
+            --platform=win32W \
+            --xml 2> cppcheck.xml || exit_code=$?
+          echo "exit_code=${exit_code:-0}" >> $GITHUB_ENV
+
+      - name: Check timeout status
+        id: check-timeout
+        if: always()
+        run: |
+          if [ "${exit_code:-0}" = "$TIMEOUT_EXIT_CODE" ]; then
+            echo "timed_out=true" >> $GITHUB_OUTPUT
+          else
+            echo "timed_out=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Debug exit code
-        run: |
-          echo "Exit code: $exit_code"
-
-      # - name: Upload cppcheck xml on success # TODO enable when retry_analysis can detect exit code
-        # if: ${{ env.exit_code != env.TIMEOUT_EXIT_CODE }}
-        # uses: actions/upload-artifact@v4
-        # with:
-          # name: cppcheck-xml
-          # path: ./cppcheck.xml
-
-  retry_analysis:
-    runs-on: ubuntu-22.04
-    needs: analysis
-    # if: needs.analysis.outputs.exit_code == 124 # FIXME condition, doesn't detect prior exit code
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Make build-dir # Cppcheck work folder
-        run: mkdir build-dir
-
-      - name: Build cppcheck 2.15.0 # https://stackoverflow.com/a/72307265
-        run: |
-          cd /tmp
-          git clone https://github.com/danmar/cppcheck.git
-          cd cppcheck 
-          git checkout 2.15.0
-          sudo make MATCHCOMPILER=yes FILESDIR=/usr/share/cppcheck HAVE_RULES=yes CXXFLAGS="-O2 -DNDEBUG -Wall -Wno-sign-compare -Wno-unused-function" install
-          cd /tmp
-          sudo rm -rf /tmp/cppcheck
-          sudo ldconfig
-          cppcheck --version
-
-      - uses: actions/cache@v4
-        id: cache-build-dir  # Check if the cache hit-or-not
-        with:
-          path: ./build-dir/  # Path of folder to cache, Cppcheck work folder
-          key: build-dir-${{ hashFiles('**/*.*') }}
-          restore-keys: |
-            build-dir-
-
-      - name: Determine number of CPU threads
-        id: cpu-info
-        run: echo "cpu_count=$(nproc)" >> $GITHUB_OUTPUT
-
-      - name: Run cppcheck analysis
-        id: cppcheck
-        run: |
-          timeout --signal=SIGTERM 350m cppcheck -j ${{ steps.cpu-info.outputs.cpu_count }} --project=VoxPopuli_vs2013.sln --check-level=exhaustive --max-ctu-depth=9999 --cppcheck-build-dir=build-dir --enable=all --std=c++03 --verbose --xml 2> cppcheck.xml || echo "cppcheck timed out but continuing"
-
-      - name: Upload cppcheck xml
+      - name: Upload analysis artifacts
+        if: success() && steps.check-timeout.outputs.timed_out != 'true'
         uses: actions/upload-artifact@v4
         with:
           name: cppcheck-xml
-          path: ./cppcheck.xml # Place cppcheck.xml in local source directory and open in cppcheck-gui
+          path: |
+            cppcheck.xml
+          retention-days: 90
+
+  retry_analysis:
+    needs: [build_cppcheck, analysis]
+    runs-on: ubuntu-22.04
+    if: needs.analysis.outputs.timed_out == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download cppcheck build
+        uses: actions/download-artifact@v4
+        with:
+          name: cppcheck-build
+          path: ./cppcheck-build
+
+      - name: Setup cppcheck
+        run: |
+          chmod +x ./cppcheck-build/cppcheck
+          echo "$PWD/cppcheck-build" >> $GITHUB_PATH
+
+      - name: Verify cppcheck
+        run: cppcheck --version
+
+      - name: Make build-dir
+        run: mkdir build-dir
+
+      - uses: actions/cache@v4
+        id: cache-build-dir
+        with:
+          path: ./build-dir/
+          key: build-dir-${{ hashFiles('**/*.*') }}
+          restore-keys: |
+            build-dir-
+
+      - name: Determine number of CPU threads
+        id: cpu-info
+        run: echo "cpu_count=$(nproc)" >> $GITHUB_OUTPUT
+
+      - name: Run cppcheck analysis
+        id: cppcheck
+        continue-on-error: true
+        run: |
+          timeout --signal=SIGTERM 350m cppcheck -j ${{ steps.cpu-info.outputs.cpu_count }} \
+            --project=VoxPopuli_vs2013.sln \
+            --check-level=exhaustive \
+            --max-ctu-depth=10 \
+            --cppcheck-build-dir=build-dir \
+            --enable=all \
+            --std=c++03 \
+            --verbose \
+            --check-library \
+            --inline-suppr \
+            --platform=win32W \
+            --xml 2> cppcheck.xml || echo "cppcheck exit code: $?"
+
+      - name: Upload analysis artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cppcheck-xml
+          path: |
+            cppcheck.xml
+          retention-days: 90


### PR DESCRIPTION
Update cppcheck to 2.16.0 and improve process. We could add sarif output to show on github, it was added in the new version. You can't do xml and sarif at the same time, so may need another run based on timeout to generate just sarif.