### PR TITLE
(2-06a and 8-35) Building_YieldPerXImprovement

### DIFF
--- a/(1) Community Patch/Database Changes/City/Buildings/NewBuildingTables.xml
+++ b/(1) Community Patch/Database Changes/City/Buildings/NewBuildingTables.xml
@@ -426,11 +426,6 @@
 		<Column name="SpecialistType" type="text" reference="Specialists(Type)" notnull="true"/>
 		<Column name="Modifier" type="integer" notnull="true"/>
 	</Table>
-	<Table name="Building_FranchiseTradeRouteCityYield">
-		<Column name="BuildingType" type="text" reference="Buildings(Type)" notnull="true"/>
-		<Column name="YieldType" type="text" reference="Yields(Type)" notnull="true"/>
-		<Column name="Yield" type="integer" notnull="true"/>
-	</Table>
 	<!-- Grants a yield based on # of corporate franchises in unowned major cities -->
 	<Table name="Building_YieldPerFranchise">
 		<Column name="BuildingType" type="text" reference="Buildings(Type)" notnull="true"/>

--- a/CvGameCoreDLL_Expansion2/CvBuildingClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvBuildingClasses.h
@@ -659,6 +659,9 @@ public:
 	int GetYieldPerXFeature(int i, int j) const;
 	int* GetYieldPerXFeatureArray(int i) const;
 
+	fraction GetYieldPerXImprovementLocal(ImprovementTypes eImprovementType, YieldTypes eYieldType) const;
+	fraction GetYieldPerXImprovementGlobal(ImprovementTypes eImprovementType, YieldTypes eYieldType) const;
+
 	int GetPlotYieldChange(int i, int j) const;
 	int* GetPlotYieldChangeArray(int i) const;
 
@@ -1089,6 +1092,8 @@ private:
 	int** m_ppaiTerrainYieldChange;
 	int** m_ppaiYieldPerXTerrain;
 	int** m_ppaiYieldPerXFeature;
+	std::map<ImprovementTypes, std::map<YieldTypes, fraction>> m_ppYieldPerXImprovementLocal;
+	std::map<ImprovementTypes, std::map<YieldTypes, fraction>> m_ppYieldPerXImprovementGlobal;
 	int** m_ppaiPlotYieldChange;
 	int** m_ppiBuildingClassYieldChanges;
 	int** m_ppiBuildingClassYieldModifiers;

--- a/CvGameCoreDLL_Expansion2/CvBuildingClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvBuildingClasses.h
@@ -126,15 +126,11 @@ public:
 	int GetMutuallyExclusiveGroup() const;
 	int GetReplacementBuildingClass() const;
 	int GetPrereqAndTech() const;
-#if defined(MOD_BALANCE_CORE)
 	int GetEra() const;
-#endif
+
 	int GetPolicyBranchType() const;
-#if defined(MOD_BALANCE_CORE_POLICIES)
 	PolicyTypes GetPolicyType() const;
 	CivilizationTypes GetCivType() const;
-#endif
-#if defined(MOD_BALANCE_CORE)
 	int GetResourceType() const;
 	int GetNumPoliciesNeeded() const;
 	int GrantsRandomResourceTerritory() const;
@@ -154,15 +150,13 @@ public:
 	int GetGreatWorksTourismModifierGlobal() const;
 	int GetEventRequiredActive() const;
 	int GetCityEventRequiredActive() const;
-#endif
+
 	int GetSpecialistType() const;
 	int GetSpecialistCount() const;
 	int GetSpecialistExtraCulture() const;
 	int GetGreatPeopleRateChange() const;
 	GreatWorkSlotType GetGreatWorkSlotType() const;
-#if defined(MOD_GLOBAL_GREATWORK_YIELDTYPES)
 	YieldTypes GetGreatWorkYieldType() const;
-#endif
 	int GetGreatWorkCount() const;
 	GreatWorkType GetFreeGreatWork() const;
 	int GetFreeBuildingClass() const;
@@ -214,15 +208,13 @@ public:
 	int GetPlotCultureCostModifier() const;
 	int GetGlobalPlotBuyCostModifier() const;
 	int GetPlotBuyCostModifier() const;
-#if defined(MOD_BUILDINGS_CITY_WORKING)
+
 	int GetGlobalCityWorkingChange() const;
 	int GetCityWorkingChange() const;
-#endif
-#if defined(MOD_BUILDINGS_CITY_AUTOMATON_WORKERS)
+
 	int GetGlobalCityAutomatonWorkersChange() const;
 	int GetCityAutomatonWorkersChange() const;
-#endif
-#if defined(MOD_BALANCE_CORE)
+
 	int GetNumRequiredTier3Tenets() const;
 	bool IsNoWater() const;
 	bool IsNoRiver() const;
@@ -238,23 +230,20 @@ public:
 	int GetNoUnhappfromXSpecialistsGlobal() const;
 
 	int GetPurchaseCooldownReduction(bool bCivilian = false) const;
-#endif
+
 	int GetVassalLevyEra() const;
-#if defined(MOD_BALANCE_CORE_POP_REQ_BUILDINGS)
+
 	int GetNationalPopulationRequired() const;
 	int GetLocalPopulationRequired() const;
-#endif
-#if defined(MOD_BALANCE_CORE_FOLLOWER_POP_WONDER)
 	int GetNationalFollowerPopRequired() const;
 	int GetGlobalFollowerPopRequired() const;
-#endif
+
 	int GetMinAreaSize() const;
 	int GetConquestProbability() const;
 	int GetHealRateChange() const;
 	int GetHappiness() const;
 	int GetUnmoddedHappiness() const;
 	int GetUnhappinessModifier() const;
-#if defined(MOD_BALANCE_CORE)
 	int GetLocalUnhappinessModifier() const;
 	int GetGlobalBuildingGoldMaintenanceMod() const;
 	int GetBuildingDefenseModifier() const;
@@ -267,7 +256,7 @@ public:
 	int CityIndirectFire() const;
 	int GetGarrisonRangedAttackModifier() const;
 	int CityRangedStrikeModifier() const;
-#endif
+
 	int GetHappinessPerCity() const;
 	int GetHappinessPerXPolicies() const;
 	int GetCityCountUnhappinessMod() const;
@@ -302,10 +291,10 @@ public:
 	int GetTradeRouteTargetBonus() const;
 	int GetNumTradeRouteBonus() const;
 	int GetInstantSpyRankChange() const;
-#if defined(MOD_RELIGION_CONVERSION_MODIFIERS)
+
 	int GetConversionModifier() const;
 	int GetGlobalConversionModifier() const;
-#endif
+
 	int GetLandmarksTourismPercent() const;
 	int GetInstantMilitaryIncrease() const;
 	int GetGreatWorksTourismModifier() const;
@@ -356,7 +345,6 @@ public:
 	bool IsHill() const;
 	bool IsFlat() const;
 	bool IsBorderObstacle() const;
-#if defined(MOD_BALANCE_CORE)
 	bool IsAnyBodyOfWater() const;
 	int GetCityAirStrikeDefense() const;
 	int GetBorderObstacleLand() const;
