### PR TITLE
Fix clang release build

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvBuildingClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuildingClasses.cpp
@@ -4511,7 +4511,7 @@ std::vector<CvBuildingEntry*>& CvBuildingXMLEntries::GetBuildingEntries()
 }
 
 /// Number of defined policies
-inline int CvBuildingXMLEntries::GetNumBuildings()
+int CvBuildingXMLEntries::GetNumBuildings()
 {
 	return m_paBuildingEntries.size();
 }

--- a/CvGameCoreDLL_Expansion2/CvGlobals.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGlobals.cpp
@@ -3877,7 +3877,7 @@ CvBuildingClassInfo* CvGlobals::getBuildingClassInfo(BuildingClassTypes eBuildin
 		return NULL;
 }
 
-inline int CvGlobals::getNumBuildingInfos()
+int CvGlobals::getNumBuildingInfos()
 {
 	return m_pBuildings->GetNumBuildings();
 }
@@ -3887,7 +3887,7 @@ std::vector<CvBuildingEntry*>& CvGlobals::getBuildingInfo()
 	return m_pBuildings->GetBuildingEntries();
 }
 
-inline CvBuildingEntry* CvGlobals::getBuildingInfo(BuildingTypes eBuildingNum)
+CvBuildingEntry* CvGlobals::getBuildingInfo(BuildingTypes eBuildingNum)
 {
 	CvAssert(eBuildingNum > -1);
 	CvAssert(eBuildingNum < GC.getNumBuildingInfos());

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -9693,7 +9693,7 @@ void CvPlayer::SetDangerPlotsDirty()
 	m_pDangerPlots->SetDirty();
 }
 
