### PR TITLE
Autoinstaller improvements

### DIFF
--- a/Opener.rtf
+++ b/Opener.rtf
@@ -1,298 +1,173 @@
-{\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}
-{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02030602050306030303}Constantia;}
-{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fhimajor\f31502\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0302020204030204}Calibri Light;}{\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}
-{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\f47\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\f48\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\f49\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}
-{\f50\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\f51\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\f52\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\f384\fbidi \froman\fcharset238\fprq2 Cambria Math CE;}
-{\f385\fbidi \froman\fcharset204\fprq2 Cambria Math Cyr;}{\f387\fbidi \froman\fcharset161\fprq2 Cambria Math Greek;}{\f388\fbidi \froman\fcharset162\fprq2 Cambria Math Tur;}{\f391\fbidi \froman\fcharset186\fprq2 Cambria Math Baltic;}
-{\f392\fbidi \froman\fcharset163\fprq2 Cambria Math (Vietnamese);}{\f474\fbidi \froman\fcharset238\fprq2 Constantia CE;}{\f475\fbidi \froman\fcharset204\fprq2 Constantia Cyr;}{\f477\fbidi \froman\fcharset161\fprq2 Constantia Greek;}
-{\f478\fbidi \froman\fcharset162\fprq2 Constantia Tur;}{\f481\fbidi \froman\fcharset186\fprq2 Constantia Baltic;}{\f482\fbidi \froman\fcharset163\fprq2 Constantia (Vietnamese);}{\flomajor\f31508\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}
-{\flomajor\f31509\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\flomajor\f31511\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\flomajor\f31512\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}
-{\flomajor\f31513\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\flomajor\f31514\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\flomajor\f31515\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}
-{\flomajor\f31516\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\fdbmajor\f31518\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\fdbmajor\f31519\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
-{\fdbmajor\f31521\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\fdbmajor\f31522\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\fdbmajor\f31523\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}
-{\fdbmajor\f31524\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\fdbmajor\f31525\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\fdbmajor\f31526\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}
-{\fhimajor\f31528\fbidi \fswiss\fcharset238\fprq2 Calibri Light CE;}{\fhimajor\f31529\fbidi \fswiss\fcharset204\fprq2 Calibri Light Cyr;}{\fhimajor\f31531\fbidi \fswiss\fcharset161\fprq2 Calibri Light Greek;}
-{\fhimajor\f31532\fbidi \fswiss\fcharset162\fprq2 Calibri Light Tur;}{\fhimajor\f31533\fbidi \fswiss\fcharset177\fprq2 Calibri Light (Hebrew);}{\fhimajor\f31534\fbidi \fswiss\fcharset178\fprq2 Calibri Light (Arabic);}
-{\fhimajor\f31535\fbidi \fswiss\fcharset186\fprq2 Calibri Light Baltic;}{\fhimajor\f31536\fbidi \fswiss\fcharset163\fprq2 Calibri Light (Vietnamese);}{\fbimajor\f31538\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}
-{\fbimajor\f31539\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\fbimajor\f31541\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\fbimajor\f31542\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}
-{\fbimajor\f31543\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\fbimajor\f31544\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\fbimajor\f31545\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}
-{\fbimajor\f31546\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\flominor\f31548\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\flominor\f31549\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
-{\flominor\f31551\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\flominor\f31552\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\flominor\f31553\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}
-{\flominor\f31554\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\flominor\f31555\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\flominor\f31556\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}
-{\fdbminor\f31558\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\fdbminor\f31559\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}{\fdbminor\f31561\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}
-{\fdbminor\f31562\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\fdbminor\f31563\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}{\fdbminor\f31564\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}
-{\fdbminor\f31565\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\fdbminor\f31566\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}{\fhiminor\f31568\fbidi \fswiss\fcharset238\fprq2 Calibri CE;}
-{\fhiminor\f31569\fbidi \fswiss\fcharset204\fprq2 Calibri Cyr;}{\fhiminor\f31571\fbidi \fswiss\fcharset161\fprq2 Calibri Greek;}{\fhiminor\f31572\fbidi \fswiss\fcharset162\fprq2 Calibri Tur;}
-{\fhiminor\f31573\fbidi \fswiss\fcharset177\fprq2 Calibri (Hebrew);}{\fhiminor\f31574\fbidi \fswiss\fcharset178\fprq2 Calibri (Arabic);}{\fhiminor\f31575\fbidi \fswiss\fcharset186\fprq2 Calibri Baltic;}
-{\fhiminor\f31576\fbidi \fswiss\fcharset163\fprq2 Calibri (Vietnamese);}{\fbiminor\f31578\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\fbiminor\f31579\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
-{\fbiminor\f31581\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\fbiminor\f31582\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\fbiminor\f31583\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}
-{\fbiminor\f31584\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\fbiminor\f31585\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\fbiminor\f31586\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}}
-{\colortbl;\red0\green0\blue0;\red0\green0\blue255;\red0\green255\blue255;\red0\green255\blue0;\red255\green0\blue255;\red255\green0\blue0;\red255\green255\blue0;\red255\green255\blue255;\red0\green0\blue128;\red0\green128\blue128;\red0\green128\blue0;
-\red128\green0\blue128;\red128\green0\blue0;\red128\green128\blue0;\red128\green128\blue128;\red192\green192\blue192;\red0\green0\blue0;\red0\green0\blue0;}{\*\defchp \fs22\loch\af31506\hich\af31506\dbch\af31505 }{\*\defpap 
-\ql \li0\ri0\sa160\sl259\slmult1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 }\noqfpromote {\stylesheet{\ql \li0\ri0\sa160\sl259\slmult1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 
-\af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang1033\langfe1033\loch\f31506\hich\af31506\dbch\af31505\cgrid\langnp1033\langfenp1033 \snext0 \sqformat \spriority0 Normal;}{\*\cs10 \additive \ssemihidden \sunhideused \spriority1 Default Paragraph Font;}{\*
-\ts11\tsrowd\trftsWidthB3\trpaddl108\trpaddr108\trpaddfl3\trpaddft3\trpaddfb3\trpaddfr3\trcbpat1\trcfpat1\tblind0\tblindtype3\tsvertalt\tsbrdrt\tsbrdrl\tsbrdrb\tsbrdrr\tsbrdrdgl\tsbrdrdgr\tsbrdrh\tsbrdrv \ql \li0\ri0\sa160\sl259\slmult1
-\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang1033\langfe1033\loch\f31506\hich\af31506\dbch\af31505\cgrid\langnp1033\langfenp1033 \snext11 \ssemihidden \sunhideused 
-Normal Table;}}{\*\listtable{\list\listtemplateid-2009032848\listsimple{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat0\levelspace0\levelindent0{\leveltext\'01*;}{\levelnumbers;}}{\listname ;}\listid-2}}
-{\*\listoverridetable{\listoverride\listid-2\listoverridecount1{\lfolevel\listoverrideformat{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat0\levelold\levelspace0\levelindent0{\leveltext\'01\u-3913 ?;}{\levelnumbers;}
-\f3\fbias0 }}\ls1}}{\*\rsidtbl \rsid26404\rsid278676\rsid1327384\rsid1862555\rsid1900942\rsid2106010\rsid2190399\rsid2511843\rsid2636462\rsid2850205\rsid2910721\rsid2962587\rsid3500149\rsid3612221\rsid4200626\rsid4200831\rsid4810636\rsid5189667
-\rsid5377835\rsid5392106\rsid5717743\rsid5788941\rsid5982898\rsid6175416\rsid6383461\rsid6488618\rsid6557624\rsid6760281\rsid8063138\rsid8792251\rsid8871109\rsid9663479\rsid10027712\rsid10634437\rsid11822905\rsid12067123\rsid12792187\rsid14769297
-\rsid15035576\rsid15085093\rsid15297860\rsid15492932\rsid16068389\rsid16520929}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Jeff Grooms}
-{\creatim\yr2018\mo10\dy10\hr22\min10}{\revtim\yr2021\mo9\dy3\hr13\min43}{\version44}{\edmins5}{\nofpages2}{\nofwords415}{\nofchars2368}{\nofcharsws2778}{\vern31}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
-\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
-\widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
-\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale100\rsidroot9663479 \nouicompat \fet0{\*\wgrffmtfilter 2450}\nofeaturethrottle1\ilfomacatclnup0\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1
-\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2\pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5
-\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang 
-{\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}\pard\plain \ltrpar\qc \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 
-\fs22\lang1033\langfe1033\loch\af31506\hich\af31506\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 Welcome to the Vox Populi Installer!
-\par }\pard \ltrpar\qc \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid5377835 {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 Installer Version }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\insrsid2850205 
-\hich\af43\dbch\af31505\loch\f43 1.0}{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\insrsid2511843 
-\par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af43\afs24 \ltrch\fcs0 \f43\fs24\insrsid5377835 
-\par }{\rtlch\fcs1 \af43\afs24 \ltrch\fcs0 \f43\fs24\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 This installer is for the Vox Populi, an un\hich\af43\dbch\af31505\loch\f43 
-official expansion for Civilization V created by the Community Patch Project team. It includes all necessary files in order for the modpack to function. }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 
-Please make sure to read all settings and options before clicking 'Next.'}{\rtlch\fcs1 \af43 \ltrch\fcs0 \f43\insrsid2511843 
-\par 
-\par }{\rtlch\fcs1 \af43\afs24 \ltrch\fcs0 \f43\fs24\insrsid2511843 
-\par }{\rtlch\fcs1 \ab\af43\afs24 \ltrch\fcs0 \b\f43\fs24\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 This Installer Includes:
-\par }{\rtlch\fcs1 \af43\afs24 \ltrch\fcs0 \f43\fs24\insrsid2511843 
-\par {\pntext\pard\plain\ltrpar \rtlch\fcs1 \af43 \ltrch\fcs0 \f3\insrsid2511843 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard \ltrpar\ql \fi-360\li720\ri0\nowidctlpar\wrapdefault{\*\pn \pnlvlblt\ilvl0\ls1\pnrnot0\pnf3 {\pntxtb \'b7}}
-\faauto\ls1\rin0\lin720\itap0\pararsid9663479 {\rtlch\fcs1 \af43\afs24 \ltrch\fcs0 \f43\fs24\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 (1) Community Patch
-\par {\pntext\pard\plain\ltrpar \rtlch\fcs1 \af43 \ltrch\fcs0 \f3\insrsid2511843 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard \ltrpar\ql \fi-360\li720\ri0\nowidctlpar\wrapdefault{\*\pn \pnlvlblt\ilvl0\ls1\pnrnot0\pnf3 {\pntxtb \'b7}}
-\faauto\ls1\rin0\lin720\itap0\pararsid9663479 {\rtlch\fcs1 \af43\afs24 \ltrch\fcs0 \f43\fs24\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 (2) Community Balance Overhaul
-\par {\pntext\pard\plain\ltrpar \rtlch\fcs1 \af43 \ltrch\fcs0 \f3\insrsid2511843 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard \ltrpar\ql \fi-360\li720\ri0\nowidctlpar\wrapdefault{\*\pn \pnlvlblt\ilvl0\ls1\pnrnot0\pnf3 {\pntxtb \'b7}}
-\faauto\ls1\rin0\lin720\itap0\pararsid9663479 {\rtlch\fcs1 \af43\afs24 \ltrch\fcs0 \f43\fs24\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 (3) City-State Diplomacy
-\par {\pntext\pard\plain\ltrpar \rtlch\fcs1 \af43 \ltrch\fcs0 \f3\insrsid2511843 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard \ltrpar\ql \fi-360\li720\ri0\nowidctlpar\wrapdefault{\*\pn \pnlvlblt\ilvl0\ls1\pnrnot0\pnf3 {\pntxtb \'b7}}
-\faauto\ls1\rin0\lin720\itap0\pararsid9663479 {\rtlch\fcs1 \af43\afs24 \ltrch\fcs0 \f43\fs24\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 (4) Civ 4 Diplomacy Features
-\par {\pntext\pard\plain\ltrpar \rtlch\fcs1 \af43 \ltrch\fcs0 \f3\insrsid2511843 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard \ltrpar\ql \fi-360\li720\ri0\nowidctlpar\wrapdefault{\*\pn \pnlvlblt\ilvl0\ls1\pnrnot0\pnf3 {\pntxtb \'b7}}
-\faauto\ls1\rin0\lin720\itap0\pararsid9663479 {\rtlch\fcs1 \af43\afs24 \ltrch\fcs0 \f43\fs24\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 (5) More Luxuries
-\par {\pntext\pard\plain\ltrpar \rtlch\fcs1 \af43 \ltrch\fcs0 \f3\insrsid2511843 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard \ltrpar\ql \fi-360\li720\ri0\nowidctlpar\wrapdefault{\*\pn \pnlvlblt\ilvl0\ls1\pnrnot0\pnf3 {\pntxtb \'b7}}
-\faauto\ls1\rin0\lin720\itap0\pararsid9663479 {\rtlch\fcs1 \af43\afs24 \ltrch\fcs0 \f43\fs24\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 (6a) Community Balance Overhaul - }{\rtlch\fcs1 \af43\afs24 \ltrch\fcs0 \f43\fs24\insrsid6383461 
-\hich\af43\dbch\af31505\loch\f43 Compatibility}{\rtlch\fcs1 \af43\afs24 \ltrch\fcs0 \f43\fs24\insrsid2511843 \hich\af43\dbch\af31505\loch\f43  Files (EUI)
-\par {\pntext\pard\plain\ltrpar \rtlch\fcs1 \af43 \ltrch\fcs0 \f3\insrsid2511843 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard \ltrpar\ql \fi-360\li720\ri0\nowidctlpar\wrapdefault{\*\pn \pnlvlblt\ilvl0\ls1\pnrnot0\pnf3 {\pntxtb \'b7}}
-\faauto\ls1\rin0\lin720\itap0\pararsid9663479 {\rtlch\fcs1 \af43\afs24 \ltrch\fcs0 \f43\fs24\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 (6b) Community Balance Overhaul - }{\rtlch\fcs1 \af43\afs24 \ltrch\fcs0 \f43\fs24\insrsid6383461 
-\hich\af43\dbch\af31505\loch\f43 Compatibility}{\rtlch\fcs1 \af43\afs24 \ltrch\fcs0 \f43\fs24\insrsid2511843 \hich\af43\dbch\af31505\loch\f43  Files\hich\af43\dbch\af31505\loch\f43  (No-EUI)
-\par {\pntext\pard\plain\ltrpar \rtlch\fcs1 \af43 \ltrch\fcs0 \f3\insrsid2511843 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard \ltrpar\ql \fi-360\li720\ri0\nowidctlpar\wrapdefault{\*\pn \pnlvlblt\ilvl0\ls1\pnrnot0\pnf3 {\pntxtb \'b7}}
-\faauto\ls1\rin0\lin720\itap0\pararsid9663479 {\rtlch\fcs1 \af43\afs24 \ltrch\fcs0 \f43\fs24\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 (6c) Community Patch - 43 Civs Edition
-\par {\pntext\pard\plain\ltrpar \rtlch\fcs1 \af43 \ltrch\fcs0 \f3\insrsid2511843 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard \ltrpar\ql \fi-360\li720\ri0\nowidctlpar\wrapdefault{\*\pn \pnlvlblt\ilvl0\ls1\pnrnot0\pnf3 {\pntxtb \'b7}}
-\faauto\ls1\rin0\lin720\itap0\pararsid9663479 {\rtlch\fcs1 \af43\afs24 \ltrch\fcs0 \f43\fs24\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 EUI 1.28h}{\rtlch\fcs1 \af43 \ltrch\fcs0 \f43\insrsid2511843 
-\par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault{\*\pn \pnlvlcont\ilvl0\ls0\pnrnot0\pndec }\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af43 \ltrch\fcs0 \f43\insrsid2511843 
-\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 Installation Requirements:
-\par {\pntext\pard\plain\ltrpar \rtlch\fcs1 \af43\afs22 \ltrch\fcs0 \f3\fs22\insrsid2511843 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard \ltrpar\ql \fi-360\li720\ri0\nowidctlpar\wrapdefault{\*\pn \pnlvlblt\ilvl0\ls1\pnrnot0\pnf3 {\pntxtb \'b7}}
-\faauto\ls1\rin0\lin720\itap0\pararsid9663479 {\rtlch\fcs1 \af43 \ltrch\fcs0 \f43\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 Civilization V (Version .279)
-\par {\pntext\pard\plain\ltrpar \rtlch\fcs1 \af43\afs22 \ltrch\fcs0 \f3\fs22\insrsid2511843 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard \ltrpar\ql \fi-360\li720\ri0\nowidctlpar\wrapdefault{\*\pn \pnlvlblt\ilvl0\ls1\pnrnot0\pnf3 {\pntxtb \'b7}}
-\faauto\ls1\rin0\lin720\itap0\pararsid9663479 {\rtlch\fcs1 \af43 \ltrch\fcs0 \f43\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 All Leader DLC (Spain+Inca, Korea, Denmark, Mongols, Polynesia)
-\par {\pntext\pard\plain\ltrpar \rtlch\fcs1 \af43\afs22 \ltrch\fcs0 \f3\fs22\insrsid2511843 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard \ltrpar\ql \fi-360\li720\ri0\nowidctlpar\wrapdefault{\*\pn \pnlvlblt\ilvl0\ls1\pnrnot0\pnf3 {\pntxtb \'b7}}
-\faauto\ls1\rin0\lin720\itap0\pararsid9663479 {\rtlch\fcs1 \af43 \ltrch\fcs0 \f43\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 Ancient Wonders DLC
-\par {\pntext\pard\plain\ltrpar \rtlch\fcs1 \af43\afs22 \ltrch\fcs0 \f3\fs22\insrsid2511843 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard \ltrpar\ql \fi-360\li720\ri0\nowidctlpar\wrapdefault{\*\pn \pnlvlblt\ilvl0\ls1\pnrnot0\pnf3 {\pntxtb \'b7}}
-\faauto\ls1\rin0\lin720\itap0\pararsid9663479 {\rtlch\fcs1 \af43 \ltrch\fcs0 \f43\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 Gods and Kings + Brave New World
-\par {\pntext\pard\plain\ltrpar \rtlch\fcs1 \af43\afs22 \ltrch\fcs0 \f3\fs22\insrsid2511843 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard \ltrpar\ql \fi-360\li720\ri0\nowidctlpar\wrapdefault{\*\pn \pnlvlblt\ilvl0\ls1\pnrnot0\pnf3 {\pntxtb \'b7}}
-\faauto\ls1\rin0\lin720\itap0\pararsid9663479 {\rtlch\fcs1 \af43 \ltrch\fcs0 \f43\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 Windows 7 or greater
-\par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault{\*\pn \pnlvlcont\ilvl0\ls0\pnrnot0\pndec }\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\insrsid2511843 
-\par \hich\af43\dbch\af31505\loch\f43 Important Information: 
-\par {\pntext\pard\plain\ltrpar \rtlch\fcs1 \af43\afs22 \ltrch\fcs0 \f3\fs22\insrsid2511843 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard \ltrpar\ql \fi-360\li720\ri0\nowidctlpar\wrapdefault{\*\pn \pnlvlblt\ilvl0\ls1\pnrnot0\pnf3 {\pntxtb \'b7}}
-\faauto\ls1\rin0\lin720\itap0\pararsid9663479 {\rtlch\fcs1 \af43 \ltrch\fcs0 \f43\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 
-If you have manually moved the MODS folder out of your Documents/My Games/Civilization 5 folder, this installer will not work!
-\par {\pntext\pard\plain\ltrpar \rtlch\fcs1 \af43\afs22 \ltrch\fcs0 \f3\fs22\insrsid2511843 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard \ltrpar\ql \fi-360\li720\ri0\nowidctlpar\wrapdefault{\*\pn \pnlvlblt\ilvl0\ls1\pnrnot0\pnf3 {\pntxtb \'b7}}
-\faauto\ls1\rin0\lin720\itap0\pararsid9663479 {\rtlch\fcs1 \af43 \ltrch\fcs0 \f43\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 Installer automatically detects and delet\hich\af43\dbch\af31505\loch\f43 
-es cache files as well as older versions of this mod. No need to manually delete older files or to clear your cache!
-\par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault{\*\pn \pnlvlcont\ilvl0\ls0\pnrnot0\pndec }\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af43 \ltrch\fcs0 \f43\insrsid2511843 
-\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 Installation Options:
-\par {\pntext\pard\plain\ltrpar \rtlch\fcs1 \ab\af43\afs22 \ltrch\fcs0 \f3\fs22\insrsid2511843 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard \ltrpar\ql \fi-360\li720\ri0\nowidctlpar\wrapdefault{\*\pn \pnlvlblt\ilvl0\ls1\pnrnot0\pnf3 {\pntxtb \'b7}}
-\faauto\ls1\rin0\lin720\itap0\pararsid9663479 {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 Core: }{\rtlch\fcs1 \af43 \ltrch\fcs0 \f43\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 
-Installs only the Community Patch. Use this option if you only want the basic AI and bugfix changes.
-\par {\pntext\pard\plain\ltrpar \rtlch\fcs1 \ab\af43\afs22 \ltrch\fcs0 \f3\fs22\insrsid2511843 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard \ltrpar\ql \fi-360\li720\ri0\nowidctlpar\wrapdefault{\*\pn \pnlvlblt\ilvl0\ls1\pnrnot0\pnf3 {\pntxtb \'b7}}
-\faauto\ls1\rin0\lin720\itap0\pararsid9663479 {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 Bas\hich\af43\dbch\af31505\loch\f43 ic: }{\rtlch\fcs1 \af43 \ltrch\fcs0 \f43\insrsid2511843 
-\hich\af43\dbch\af31505\loch\f43 Installs the Community Patch and the Community Balance }{\rtlch\fcs1 \af43\afs24 \ltrch\fcs0 \f43\fs24\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 Overhaul}{\rtlch\fcs1 \af43 \ltrch\fcs0 \f43\insrsid2511843 .
-\par {\pntext\pard\plain\ltrpar \rtlch\fcs1 \ab\af43\afs22 \ltrch\fcs0 \f3\fs22\insrsid2511843 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard \ltrpar\ql \fi-360\li720\ri0\nowidctlpar\wrapdefault{\*\pn \pnlvlblt\ilvl0\ls1\pnrnot0\pnf3 {\pntxtb \'b7}}
-\faauto\ls1\rin0\lin720\itap0\pararsid9663479 {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 Full with EUI: }{\rtlch\fcs1 \af43 \ltrch\fcs0 \f43\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 
-Installs all aspects of Vox Populi, including EUI. Uses the registry to find your Civilization V install directory in order to install EUI.
-\par {\pntext\pard\plain\ltrpar \rtlch\fcs1 \ab\af43\afs22 \ltrch\fcs0 \f3\fs22\insrsid2511843 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard \ltrpar\ql \fi-360\li1080\ri0\nowidctlpar\wrapdefault{\*\pn \pnlvlblt\ilvl0\ls1\pnrnot0\pnf3 {\pntxtb \'b7}}
-\faauto\ls1\rin0\lin1080\itap0\pararsid9663479 {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 NOTE: }{\rtlch\fcs1 \af43 \ltrch\fcs0 \f43\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 If your registry doe
-\hich\af43\dbch\af31505\loch\f43 s not match the current location of Civilization V on your computer, EUI will }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 NOT}{\rtlch\fcs1 \af43 \ltrch\fcs0 
-\f43\insrsid2511843 \hich\af43\dbch\af31505\loch\f43  install correctly! This can happen if you have copy/pasted your Civilization V folder without running the game, or if you are using a bootleg copy.
-\par {\pntext\pard\plain\ltrpar \rtlch\fcs1 \ab\af43\afs22 \ltrch\fcs0 \f3\fs22\insrsid2511843 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard \ltrpar\ql \fi-360\li720\ri0\nowidctlpar\wrapdefault{\*\pn \pnlvlblt\ilvl0\ls1\pnrnot0\pnf3 {\pntxtb \'b7}}
-\faauto\ls1\rin0\lin720\itap0\pararsid9663479 {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 Full with no-EUI: }{\rtlch\fcs1 \af43 \ltrch\fcs0 \f43\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 Insta
-\hich\af43\dbch\af31505\loch\f43 lls all aspects of the Vox Populi, but skips EUI.}{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\insrsid2511843 
-\par {\pntext\pard\plain\ltrpar \rtlch\fcs1 \ab\af43\afs22 \ltrch\fcs0 \f3\fs22\insrsid2511843 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard \ltrpar\ql \fi-360\li720\ri0\nowidctlpar\wrapdefault{\*\pn \pnlvlblt\ilvl0\ls1\pnrnot0\pnf3 {\pntxtb \'b7}}
-\faauto\ls1\rin0\lin720\itap0\pararsid9663479 {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 43 Civ CP Only: }{\rtlch\fcs1 \af43 \ltrch\fcs0 \f43\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 
-Installs a version of the Community Patch that supports up to 43 Major Civilizations}{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\insrsid2511843 
-\par {\pntext\pard\plain\ltrpar \rtlch\fcs1 \ab\af43\afs22 \ltrch\fcs0 \f3\fs22\insrsid2511843 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard \ltrpar\ql \fi-360\li720\ri0\nowidctlpar\wrapdefault{\*\pn \pnlvlblt\ilvl0\ls1\pnrnot0\pnf3 {\pntxtb \'b7}}
-\faauto\ls1\rin0\lin720\itap0\pararsid9663479 {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 43 Civ Vox Populi No-EUI: }{\rtlch\fcs1 \af43 \ltrch\fcs0 \f43\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 
-Installs a version of Vox Populi without EUI that supports up to 43 Major\hich\af43\dbch\af31505\loch\f43  Civilizations}{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\insrsid2511843 
-\par {\pntext\pard\plain\ltrpar \rtlch\fcs1 \ab\af43\afs22 \ltrch\fcs0 \f3\fs22\insrsid2511843 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard \ltrpar\ql \fi-360\li720\ri0\nowidctlpar\wrapdefault{\*\pn \pnlvlblt\ilvl0\ls1\pnrnot0\pnf3 {\pntxtb \'b7}}
-\faauto\ls1\rin0\lin720\itap0\pararsid9663479 {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 43 Civ Vox Populi EUI: }{\rtlch\fcs1 \af43 \ltrch\fcs0 \f43\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 
-Installs a version of Vox Populi with EUI that supports up to 43 Major Civilizations}{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\insrsid2511843 
-\par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault{\*\pn \pnlvlcont\ilvl0\ls0\pnrnot0\pndec }\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\insrsid2511843 
-\par \hich\af43\dbch\af31505\loch\f43 Uninstallation Instructions:
-\par {\pntext\pard\plain\ltrpar \rtlch\fcs1 \ab\af43\afs22 \ltrch\fcs0 \f3\fs22\insrsid2511843 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard \ltrpar\ql \fi-360\li720\ri0\nowidctlpar\wrapdefault{\*\pn \pnlvlblt\ilvl0\ls1\pnrnot0\pnf3 {\pntxtb \'b7}}
-\faauto\ls1\rin0\lin720\itap0\pararsid9663479 {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 Full/43 Civ with EUI: }{\rtlch\fcs1 \af43 \ltrch\fcs0 \f43\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 
-Delete all mods listed above in your Documents/My Games/Civ 5/MODS folder. \hich\af43\dbch\af31505\loch\f43 Delete ui_bc1 in your DLC folder of your civ install.}{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\insrsid2511843 
-\par {\pntext\pard\plain\ltrpar \rtlch\fcs1 \ab\af43\afs22 \ltrch\fcs0 \f3\fs22\insrsid2511843 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard \ltrpar\ql \fi-360\li720\ri0\nowidctlpar\wrapdefault{\*\pn \pnlvlblt\ilvl0\ls1\pnrnot0\pnf3 {\pntxtb \'b7}}
-\faauto\ls1\rin0\lin720\itap0\pararsid9663479 {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 Full/43 Civ with no-EUI: }{\rtlch\fcs1 \af43 \ltrch\fcs0 \f43\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 
-Delete all mods listed above in your Documents/My Games/Civ 5/MODS folder.}{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\insrsid2511843 
-\par {\pntext\pard\plain\ltrpar \rtlch\fcs1 \ab\af43\afs22 \ltrch\fcs0 \f3\fs22\insrsid2511843 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard \ltrpar\ql \fi-360\li720\ri0\nowidctlpar\wrapdefault{\*\pn \pnlvlblt\ilvl0\ls1\pnrnot0\pnf3 {\pntxtb \'b7}}
-\faauto\ls1\rin0\lin720\itap0\pararsid9663479 {\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 Core, Basic, or 43 Civ CP Only: }{\rtlch\fcs1 \af43 \ltrch\fcs0 \f43\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 
-Delete all mods in your Documents/My Games/Civ 5/MODS folder.}{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\insrsid2511843 
-\par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 {\rtlch\fcs1 \af43\afs24 \ltrch\fcs0 \f43\fs24\insrsid2511843 
-\par }{\rtlch\fcs1 \ab\af43\afs24 \ltrch\fcs0 \b\f43\fs24\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 Final Notes:
-\par }{\rtlch\fcs1 \af43\afs24 \ltrch\fcs0 \f43\fs24\insrsid2511843 
-\par \hich\af43\dbch\af31505\loch\f43 If you have any questions or concerns, make sure to visit the Community Patch Project Forums: }{\field{\*\fldinst {\rtlch\fcs1 \af43\afs24 \ltrch\fcs0 \f43\fs24\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 
-HYPERLINK http://forums.civfanatics.com/forumdisplay.php?f=497\\\\par }{\rtlch\fcs1 \af43\afs24 \ltrch\fcs0 \f43\fs24\insrsid9663479 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b8a00000068007400740070003a002f002f0066006f00720075006d0073002e00630069007600660061006e00610074006900630073002e0063006f006d002f0066006f00720075006d0064006900730070006c006100
-79002e007000680070003f0066003d003400390037005c007000610072000000795881f43b1d7f48af2c825dc485276300000000a5ab000300726d390061006c002802330000003631000000002c006b444100ff0022003b34010173004c00}}}{\fldrslt {\rtlch\fcs1 \af43\afs24 \ltrch\fcs0 
-\f43\fs24\insrsid2511843 \hich\af43\dbch\af31505\loch\f43 http://forums.civfanatics.com/forumdisplay.php?f=497\\par}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \ab\af43\afs24 \ltrch\fcs0 \b\f43\fs24\insrsid2511843 
-\par }{\rtlch\fcs1 \ab\af43 \ltrch\fcs0 \b\f43\insrsid2511843 
-\par 
-\par }{\*\themedata 504b030414000600080000002100e9de0fbfff0000001c020000130000005b436f6e74656e745f54797065735d2e786d6cac91cb4ec3301045f748fc83e52d4a
-9cb2400825e982c78ec7a27cc0c8992416c9d8b2a755fbf74cd25442a820166c2cd933f79e3be372bd1f07b5c3989ca74aaff2422b24eb1b475da5df374fd9ad
-5689811a183c61a50f98f4babebc2837878049899a52a57be670674cb23d8e90721f90a4d2fa3802cb35762680fd800ecd7551dc18eb899138e3c943d7e503b6
-b01d583deee5f99824e290b4ba3f364eac4a430883b3c092d4eca8f946c916422ecab927f52ea42b89a1cd59c254f919b0e85e6535d135a8de20f20b8c12c3b0
-0c895fcf6720192de6bf3b9e89ecdbd6596cbcdd8eb28e7c365ecc4ec1ff1460f53fe813d3cc7f5b7f020000ffff0300504b030414000600080000002100a5d6
-a7e7c0000000360100000b0000005f72656c732f2e72656c73848fcf6ac3300c87ef85bd83d17d51d2c31825762fa590432fa37d00e1287f68221bdb1bebdb4f
-c7060abb0884a4eff7a93dfeae8bf9e194e720169aaa06c3e2433fcb68e1763dbf7f82c985a4a725085b787086a37bdbb55fbc50d1a33ccd311ba548b6309512
-0f88d94fbc52ae4264d1c910d24a45db3462247fa791715fd71f989e19e0364cd3f51652d73760ae8fa8c9ffb3c330cc9e4fc17faf2ce545046e37944c69e462
-a1a82fe353bd90a865aad41ed0b5b8f9d6fd010000ffff0300504b0304140006000800000021006b799616830000008a0000001c0000007468656d652f746865
-6d652f7468656d654d616e616765722e786d6c0ccc4d0ac3201040e17da17790d93763bb284562b2cbaebbf600439c1a41c7a0d29fdbd7e5e38337cedf14d59b
-4b0d592c9c070d8a65cd2e88b7f07c2ca71ba8da481cc52c6ce1c715e6e97818c9b48d13df49c873517d23d59085adb5dd20d6b52bd521ef2cdd5eb9246a3d8b
-4757e8d3f729e245eb2b260a0238fd010000ffff0300504b030414000600080000002100b6f4679893070000c9200000160000007468656d652f7468656d652f
-7468656d65312e786d6cec59cd8b1bc915bf07f23f347d97f5d5ad8fc1f2a24fcfda33b6b164873dd648a5eef2547789aad28cc56208de532e81c026e49085bd
-ed21842cecc22eb9e48f31d8249b3f22afaa5bdd5552c99e191c3061463074977eefd5afde7bf5de53d5ddcf5e26d4bbc05c1096f6fcfa9d9aefe174ce16248d
-7afeb3d9a4d2f13d2151ba4094a5b8e76fb0f03fbbf7eb5fdd454732c609f6403e1547a8e7c752ae8eaa5531876124eeb0154ee1bb25e30992f0caa3ea82a34b
-d09bd06aa3566b55134452df4b51026a1f2f97648ebd9952e9dfdb2a1f53784da5500373caa74a35b6243476715e5708b11143cabd0b447b3eccb3609733fc52
-fa1e4542c2173dbfa6fffceabdbb5574940b517940d6909be8bf5c2e17589c37f49c3c3a2b260d823068f50bfd1a40e53e6edc1eb7c6ad429f06a0f91c569a71
-b175b61bc320c71aa0ecd1a17bd41e35eb16ded0dfdce3dc0fd5c7c26b50a63fd8c34f2643b0a285d7a00c1feee1c3417730b2f56b50866fede1dbb5fe28685b
-fa3528a6243ddf43d7c25673b85d6d0159327aec8477c360d26ee4ca4b144443115d6a8a254be5a1584bd00bc6270050408a24493db959e1259a43140f112567
-9c7827248a21f056286502866b8ddaa4d684ffea13e827ed5174849121ad780113b137a4f87862cec94af6fc07a0d537206f7ffef9cdeb1fdfbcfee9cd575fbd
-79fdf77c6eadca923b466964cafdf2dd1ffef3cd6fbd7ffff0ed2f5fff319b7a172f4cfcbbbffdeedd3ffef93ef5b0e2d2146ffff4fdbb1fbf7ffbe7dfffebaf
-5f3bb4f7393a33e1339260e13dc297de5396c0021dfcf119bf9ec42c46c494e8a791402952b338f48f656ca11f6d10450edc00db767cce21d5b880f7d72f2cc2
-d398af2571687c182716f094313a60dc6985876a2ec3ccb3751ab927e76b13f714a10bd7dc43945a5e1eaf579063894be530c616cd2714a5124538c5d253dfb1
-738c1dabfb8210cbaea764ce99604be97d41bc01224e93ccc899154da5d03149c02f1b1741f0b7659bd3e7de8051d7aa47f8c246c2de40d4417e86a965c6fb68
-2d51e252394309350d7e8264ec2239ddf0b9891b0b099e8e3065de78818570c93ce6b05ec3e90f21cdb8dd7e4a37898de4929cbb749e20c64ce4889d0f6394ac
-5cd829496313fbb938871045de13265df05366ef10f50e7e40e941773f27d872f787b3c133c8b026a53240d4376beef0e57dccacf89d6ee8126157aae9f3c44a
-b17d4e9cd131584756689f604cd1255a60ec3dfbdcc160c05696cd4bd20f62c82ac7d815580f901dabea3dc5027a25d5dcece7c91322ac909de2881de073bad9
-493c1b9426881fd2fc08bc6eda7c0ca52e7105c0633a3f37818f08f480102f4ea33c16a0c308ee835a9fc4c82a60ea5db8e375c32dff5d658fc1be7c61d1b8c2
-be04197c6d1948eca6cc7b6d3343d49aa00c9819822ec3956e41c4727f29a28aab165b3be596f6a62ddd00dd91d5f42424fd6007b4d3fb84ffbbde073a8cb77f
-f9c6b10f3e4ebfe3566c25ab6b763a8792c9f14e7f7308b7dbd50c195f904fbfa919a175fa04431dd9cf58b73dcd6d4fe3ffdff73487f6f36d2773a8dfb8ed64
-7ce8306e3b99fc70e5e3743265f3027d8d3af0c80e7af4b14f72f0d46749289dca0dc527421ffc08f83db398c0a092d3279eb838055cc5f0a8ca1c4c60e1228e
-b48cc799fc0d91f134462b381daafb4a492472d591f0564cc0a1911e76ea5678ba4e4ed9223becacd7d5c16656590592e5782d2cc6e1a04a66e856bb3cc02bd4
-6bb6913e68dd1250b2d721614c6693683a48b4b783ca48fa58178ce620a157f65158741d2c3a4afdd6557b2c805ae115f8c1edc1cff49e1f06200242701e07cd
-f942f92973f5d6bbda991fd3d3878c69450034d8db08283ddd555c0f2e4fad2e0bb52b78da2261849b4d425b46377822869fc17974aad1abd0b8aeafbba54b2d
-7aca147a3e08ad9246bbf33e1637f535c8ede6069a9a9982a6de65cf6f35430899395af5fc251c1ac363b282d811ea3717a211dcbccc25cf36fc4d32cb8a0b39
-4222ce0cae934e960d122231f728497abe5a7ee1069aea1ca2b9d51b90103e59725d482b9f1a3970baed64bc5ce2b934dd6e8c284b67af90e1b35ce1fc568bdf
-1cac24d91adc3d8d1797de195df3a708422c6cd795011744c0dd413db3e682c0655891c8caf8db294c79da356fa3740c65e388ae62945714339967709dca0b3a
-faadb081f196af190c6a98242f8467912ab0a651ad6a5a548d8cc3c1aafb6121653923699635d3ca2aaa6abab39835c3b60cecd8f26645de60b53531e434b3c2
-67a97b37e576b7b96ea74f28aa0418bcb09fa3ea5ea12018d4cac92c6a8af17e1a56393b1fb56bc776811fa07695226164fdd656ed8edd8a1ae19c0e066f54f9
-416e376a6168b9ed2bb5a5f5adb979b1cdce5e40f2184197bba6526857c2c92e47d0104d754f92a50dd8222f65be35e0c95b73d2f3bfac85fd60d80887955a27
-1c57826650ab74c27eb3d20fc3667d1cd66ba341e31514161927f530bbb19fc00506dde4f7f67a7cefee3ed9ded1dc99b3a4caf4dd7c5513d777f7f5c6e1bb7b
-8f40d2f9b2d598749bdd41abd26df627956034e854bac3d6a0326a0ddba3c9681876ba9357be77a1c141bf390c5ae34ea5551f0e2b41aba6e877ba9576d068f4
-8376bf330efaaff23606569ea58fdc16605ecdebde7f010000ffff0300504b0304140006000800000021000dd1909fb60000001b010000270000007468656d65
-2f7468656d652f5f72656c732f7468656d654d616e616765722e786d6c2e72656c73848f4d0ac2301484f78277086f6fd3ba109126dd88d0add40384e4350d36
-3f2451eced0dae2c082e8761be9969bb979dc9136332de3168aa1a083ae995719ac16db8ec8e4052164e89d93b64b060828e6f37ed1567914b284d262452282e
-3198720e274a939cd08a54f980ae38a38f56e422a3a641c8bbd048f7757da0f19b017cc524bd62107bd5001996509affb3fd381a89672f1f165dfe514173d985
-0528a2c6cce0239baa4c04ca5bbabac4df000000ffff0300504b01022d0014000600080000002100e9de0fbfff0000001c020000130000000000000000000000
-0000000000005b436f6e74656e745f54797065735d2e786d6c504b01022d0014000600080000002100a5d6a7e7c0000000360100000b00000000000000000000
-000000300100005f72656c732f2e72656c73504b01022d00140006000800000021006b799616830000008a0000001c0000000000000000000000000019020000
-7468656d652f7468656d652f7468656d654d616e616765722e786d6c504b01022d0014000600080000002100b6f4679893070000c92000001600000000000000
-000000000000d60200007468656d652f7468656d652f7468656d65312e786d6c504b01022d00140006000800000021000dd1909fb60000001b01000027000000
-000000000000000000009d0a00007468656d652f7468656d652f5f72656c732f7468656d654d616e616765722e786d6c2e72656c73504b050600000000050005005d010000980b00000000}
-{\*\colorschememapping 3c3f786d6c2076657273696f6e3d22312e302220656e636f64696e673d225554462d3822207374616e64616c6f6e653d22796573223f3e0d0a3c613a636c724d
-617020786d6c6e733a613d22687474703a2f2f736368656d61732e6f70656e786d6c666f726d6174732e6f72672f64726177696e676d6c2f323030362f6d6169
-6e22206267313d226c743122207478313d22646b3122206267323d226c743222207478323d22646b322220616363656e74313d22616363656e74312220616363
-656e74323d22616363656e74322220616363656e74333d22616363656e74332220616363656e74343d22616363656e74342220616363656e74353d22616363656e74352220616363656e74363d22616363656e74362220686c696e6b3d22686c696e6b2220666f6c486c696e6b3d22666f6c486c696e6b222f3e}
-{\*\latentstyles\lsdstimax376\lsdlockeddef0\lsdsemihiddendef0\lsdunhideuseddef0\lsdqformatdef0\lsdprioritydef99{\lsdlockedexcept \lsdqformat1 \lsdpriority0 \lsdlocked0 Normal;\lsdqformat1 \lsdpriority9 \lsdlocked0 heading 1;
-\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 2;\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 3;\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 4;
-\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 5;\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 6;\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 7;
-\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 8;\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 9;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 index 1;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 index 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 index 3;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 index 4;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 index 5;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 index 6;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 index 7;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 index 8;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 index 9;
-\lsdsemihidden1 \lsdunhideused1 \lsdpriority39 \lsdlocked0 toc 1;\lsdsemihidden1 \lsdunhideused1 \lsdpriority39 \lsdlocked0 toc 2;\lsdsemihidden1 \lsdunhideused1 \lsdpriority39 \lsdlocked0 toc 3;
-\lsdsemihidden1 \lsdunhideused1 \lsdpriority39 \lsdlocked0 toc 4;\lsdsemihidden1 \lsdunhideused1 \lsdpriority39 \lsdlocked0 toc 5;\lsdsemihidden1 \lsdunhideused1 \lsdpriority39 \lsdlocked0 toc 6;
-\lsdsemihidden1 \lsdunhideused1 \lsdpriority39 \lsdlocked0 toc 7;\lsdsemihidden1 \lsdunhideused1 \lsdpriority39 \lsdlocked0 toc 8;\lsdsemihidden1 \lsdunhideused1 \lsdpriority39 \lsdlocked0 toc 9;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Normal Indent;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 footnote text;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 annotation text;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 header;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 footer;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 index heading;\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority35 \lsdlocked0 caption;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 table of figures;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 envelope address;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 envelope return;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 footnote reference;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 annotation reference;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 line number;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 page number;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 endnote reference;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 endnote text;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 table of authorities;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 macro;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 toa heading;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Bullet;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Number;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List 3;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List 4;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List 5;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Bullet 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Bullet 3;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Bullet 4;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Bullet 5;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Number 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Number 3;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Number 4;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Number 5;\lsdqformat1 \lsdpriority10 \lsdlocked0 Title;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Closing;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Signature;\lsdsemihidden1 \lsdunhideused1 \lsdpriority1 \lsdlocked0 Default Paragraph Font;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Body Text;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Body Text Indent;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Continue;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Continue 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Continue 3;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Continue 4;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 List Continue 5;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Message Header;\lsdqformat1 \lsdpriority11 \lsdlocked0 Subtitle;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Salutation;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Date;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Body Text First Indent;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Body Text First Indent 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Note Heading;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Body Text 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Body Text 3;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Body Text Indent 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Body Text Indent 3;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Block Text;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Hyperlink;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 FollowedHyperlink;\lsdqformat1 \lsdpriority22 \lsdlocked0 Strong;
-\lsdqformat1 \lsdpriority20 \lsdlocked0 Emphasis;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Document Map;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Plain Text;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 E-mail Signature;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Top of Form;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Bottom of Form;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Normal (Web);\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Acronym;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Address;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Cite;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Code;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Definition;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Keyboard;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Preformatted;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Sample;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Typewriter;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 HTML Variable;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 annotation subject;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 No List;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Outline List 1;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Outline List 2;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Outline List 3;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Balloon Text;\lsdpriority39 \lsdlocked0 Table Grid;
-\lsdsemihidden1 \lsdlocked0 Placeholder Text;\lsdqformat1 \lsdpriority1 \lsdlocked0 No Spacing;\lsdpriority60 \lsdlocked0 Light Shading;\lsdpriority61 \lsdlocked0 Light List;\lsdpriority62 \lsdlocked0 Light Grid;
-\lsdpriority63 \lsdlocked0 Medium Shading 1;\lsdpriority64 \lsdlocked0 Medium Shading 2;\lsdpriority65 \lsdlocked0 Medium List 1;\lsdpriority66 \lsdlocked0 Medium List 2;\lsdpriority67 \lsdlocked0 Medium Grid 1;\lsdpriority68 \lsdlocked0 Medium Grid 2;
-\lsdpriority69 \lsdlocked0 Medium Grid 3;\lsdpriority70 \lsdlocked0 Dark List;\lsdpriority71 \lsdlocked0 Colorful Shading;\lsdpriority72 \lsdlocked0 Colorful List;\lsdpriority73 \lsdlocked0 Colorful Grid;\lsdpriority60 \lsdlocked0 Light Shading Accent 1;
-\lsdpriority61 \lsdlocked0 Light List Accent 1;\lsdpriority62 \lsdlocked0 Light Grid Accent 1;\lsdpriority63 \lsdlocked0 Medium Shading 1 Accent 1;\lsdpriority64 \lsdlocked0 Medium Shading 2 Accent 1;\lsdpriority65 \lsdlocked0 Medium List 1 Accent 1;
-\lsdsemihidden1 \lsdlocked0 Revision;\lsdqformat1 \lsdpriority34 \lsdlocked0 List Paragraph;\lsdqformat1 \lsdpriority29 \lsdlocked0 Quote;\lsdqformat1 \lsdpriority30 \lsdlocked0 Intense Quote;\lsdpriority66 \lsdlocked0 Medium List 2 Accent 1;
-\lsdpriority67 \lsdlocked0 Medium Grid 1 Accent 1;\lsdpriority68 \lsdlocked0 Medium Grid 2 Accent 1;\lsdpriority69 \lsdlocked0 Medium Grid 3 Accent 1;\lsdpriority70 \lsdlocked0 Dark List Accent 1;\lsdpriority71 \lsdlocked0 Colorful Shading Accent 1;
-\lsdpriority72 \lsdlocked0 Colorful List Accent 1;\lsdpriority73 \lsdlocked0 Colorful Grid Accent 1;\lsdpriority60 \lsdlocked0 Light Shading Accent 2;\lsdpriority61 \lsdlocked0 Light List Accent 2;\lsdpriority62 \lsdlocked0 Light Grid Accent 2;
-\lsdpriority63 \lsdlocked0 Medium Shading 1 Accent 2;\lsdpriority64 \lsdlocked0 Medium Shading 2 Accent 2;\lsdpriority65 \lsdlocked0 Medium List 1 Accent 2;\lsdpriority66 \lsdlocked0 Medium List 2 Accent 2;
-\lsdpriority67 \lsdlocked0 Medium Grid 1 Accent 2;\lsdpriority68 \lsdlocked0 Medium Grid 2 Accent 2;\lsdpriority69 \lsdlocked0 Medium Grid 3 Accent 2;\lsdpriority70 \lsdlocked0 Dark List Accent 2;\lsdpriority71 \lsdlocked0 Colorful Shading Accent 2;
-\lsdpriority72 \lsdlocked0 Colorful List Accent 2;\lsdpriority73 \lsdlocked0 Colorful Grid Accent 2;\lsdpriority60 \lsdlocked0 Light Shading Accent 3;\lsdpriority61 \lsdlocked0 Light List Accent 3;\lsdpriority62 \lsdlocked0 Light Grid Accent 3;
-\lsdpriority63 \lsdlocked0 Medium Shading 1 Accent 3;\lsdpriority64 \lsdlocked0 Medium Shading 2 Accent 3;\lsdpriority65 \lsdlocked0 Medium List 1 Accent 3;\lsdpriority66 \lsdlocked0 Medium List 2 Accent 3;
-\lsdpriority67 \lsdlocked0 Medium Grid 1 Accent 3;\lsdpriority68 \lsdlocked0 Medium Grid 2 Accent 3;\lsdpriority69 \lsdlocked0 Medium Grid 3 Accent 3;\lsdpriority70 \lsdlocked0 Dark List Accent 3;\lsdpriority71 \lsdlocked0 Colorful Shading Accent 3;
-\lsdpriority72 \lsdlocked0 Colorful List Accent 3;\lsdpriority73 \lsdlocked0 Colorful Grid Accent 3;\lsdpriority60 \lsdlocked0 Light Shading Accent 4;\lsdpriority61 \lsdlocked0 Light List Accent 4;\lsdpriority62 \lsdlocked0 Light Grid Accent 4;
-\lsdpriority63 \lsdlocked0 Medium Shading 1 Accent 4;\lsdpriority64 \lsdlocked0 Medium Shading 2 Accent 4;\lsdpriority65 \lsdlocked0 Medium List 1 Accent 4;\lsdpriority66 \lsdlocked0 Medium List 2 Accent 4;
-\lsdpriority67 \lsdlocked0 Medium Grid 1 Accent 4;\lsdpriority68 \lsdlocked0 Medium Grid 2 Accent 4;\lsdpriority69 \lsdlocked0 Medium Grid 3 Accent 4;\lsdpriority70 \lsdlocked0 Dark List Accent 4;\lsdpriority71 \lsdlocked0 Colorful Shading Accent 4;
-\lsdpriority72 \lsdlocked0 Colorful List Accent 4;\lsdpriority73 \lsdlocked0 Colorful Grid Accent 4;\lsdpriority60 \lsdlocked0 Light Shading Accent 5;\lsdpriority61 \lsdlocked0 Light List Accent 5;\lsdpriority62 \lsdlocked0 Light Grid Accent 5;
-\lsdpriority63 \lsdlocked0 Medium Shading 1 Accent 5;\lsdpriority64 \lsdlocked0 Medium Shading 2 Accent 5;\lsdpriority65 \lsdlocked0 Medium List 1 Accent 5;\lsdpriority66 \lsdlocked0 Medium List 2 Accent 5;
-\lsdpriority67 \lsdlocked0 Medium Grid 1 Accent 5;\lsdpriority68 \lsdlocked0 Medium Grid 2 Accent 5;\lsdpriority69 \lsdlocked0 Medium Grid 3 Accent 5;\lsdpriority70 \lsdlocked0 Dark List Accent 5;\lsdpriority71 \lsdlocked0 Colorful Shading Accent 5;
-\lsdpriority72 \lsdlocked0 Colorful List Accent 5;\lsdpriority73 \lsdlocked0 Colorful Grid Accent 5;\lsdpriority60 \lsdlocked0 Light Shading Accent 6;\lsdpriority61 \lsdlocked0 Light List Accent 6;\lsdpriority62 \lsdlocked0 Light Grid Accent 6;
-\lsdpriority63 \lsdlocked0 Medium Shading 1 Accent 6;\lsdpriority64 \lsdlocked0 Medium Shading 2 Accent 6;\lsdpriority65 \lsdlocked0 Medium List 1 Accent 6;\lsdpriority66 \lsdlocked0 Medium List 2 Accent 6;
-\lsdpriority67 \lsdlocked0 Medium Grid 1 Accent 6;\lsdpriority68 \lsdlocked0 Medium Grid 2 Accent 6;\lsdpriority69 \lsdlocked0 Medium Grid 3 Accent 6;\lsdpriority70 \lsdlocked0 Dark List Accent 6;\lsdpriority71 \lsdlocked0 Colorful Shading Accent 6;
-\lsdpriority72 \lsdlocked0 Colorful List Accent 6;\lsdpriority73 \lsdlocked0 Colorful Grid Accent 6;\lsdqformat1 \lsdpriority19 \lsdlocked0 Subtle Emphasis;\lsdqformat1 \lsdpriority21 \lsdlocked0 Intense Emphasis;
-\lsdqformat1 \lsdpriority31 \lsdlocked0 Subtle Reference;\lsdqformat1 \lsdpriority32 \lsdlocked0 Intense Reference;\lsdqformat1 \lsdpriority33 \lsdlocked0 Book Title;\lsdsemihidden1 \lsdunhideused1 \lsdpriority37 \lsdlocked0 Bibliography;
-\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority39 \lsdlocked0 TOC Heading;\lsdpriority41 \lsdlocked0 Plain Table 1;\lsdpriority42 \lsdlocked0 Plain Table 2;\lsdpriority43 \lsdlocked0 Plain Table 3;\lsdpriority44 \lsdlocked0 Plain Table 4;
-\lsdpriority45 \lsdlocked0 Plain Table 5;\lsdpriority40 \lsdlocked0 Grid Table Light;\lsdpriority46 \lsdlocked0 Grid Table 1 Light;\lsdpriority47 \lsdlocked0 Grid Table 2;\lsdpriority48 \lsdlocked0 Grid Table 3;\lsdpriority49 \lsdlocked0 Grid Table 4;
-\lsdpriority50 \lsdlocked0 Grid Table 5 Dark;\lsdpriority51 \lsdlocked0 Grid Table 6 Colorful;\lsdpriority52 \lsdlocked0 Grid Table 7 Colorful;\lsdpriority46 \lsdlocked0 Grid Table 1 Light Accent 1;\lsdpriority47 \lsdlocked0 Grid Table 2 Accent 1;
-\lsdpriority48 \lsdlocked0 Grid Table 3 Accent 1;\lsdpriority49 \lsdlocked0 Grid Table 4 Accent 1;\lsdpriority50 \lsdlocked0 Grid Table 5 Dark Accent 1;\lsdpriority51 \lsdlocked0 Grid Table 6 Colorful Accent 1;
-\lsdpriority52 \lsdlocked0 Grid Table 7 Colorful Accent 1;\lsdpriority46 \lsdlocked0 Grid Table 1 Light Accent 2;\lsdpriority47 \lsdlocked0 Grid Table 2 Accent 2;\lsdpriority48 \lsdlocked0 Grid Table 3 Accent 2;
-\lsdpriority49 \lsdlocked0 Grid Table 4 Accent 2;\lsdpriority50 \lsdlocked0 Grid Table 5 Dark Accent 2;\lsdpriority51 \lsdlocked0 Grid Table 6 Colorful Accent 2;\lsdpriority52 \lsdlocked0 Grid Table 7 Colorful Accent 2;
-\lsdpriority46 \lsdlocked0 Grid Table 1 Light Accent 3;\lsdpriority47 \lsdlocked0 Grid Table 2 Accent 3;\lsdpriority48 \lsdlocked0 Grid Table 3 Accent 3;\lsdpriority49 \lsdlocked0 Grid Table 4 Accent 3;
-\lsdpriority50 \lsdlocked0 Grid Table 5 Dark Accent 3;\lsdpriority51 \lsdlocked0 Grid Table 6 Colorful Accent 3;\lsdpriority52 \lsdlocked0 Grid Table 7 Colorful Accent 3;\lsdpriority46 \lsdlocked0 Grid Table 1 Light Accent 4;
-\lsdpriority47 \lsdlocked0 Grid Table 2 Accent 4;\lsdpriority48 \lsdlocked0 Grid Table 3 Accent 4;\lsdpriority49 \lsdlocked0 Grid Table 4 Accent 4;\lsdpriority50 \lsdlocked0 Grid Table 5 Dark Accent 4;
-\lsdpriority51 \lsdlocked0 Grid Table 6 Colorful Accent 4;\lsdpriority52 \lsdlocked0 Grid Table 7 Colorful Accent 4;\lsdpriority46 \lsdlocked0 Grid Table 1 Light Accent 5;\lsdpriority47 \lsdlocked0 Grid Table 2 Accent 5;
-\lsdpriority48 \lsdlocked0 Grid Table 3 Accent 5;\lsdpriority49 \lsdlocked0 Grid Table 4 Accent 5;\lsdpriority50 \lsdlocked0 Grid Table 5 Dark Accent 5;\lsdpriority51 \lsdlocked0 Grid Table 6 Colorful Accent 5;
-\lsdpriority52 \lsdlocked0 Grid Table 7 Colorful Accent 5;\lsdpriority46 \lsdlocked0 Grid Table 1 Light Accent 6;\lsdpriority47 \lsdlocked0 Grid Table 2 Accent 6;\lsdpriority48 \lsdlocked0 Grid Table 3 Accent 6;
-\lsdpriority49 \lsdlocked0 Grid Table 4 Accent 6;\lsdpriority50 \lsdlocked0 Grid Table 5 Dark Accent 6;\lsdpriority51 \lsdlocked0 Grid Table 6 Colorful Accent 6;\lsdpriority52 \lsdlocked0 Grid Table 7 Colorful Accent 6;
-\lsdpriority46 \lsdlocked0 List Table 1 Light;\lsdpriority47 \lsdlocked0 List Table 2;\lsdpriority48 \lsdlocked0 List Table 3;\lsdpriority49 \lsdlocked0 List Table 4;\lsdpriority50 \lsdlocked0 List Table 5 Dark;
-\lsdpriority51 \lsdlocked0 List Table 6 Colorful;\lsdpriority52 \lsdlocked0 List Table 7 Colorful;\lsdpriority46 \lsdlocked0 List Table 1 Light Accent 1;\lsdpriority47 \lsdlocked0 List Table 2 Accent 1;\lsdpriority48 \lsdlocked0 List Table 3 Accent 1;
-\lsdpriority49 \lsdlocked0 List Table 4 Accent 1;\lsdpriority50 \lsdlocked0 List Table 5 Dark Accent 1;\lsdpriority51 \lsdlocked0 List Table 6 Colorful Accent 1;\lsdpriority52 \lsdlocked0 List Table 7 Colorful Accent 1;
-\lsdpriority46 \lsdlocked0 List Table 1 Light Accent 2;\lsdpriority47 \lsdlocked0 List Table 2 Accent 2;\lsdpriority48 \lsdlocked0 List Table 3 Accent 2;\lsdpriority49 \lsdlocked0 List Table 4 Accent 2;
-\lsdpriority50 \lsdlocked0 List Table 5 Dark Accent 2;\lsdpriority51 \lsdlocked0 List Table 6 Colorful Accent 2;\lsdpriority52 \lsdlocked0 List Table 7 Colorful Accent 2;\lsdpriority46 \lsdlocked0 List Table 1 Light Accent 3;
-\lsdpriority47 \lsdlocked0 List Table 2 Accent 3;\lsdpriority48 \lsdlocked0 List Table 3 Accent 3;\lsdpriority49 \lsdlocked0 List Table 4 Accent 3;\lsdpriority50 \lsdlocked0 List Table 5 Dark Accent 3;
-\lsdpriority51 \lsdlocked0 List Table 6 Colorful Accent 3;\lsdpriority52 \lsdlocked0 List Table 7 Colorful Accent 3;\lsdpriority46 \lsdlocked0 List Table 1 Light Accent 4;\lsdpriority47 \lsdlocked0 List Table 2 Accent 4;
-\lsdpriority48 \lsdlocked0 List Table 3 Accent 4;\lsdpriority49 \lsdlocked0 List Table 4 Accent 4;\lsdpriority50 \lsdlocked0 List Table 5 Dark Accent 4;\lsdpriority51 \lsdlocked0 List Table 6 Colorful Accent 4;
-\lsdpriority52 \lsdlocked0 List Table 7 Colorful Accent 4;\lsdpriority46 \lsdlocked0 List Table 1 Light Accent 5;\lsdpriority47 \lsdlocked0 List Table 2 Accent 5;\lsdpriority48 \lsdlocked0 List Table 3 Accent 5;
-\lsdpriority49 \lsdlocked0 List Table 4 Accent 5;\lsdpriority50 \lsdlocked0 List Table 5 Dark Accent 5;\lsdpriority51 \lsdlocked0 List Table 6 Colorful Accent 5;\lsdpriority52 \lsdlocked0 List Table 7 Colorful Accent 5;
-\lsdpriority46 \lsdlocked0 List Table 1 Light Accent 6;\lsdpriority47 \lsdlocked0 List Table 2 Accent 6;\lsdpriority48 \lsdlocked0 List Table 3 Accent 6;\lsdpriority49 \lsdlocked0 List Table 4 Accent 6;
-\lsdpriority50 \lsdlocked0 List Table 5 Dark Accent 6;\lsdpriority51 \lsdlocked0 List Table 6 Colorful Accent 6;\lsdpriority52 \lsdlocked0 List Table 7 Colorful Accent 6;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Mention;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Smart Hyperlink;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Hashtag;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Unresolved Mention;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Smart Link;}}{\*\datastore 01050000
-02000000180000004d73786d6c322e534158584d4c5265616465722e362e3000000000000000000000060000
-d0cf11e0a1b11ae1000000000000000000000000000000003e000300feff090006000000000000000000000001000000010000000000000000100000feffffff00000000feffffff0000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000f09c
-1095f3a0d701feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
-00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
-000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
-0000000000000000000000000000000000000000000000000105000000000000}}
+{\rtf1\ansi\deff3\adeflang1025
+{\fonttbl{\f0\froman\fprq2\fcharset0 Times New Roman;}{\f1\froman\fprq2\fcharset2 Symbol;}{\f2\fswiss\fprq2\fcharset0 Arial;}{\f3\froman\fprq2\fcharset0 Liberation Serif{\*\falt Times New Roman};}{\f4\froman\fprq2\fcharset0 Calibri;}{\f5\froman\fprq2\fcharset0 Constantia;}{\f6\fswiss\fprq2\fcharset0 Liberation Sans{\*\falt Arial};}{\f7\fnil\fprq2\fcharset0 Times New Roman;}{\f8\fnil\fprq2\fcharset0 Microsoft YaHei;}{\f9\fnil\fprq2\fcharset0 Calibri;}{\f10\fnil\fprq2\fcharset0 Constantia;}{\f11\fswiss\fprq0\fcharset128 Lucida Sans;}{\f12\fnil\fprq2\fcharset0 Lucida Sans;}}
+{\colortbl;\red0\green0\blue0;\red0\green0\blue255;\red0\green255\blue255;\red0\green255\blue0;\red255\green0\blue255;\red255\green0\blue0;\red255\green255\blue0;\red255\green255\blue255;\red0\green0\blue128;\red0\green128\blue128;\red0\green128\blue0;\red128\green0\blue128;\red128\green0\blue0;\red128\green128\blue0;\red128\green128\blue128;\red192\green192\blue192;}
+{\stylesheet{\s0\snext0\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\hyphpar0\ltrpar\loch\f4\fs22\lang1033\cf0\kerning1 Normal;}
+{\*\cs15\snext15 Default Paragraph Font;}
+{\*\cs16\snext16\langfe255\alang255\cf9\lang255\ul\ulc0 Internetverkn\u252\'fcpfung;}
+{\s17\sbasedon0\snext18\dbch\af8\langfe1033\dbch\af12\afs28\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb240\sa120\keepn\loch\f6\fs28\lang1033 Caption;}
+{\s18\sbasedon0\snext18\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl276\slmult1\ql\widctlpar\faauto\sb0\sa140\loch\f4\fs22\lang1033 Text;}
+{\s19\sbasedon18\snext19\dbch\af7\langfe1033\dbch\af11\afs22\alang1025\sl276\slmult1\ql\widctlpar\faauto\sb0\sa140\loch\f4\fs22\lang1033 List;}
+{\s20\sbasedon0\snext20\dbch\af7\langfe1033\dbch\af11\afs24\alang1025\ai\sl256\slmult1\ql\widctlpar\faauto\sb120\sa120\noline\loch\f4\fs24\lang1033\i Label;}
+{\s21\sbasedon0\snext21\dbch\af7\langfe1033\dbch\af11\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\noline\loch\f4\fs22\lang1033 Directory;}
+{\s22\snext22\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\hyphpar0\ltrpar\loch\f4\fs22\lang1033\cf0\kerning1 Normal Table;}
+}{\*\listtable{\list\listtemplateid1
+{\listlevel\levelnfc23\leveljc0\levelstartat0\levelfollow0{\leveltext \'01\u61623 ?;}{\levelnumbers;}\f1\fi0\li0}
+{\listlevel\levelnfc0\leveljc0\levelstartat1\levelfollow0{\leveltext \'02\'01.;}{\levelnumbers\'01;}\fi-360\li1080}
+{\listlevel\levelnfc0\leveljc0\levelstartat1\levelfollow0{\leveltext \'02\'02.;}{\levelnumbers\'01;}\fi-360\li1440}
+{\listlevel\levelnfc0\leveljc0\levelstartat1\levelfollow0{\leveltext \'02\'03.;}{\levelnumbers\'01;}\fi-360\li1800}
+{\listlevel\levelnfc0\leveljc0\levelstartat1\levelfollow0{\leveltext \'02\'04.;}{\levelnumbers\'01;}\fi-360\li2160}
+{\listlevel\levelnfc0\leveljc0\levelstartat1\levelfollow0{\leveltext \'02\'05.;}{\levelnumbers\'01;}\fi-360\li2520}
+{\listlevel\levelnfc0\leveljc0\levelstartat1\levelfollow0{\leveltext \'02\'06.;}{\levelnumbers\'01;}\fi-360\li2880}
+{\listlevel\levelnfc0\leveljc0\levelstartat1\levelfollow0{\leveltext \'02\'07.;}{\levelnumbers\'01;}\fi-360\li3240}
+{\listlevel\levelnfc0\leveljc0\levelstartat1\levelfollow0{\leveltext \'02\'08.;}{\levelnumbers\'01;}\fi-360\li3600}\listid1}
+{\list\listtemplateid2
+{\listlevel\levelnfc255\leveljc0\levelstartat1\levelfollow2{\leveltext \'00;}{\levelnumbers;}\fi0\li0}
+{\listlevel\levelnfc255\leveljc0\levelstartat1\levelfollow2{\leveltext \'00;}{\levelnumbers;}\fi0\li0}
+{\listlevel\levelnfc255\leveljc0\levelstartat1\levelfollow2{\leveltext \'00;}{\levelnumbers;}\fi0\li0}
+{\listlevel\levelnfc255\leveljc0\levelstartat1\levelfollow2{\leveltext \'00;}{\levelnumbers;}\fi0\li0}
+{\listlevel\levelnfc255\leveljc0\levelstartat1\levelfollow2{\leveltext \'00;}{\levelnumbers;}\fi0\li0}
+{\listlevel\levelnfc255\leveljc0\levelstartat1\levelfollow2{\leveltext \'00;}{\levelnumbers;}\fi0\li0}
+{\listlevel\levelnfc255\leveljc0\levelstartat1\levelfollow2{\leveltext \'00;}{\levelnumbers;}\fi0\li0}
+{\listlevel\levelnfc255\leveljc0\levelstartat1\levelfollow2{\leveltext \'00;}{\levelnumbers;}\fi0\li0}
+{\listlevel\levelnfc255\leveljc0\levelstartat1\levelfollow2{\leveltext \'00;}{\levelnumbers;}\fi0\li0}\listid2}
+}{\listoverridetable{\listoverride\listid1\listoverridecount0\ls1}{\listoverride\listid2\listoverridecount0\ls2}}{\*\generator LibreOffice/6.4.2.2$Windows_X86_64 LibreOffice_project/4e471d8c02c9c90f512f7f9ead8875b57fcb1ec3}{\info{\creatim\yr2018\mo10\dy10\hr22\min10}{\revtim\yr2025\mo2\dy27\hr18\min28}{\printim\yr0\mo0\dy0\hr0\min0}}{\*\userprops{\propname Operator}\proptype30{\staticval Jeff Grooms}}\deftab720\deftab720
+\hyphauto1\viewscale100
+{\*\pgdsctbl
+{\pgdsc0\pgdscuse451\pgwsxn12240\pghsxn15840\marglsxn1440\margrsxn1440\margtsxn1440\margbsxn1440\pgdscnxt0 Standard;}}
+\formshade{\*\pgdscno0}\paperh15840\paperw12240\margl1440\margr1440\margt1440\margb1440\sectd\sbknone\sectunlocked1\pgndec\pgwsxn12240\pghsxn15840\marglsxn1440\margrsxn1440\margtsxn1440\margbsxn1440\ftnbj\ftnstart1\ftnrstcont\ftnnar\aenddoc\aftnrstcont\aftnstart1\aftnnrlc
+{\*\ftnsep\chftnsep}\pgndec\pard\plain \s0\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\hyphpar0\ltrpar\loch\f4\fs22\lang1033\cf0\kerning1\qc\nowidctlpar\li0\ri0\lin0\rin0\fi0\sb0\sa0\ltrpar{\rtlch\dbch\af10\ab\hich\af5 \ltrch\b\loch\f5\loch
+Welcome to the Vox Populi Installer!}
+\par \pard\plain \s0\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\hyphpar0\ltrpar\loch\f4\fs22\lang1033\cf0\kerning1\qc\nowidctlpar\li0\ri0\lin0\rin0\fi0\sb0\sa0\ltrpar{\rtlch\dbch\af10\ab\hich\af5 \ltrch\b\loch\f5\loch
+Installer Version 1.}{\rtlch\dbch\af10\ab\hich\af5 \ltrch\b\loch\f5\loch
+1}
+\par \pard\plain \s0\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\hyphpar0\ltrpar\loch\f4\fs22\lang1033\cf0\kerning1\nowidctlpar\li0\ri0\lin0\rin0\fi0\sb0\sa0\ltrpar\rtlch\dbch\af10\afs24\hich\af5 \ltrch\fs24\loch\f5\loch
+
+\par \pard\plain \s0\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\hyphpar0\ltrpar\loch\f4\fs22\lang1033\cf0\kerning1\nowidctlpar\li0\ri0\lin0\rin0\fi0\sb0\sa0\ltrpar{\rtlch\dbch\af10\afs24\hich\af5 \ltrch\fs24\loch\f5\loch
+This installer is for }{\rtlch\dbch\af10\afs24\hich\af5 \ltrch\fs24\loch\f5\loch
+the mods "Community Patch" and "}{\rtlch\dbch\af10\afs24\hich\af5 \ltrch\fs24\loch\f5\loch
+Vox Populi}{\rtlch\dbch\af10\afs24\hich\af5 \ltrch\fs24\loch\f5\loch
+"}{\rtlch\dbch\af10\afs24\hich\af5 \ltrch\fs24\loch\f5\loch
+, unofficial expansion}{\rtlch\dbch\af10\afs24\hich\af5 \ltrch\fs24\loch\f5\loch
+s}{\rtlch\dbch\af10\afs24\hich\af5 \ltrch\fs24\loch\f5\loch
+ for Civilization V created by the Community Patch Project team. It includes all necessary files in order for the mod}{\rtlch\dbch\af7\langfe1033\dbch\af10\afs24\alang1025\hich\af5 \ltrch\fs24\lang1033\loch\f5\loch
+s}{\rtlch\dbch\af10\afs24\hich\af5 \ltrch\fs24\loch\f5\loch
+ to function. }{\rtlch\dbch\af10\ab\hich\af5 \ltrch\b\loch\f5\loch
+Please make sure to read all settings and options before clicking 'Next.'}
+\par \pard\plain \s0\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\hyphpar0\ltrpar\loch\f4\fs22\lang1033\cf0\kerning1\nowidctlpar\li0\ri0\lin0\rin0\fi0\sb0\sa0\ltrpar\rtlch\dbch\af10\hich\af5 \ltrch\loch\f5\loch
+
+\par \pard\plain \s0\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\hyphpar0\ltrpar\loch\f4\fs22\lang1033\cf0\kerning1\nowidctlpar\li0\ri0\lin0\rin0\fi0\sb0\sa0\ltrpar\rtlch\dbch\af10\afs24\hich\af5 \ltrch\fs24\loch\f5\loch
+
+\par \pard\plain \s0\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\hyphpar0\ltrpar\loch\f4\fs22\lang1033\cf0\kerning1\nowidctlpar\li0\ri0\lin0\rin0\fi0\sb0\sa0\ltrpar{\rtlch\dbch\af10\afs24\ab\hich\af5 \ltrch\fs24\b\loch\f5\loch
+This Installer Includes:}
+\par \pard\plain \s0\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\hyphpar0\ltrpar\loch\f4\fs22\lang1033\cf0\kerning1\nowidctlpar\li0\ri0\lin0\rin0\fi0\sb0\sa0\ltrpar\rtlch\dbch\af10\afs24\hich\af5 \ltrch\fs24\loch\f5\loch
+
+\par \pard\plain \s0\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\hyphpar0\ltrpar\loch\f4\fs22\lang1033\cf0\kerning1{\listtext\pard\plain  \u61623\'3f\tab}\ilvl0\ls1 \li0\ri0\lin0\rin0\fi0\nowidctlpar\sb0\sa0\ltrpar{\rtlch\dbch\af10\afs24\hich\af5 \ltrch\fs24\loch\f5\loch
+(1) Community Patch}
+\par \pard\plain \s0\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\hyphpar0\ltrpar\loch\f4\fs22\lang1033\cf0\kerning1{\listtext\pard\plain  \u61623\'3f\tab}\ilvl0\ls1 \li0\ri0\lin0\rin0\fi0\nowidctlpar\sb0\sa0\ltrpar{\rtlch\dbch\af10\afs24\hich\af5 \ltrch\fs24\loch\f5\loch
+(2) }{\rtlch\dbch\af7\langfe1033\dbch\af10\afs24\alang1025\hich\af5 \ltrch\fs24\lang1033\loch\f5\loch
+Vox Populi}
+\par \pard\plain \s0\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\hyphpar0\ltrpar\loch\f4\fs22\lang1033\cf0\kerning1{\listtext\pard\plain  \u61623\'3f\tab}\ilvl0\ls1 \li0\ri0\lin0\rin0\fi0\nowidctlpar\sb0\sa0\ltrpar{\rtlch\dbch\af10\afs24\hich\af5 \ltrch\fs24\loch\f5\loch
+(3a) EUI Compatibility Files}
+\par \pard\plain \s0\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\hyphpar0\ltrpar\loch\f4\fs22\lang1033\cf0\kerning1{\listtext\pard\plain  \u61623\'3f\tab}\ilvl0\ls1 \li0\ri0\lin0\rin0\fi0\nowidctlpar\sb0\sa0\ltrpar{\rtlch\dbch\af10\afs24\hich\af5 \ltrch\fs24\loch\f5\loch
+(3b) 43 Civs Community Patch}
+\par \pard\plain \s0\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\hyphpar0\ltrpar\loch\f4\fs22\lang1033\cf0\kerning1{\listtext\pard\plain  \u61623\'3f\tab}\ilvl0\ls1 \li0\ri0\lin0\rin0\fi0\nowidctlpar\sb0\sa0\ltrpar{\rtlch\dbch\af10\afs24\hich\af5 \ltrch\fs24\loch\f5\loch
+(4a) Squads for VP}
+\par \pard\plain \s0\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\hyphpar0\ltrpar\loch\f4\fs22\lang1033\cf0\kerning1\nowidctlpar\li0\ri0\lin0\rin0\fi0\sb0\sa0\ltrpar\rtlch\dbch\af10\hich\af5 \ltrch\loch\f5\loch
+
+\par \pard\plain \s0\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\hyphpar0\ltrpar\loch\f4\fs22\lang1033\cf0\kerning1\nowidctlpar\li0\ri0\lin0\rin0\fi0\sb0\sa0\ltrpar{\rtlch\dbch\af10\ab\hich\af5 \ltrch\b\loch\f5\loch
+Installation Requirements:}
+\par \pard\plain \s0\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\hyphpar0\ltrpar\loch\f4\fs22\lang1033\cf0\kerning1{\listtext\pard\plain  \u61623\'3f\tab}\ilvl0\ls1 \li0\ri0\lin0\rin0\fi0\nowidctlpar\sb0\sa0\ltrpar{\rtlch\dbch\af10\hich\af5 \ltrch\loch\f5\loch
+Civilization V (Version .279)}
+\par \pard\plain \s0\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\hyphpar0\ltrpar\loch\f4\fs22\lang1033\cf0\kerning1{\listtext\pard\plain  \u61623\'3f\tab}\ilvl0\ls1 \li0\ri0\lin0\rin0\fi0\nowidctlpar\sb0\sa0\ltrpar{\rtlch\dbch\af10\hich\af5 \ltrch\loch\f5\loch
+All Leader DLC (Spain+Inca, Korea, Denmark, Mongols, Polynesia)}
+\par \pard\plain \s0\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\hyphpar0\ltrpar\loch\f4\fs22\lang1033\cf0\kerning1{\listtext\pard\plain  \u61623\'3f\tab}\ilvl0\ls1 \li0\ri0\lin0\rin0\fi0\nowidctlpar\sb0\sa0\ltrpar{\rtlch\dbch\af10\hich\af5 \ltrch\loch\f5\loch
+Ancient Wonders DLC}
+\par \pard\plain \s0\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\hyphpar0\ltrpar\loch\f4\fs22\lang1033\cf0\kerning1{\listtext\pard\plain  \u61623\'3f\tab}\ilvl0\ls1 \li0\ri0\lin0\rin0\fi0\nowidctlpar\sb0\sa0\ltrpar{\rtlch\dbch\af10\hich\af5 \ltrch\loch\f5\loch
+Gods and Kings + Brave New World}
+\par \pard\plain \s0\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\hyphpar0\ltrpar\loch\f4\fs22\lang1033\cf0\kerning1{\listtext\pard\plain  \u61623\'3f\tab}\ilvl0\ls1 \li0\ri0\lin0\rin0\fi0\nowidctlpar\sb0\sa0\ltrpar{\rtlch\dbch\af10\hich\af5 \ltrch\loch\f5\loch
+Windows 7 or greater}
+\par \pard\plain \s0\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\hyphpar0\ltrpar\loch\f4\fs22\lang1033\cf0\kerning1\nowidctlpar\li0\ri0\lin0\rin0\fi0\sb0\sa0\ltrpar\rtlch\dbch\af10\ab\hich\af5 \ltrch\b\loch\f5\loch
+
+\par \pard\plain \s0\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\hyphpar0\ltrpar\loch\f4\fs22\lang1033\cf0\kerning1\nowidctlpar\li0\ri0\lin0\rin0\fi0\sb0\sa0\ltrpar{\rtlch\dbch\af10\ab\hich\af5 \ltrch\b\loch\f5\loch
+Important Information: }
+\par \pard\plain \s0\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\hyphpar0\ltrpar\loch\f4\fs22\lang1033\cf0\kerning1{\listtext\pard\plain  \u61623\'3f\tab}\ilvl0\ls1 \li0\ri0\lin0\rin0\fi0\nowidctlpar\sb0\sa0\ltrpar{\rtlch\dbch\af10\hich\af5 \ltrch\loch\f5\loch
+If you have manually moved the MODS folder out of your Documents/My Games/Civilization 5 folder, this installer will not work!}
+\par \pard\plain \s0\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\hyphpar0\ltrpar\loch\f4\fs22\lang1033\cf0\kerning1{\listtext\pard\plain  \u61623\'3f\tab}\ilvl0\ls1 \li0\ri0\lin0\rin0\fi0\nowidctlpar\sb0\sa0\ltrpar{\rtlch\dbch\af10\hich\af5 \ltrch\loch\f5\loch
+The i}{\rtlch\dbch\af10\hich\af5 \ltrch\loch\f5\loch
+nstaller automatically detects and deletes cache files as well as older versions of this mod. No need to manually delete older files or to clear your cache!}
+\par \pard\plain \s0\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\hyphpar0\ltrpar\loch\f4\fs22\lang1033\cf0\kerning1\nowidctlpar\li0\ri0\lin0\rin0\fi0\sb0\sa0\ltrpar\rtlch\dbch\af10\hich\af5 \ltrch\loch\f5\loch
+
+\par \pard\plain \s0\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\hyphpar0\ltrpar\loch\f4\fs22\lang1033\cf0\kerning1\nowidctlpar\li0\ri0\lin0\rin0\fi0\sb0\sa0\ltrpar{\rtlch\dbch\af10\ab\hich\af5 \ltrch\b\loch\f5\loch
+Installation Options:}
+\par \pard\plain \s0\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\hyphpar0\ltrpar\loch\f4\fs22\lang1033\cf0\kerning1{\listtext\pard\plain  \u61623\'3f\tab}\ilvl0\ls1 \li0\ri0\lin0\rin0\fi0\nowidctlpar\sb0\sa0\ltrpar{\rtlch\dbch\af10\ab\hich\af5 \ltrch\b\loch\f5\loch
+Vox Populi (with}{\rtlch\dbch\af10\ab\hich\af5 \ltrch\b\loch\f5\loch
+ EUI}{\rtlch\dbch\af10\ab\hich\af5 \ltrch\b\loch\f5\loch
+)}{\rtlch\dbch\af10\ab\hich\af5 \ltrch\b\loch\f5\loch
+: }{\rtlch\dbch\af10\hich\af5 \ltrch\loch\f5\loch
+Installs all aspects of Vox Populi, including }{\rtlch\dbch\af7\langfe1033\dbch\af10\afs22\alang1025\hich\af5 \ltrch\fs22\lang1033\loch\f5\loch
+the Enhanced User Interface (EUI)}{\rtlch\dbch\af10\hich\af5 \ltrch\loch\f5\loch
+.}
+\par \pard\plain \s0\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\hyphpar0\ltrpar\loch\f4\fs22\lang1033\cf0\kerning1{\listtext\pard\plain  \u61623\'3f\tab}\ilvl0\ls1 \li0\ri0\lin0\rin0\fi0\nowidctlpar\sb0\sa0\ltrpar{\rtlch\dbch\af10\ab\hich\af5 \ltrch\b\loch\f5\loch
+Vox Populi (}{\rtlch\dbch\af7\langfe1033\dbch\af10\afs22\alang1025\ab\hich\af5 \ltrch\fs22\lang1033\b\loch\f5\loch
+no-}{\rtlch\dbch\af10\ab\hich\af5 \ltrch\b\loch\f5\loch
+EUI}{\rtlch\dbch\af10\ab\hich\af5 \ltrch\b\loch\f5\loch
+)}{\rtlch\dbch\af10\ab\hich\af5 \ltrch\b\loch\f5\loch
+: }{\rtlch\dbch\af10\hich\af5 \ltrch\loch\f5\loch
+Installs all aspects of the Vox Populi, but skips EUI.}
+\par \pard\plain \s0\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\hyphpar0\ltrpar\loch\f4\fs22\lang1033\cf0\kerning1{\listtext\pard\plain  \u61623\'3f\tab}\ilvl0\ls1 \li0\ri0\lin0\rin0\fi0\nowidctlpar\sb0\sa0\ltrpar{\rtlch\dbch\af7\langfe1033\dbch\af10\afs22\alang1025\ab\hich\af5 \ltrch\fs22\lang1033\b\loch\f5\loch
+Community Patch only}{\rtlch\dbch\af10\ab\hich\af5 \ltrch\b\loch\f5\loch
+: }{\rtlch\dbch\af10\hich\af5 \ltrch\loch\f5\loch
+Installs only the Community Patch. Use this option if you only want the basic AI and bugfix changes.}
+\par \pard\plain \s0\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\hyphpar0\ltrpar\loch\f4\fs22\lang1033\cf0\kerning1{\listtext\pard\plain  \u61623\'3f\tab}\ilvl0\ls1 \li0\ri0\lin0\rin0\fi0\nowidctlpar\sb0\sa0\ltrpar{\rtlch\dbch\af10\ab\hich\af5 \ltrch\b\loch\f5\loch
+43 Civ }{\rtlch\dbch\af7\langfe1033\dbch\af10\afs22\alang1025\ab\hich\af5 \ltrch\fs22\lang1033\b\loch\f5\loch
+Community Patch only}{\rtlch\dbch\af10\ab\hich\af5 \ltrch\b\loch\f5\loch
+: }{\rtlch\dbch\af10\hich\af5 \ltrch\loch\f5\loch
+Installs a version of the Community Patch that supports up to 43 Major Civilizations}
+\par \pard\plain \s0\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\hyphpar0\ltrpar\loch\f4\fs22\lang1033\cf0\kerning1{\listtext\pard\plain  \u61623\'3f\tab}\ilvl0\ls1 \li0\ri0\lin0\rin0\fi0\nowidctlpar\sb0\sa0\ltrpar{\rtlch\dbch\af10\ab\hich\af5 \ltrch\b\loch\f5\loch
+43 Civ Vox Populi }{\rtlch\dbch\af10\ab\hich\af5 \ltrch\b\loch\f5\loch
+(n}{\rtlch\dbch\af10\ab\hich\af5 \ltrch\b\loch\f5\loch
+o-EUI}{\rtlch\dbch\af10\ab\hich\af5 \ltrch\b\loch\f5\loch
+)}{\rtlch\dbch\af10\ab\hich\af5 \ltrch\b\loch\f5\loch
+: }{\rtlch\dbch\af10\hich\af5 \ltrch\loch\f5\loch
+Installs a version of Vox Populi without EUI that supports up to 43 Major Civilizations}
+\par \pard\plain \s0\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\hyphpar0\ltrpar\loch\f4\fs22\lang1033\cf0\kerning1{\listtext\pard\plain  \u61623\'3f\tab}\ilvl0\ls1 \li0\ri0\lin0\rin0\fi0\nowidctlpar\sb0\sa0\ltrpar{\rtlch\dbch\af10\ab\hich\af5 \ltrch\b\loch\f5\loch
+43 Civ Vox Populi }{\rtlch\dbch\af10\ab\hich\af5 \ltrch\b\loch\f5\loch
+(with }{\rtlch\dbch\af10\ab\hich\af5 \ltrch\b\loch\f5\loch
+EUI}{\rtlch\dbch\af10\ab\hich\af5 \ltrch\b\loch\f5\loch
+)}{\rtlch\dbch\af10\ab\hich\af5 \ltrch\b\loch\f5\loch
+: }{\rtlch\dbch\af10\hich\af5 \ltrch\loch\f5\loch
+Installs a version of Vox Populi with EUI that supports up to 43 Major Civilizations}
+\par \pard\plain \s0\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\hyphpar0\ltrpar\loch\f4\fs22\lang1033\cf0\kerning1\nowidctlpar\li0\ri0\lin0\rin0\fi0\sb0\sa0\ltrpar\rtlch\dbch\af10\ab\hich\af5 \ltrch\b\loch\f5\loch
+
+\par \pard\plain \s0\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\hyphpar0\ltrpar\loch\f4\fs22\lang1033\cf0\kerning1\nowidctlpar\li0\ri0\lin0\rin0\fi0\sb0\sa0\ltrpar{\rtlch\dbch\af10\ab\hich\af5 \ltrch\b\loch\f5\loch
+Uninstallation Instructions:}
+\par \pard\plain \s0\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\hyphpar0\ltrpar\loch\f4\fs22\lang1033\cf0\kerning1\nowidctlpar\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s0\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\hyphpar0\ltrpar\loch\f4\fs22\lang1033\cf0\kerning1{\listtext\pard\plain  \u61623\'3f\tab}\ilvl0\ls1 \li0\ri0\lin0\rin0\fi0\nowidctlpar\sb0\sa0\ltrpar{\rtlch\dbch\af10\hich\af5 \ltrch\loch\f5\loch
+Delete all mods in your Documents/My Games/Civ 5/MODS folder.}
+\par \pard\plain \s0\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\hyphpar0\ltrpar\loch\f4\fs22\lang1033\cf0\kerning1{\listtext\pard\plain  \u61623\'3f\tab}\ilvl0\ls1 \li0\ri0\lin0\rin0\fi0\nowidctlpar\sb0\sa0\ltrpar{\rtlch\dbch\af7\langfe1033\dbch\af10\afs22\alang1025\ab\hich\af5 \ltrch\fs22\lang1033\b\loch\f5\loch
+If you installed}{\rtlch\dbch\af10\ab\hich\af5 \ltrch\b\loch\f5\loch
+ EUI: }{\rtlch\dbch\af10\hich\af5 \ltrch\loch\f5\loch
+Delete }{\rtlch\dbch\af10\hich\af5 \ltrch\loch\f5\loch
+the folder "}{\rtlch\dbch\af10\hich\af5 \ltrch\loch\f5\loch
+ui_bc1}{\rtlch\dbch\af10\hich\af5 \ltrch\loch\f5\loch
+"}{\rtlch\dbch\af10\hich\af5 \ltrch\loch\f5\loch
+ in }{\rtlch\dbch\af10\hich\af5 \ltrch\loch\f5\loch
+\{folder of your civ install\}\\Assets\\DLC}{\rtlch\dbch\af10\hich\af5 \ltrch\loch\f5\loch
+.}
+\par \pard\plain \s0\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\hyphpar0\ltrpar\loch\f4\fs22\lang1033\cf0\kerning1\nowidctlpar\sb0\sa0\ltrpar\loch
+
+\par \pard\plain \s0\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\hyphpar0\ltrpar\loch\f4\fs22\lang1033\cf0\kerning1\nowidctlpar\li0\ri0\lin0\rin0\fi0\sb0\sa0\ltrpar\rtlch\dbch\af10\afs24\hich\af5 \ltrch\fs24\loch\f5\loch
+
+\par \pard\plain \s0\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\hyphpar0\ltrpar\loch\f4\fs22\lang1033\cf0\kerning1\nowidctlpar\li0\ri0\lin0\rin0\fi0\sb0\sa0\ltrpar{\rtlch\dbch\af10\afs24\ab\hich\af5 \ltrch\fs24\b\loch\f5\loch
+Final Notes:}
+\par \pard\plain \s0\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\hyphpar0\ltrpar\loch\f4\fs22\lang1033\cf0\kerning1\nowidctlpar\li0\ri0\lin0\rin0\fi0\sb0\sa0\ltrpar\rtlch\dbch\af10\afs24\hich\af5 \ltrch\fs24\loch\f5\loch
+
+\par \pard\plain \s0\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\hyphpar0\ltrpar\loch\f4\fs22\lang1033\cf0\kerning1\nowidctlpar\li0\ri0\lin0\rin0\fi0\sb0\sa0\ltrpar{\rtlch\dbch\af10\afs24\hich\af5 \ltrch\fs24\loch\f5\loch
+If you have any questions or concerns, make sure to visit the Community Patch Project Forums: }{{\field{\*\fldinst HYPERLINK "http://forums.civfanatics.com/forumdisplay.php?f=497\\\\par" }{\fldrslt {\rtlch\dbch\af10\afs24\hich\af5 \ltrch\fs24\loch\f5\loch
+http://forums.civfanatics.com/forumdisplay.php?f=497\\par}}}}
+\par \pard\plain \s0\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\hyphpar0\ltrpar\loch\f4\fs22\lang1033\cf0\kerning1\nowidctlpar\li0\ri0\lin0\rin0\fi0\sb0\sa0\ltrpar\rtlch\dbch\af10\ab\hich\af5 \ltrch\b\loch\f5\loch
+
+\par \pard\plain \s0\dbch\af7\langfe1033\dbch\af9\afs22\alang1025\sl256\slmult1\ql\widctlpar\faauto\sb0\sa160\hyphpar0\ltrpar\loch\f4\fs22\lang1033\cf0\kerning1\nowidctlpar\li0\ri0\lin0\rin0\fi0\sb0\sa0\ltrpar\loch
+
+\par }


### PR DESCRIPTION
- Updated installer text (still mentioned mods (5) and (6))
- The installer no longer suggests a folder for the Civ 5 folder if the game is not installed in the default location
- The installer gives a warning message if an incorrect path to the Civ 5 folder is provided
- The installer gives a warning message if not all DLC are installed
- Fix custom text on finish page not working; added instruction on the finish page to click on "NEXT" in the MODS menu when loading the mods


This should fix the most common installation problems


![image](https://github.com/user-attachments/assets/9b658c81-9452-4d3e-9614-4f0392b316ee)

New text:
![Screenshot (1139)](https://github.com/user-attachments/assets/ae34b354-589d-4158-bfd1-70635d891099)
![Screenshot (1140)](https://github.com/user-attachments/assets/ccf66cd6-db29-427e-9980-4b65640edf1e)
![Screenshot (1141)](https://github.com/user-attachments/assets/3a2751df-fa29-40f8-a5fe-caea5d77945c)
![Screenshot (1142)](https://github.com/user-attachments/assets/ca769f28-145d-457c-86b3-e6bc52eefe41)
![Screenshot (1143)](https://github.com/user-attachments/assets/a6e7363f-d4c8-4741-9824-cd6cdc8ee02f)
![Screenshot (1145)](https://github.com/user-attachments/assets/a8a8521c-fe92-44ff-a4c5-4c76a19356ee)