@@ -369,12 +357,12 @@ public:
 	int GetAlwaysHeal() const;
 	bool IsCorp() const;
 	int GetNukeInterceptionChance() const;
-#endif
+
 	int GetFoodBonusPerCityMajorityFollower() const;
-#if defined(HH_MOD_BUILDINGS_FRUITLESS_PILLAGE)
+
 	bool IsPlayerBorderGainlessPillage() const;
 	bool IsCityGainlessPillage() const;
-#endif
+
 	bool IsPlayerBorderObstacle() const;
 	bool IsCityWall() const;
 	bool IsCapital() const;
@@ -429,11 +417,9 @@ public:
 
 	int GetNeedBuildingThisCity() const;
 
-#if defined(MOD_BALANCE_CORE_POLICIES)
 	int GetYieldFromDeath(int i) const;
 	int* GetYieldFromDeathArray() const;
-#endif
-#if defined(MOD_BALANCE_CORE)
+
 	int GetYieldFromVictory(int i) const;
 	int* GetYieldFromVictoryArray() const;
 
@@ -561,16 +547,13 @@ public:
 	int GetYieldFromSpyRigElection(int i) const;
 	int* GetYieldFromSpyRigElectionArray() const;
 
-#endif
 	int GetYieldChange(int i) const;
 	int* GetYieldChangeArray() const;
 	int GetYieldChangeEraScalingTimes100(int i) const;
 	fraction GetYieldChangePerBuilding(int i) const;
 	int GetYieldChangePerPop(int i) const;
 	int* GetYieldChangePerPopArray() const;
-#if defined(MOD_BALANCE_CORE)
 	int GetYieldChangePerPopInEmpire(int i) const;
-#endif
 	int GetYieldChangePerReligion(int i) const;
 	int* GetYieldChangePerReligionArray() const;
 	set<int> GetUnitClassTrainingAllowed() const;
@@ -598,10 +581,8 @@ public:
 	int GetUnitCombatProductionModifierGlobal(int i) const;
 	int GetDomainFreeExperience(int i) const;
 	int GetDomainFreeExperiencePerGreatWork(int i) const;
-#if defined(MOD_BALANCE_CORE)
 	int GetDomainFreeExperiencePerGreatWorkGlobal(int i) const;
 	int GetDomainFreeExperienceGlobal(int i) const;
-#endif
 	int GetDomainProductionModifier(int i) const;
 	int GetLockedBuildingClasses(int i) const;
 	int GetPrereqAndTechs(int i) const;
@@ -616,7 +597,6 @@ public:
 	int GetLocalResourceAnd(uint ui) const;
 	uint GetLocalResourceOrSize() const;
 	int GetLocalResourceOr(uint ui) const;
-#if defined(MOD_BALANCE_CORE_RESOURCE_MONOPOLIES)
 	int GetFeatureOr(int i) const;
 	int GetFeatureAnd(int i) const;
 	uint GetResourceMonopolyAndSize() const;
@@ -627,14 +607,11 @@ public:
 	int GetResourceQuantityPerXFranchises(int i) const;
 	int GetYieldChangePerMonopoly(int i) const;
 	int GetYieldPerFranchise(int i) const;
-#endif
+
 	int GetResourceQuantityFromPOP(int i) const;
 	int GetHurryModifier(int i) const;
-#if defined(MOD_BALANCE_CORE)
 	int GetHurryModifierLocal(int i) const;
-#endif
 	bool IsBuildingClassNeededInCity(int i) const;
-#if defined(MOD_BALANCE_CORE)
 	bool IsBuildingClassNeededAnywhere(int i) const;
 	bool IsBuildingClassNeededNowhere(int i) const;
 	int GetNumFreeSpecialUnits(int i) const;
@@ -644,9 +621,8 @@ public:
 	int GetYieldPerAlly(int i) const;
 	int GetYieldChangeWorldWonder(int i) const;
 	int GetYieldChangeWorldWonderGlobal(int i) const;
-#endif
+
 	int GetNumFreeUnits(int i) const;
-#if defined(MOD_BALANCE_CORE_BUILDING_INSTANT_YIELD)
 	int GetInstantYield(int i) const;
 	int* GetInstantYieldArray() const;
 
@@ -655,13 +631,11 @@ public:
 	int GetYieldFromYieldGlobal(int i, int j) const;
 
 	int GetInstantReligionPressure() const;
-#endif
 	int GetDefensePerXWonder() const;
 	int GetResourceYieldChange(int i, int j) const;
 	int* GetResourceYieldChangeArray(int i) const;
 	int GetFeatureYieldChange(int i, int j) const;
 	int* GetFeatureYieldChangeArray(int i) const;
-#if defined(MOD_BALANCE_CORE)
 	int GetResourceYieldChangeGlobal(int iResource, int iYieldType) const;
 	std::map<int, std::map<int, int>> GetTechEnhancedYields() const;
 	std::map<pair<GreatPersonTypes, EraTypes>, int> GetGreatPersonPointFromConstruction() const;
@@ -672,7 +646,6 @@ public:
 	int* GetImprovementYieldChangeGlobalArray(int i) const;
 	int GetSpecialistYieldChangeLocal(int i, int j) const;
 	int* GetSpecialistYieldChangeLocalArray(int i) const;
-#endif
 	int GetSpecialistYieldChange(int i, int j) const;
 	int* GetSpecialistYieldChangeArray(int i) const;
 	int GetResourceYieldModifier(int i, int j) const;
@@ -691,17 +664,13 @@ public:
 
 	int GetBuildingClassYieldChange(int i, int j) const;
 	int GetBuildingClassYieldModifier(int i, int j) const;
-#if defined(MOD_BALANCE_CORE)
 	int GetBuildingClassLocalYieldChange(int i, int j) const;
 	int GetBuildingClassLocalHappiness(int i) const;
 	int GetSpecificGreatPersonRateModifier(int) const;
 	int GetResourceHappiness(int i) const;
-#endif
 	int GetBuildingClassHappiness(int i) const;
 
-#if defined(MOD_BALANCE_CORE)
 	std::multimap<int, std::pair<int, int>> GetGreatPersonProgressFromConstructionArray() const;
-#endif
 
 	CvThemingBonusInfo *GetThemingBonusInfo(int i) const;
 	int GetNumThemingBonuses() const { return m_iNumThemingBonuses; }
@@ -725,11 +694,8 @@ private:
 	int m_iReplacementBuildingClass;
 	int m_iPrereqAndTech;
 	int m_iPolicyBranchType;
-#if defined(MOD_BALANCE_CORE_POLICIES)
 	PolicyTypes m_iPolicyType;
 	CivilizationTypes m_eCivType;
-#endif
-#if defined(MOD_BALANCE_CORE)
 	int m_iNumPoliciesNeeded;
 	int m_iResourceType;
 	int m_iGrantsRandomResourceTerritory;
@@ -747,15 +713,12 @@ private:
 	bool m_bDummy;
 	int m_iLandmarksTourismPercentGlobal;
 	int m_iGreatWorksTourismModifierGlobal;
-#endif
 	int m_iSpecialistType;
 	int m_iSpecialistCount;
 	int m_iSpecialistExtraCulture;
 	int m_iGreatPeopleRateChange;
 	GreatWorkSlotType m_eGreatWorkSlotType;