-inline bool CvPlayer::isHuman() const
+bool CvPlayer::isHuman() const
 {
 	if(GetID() == NO_PLAYER)
 	{

--- a/CvGameCoreDLL_Expansion2/CvPlayerAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayerAI.cpp
@@ -44,7 +44,7 @@
 
 static CvEnumMap<PlayerTypes, CvPlayerAI> s_players;
 
-inline CvPlayerAI& CvPlayerAI::getPlayer(PlayerTypes ePlayer)
+CvPlayerAI& CvPlayerAI::getPlayer(PlayerTypes ePlayer)
 {
 	CvAssertMsg(ePlayer != NO_PLAYER, "Player is not assigned a valid value");
 	CvAssertMsg(ePlayer < MAX_PLAYERS, "Player is not assigned a valid value");

--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -14027,7 +14027,7 @@ int CvPlot::countNumAirUnits(TeamTypes eTeam, bool bNoSuicide) const
 }
 
 //	--------------------------------------------------------------------------------
-inline int CvPlot::GetPlotIndex() const
+int CvPlot::GetPlotIndex() const
 {
 	return m_iPlotIndex;
 }

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -18110,7 +18110,7 @@ inline int CvUnit::getIsConvertUnit() const
 	VALIDATE_OBJECT
 	return	m_iConvertUnit;
 }
-inline bool CvUnit::isConvertUnit() const
+bool CvUnit::isConvertUnit() const
 {
 	VALIDATE_OBJECT
 	return getIsConvertUnit() > 0;


### PR DESCRIPTION
Remove inline from the code for the reported spots so linking works. Clang release build now works.

```
1>lld-link : error : undefined symbol: public: static class CvPlayerAI & __cdecl CvPlayerAI::getPlayer(enum PlayerTypes)
1>>>> referenced by C:\Users\user\Documents\GitHub\Community-Patch-DLL\CvGameCoreDLL_Expansion2\Lua\CvLuaCity.cpp
1>>>>               C:\Users\user\Documents\GitHub\Community-Patch-DLL\clang-build\Release\CvGameCoreDLL_Expansion2\Lua\CvLuaCity.obj
1>>>> referenced by C:\Users\user\Documents\GitHub\Community-Patch-DLL\CvGameCoreDLL_Expansion2\Lua\CvLuaDeal.cpp
1>>>>               C:\Users\user\Documents\GitHub\Community-Patch-DLL\clang-build\Release\CvGameCoreDLL_Expansion2\Lua\CvLuaDeal.obj
1>>>> referenced by C:\Users\user\Documents\GitHub\Community-Patch-DLL\CvGameCoreDLL_Expansion2\Lua\CvLuaGame.cpp
1>>>>               C:\Users\user\Documents\GitHub\Community-Patch-DLL\clang-build\Release\CvGameCoreDLL_Expansion2\Lua\CvLuaGame.obj
1>>>> referenced 76 more times
1>
1>lld-link : error : undefined symbol: public: class CvBuildingEntry * __thiscall CvGlobals::getBuildingInfo(enum BuildingTypes)
1>>>> referenced by C:\Users\user\Documents\GitHub\Community-Patch-DLL\CvGameCoreDLL_Expansion2\Lua\CvLuaCity.cpp
1>>>>               C:\Users\user\Documents\GitHub\Community-Patch-DLL\clang-build\Release\CvGameCoreDLL_Expansion2\Lua\CvLuaCity.obj
1>>>> referenced by C:\Users\user\Documents\GitHub\Community-Patch-DLL\CvGameCoreDLL_Expansion2\Lua\CvLuaGame.cpp
1>>>>               C:\Users\user\Documents\GitHub\Community-Patch-DLL\clang-build\Release\CvGameCoreDLL_Expansion2\Lua\CvLuaGame.obj
1>>>> referenced by C:\Users\user\Documents\GitHub\Community-Patch-DLL\CvGameCoreDLL_Expansion2\Lua\CvLuaPlayer.cpp
1>>>>               C:\Users\user\Documents\GitHub\Community-Patch-DLL\clang-build\Release\CvGameCoreDLL_Expansion2\Lua\CvLuaPlayer.obj
1>>>> referenced 36 more times
1>
1>lld-link : error : undefined symbol: public: int __thiscall CvGlobals::getNumBuildingInfos(void)
1>>>> referenced by C:\Users\user\Documents\GitHub\Community-Patch-DLL\CvGameCoreDLL_Expansion2\Lua\CvLuaCity.cpp
1>>>>               C:\Users\user\Documents\GitHub\Community-Patch-DLL\clang-build\Release\CvGameCoreDLL_Expansion2\Lua\CvLuaCity.obj
1>>>> referenced by C:\Users\user\Documents\GitHub\Community-Patch-DLL\CvGameCoreDLL_Expansion2\Lua\CvLuaGame.cpp
1>>>>               C:\Users\user\Documents\GitHub\Community-Patch-DLL\clang-build\Release\CvGameCoreDLL_Expansion2\Lua\CvLuaGame.obj
1>>>> referenced by C:\Users\user\Documents\GitHub\Community-Patch-DLL\CvGameCoreDLL_Expansion2\Lua\CvLuaPlayer.cpp
1>>>>               C:\Users\user\Documents\GitHub\Community-Patch-DLL\clang-build\Release\CvGameCoreDLL_Expansion2\Lua\CvLuaPlayer.obj
1>>>> referenced 23 more times
1>
1>lld-link : error : undefined symbol: public: bool __thiscall CvPlayer::isHuman(void) const
1>>>> referenced by C:\Users\user\Documents\GitHub\Community-Patch-DLL\CvGameCoreDLL_Expansion2\Lua\CvLuaPlayer.cpp
1>>>>               C:\Users\user\Documents\GitHub\Community-Patch-DLL\clang-build\Release\CvGameCoreDLL_Expansion2\Lua\CvLuaPlayer.obj
1>>>> referenced by C:\Users\user\Documents\GitHub\Community-Patch-DLL\CvGameCoreDLL_Expansion2\CvAchievementUnlocker.cpp
1>>>>               C:\Users\user\Documents\GitHub\Community-Patch-DLL\clang-build\Release\CvGameCoreDLL_Expansion2\CvAchievementUnlocker.obj
1>>>> referenced by C:\Users\user\Documents\GitHub\Community-Patch-DLL\CvGameCoreDLL_Expansion2\CvBarbarians.cpp
1>>>>               C:\Users\user\Documents\GitHub\Community-Patch-DLL\clang-build\Release\CvGameCoreDLL_Expansion2\CvBarbarians.obj
1>>>> referenced 42 more times
1>
1>lld-link : error : undefined symbol: public: int __thiscall CvPlot::GetPlotIndex(void) const
1>>>> referenced by C:\Users\user\Documents\GitHub\Community-Patch-DLL\CvGameCoreDLL_Expansion2\Lua\CvLuaPlot.cpp
1>>>>               C:\Users\user\Documents\GitHub\Community-Patch-DLL\clang-build\Release\CvGameCoreDLL_Expansion2\Lua\CvLuaPlot.obj
1>>>> referenced by C:\Users\user\Documents\GitHub\Community-Patch-DLL\CvGameCoreDLL_Expansion2\CvAIOperation.cpp
1>>>>               C:\Users\user\Documents\GitHub\Community-Patch-DLL\clang-build\Release\CvGameCoreDLL_Expansion2\CvAIOperation.obj
1>>>> referenced by C:\Users\user\Documents\GitHub\Community-Patch-DLL\CvGameCoreDLL_Expansion2\CvAStar.cpp
1>>>>               C:\Users\user\Documents\GitHub\Community-Patch-DLL\clang-build\Release\CvGameCoreDLL_Expansion2\CvAStar.obj
1>>>> referenced 27 more times
1>
1>lld-link : error : undefined symbol: public: int __thiscall CvBuildingXMLEntries::GetNumBuildings(void)
1>>>> referenced by C:\Users\user\Documents\GitHub\Community-Patch-DLL\CvGameCoreDLL_Expansion2\CvAdvisorRecommender.cpp
1>>>>               C:\Users\user\Documents\GitHub\Community-Patch-DLL\clang-build\Release\CvGameCoreDLL_Expansion2\CvAdvisorRecommender.obj
1>>>> referenced by C:\Users\user\Documents\GitHub\Community-Patch-DLL\CvGameCoreDLL_Expansion2\CvBuildingProductionAI.cpp
1>>>>               C:\Users\user\Documents\GitHub\Community-Patch-DLL\clang-build\Release\CvGameCoreDLL_Expansion2\CvBuildingProductionAI.obj
1>>>> referenced by C:\Users\user\Documents\GitHub\Community-Patch-DLL\CvGameCoreDLL_Expansion2\CvCity.cpp
1>>>>               C:\Users\user\Documents\GitHub\Community-Patch-DLL\clang-build\Release\CvGameCoreDLL_Expansion2\CvCity.obj
1>>>> referenced 6 more times
1>
1>lld-link : error : undefined symbol: public: bool __thiscall CvUnit::isConvertUnit(void) const
1>>>> referenced by C:\Users\user\Documents\GitHub\Community-Patch-DLL\CvGameCoreDLL_Expansion2\CvPlot.cpp
1>>>>               C:\Users\user\Documents\GitHub\Community-Patch-DLL\clang-build\Release\CvGameCoreDLL_Expansion2\CvPlot.obj
1>>>> referenced by C:\Users\user\Documents\GitHub\Community-Patch-DLL\CvGameCoreDLL_Expansion2\CvUnitMovement.cpp
1>>>>               C:\Users\user\Documents\GitHub\Community-Patch-DLL\clang-build\Release\CvGameCoreDLL_Expansion2\CvUnitMovement.obj
```