### PR TITLE
Fix another city-state influence bug

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvMinorCivAI.h
+++ b/CvGameCoreDLL_Expansion2/CvMinorCivAI.h
@@ -864,7 +864,7 @@ public:
 private:
 	//return true if an actual change occurred
 	bool SetAllyInternal(PlayerTypes eNewAlly);
-	void ProcessAllyChangeNotifications(PlayerTypes eOldAlly, PlayerTypes eNewAlly, bool bSuppressDirectNotification);
+	void ProcessAllyChangeNotifications(PlayerTypes eOldAlly, PlayerTypes eNewAlly, bool bSuppressNotificationForNewAlly);
 	void DoSetBonus(PlayerTypes ePlayer, bool bAdd, bool bFriendChange, bool bAllyChange);
 
 	CvPlayer* m_pPlayer;


### PR DESCRIPTION
Fixed another bug in city-state influence calculation, hopefully the last one. Fixed missing notification when losing ally status with a city-state because another player completed a quest. 