-#if defined(MOD_GLOBAL_GREATWORK_YIELDTYPES)
 	YieldTypes m_eGreatWorkYieldType;
-#endif
 	int m_iGreatWorkCount;
 	GreatWorkType m_eFreeGreatWork;
 	int m_iFreeBuildingClass;
@@ -807,21 +770,16 @@ private:
 	int m_iPlotCultureCostModifier;
 	int m_iGlobalPlotBuyCostModifier;
 	int m_iPlotBuyCostModifier;
-#if defined(MOD_BUILDINGS_CITY_WORKING)
 	int m_iGlobalCityWorkingChange;
 	int m_iCityWorkingChange;
-#endif
-#if defined(MOD_BUILDINGS_CITY_AUTOMATON_WORKERS)
 	int m_iGlobalCityAutomatonWorkersChange;
 	int m_iCityAutomatonWorkersChange;
-#endif
 	int m_iMinAreaSize;
 	int m_iConquestProbability;
 	int m_iHealRateChange;
 	int m_iHappiness;
 	int m_iUnmoddedHappiness;
 	int m_iUnhappinessModifier;
-#if defined(MOD_BALANCE_CORE)
 	int m_iLocalUnhappinessModifier;
 	int m_iGlobalBuildingGoldMaintenanceMod;
 	int m_iBuildingDefenseModifier;
@@ -834,7 +792,6 @@ private:
 	int m_iCityIndirectFire;
 	int m_iRangedStrikeModifier;
 	int m_iGarrisonRangedAttackModifier;
-#endif
 	int m_iHappinessPerCity;
 	int m_iHappinessPerXPolicies;
 	int m_iCityCountUnhappinessMod;
@@ -868,10 +825,8 @@ private:
 	int m_iSpyRankChange;
 	int m_iInstantSpyRankChange;
 
-#if defined(MOD_RELIGION_CONVERSION_MODIFIERS)
 	int m_iConversionModifier;
 	int m_iGlobalConversionModifier;
-#endif
 
 	int m_iLandmarksTourismPercent;
 	int m_iInstantMilitaryIncrease;
@@ -932,7 +887,6 @@ private:
 	bool m_bSecondaryPantheon;
 	int* m_piGreatWorkYieldChange;
 	int* m_piGreatWorkYieldChangeLocal;
-#if defined(MOD_BALANCE_CORE)
 	int m_iNumRequiredTier3Tenets;
 	bool m_bIsNoWater;
 	bool m_bIsNoRiver;
@@ -949,25 +903,17 @@ private:
 	int m_iNoUnhappfromXSpecialistsGlobal;
 	int m_iPurchaseCooldownReduction;
 	int m_iPurchaseCooldownReductionCivilian;
-#endif
-#if defined(MOD_BALANCE_CORE_EVENTS)
 	int m_iEventRequiredActive;
 	int m_iCityEventRequiredActive;
-#endif
 	int m_iVassalLevyEra;
-#if defined(MOD_BALANCE_CORE_POP_REQ_BUILDINGS)
 	int m_iNationalPopRequired;
 	int m_iLocalPopRequired;
-#endif
-#if defined(MOD_BALANCE_CORE_FOLLOWER_POP_WONDER)
 	int m_iNationalFollowerPopRequired;
 	int m_iGlobalFollowerPopRequired;
-#endif
 	bool m_bMountain;
 	bool m_bHill;
 	bool m_bFlat;
 	bool m_bBorderObstacle;
-#if defined(MOD_BALANCE_CORE)
 	int m_iCityAirStrikeDefense;
 	int m_iBorderObstacleCity;
 	int m_iBorderObstacleWater;
@@ -979,12 +925,9 @@ private:
 	int m_iAlwaysHeal;
 	bool m_bIsCorp;
 	int m_iNukeInterceptionChance;
-#endif
 	int m_iFoodBonusPerCityMajorityFollower;
-#if defined(HH_MOD_BUILDINGS_FRUITLESS_PILLAGE)
 	bool m_bPlayerBorderGainlessPillage;
 	bool m_bCityGainlessPillage;
-#endif
 	bool m_bPlayerBorderObstacle;
 	bool m_bCapital;
 	bool m_bGoldenAge;
@@ -1036,10 +979,7 @@ private:
 	int* m_piSeaResourceYieldChange;
 	int* m_piGrowthExtraYield;
 	int m_iNeedBuildingThisCity;
-#if defined(MOD_BALANCE_CORE_POLICIES)
 	int* m_piYieldFromDeath;
-#endif
-#if defined(MOD_BALANCE_CORE)
 	int* m_piYieldFromVictory;
 	int* m_piYieldFromVictoryGlobal;
 	int* m_piYieldFromVictoryGlobalEraScaling;
@@ -1085,14 +1025,12 @@ private:
 	int* m_piYieldFromGPBirthScaledWithWriterBulb;
 	int* m_piYieldFromGPBirthScaledWithArtistBulb;
 	map<GreatPersonTypes, map<pair<YieldTypes, YieldTypes>, int>> m_miYieldFromGPBirthScaledWithPerTurnYield;
-#endif
 	int* m_piYieldChange;
 	int* m_piYieldChangeEraScalingTimes100;
 	fraction* m_pfYieldChangePerBuilding;
 	int* m_piYieldChangePerPop;
-#if defined(MOD_BALANCE_CORE)
 	std::map<int, int> m_piYieldChangePerPopInEmpire;
-#endif
+
 	set<int> m_siUnitClassTrainingAllowed;
 	set<std::pair<int,bool>> m_sibResourceClaim;
 	int* m_piYieldChangePerReligion;
@@ -1104,16 +1042,13 @@ private:
 	int* m_piUnitCombatProductionModifiersGlobal;
 	int* m_piDomainFreeExperience;
 	int* m_piDomainFreeExperiencePerGreatWork;
-#if defined(MOD_BALANCE_CORE)
 	int* m_piDomainFreeExperiencePerGreatWorkGlobal;
 	std::map<int, int> m_piDomainFreeExperienceGlobal;
-#endif
 	int* m_piDomainProductionModifier;
 	int* m_piPrereqNumOfBuildingClass;
 	int* m_piFlavorValue;
 	std::vector<int> m_viLocalResourceAnds;
 	std::vector<int> m_viLocalResourceOrs;
-#if defined(MOD_BALANCE_CORE_RESOURCE_MONOPOLIES)
 	int* m_piLocalFeatureOrs;
 	int* m_piLocalFeatureAnds;
 	std::vector<int> m_viResourceMonopolyAnds;
@@ -1122,12 +1057,11 @@ private:
 	int* m_piYieldPerFranchise;
 	int m_iGPRateModifierPerXFranchises;
 	int* m_piResourceQuantityPerXFranchises;
-#endif
 	int* m_piResourceQuantityFromPOP;
 	int* m_paiHurryModifier;
 
 	bool* m_pbBuildingClassNeededInCity;
-#if defined(MOD_BALANCE_CORE)
+
 	int* m_paiHurryModifierLocal;
 	bool* m_pbBuildingClassNeededAnywhere;
 	bool* m_pbBuildingClassNeededNowhere;
