### PR TITLE
Fix crash

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -8877,7 +8877,7 @@ CvPlot* CvPlot::GetAdjacentResourceSpawnPlot(PlayerTypes ePlayer) const
 	if (aSpawnPlots.empty())
 		return NULL;
 
-	int iRandomIndex = GC.getGame().urandLimitExclusive(aSpawnPlots.size(), GET_PLAYER(getOwner()).GetPseudoRandomSeed().mix(GetPseudoRandomSeed()));
+	int iRandomIndex = GC.getGame().urandLimitExclusive(aSpawnPlots.size(), GET_PLAYER(ePlayer).GetPseudoRandomSeed().mix(GetPseudoRandomSeed()));
 
 	return aSpawnPlots[iRandomIndex];
 }


### PR DESCRIPTION
Fix crash when building an improvement, that spawns an adjacent resource, on an unowned tile.