### PR TITLE
Fix all policies being available from ancient era on in CP

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvPolicyClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPolicyClasses.cpp
@@ -5420,10 +5420,13 @@ bool CvPlayerPolicies::CanUnlockPolicyBranch(PolicyBranchTypes eBranchType)
 				}
 			}
 			//Using a system of numbers instead? Okay.
-			int iNumPolicies = GetPlayer()->GetPlayerPolicies()->GetNumPoliciesOwned(true, true);
-			if(iNumPolicies >= pkBranchEntry->GetNumPolicyRequirement())
+			if (MOD_BALANCE_VP)
 			{
-				bCanUnlockEarly = true;
+				int iNumPolicies = GetPlayer()->GetPlayerPolicies()->GetNumPoliciesOwned(true, true);
+				if (iNumPolicies >= pkBranchEntry->GetNumPolicyRequirement())
+				{
+					bCanUnlockEarly = true;
+				}
 			}
 
 			if(!bCanUnlockEarly && GET_TEAM(GetPlayer()->getTeam()).GetCurrentEra() < ePrereqEra)


### PR DESCRIPTION
In 4.18 CP all policy branches are available already in ancient era because they have `GetNumPolicyRequirement = 0`. We can fix this either by disabling early policy branch unlocking in CP altogether, or by setting the default value of the column to a high value. The latter is how it was done in pre-4.17:
![image](https://github.com/user-attachments/assets/5583728d-8ff3-4c10-8c0b-8b6823e9181a)

Any preferences?