@@ -1137,12 +1071,11 @@ private:
 	int* m_piYieldPerAlly;
 	int* m_piYieldChangeWorldWonder;
 	int* m_piYieldChangeWorldWonderGlobal;
-#endif
+	
 	int* m_piNumFreeUnits;
 
 	int** m_ppaiResourceYieldChange;
 	int** m_ppaiFeatureYieldChange;
-#if defined(MOD_BALANCE_CORE)
 	std::map<int, std::map<int, int>> m_ppiResourceYieldChangeGlobal;
 	std::map<int, std::map<int, int>> m_miTechEnhancedYields;
 	std::map<pair<GreatPersonTypes, EraTypes>, int> m_miGreatPersonPointFromConstruction;
@@ -1151,7 +1084,6 @@ private:
 	int** m_ppaiImprovementYieldChange;
 	int** m_ppaiImprovementYieldChangeGlobal;
 	int** m_ppaiSpecialistYieldChangeLocal;
-#endif
 	int** m_ppaiSpecialistYieldChange;
 	int** m_ppaiResourceYieldModifier;
 	int** m_ppaiTerrainYieldChange;
@@ -1160,19 +1092,14 @@ private:
 	int** m_ppaiPlotYieldChange;
 	int** m_ppiBuildingClassYieldChanges;
 	int** m_ppiBuildingClassYieldModifiers;
-#if defined(MOD_BALANCE_CORE)
 	int** m_ppiBuildingClassLocalYieldChanges;
 	int* m_paiBuildingClassLocalHappiness;
 	int* m_paiSpecificGreatPersonRateModifier;
 	int* m_paiResourceHappinessChange;
-#endif
 	int* m_paiBuildingClassHappiness;
-#if defined(MOD_BALANCE_CORE_BUILDING_INSTANT_YIELD)
 	int* m_piInstantYield;
-#endif
-#if defined(MOD_BALANCE_CORE)
+	
 	std::multimap<int, std::pair<int, int>> m_piiGreatPersonProgressFromConstruction;
-#endif
 
 	CvThemingBonusInfo* m_paThemingBonusInfo;
 	int m_iNumThemingBonuses;
@@ -1335,9 +1262,7 @@ public:
 	bool CheckForAllWondersBuilt();
 	bool CheckForSevenAncientWondersBuilt();
 
-#if defined(MOD_BALANCE_CORE)
 	const std::vector<BuildingTypes>& GetAllBuildingsHere() const { return m_buildingsThatExistAtLeastOnce; }
-#endif
 private:
 	void NotifyNewBuildingStarted(BuildingTypes eIndex);
 
@@ -1358,17 +1283,13 @@ private:
 	int* m_paiBuildingOriginalTime;
 	int* m_paiNumRealBuilding;
 	int* m_paiNumFreeBuilding;
-#if defined(MOD_BALANCE_CORE)
 	int* m_paiFirstTimeBuilding;
 	int* m_paiThemingBonusIndex;
-#endif
 
-#if defined(MOD_BALANCE_CORE)
 	std::vector<BuildingTypes> m_buildingsThatExistAtLeastOnce;
 
 	mutable bool b_existBuildingsAreDirty;
 	mutable std::map<BuildingClassTypes, BuildingTypes> m_buildingTypeByClass;
-#endif
 
 	std::vector<BuildingYieldChange> m_aBuildingYieldChange;
 	std::vector<BuildingGreatWork> m_aBuildingGreatWork;

--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -480,6 +480,7 @@ CvCity::CvCity() :
 	, m_paiNumFeaturelessTerrainWorked()
 	, m_paiNumFeatureWorked()
 	, m_paiNumImprovementWorked()
+	, m_paiImprovementCount()
 #endif
 #if defined(MOD_BALANCE_CORE_POLICIES)
 	, m_paiBuildingClassCulture()
@@ -1826,9 +1827,12 @@ void CvCity::reset(int iID, PlayerTypes eOwner, int iX, int iY, bool bConstructo
 
 		m_paiNumImprovementWorked.clear();
 		m_paiNumImprovementWorked.resize(iNumImprovementInfos);
+		m_paiImprovementCount.clear();
+		m_paiImprovementCount.resize(iNumImprovementInfos);
 		for (iI = 0; iI < iNumImprovementInfos; iI++)
 		{
 			m_paiNumImprovementWorked[iI] = 0;
+			m_paiImprovementCount[iI] = 0;
 		}
 #endif
 	}
@@ -14985,7 +14989,7 @@ void CvCity::processBuilding(BuildingTypes eBuilding, int iChange, bool bFirst, 
 					ChangeResourceExtraYield(((ResourceTypes)iJ), eYield, (pkCorporationInfo->GetResourceYieldChange(iJ, eYield) * iChange));
 				}
 			}
-			// Yield Changes to Nearby Improvements
+			// Yield Changes to/from Nearby Improvements
 			for (int iJ = 0; iJ < GC.getNumImprovementInfos(); iJ++)
 			{
 				ImprovementTypes eImprovement = (ImprovementTypes)iJ;
@@ -14995,6 +14999,16 @@ void CvCity::processBuilding(BuildingTypes eBuilding, int iChange, bool bFirst, 
 					if (iYieldChange > 0)
 					{
 						ChangeImprovementExtraYield(eImprovement, eYield, (iYieldChange * iChange));
+					}
+					fraction fYieldChange = pBuildingInfo->GetYieldPerXImprovementLocal(eImprovement, eYield);
+					if (fYieldChange != 0)
+					{
+						ChangeYieldPerXImprovementLocal(eImprovement, eYield, fYieldChange);
+					}
+					fYieldChange = pBuildingInfo->GetYieldPerXImprovementGlobal(eImprovement, eYield);
+					if (fYieldChange != 0)
+					{
+						ChangeYieldPerXImprovementGlobal(eImprovement, eYield, fYieldChange);
 					}
 				}
 			}
@@ -18247,6 +18261,35 @@ void CvCity::ChangeNumImprovementWorked(ImprovementTypes eImprovement, int iChan
 	m_paiNumImprovementWorked[eImprovement] = m_paiNumImprovementWorked[eImprovement] + iChange;
 	ASSERT_DEBUG(GetNumImprovementWorked(eImprovement) >= 0);
 }
