### PR TITLE
Fix #11521

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvTacticalAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTacticalAI.cpp
@@ -6281,7 +6281,7 @@ bool TacticalAIHelpers::IsAttackNetPositive(CvUnit* pUnit, const CvPlot* pTarget
 //see if there is a possible target around the unit
 bool TacticalAIHelpers::PerformOpportunityAttack(CvUnit* pUnit, bool bAllowMovement)
 {
-	if (!pUnit || !pUnit->IsCanAttack() || !pUnit->canMove())
+	if (!pUnit || !pUnit->IsCanAttack() || !pUnit->canMove() || pUnit->isDelayedDeath())
 		return false;
 
 	//for ranged we have a readymade method


### PR DESCRIPTION
In the following code (`PlotGarrisonMoves`), it can happen that `pUnit` is upgraded in `ExecuteMoveToPlot`. Allowing `pUnit` to still perform opportunity attacks is a bug.


![image](https://github.com/user-attachments/assets/1a1c1657-829f-4202-8f7d-cbbeb7ec830d)
