### PR TITLE
Fix clang build warnings

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvBarbarians.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBarbarians.cpp
@@ -1137,7 +1137,7 @@ void CvBarbarians::SpawnBarbarianUnits(CvPlot* pPlot, int iNumUnits, BarbSpawnRe
 				continue;
 
 			ResourceTypes eLoopPlotResource = pLoopPlot->getResourceType();
-			if (eLoopPlotResource != NO_RESOLUTION && std::find(vValidResources.begin(), vValidResources.end(), eResource) == vValidResources.end())
+			if (eLoopPlotResource != NO_RESOURCE && std::find(vValidResources.begin(), vValidResources.end(), eLoopPlotResource) == vValidResources.end())
 			{
 				vValidResources.push_back(eResource);
 			}

--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
@@ -2965,6 +2965,10 @@ pair<int,int> CvBuilderTaskingAI::ScorePlotBuild(CvPlot* pPlot, ImprovementTypes
 			break;
 		case LIKELYHOOD_UNLIKELY:
 			iSecondaryScore += 40;
+			break;
+		case LIKELYHOOD_IMPOSSIBLE:
+			// No bonus for blocking tile steal if theft is impossible
+			break;
 		}
 	}
 	else if (pkImprovementInfo && pkImprovementInfo->IsCreatedByGreatPerson() && !bIsCultureBomb)
@@ -2982,6 +2986,10 @@ pair<int,int> CvBuilderTaskingAI::ScorePlotBuild(CvPlot* pPlot, ImprovementTypes
 			break;
 		case LIKELYHOOD_UNLIKELY:
 			iSecondaryScore -= 40;
+			break;
+		case LIKELYHOOD_IMPOSSIBLE:
+			// No penalty for great person improvements if theft is impossible
+			break;
 		}
 	}
 
@@ -4195,7 +4203,7 @@ void CvBuilderTaskingAI::SetupExtraXAdjacentPlotsForBuild(BuildTypes eBuild, Imp
 			if (!pPlot->canBuild(eBuild, m_pPlayer->GetID(), false, false, true))
 				continue;
 
-			if (pPlot->canBuild(eBuild, m_pPlayer->GetID()), false, false)
+			if (pPlot->canBuild(eBuild, m_pPlayer->GetID(), false, false))
 			{
 				m_extraPlotsForXAdjacentImprovements[eImprovement].insert(pPlot);
 


### PR DESCRIPTION
Fix some warnings, one is left, not sure on how to handle the minor logic so someone else will need to look at that.

https://github.com/LoneGazebo/Community-Patch-DLL/blame/master/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp#L49030
```
==== C:\Users\user\Documents\GitHub\Community-Patch-DLL\CvGameCoreDLL_Expansion2\CvDiplomacyAI.cpp ====
C:\Users\user\Documents\GitHub\Community-Patch-DLL\CvGameCoreDLL_Expansion2\CvDiplomacyAI.cpp(49030,10) : warning: enumeration value 'THEFT_TYPE_EMBASSY' not handled in switch [-Wswitch]
 49030 |                 switch (eTheftType)
       |                         ^~~~~~~~~~
1 warning generated.
```

For major civs (later in the code), embassy theft is only blocked if:
The target is a content vassal
We're not a human player

Have THEFT_TYPE_EMBASSY case with logic similar to THEFT_TYPE_CULTURE_BOMB since they have similar diplomatic implications?
Returns true (don't steal) if we're friendly or allied with the minor civ as AI
Returns true if we're friends with the minor civ as a human player
Otherwise allows the theft (via the default return false after the switch)