+// All improvements controlled by city (including city override plots)
+//	--------------------------------------------------------------------------------
+int CvCity::GetImprovementCount(ImprovementTypes eImprovement)
+{
+	CvAssertMsg(eImprovement >= 0, "eImprovement is expected to be non-negative (invalid Index)");
+	CvAssertMsg(eImprovement < GC.getNumImprovementInfos(), "eImprovement is expected to be within maxiumum bounds (invalid Index)");
+	return m_paiImprovementCount[eImprovement];
+}
+//	--------------------------------------------------------------------------------
+void CvCity::ChangeImprovementCount(ImprovementTypes eImprovement, int iChange)
+{
+	CvAssertMsg(eImprovement >= 0, "eImprovement is expected to be non-negative (invalid Index)");
+	CvAssertMsg(eImprovement < GC.getNumImprovementInfos(), "eImprovement is expected to be within maxiumum bounds (invalid Index)");
+	m_paiImprovementCount[eImprovement] = m_paiImprovementCount[eImprovement] + iChange;
+	CvAssert(GetImprovementCount(eImprovement) >= 0);
+	
+	//Update yields (needs a rewrite of SCityExtraYields in order for this to be optimized)
+	for (int iI = 0; iI < NUM_YIELD_TYPES; iI++)
+	{
+		//Simplification - errata yields not worth considering.
+		if ((YieldTypes)iI > YIELD_GOLDEN_AGE_POINTS && !MOD_BALANCE_CORE_JFD)
+			break;
+
+		if (GetYieldPerXImprovementLocal(eImprovement, (YieldTypes)iI) == 0)
+			continue;
+
+		UpdateYieldPerXImprovement(((YieldTypes)iI), eImprovement);
+	}
+}
 
 //	--------------------------------------------------------------------------------
 ///Extra yield for a Terrain this city is working?
@@ -18701,6 +18744,132 @@ void CvCity::UpdateYieldPerXUnimprovedFeature(YieldTypes eYield, FeatureTypes eF
 				}
 				SetYieldPerXUnimprovedFeature(eFeature, eYield, iYield);
 			}
+		}
+	}
+}
+
+//	--------------------------------------------------------------------------------
+/// Extra yield in city for nearby/global improvements?
+//	--------------------------------------------------------------------------------
+//	per instance of Improvement
+fraction CvCity::GetYieldPerXImprovementLocal(ImprovementTypes eImprovement, YieldTypes eYield) const
+{
+	VALIDATE_OBJECT
+	CvAssertMsg(eImprovement > -1 && eImprovement < GC.getNumImprovementInfos(), "Invalid Improvement index.");
+	CvAssertMsg(eYield > -1 && eYield < NUM_YIELD_TYPES, "Invalid yield index.");
+
+	return ModifierLookup(m_yieldChanges[eYield].fromImprovementLocal, eImprovement);
+}
+//	--------------------------------------------------------------------------------
+void CvCity::ChangeYieldPerXImprovementLocal(ImprovementTypes eImprovement, YieldTypes eYield, fraction fChange)
+{
+	VALIDATE_OBJECT
+	CvAssertMsg(eImprovement > -1 && eImprovement < GC.getNumTerrainInfos(), "Invalid Improvement index.");
+	CvAssertMsg(eYield > -1 && eYield < NUM_YIELD_TYPES, "Invalid yield index.");
+
+	SCityExtraYields& y = m_yieldChanges[eYield];
+	if (ModifierUpdateInsertRemove(y.fromImprovementLocal, eImprovement, fChange, true))
+	{
+		UpdateYieldPerXImprovement(eYield, eImprovement);
+		updateYield(false);
+	}
+}
+//	--------------------------------------------------------------------------------
+fraction CvCity::GetYieldPerXImprovementGlobal(ImprovementTypes eImprovement, YieldTypes eYield) const
+{
+	VALIDATE_OBJECT
+	CvAssertMsg(eImprovement > -1 && eImprovement < GC.getNumImprovementInfos(), "Invalid Improvement index.");
+	CvAssertMsg(eYield > -1 && eYield < NUM_YIELD_TYPES, "Invalid yield index.");
+
+	return ModifierLookup(m_yieldChanges[eYield].fromImprovementGlobal, eImprovement);
+}
+//	--------------------------------------------------------------------------------
+void CvCity::ChangeYieldPerXImprovementGlobal(ImprovementTypes eImprovement, YieldTypes eYield, fraction fChange)
+{
+	VALIDATE_OBJECT
+	CvAssertMsg(eImprovement > -1 && eImprovement < GC.getNumTerrainInfos(), "Invalid Improvement index.");
+	CvAssertMsg(eYield > -1 && eYield < NUM_YIELD_TYPES, "Invalid yield index.");
+
+	SCityExtraYields& y = m_yieldChanges[eYield];
+	if (ModifierUpdateInsertRemove(y.fromImprovementGlobal, eImprovement, fChange, true))
+	{
+		UpdateYieldPerXImprovement(eYield, eImprovement);
+		updateYield(false);
+	}
+}
+//	--------------------------------------------------------------------------------
+//	total yield due to all instances of Improvement
+fraction CvCity::GetYieldPerXImprovement(ImprovementTypes eImprovement, YieldTypes eYield) const
+{
+	VALIDATE_OBJECT
+	CvAssertMsg(eImprovement > -1 && eImprovement < GC.getNumImprovementInfos(), "Invalid Improvement index.");
+	CvAssertMsg(eYield > -1 && eYield < NUM_YIELD_TYPES, "Invalid yield index.");
+
+	return ModifierLookup(m_yieldChanges[eYield].fromImprovement, eImprovement);
+}
+//	--------------------------------------------------------------------------------
+void CvCity::SetYieldPerXImprovement(ImprovementTypes eImprovement, YieldTypes eYield, fraction fValue)
+{
+	VALIDATE_OBJECT
+	CvAssertMsg(eImprovement > -1 && eImprovement < GC.getNumFeatureInfos(), "Invalid Improvement index.");
+	CvAssertMsg(eYield > -1 && eYield < NUM_YIELD_TYPES, "Invalid yield index.");
+
+	SCityExtraYields& y = m_yieldChanges[eYield];
+	if (ModifierUpdateInsertRemove(y.fromImprovement, eImprovement, fValue, false))
+		updateYield(false);
+}
+//	--------------------------------------------------------------------------------
+void CvCity::UpdateYieldPerXImprovement(YieldTypes eYield, ImprovementTypes eImprovement)
+{
+	VALIDATE_OBJECT
+	fraction fYield = 0;
+
+	fraction fBaseYieldLocal = 0;
+	fraction fBaseYieldGlobal = 0;
+
+	//Passed in an improvement? Let's only update that.
+	if (eImprovement != NO_IMPROVEMENT)
+	{
+		fBaseYieldLocal = GetYieldPerXImprovementLocal(eImprovement, eYield);
+		fBaseYieldGlobal = GetYieldPerXImprovementGlobal(eImprovement, eYield);
+
+		if (fBaseYieldGlobal != 0)
+		{
+			fYield += (fBaseYieldGlobal * GET_PLAYER(getOwner()).getImprovementCount(eImprovement));
+		}
+		if (fBaseYieldLocal != 0)
+		{
+			fYield += fBaseYieldLocal * GetImprovementCount(eImprovement);
+		}
+		if (fYield != 0)
+		{
+			//Determine +/- of difference from old value
+			int iOriginal = GetYieldPerXImprovement(eImprovement, eYield).Truncate();
+			int iDifference = fYield.Truncate() - iOriginal;
+
+			//Change base rate first
+			ChangeBaseYieldRateFromBuildings(eYield, iDifference);
+
+			//then set base rate for retrieval next time.
+			SetYieldPerXImprovement(eImprovement, eYield, fYield);
+		}
+		else if (GetYieldPerXImprovement(eImprovement, eYield) > 0)
+		{
+			//No bonuses? Clear it out.
+			ChangeBaseYieldRateFromBuildings(eYield, -GetYieldPerXImprovement(eImprovement, eYield).Truncate());
+			SetYieldPerXImprovement(eImprovement, eYield, 0);
+		}
+	}
+	else
+	{
+		for (int iI = 0; iI < GC.getNumImprovementInfos(); iI++)
+		{
+			eImprovement = (ImprovementTypes)iI;
+			if (eImprovement == NO_IMPROVEMENT)
+			{
+				continue;
+			}
+			UpdateYieldPerXImprovement(eYield, eImprovement);
 		}
 	}
 }
