### PR TITLE
Unit_Bounties table Implementation (4UC Integration)

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -25911,6 +25911,9 @@ void CvPlayer::doInstantYield(InstantYieldType iType, bool bCityFaith, GreatPers
 							if (iKillYield > 0)
 								iValue += iKillYield;
 						}
+					
+						// Apply any bounty that may exist for killing the unit
+						iValue += pkKilledUnitInfo->GetYieldOnBountyToKiller(eYield);
 					}
 					int iTempYield = pLoopCity->GetYieldFromVictory(eYield);
 					if (bEraScale)

--- a/CvGameCoreDLL_Expansion2/CvUnitClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnitClasses.cpp
@@ -484,6 +484,7 @@ bool CvUnitEntry::CacheResults(Database::Results& kResults, CvDatabaseUtility& k
 	kUtility.PopulateArrayByValue(m_piResourceQuantityRequirements, "Resources", "Unit_ResourceQuantityRequirements", "ResourceType", "UnitType", szUnitType, "Cost");
 	kUtility.PopulateArrayByValue(m_piResourceQuantityExpended, "Resources", "Unit_ResourceQuantityExpended", "ResourceType", "UnitType", szUnitType, "Amount");
 	kUtility.PopulateArrayByValue(m_piProductionModifierBuildings, "Buildings", "Unit_ProductionModifierBuildings", "BuildingType", "UnitType", szUnitType, "ProductionModifier");
+	kUtility.PopulateArrayByValue(m_piYieldOnBountyToKiller, "Yields", "Unit_Bounties", "YieldType", "UnitType", szUnitType, "Yield");
 	kUtility.PopulateArrayByValue(m_piYieldFromKills, "Yields", "Unit_YieldFromKills", "YieldType", "UnitType", szUnitType, "Yield");
 	kUtility.PopulateArrayByValue(m_piYieldFromBarbarianKills, "Yields", "Unit_YieldFromBarbarianKills", "YieldType", "UnitType", szUnitType, "Yield");
 	kUtility.PopulateArrayByValue(m_piYieldOnCompletion, "Yields", "Unit_YieldOnCompletion", "YieldType", "UnitType", szUnitType, "Yield");
@@ -1482,6 +1483,14 @@ int CvUnitEntry::GetBuildingProductionModifier(BuildingTypes eBuilding) const
 	ASSERT_DEBUG((int)eBuilding < GC.getNumBuildingInfos(), "Building type out of bounds");
 	ASSERT_DEBUG((int)eBuilding > -1, "Index out of bounds");
 	return m_piProductionModifierBuildings[(int)eBuilding];
+}
+
+// How many yields of type eYield does this units killer get as a county?
+int CvUnitEntry::GetYieldOnBountyToKiller(YieldTypes eYield) const
+{
+	ASSERT_DEBUG((int)eYield < NUM_YIELD_TYPES, "Yield type out of bounds");
+	ASSERT_DEBUG((int)eYield > -1, "Index out of bounds");
+	return m_piYieldOnBountyToKiller[(int)eYield];
 }
 
 /// Do we get one of our yields from defeating an enemy?

--- a/CvGameCoreDLL_Expansion2/CvUnitClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvUnitClasses.h
@@ -220,6 +220,7 @@ public:
 	int GetResourceQuantityRequirement(int i) const;
 	int GetResourceQuantityExpended(int i) const;
 	int GetBuildingProductionModifier(BuildingTypes eBuilding) const;
+	int GetYieldOnBountyToKiller(YieldTypes eYield) const;
 	int GetYieldFromKills(YieldTypes eYield) const;
 	int GetYieldFromBarbarianKills(YieldTypes eYield) const;
 	int GetYieldOnCompletion(YieldTypes eYield) const;
@@ -440,6 +441,7 @@ private:
 	int* m_piProductionTraits;
 	int* m_piFlavorValue;
 	int* m_piProductionModifierBuildings;
+	int* m_piYieldOnBountyToKiller;
 	int* m_piYieldFromKills;
 	int* m_piYieldFromBarbarianKills;
 	int* m_piYieldOnCompletion;


### PR DESCRIPTION
New table: `Unit_Bounties (UnitType, YieldType, Yield)`

* Awards instant yields to the city, or the origin city of the unit that defeats this unit