### PR TITLE
Fix city states being able to have one embassy of each type

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
@@ -6404,13 +6404,16 @@ CvPlot* HomelandAIHelpers::GetPlotForEmbassy(CvUnit* pUnit, CvCity* pCity)
 	if (!pCity->plot()->isAdjacentRevealed(kPlayer.getTeam()))
 		return NULL;
 
-	ImprovementTypes eEmbassyImprovement = static_cast<ImprovementTypes>(GD_INT_GET(EMBASSY_IMPROVEMENT));
-	if (eEmbassyImprovement == NO_IMPROVEMENT)
-		return NULL;
-
 	// Does somebody already have an embassy here?
-	if (kCityPlayer.getImprovementCount(eEmbassyImprovement, false) > 0)
-		return NULL;
+	for (int iI = 0; iI < GC.getNumImprovementInfos(); iI++)
+	{
+		ImprovementTypes eEmbassyImprovement = (ImprovementTypes)iI;
+		if (!GC.getImprovementInfo(eEmbassyImprovement)->IsEmbassy())
+			continue;
+
+		if (kCityPlayer.getImprovementCount(eEmbassyImprovement, false) > 0)
+			return NULL;
+	}
 
 	//Are we planning on conquering them?
 	if (kPlayer.GetDiplomacyAI()->GetCivApproach(kCityPlayer.GetID()) == CIV_APPROACH_WAR || kPlayer.GetNumOurCitiesOwnedBy(kCityPlayer.GetID()) > 0)

--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -3121,8 +3121,15 @@ bool CvPlot::canBuild(BuildTypes eBuild, PlayerTypes ePlayer, bool bTestVisible,
 							// If this is an embassy, check for existing embassies
 							if (GC.getImprovementInfo(eImprovement)->IsEmbassy())
 							{
-								if (GET_PLAYER(getOwner()).getImprovementCount(eImprovement, false) > 0)
-									return false;
+								for (int iI = 0; iI < GC.getNumImprovementInfos(); iI++)
+								{
+									ImprovementTypes eOtherEmbassyImprovement = (ImprovementTypes)iI;
+									if (!GC.getImprovementInfo(eOtherEmbassyImprovement)->IsEmbassy())
+										continue;
+
+									if (GET_PLAYER(getOwner()).getImprovementCount(eOtherEmbassyImprovement, false) > 0)
+										return false;
+								}
 							}
 						}
 						else


### PR DESCRIPTION
If there are several different improvements that are embassies, city states could have one of each.