@@ -32035,6 +32204,7 @@ void CvCity::Serialize(City& city, Visitor& visitor)
 	visitor(city.m_paiNumFeaturelessTerrainWorked);
 	visitor(city.m_paiNumFeatureWorked);
 	visitor(city.m_paiNumImprovementWorked);
+	visitor(city.m_paiImprovementCount);
 	visitor(city.m_strScriptData);
 	visitor(city.m_iDamageTakenThisTurn);
 	visitor(city.m_iDamageTakenLastTurn);
@@ -35487,6 +35657,9 @@ FDataStream& operator<<(FDataStream& saveTo, const SCityExtraYields& readFrom)
 	saveTo << readFrom.forFeatureUnimproved;
 
 	saveTo << readFrom.forImprovement;
+	saveTo << readFrom.fromImprovement;
+	saveTo << readFrom.fromImprovementLocal;
+	saveTo << readFrom.fromImprovementGlobal;
 	saveTo << readFrom.forSpecialist;
 	saveTo << readFrom.forResource;
 	saveTo << readFrom.forPlot;
@@ -35510,6 +35683,9 @@ FDataStream& operator>>(FDataStream& loadFrom, SCityExtraYields& writeTo)
 	loadFrom >> writeTo.forFeatureUnimproved;
 
 	loadFrom >> writeTo.forImprovement;
+	loadFrom >> writeTo.fromImprovement;
+	loadFrom >> writeTo.fromImprovementLocal;
+	loadFrom >> writeTo.fromImprovementGlobal;
 	loadFrom >> writeTo.forSpecialist;
 	loadFrom >> writeTo.forResource;
 	loadFrom >> writeTo.forPlot;

--- a/CvGameCoreDLL_Expansion2/CvCity.h
+++ b/CvGameCoreDLL_Expansion2/CvCity.h
@@ -41,6 +41,7 @@ struct SCityExtraYields
 	vector<pair<TerrainTypes, int>> forTerrain, forXTerrain, forTerrainFromBuildings, forTerrainFromReligion;
 	vector<pair<FeatureTypes, int>> forFeature, forXFeature, forFeatureFromBuildings, forFeatureFromReligion, forFeatureUnimproved;
 	vector<pair<ImprovementTypes, int>> forImprovement;
+	vector<pair<ImprovementTypes, fraction>> fromImprovement, fromImprovementLocal, fromImprovementGlobal;
 	vector<pair<SpecialistTypes, int>> forSpecialist;
 	vector<pair<ResourceTypes, int>> forResource;
 	vector<pair<PlotTypes, int>> forPlot;
@@ -297,6 +298,8 @@ public:
 	void ChangeNumImprovementWorked(ImprovementTypes eImprovement, int iChange);
 	int GetNumImprovementWorked(ImprovementTypes eImprovement);
 
+	void ChangeImprovementCount(ImprovementTypes eImprovement, int iChange);
+	int GetImprovementCount(ImprovementTypes eImprovement);
 
 	int GetYieldPerXTerrainFromBuildingsTimes100(TerrainTypes eTerrain, YieldTypes eYield) const;
 	void ChangeYieldPerXTerrainFromBuildingsTimes100(TerrainTypes eTerrain, YieldTypes eYield, int iChange);
@@ -319,6 +322,14 @@ public:
 	int GetYieldPerTurnFromUnimprovedFeatures(FeatureTypes eFeature, YieldTypes eYield) const;
 	void SetYieldPerXUnimprovedFeature(FeatureTypes eFeature, YieldTypes eYield, int iValue);
 	void UpdateYieldPerXUnimprovedFeature(YieldTypes eYield, FeatureTypes eFeature = NO_FEATURE);
+
+	fraction GetYieldPerXImprovementLocal(ImprovementTypes eImprovement, YieldTypes eYield) const;
+	void ChangeYieldPerXImprovementLocal(ImprovementTypes eImprovement, YieldTypes eYield, fraction fChange);
+	fraction GetYieldPerXImprovementGlobal(ImprovementTypes eImprovement, YieldTypes eYield) const;
+	void ChangeYieldPerXImprovementGlobal(ImprovementTypes eImprovement, YieldTypes eYield, fraction fChange);
+	fraction GetYieldPerXImprovement(ImprovementTypes eImprovement, YieldTypes eYield) const;
+	void SetYieldPerXImprovement(ImprovementTypes eImprovement, YieldTypes eYield, fraction fValue);
+	void UpdateYieldPerXImprovement(YieldTypes eYield, ImprovementTypes eImprovement = NO_IMPROVEMENT);
 
 	int getHurryModifier(HurryTypes eIndex) const;
 	void changeHurryModifier(HurryTypes eIndex, int iChange);
@@ -2153,6 +2164,7 @@ protected:
 	std::vector<int> m_paiNumFeaturelessTerrainWorked;
 	std::vector<int> m_paiNumFeatureWorked;
 	std::vector<int> m_paiNumImprovementWorked;
+	std::vector<int> m_paiImprovementCount;
 #endif
 	CvString m_strScriptData;
 
@@ -2563,6 +2575,7 @@ SYNC_ARCHIVE_VAR(std::vector<int>, m_paiNumTerrainWorked)
 SYNC_ARCHIVE_VAR(std::vector<int>, m_paiNumFeaturelessTerrainWorked)
 SYNC_ARCHIVE_VAR(std::vector<int>, m_paiNumFeatureWorked)
 SYNC_ARCHIVE_VAR(std::vector<int>, m_paiNumImprovementWorked)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_paiImprovementCount)
 SYNC_ARCHIVE_VAR(CvString, m_strScriptData)
 SYNC_ARCHIVE_VAR(int, m_iDamageTakenThisTurn)
 SYNC_ARCHIVE_VAR(int, m_iDamageTakenLastTurn)

--- a/CvGameCoreDLL_Expansion2/CvCity.h
+++ b/CvGameCoreDLL_Expansion2/CvCity.h
@@ -285,12 +285,6 @@ public:
 	int GetExtraBuildingMaintenance() const;
 	void SetExtraBuildingMaintenance(int iChange);
 
-	int GetYieldPerXTerrain(TerrainTypes eTerrain, YieldTypes eYield) const;
-	int GetYieldPerXTerrainFromReligion(TerrainTypes eTerrain, YieldTypes eYield) const;
-
-	void UpdateYieldPerXTerrain(YieldTypes eYield, TerrainTypes eTerrain = NO_TERRAIN);
-	void UpdateYieldPerXTerrainFromReligion(YieldTypes eYield, TerrainTypes eTerrain = NO_TERRAIN);
-
 	void ChangeNumTerrainWorked(TerrainTypes eTerrain, int iChange);
 	int GetNumTerrainWorked(TerrainTypes eTerrain);
 
