### PR TITLE
Unit production tweak + various fixes/other tweaks

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
@@ -1991,7 +1991,7 @@ static void UpdateGreatPersonDirectives(vector<OptionWithScore<BuilderDirective>
 			}
 
 			int iPotentialScore = it2->option.GetPotentialScore();
-			int iOtherScore = it2->option.m_iScore + it2->option.m_iPotentialBonusScore / 3;
+			int iOtherScore = it2->option.m_iScore;
 
 			if (iPotentialScore > iBestPotentialScoreInPlot)
 			{
@@ -2188,7 +2188,7 @@ void CvBuilderTaskingAI::AddImprovingPlotsDirective(vector<OptionWithScore<Build
 		int iPotentialScore = pScore.second;
 
 		// if we're going backward, bail out!
-		if(iScore <= 0)
+		if(iScore + iPotentialScore <= 0)
 		{
 			continue;
 		}
@@ -3951,9 +3951,8 @@ pair<int,int> CvBuilderTaskingAI::ScorePlotBuild(CvPlot* pPlot, ImprovementTypes
 
 		if (iSimplifiedYieldValue <= iWorstWorkedValue)
 		{
-			int iPenalty = iYieldScore / 2;
-			iYieldScore -= iPenalty;
-			iPotentialScore += iPenalty;
+			iPotentialScore += iYieldScore;
+			iYieldScore = 0;
 		}
 	}
 

--- a/CvGameCoreDLL_Expansion2/CvGame.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGame.cpp
@@ -135,6 +135,7 @@ CvGame::CvGame() :
 	, m_processPlayerAutoMoves(false)
 	, m_cityDistancePathLength(NO_DOMAIN) //for now!
 	, m_cityDistancePlots()
+	, m_eCurrentVisibilityPlayer(NO_PLAYER)
 {
 	m_pSettlerSiteEvaluator = NULL;
 	m_pStartSiteEvaluator = NULL;
@@ -1127,6 +1128,7 @@ void CvGame::uninit()
 	m_bArchaeologyTriggered = false;
 	m_bIsDesynced = false;
 	m_eObserverUIOverridePlayer = NO_PLAYER;
+	m_eCurrentVisibilityPlayer = NO_PLAYER;
 
 	m_eHandicap = NO_HANDICAP;
 	m_ePausePlayer = NO_PLAYER;
@@ -9076,6 +9078,18 @@ void CvGame::updateMoves()
 
 		if(player.isAlive())
 		{
+			if (player.isHuman())
+			{
+				if (GC.getGame().getActivePlayer() == player.GetID())
+				{
+					GC.getGame().SetCurrentVisibilityPlayer(player.GetID());
+				}
+			}
+			else
+			{
+				GC.getGame().SetCurrentVisibilityPlayer(player.GetID());
+			}
+
 			bool bAutomatedUnitNeedsUpdate = player.hasUnitsThatNeedAIUpdate();
 			bool bHomelandAINeedsUpdate = player.GetHomelandAI()->NeedsUpdate();
 			if(player.isTurnActive() || bAutomatedUnitNeedsUpdate || bHomelandAINeedsUpdate)
@@ -14256,6 +14270,16 @@ bool CvGame::CreateFreeCityPlayer(CvCity* pStartingCity, bool bJustChecking, boo
 bool CvGame::isFirstActivationOfPlayersAfterLoad() const
 {
 	return m_firstActivationOfPlayersAfterLoad;
+}
+
+void CvGame::SetCurrentVisibilityPlayer(PlayerTypes ePlayer)
+{
+	m_eCurrentVisibilityPlayer = ePlayer;
+}
+
+PlayerTypes CvGame::GetCurrentVisibilityPlayer() const
+{
+	return m_eCurrentVisibilityPlayer;
 }
 
 //	--------------------------------------------------------------------------------

--- a/CvGameCoreDLL_Expansion2/CvGame.h
+++ b/CvGameCoreDLL_Expansion2/CvGame.h
@@ -813,6 +813,9 @@ public:
 	TeamTypes GetPotentialFreeCityTeam(CvCity* pCity = NULL);
 	bool CreateFreeCityPlayer(CvCity* pStartingCity, bool bJustChecking, bool bMajorFoundingCityState);
 
+	void SetCurrentVisibilityPlayer(PlayerTypes ePlayer);
+	PlayerTypes GetCurrentVisibilityPlayer() const;
+
 	//------------------------------------------------------------
 	PlayerTypes GetAutoPlayReturnPlayer() const { return m_eAIAutoPlayReturnPlayer;	}
 	//------------------------------------------------------------
@@ -893,6 +896,7 @@ protected:
 	PlayerTypes m_eObserverUIOverridePlayer;
 	PlayerTypes m_eWaitDiploPlayer;
 	TechTypes m_eTechAstronomy;
+	PlayerTypes m_eCurrentVisibilityPlayer;
 
 	bool m_bFOW;
 

--- a/CvGameCoreDLL_Expansion2/CvTacticalAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTacticalAI.cpp
@@ -468,7 +468,7 @@ void CvTacticalAI::UpdateVisibilityFromUnits(CvPlot* pPlot)
 		{
 			PlayerTypes eTradeUnitOwner = GC.getGame().GetGameTrade()->GetOwnerFromID(*it);
 
-			if (eTradeUnitOwner != NO_PLAYER)
+			if (eTradeUnitOwner != NO_PLAYER && GET_PLAYER(eTradeUnitOwner).getTeam() != ePlayerTeam)
 				pPlot->IncreaseKnownVisibilityCount(GET_PLAYER(eTradeUnitOwner).getTeam(), NO_TEAM);
 		}
 	}


### PR DESCRIPTION
Unit production/unit composition planning AI rework:

Rework AI army planning to make it split its total supply into land/naval units. Previously it would not take the maximum supply into account properly so it would sometimes decide that it needs more defensive land units than the total supply allows.

With this new system the function in CvMilitaryAI will decide the exact number of land/naval units it wants up to the supply limit.

Future consideration: could update the CvMilitaryAI functionality to plan out how many units it wants of every unit type/unit AI type.

Various other tweaks and fixes:

Fix crash when building Eki (or similar) outside owned borders.

Add functionality for the game to keep track of who the current player is in regards to known other player vision logic. Should hopefully work with simultaneous turns etc.

Fix GPTIs being built in deserts/snow/other poor yield plots when there are perfectly fine plots to put them where we weren't planning on doing anything useful anyway.