@@ -303,20 +297,27 @@ public:
 	void ChangeNumImprovementWorked(ImprovementTypes eImprovement, int iChange);
 	int GetNumImprovementWorked(ImprovementTypes eImprovement);
 
-	void SetYieldPerXTerrain(TerrainTypes eTerrain, YieldTypes eYield, int iValue);
-	void SetYieldPerXTerrainFromReligion(TerrainTypes eTerrain, YieldTypes eYield, int iValue);
 
 	int GetYieldPerXTerrainFromBuildingsTimes100(TerrainTypes eTerrain, YieldTypes eYield) const;
 	void ChangeYieldPerXTerrainFromBuildingsTimes100(TerrainTypes eTerrain, YieldTypes eYield, int iChange);
+	int GetYieldPerXTerrain(TerrainTypes eTerrain, YieldTypes eYield) const;
+	void SetYieldPerXTerrain(TerrainTypes eTerrain, YieldTypes eYield, int iValue);
+	void UpdateYieldPerXTerrain(YieldTypes eYield, TerrainTypes eTerrain = NO_TERRAIN);
+
+	int GetYieldPerXTerrainFromReligion(TerrainTypes eTerrain, YieldTypes eYield) const;
+	void SetYieldPerXTerrainFromReligion(TerrainTypes eTerrain, YieldTypes eYield, int iValue);
+	void UpdateYieldPerXTerrainFromReligion(YieldTypes eYield, TerrainTypes eTerrain = NO_TERRAIN);
 
 	int GetYieldPerXFeatureFromBuildingsTimes100(FeatureTypes eFeature, YieldTypes eYield) const;
 	void ChangeYieldPerXFeatureFromBuildingsTimes100(FeatureTypes eFeature, YieldTypes eYield, int iChange);
-
+	int GetYieldPerXFeature(FeatureTypes eFeature, YieldTypes eYield) const;
 	void SetYieldPerXFeature(FeatureTypes eFeature, YieldTypes eYield, int iValue);
+	int GetYieldPerXFeatureFromReligion(FeatureTypes eFeature, YieldTypes eYield) const;
 	void SetYieldPerXFeatureFromReligion(FeatureTypes eFeature, YieldTypes eYield, int iValue);
-	void SetYieldPerXUnimprovedFeature(FeatureTypes eFeature, YieldTypes eYield, int iValue);
-
 	void UpdateYieldPerXFeature(YieldTypes eYield, FeatureTypes eFeature = NO_FEATURE);
+
+	int GetYieldPerTurnFromUnimprovedFeatures(FeatureTypes eFeature, YieldTypes eYield) const;
+	void SetYieldPerXUnimprovedFeature(FeatureTypes eFeature, YieldTypes eYield, int iValue);
 	void UpdateYieldPerXUnimprovedFeature(YieldTypes eYield, FeatureTypes eFeature = NO_FEATURE);
 
 	int getHurryModifier(HurryTypes eIndex) const;
@@ -686,10 +687,6 @@ public:
 
 	int GetFaithPerTurnFromPolicies() const;
 	void ChangeFaithPerTurnFromPolicies(int iChange);
-
-	int GetYieldPerXFeature(FeatureTypes eFeature, YieldTypes eYield) const;
-	int GetYieldPerXFeatureFromReligion(FeatureTypes eFeature, YieldTypes eYield) const;
-	int GetYieldPerTurnFromUnimprovedFeatures(FeatureTypes eFeature, YieldTypes eYield) const;
 
 	int GetFaithPerTurnFromReligion() const;
 

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -38396,6 +38396,23 @@ void CvPlayer::changeImprovementCount(ImprovementTypes eIndex, int iChange, bool
 		m_paiImprovementBuiltCount[eIndex] += iChange;
 		ASSERT_DEBUG(getImprovementCount(eIndex, true) >= 0);
 	}
+
+	//Update yields (needs a rewrite of SCityExtraYields in order for this to be optimized)
+	int iLoop = 0;
+	for(CvCity* pLoopCity = firstCity(&iLoop); pLoopCity != NULL; pLoopCity = nextCity(&iLoop))
+	{
+		for (int iI = 0; iI < NUM_YIELD_TYPES; iI++)
+		{
+			//Simplification - errata yields not worth considering.
+			if ((YieldTypes)iI > YIELD_GOLDEN_AGE_POINTS && !MOD_BALANCE_CORE_JFD)
+				break;
+
+			if (pLoopCity->GetYieldPerXImprovementGlobal(eIndex, (YieldTypes)iI) == 0)
+				continue;
+
+			pLoopCity->UpdateYieldPerXImprovement(((YieldTypes)iI), eIndex);
+		}
+	}
 }
 
 #if defined(MOD_BALANCE_CORE)

--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -6460,7 +6460,6 @@ void CvPlot::updatePotentialCityWork()
 //	--------------------------------------------------------------------------------
 void CvPlot::setOwner(PlayerTypes eNewValue, int iAcquiringCityID, bool bCheckUnits, bool, bool bFoundingCity)
 {
-	CvCity* pOldCity = NULL;
 	CvString strBuffer;
 	int iI = 0;
 	ImprovementTypes eLandmarkImprovement = (ImprovementTypes)GC.getInfoTypeForString("IMPROVEMENT_LANDMARK");
@@ -6475,7 +6474,8 @@ void CvPlot::setOwner(PlayerTypes eNewValue, int iAcquiringCityID, bool bCheckUn
 
 		GC.getGame().addReplayMessage(REPLAY_MESSAGE_PLOT_OWNER_CHANGE, eNewValue, "", getX(), getY());
 
-		pOldCity = getPlotCity();
+		CvCity* pOldCity = getPlotCity();
+		CvCity* pOldOwningCity = getEffectiveOwningCity();
 
 		{
 			setOwnershipDuration(0);
@@ -6556,6 +6556,10 @@ void CvPlot::setOwner(PlayerTypes eNewValue, int iAcquiringCityID, bool bCheckUn
 				if (eImprovement != NO_IMPROVEMENT)
 				{
 					GET_PLAYER(eOldOwner).changeImprovementCount(eImprovement, -1, eOldOwner == eBuilder);
+					if (pOldOwningCity->GetID() != iAcquiringCityID)
+					{
+						pOldOwningCity->ChangeImprovementCount(eImprovement, -1);
+					}
 
 					// Remove siphoned resources
 					CvImprovementEntry* pImprovementInfo = GC.getImprovementInfo(eImprovement);
@@ -6624,13 +6628,14 @@ void CvPlot::setOwner(PlayerTypes eNewValue, int iAcquiringCityID, bool bCheckUn
 				}
 			}
 
-			// This plot is ABOUT TO BE owned. Pop Goody Huts/remove barb camps, etc. Otherwise it will try to reduce the # of Improvements we have in our borders, and these guys shouldn't apply to that count
+			// This plot is ABOUT TO BE owned. Pop Goody Huts/remove barb camps, etc. Otherwise it will try to increase/reduce the # of Improvements we have in our borders, and these guys shouldn't apply to that count
 			if(eNewValue != NO_PLAYER)
 			{
 				// Pop Goody Huts here
 				if(isGoody())
 				{
 					GET_PLAYER(eNewValue).doGoody(this, NULL);
+					eImprovement = NO_IMPROVEMENT;
 				}
 
 				// If there's a camp here, clear it
@@ -6639,6 +6644,7 @@ void CvPlot::setOwner(PlayerTypes eNewValue, int iAcquiringCityID, bool bCheckUn
 					setImprovementType(NO_IMPROVEMENT);
 					CvBarbarians::DoBarbCampCleared(this, eNewValue);
 					SetPlayerThatClearedBarbCampHere(eNewValue);
+					eImprovement = NO_IMPROVEMENT;
 				}
 
 				// Transfer responsibility of routes and improvements if the plot is now owned by someone else
@@ -6721,6 +6727,12 @@ void CvPlot::setOwner(PlayerTypes eNewValue, int iAcquiringCityID, bool bCheckUn
 				if(eImprovement != NO_IMPROVEMENT)
 				{
 					GET_PLAYER(eNewValue).changeImprovementCount(eImprovement, 1, getOwner() == eBuilder);
+					// city owner changes hands later or maybe earlier? ugh
+					if (!pOldOwningCity || pOldOwningCity->GetID() != iAcquiringCityID)
+					{
+						CvCity* pNewOwningCity = ::GetPlayerCity(IDInfo(eNewValue, iAcquiringCityID));
+						pNewOwningCity->ChangeImprovementCount(eImprovement, 1);
+					}
 
 					// Add siphoned resources
 					CvImprovementEntry* pImprovementInfo = GC.getImprovementInfo(eImprovement);
@@ -8091,6 +8103,7 @@ void CvPlot::setImprovementType(ImprovementTypes eNewValue, PlayerTypes eBuilder
 			{
 				CvPlayer& owningPlayer = GET_PLAYER(owningPlayerID);
 				owningPlayer.changeImprovementCount(eOldImprovement, -1, eOldBuilder == owningPlayerID);
+				pOwningCity->ChangeImprovementCount(eOldImprovement, -1);
 
 				// Siphon resource changes
 				if (oldImprovementEntry.GetLuxuryCopiesSiphonedFromMinor() > 0 && eOldBuilder != NO_PLAYER)
@@ -8497,6 +8510,7 @@ void CvPlot::setImprovementType(ImprovementTypes eNewValue, PlayerTypes eBuilder
 			{
 				CvPlayer& owningPlayer = GET_PLAYER(owningPlayerID);
 				owningPlayer.changeImprovementCount(eNewValue, 1, eBuilder == owningPlayerID);
+				pOwningCity->ChangeImprovementCount(eNewValue, 1);
 
 				//DLC_04 Achievement
 				if (MOD_API_ACHIEVEMENTS)
@@ -9594,6 +9608,18 @@ void CvPlot::setOwningCity(PlayerTypes ePlayer, int iCityID)
 	CvCity* pNewCity = ::GetPlayerCity(IDInfo(ePlayer, iCityID));
 
 	m_owningCity = IDInfo(ePlayer, iCityID);
+	
+	// change improvement ownership
+	ImprovementTypes eImprovement = getImprovementType();
+	if (eImprovement != NO_IMPROVEMENT)
+	{
+		// improvement counts of override city are updated in setOwningCityOverride()
+		if (!pOldCityOverride && pOldCity)
+			pOldCity->ChangeImprovementCount(eImprovement, -1);
+
+		if (pNewCity)
+			pNewCity->ChangeImprovementCount(eImprovement, 1);
+	}
 
 	// if the plot is being worked and the city is about to change then put the citizen somewhere else
 	if (pOldCityOverride && pOldCityOverride != pNewCity)
@@ -9721,7 +9747,7 @@ CvCity* CvPlot::getOwningCityOverride() const
 }
 
 //	--------------------------------------------------------------------------------
-void CvPlot::setOwningCityOverride(const CvCity* pNewValue)
+void CvPlot::setOwningCityOverride(CvCity* pNewValue)
 {
 	CvCity* pCurrentCity = getOwningCityOverride();
 	if ( pNewValue != pCurrentCity )
@@ -9733,6 +9759,15 @@ void CvPlot::setOwningCityOverride(const CvCity* pNewValue)
 		else
 		{
 			m_owningCityOverride.reset();
+		}
+
+		ImprovementTypes eImprovement = getImprovementType();
+		if (eImprovement != NO_IMPROVEMENT)
+		{
+			if (pCurrentCity != NULL)
+				pCurrentCity->ChangeImprovementCount(eImprovement, -1);
+			if (pNewValue != NULL)
+				pNewValue->ChangeImprovementCount(eImprovement, 1);
 		}
 
 		// Remove citizen from this plot if another city was using it

--- a/CvGameCoreDLL_Expansion2/CvPlot.h
+++ b/CvGameCoreDLL_Expansion2/CvPlot.h
@@ -558,7 +558,7 @@ public:
 	bool isEffectiveOwner(const CvCity* pCity) const;
 
 	CvCity* getOwningCityOverride() const;
-	void setOwningCityOverride(const CvCity* pNewValue);
+	void setOwningCityOverride(CvCity* pNewValue);
 
 	int getReconCount() const;
 	void changeReconCount(int iChange);


### PR DESCRIPTION
﻿**GENERAL IMPROVEMENTS**
CvBuildingClasses:
- removed #if defines
- removed Building_FranchiseTradeRouteCityYield from NewBuildingTables.xml. It doesn't exist anywhere else.

CvCity::YieldPerX~
 - reorganized postions of functions
 - simplified UpdateYieldPerX~ functions

CvCity::processBuilding
 - reorganization of the yield section

SCityExtraYields
 - generalized its linked ModifierLookup and ModifierInsertRemove functions

**NEW BUILDING FEATURES**
Building_YieldPerXImprovementLocal and BuildingYieldPerXImprovementGlobal:
 - building yields are increased by specific improvements in city/empire borders
 - for now, pillaging an improvement does not reduce the yields provided by this mechanic
 - tables already added in database

**IMPLEMENT FEATURES GAME-WIDE**
﻿YieldPerXImprovement: 
 - dll additions for Building_YieldPerXImprovement, following the process for Building_YieldPerXTerrain
 - cities now have their own separately tracked improvement count, based on who effectively owns it (ie overrides)
 - every time a plot changes hands between cities, CvCity::ChangeImprovementCount() is called, and therefore the UpdateYieldPerXImprovement code
 - cityOverride is all over the place, not all that happy about it
 - CvCitizens::GetPlotValue() might want to take the City version into account, but the code is pretty messed up, and I think wrong/poorly optimized
 
The current implementation use-case is for the Roman Villa's "Food in the Capital" ability.  Attach the Villa Improvement to the Palace via the global ability; this follows the Roman player's capital if they ever lose their primary, and it also works for players who gain villas by land grabs or conquest.  The local version is useful for the Supermarket building concept that has been floated around for a while.

*Please keep the commits separate*