### PR TITLE
Unit production tweak + various fixes/other tweaks (#11708)

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
@@ -1988,7 +1988,7 @@ static void UpdateGreatPersonDirectives(vector<OptionWithScore<BuilderDirective>
 			}
 
 			int iPotentialScore = it2->option.GetPotentialScore();
-			int iOtherScore = it2->option.m_iScore + it2->option.m_iPotentialBonusScore / 3;
+			int iOtherScore = it2->option.m_iScore;
 
 			if (iPotentialScore > iBestPotentialScoreInPlot)
 			{
@@ -2180,7 +2180,7 @@ void CvBuilderTaskingAI::AddImprovingPlotsDirective(vector<OptionWithScore<Build
 		int iPotentialScore = pScore.second;
 
 		// if we're going backward, bail out!
-		if(iScore <= 0)
+		if(iScore + iPotentialScore <= 0)
 		{
 			continue;
 		}
@@ -3942,9 +3942,8 @@ pair<int,int> CvBuilderTaskingAI::ScorePlotBuild(CvPlot* pPlot, ImprovementTypes
 
 		if (iSimplifiedYieldValue <= iWorstWorkedValue)
 		{
-			int iPenalty = iYieldScore / 2;
-			iYieldScore -= iPenalty;
-			iPotentialScore += iPenalty;
+			iPotentialScore += iYieldScore;
+			iYieldScore = 0;
 		}
 	}
 

--- a/CvGameCoreDLL_Expansion2/CvGame.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGame.cpp
@@ -132,6 +132,7 @@ CvGame::CvGame() :
 	, m_processPlayerAutoMoves(false)
 	, m_cityDistancePathLength(NO_DOMAIN) //for now!
 	, m_cityDistancePlots()
+	, m_eCurrentVisibilityPlayer(NO_PLAYER)
 {
 	m_pSettlerSiteEvaluator = NULL;
 	m_pStartSiteEvaluator = NULL;
@@ -1124,6 +1125,7 @@ void CvGame::uninit()
 	m_bArchaeologyTriggered = false;
 	m_bIsDesynced = false;
 	m_eObserverUIOverridePlayer = NO_PLAYER;
+	m_eCurrentVisibilityPlayer = NO_PLAYER;
 
 	m_eHandicap = NO_HANDICAP;
 	m_ePausePlayer = NO_PLAYER;
@@ -9084,6 +9086,18 @@ void CvGame::updateMoves()
 
 		if(player.isAlive())
 		{
+			if (player.isHuman())
+			{
+				if (GC.getGame().getActivePlayer() == player.GetID())
+				{
+					GC.getGame().SetCurrentVisibilityPlayer(player.GetID());
+				}
+			}
+			else
+			{
+				GC.getGame().SetCurrentVisibilityPlayer(player.GetID());
+			}
+
 			bool bAutomatedUnitNeedsUpdate = player.hasUnitsThatNeedAIUpdate();
 			bool bHomelandAINeedsUpdate = player.GetHomelandAI()->NeedsUpdate();
 			if(player.isTurnActive() || bAutomatedUnitNeedsUpdate || bHomelandAINeedsUpdate)
@@ -14248,6 +14262,16 @@ bool CvGame::CreateFreeCityPlayer(CvCity* pStartingCity, bool bJustChecking, boo
 bool CvGame::isFirstActivationOfPlayersAfterLoad() const
 {
 	return m_firstActivationOfPlayersAfterLoad;
+}
+
+void CvGame::SetCurrentVisibilityPlayer(PlayerTypes ePlayer)
+{
+	m_eCurrentVisibilityPlayer = ePlayer;
+}
+
+PlayerTypes CvGame::GetCurrentVisibilityPlayer() const
+{
+	return m_eCurrentVisibilityPlayer;
 }
 
 //	--------------------------------------------------------------------------------

--- a/CvGameCoreDLL_Expansion2/CvGame.h
+++ b/CvGameCoreDLL_Expansion2/CvGame.h
@@ -813,6 +813,9 @@ public:
 	TeamTypes GetPotentialFreeCityTeam(CvCity* pCity = NULL);
 	bool CreateFreeCityPlayer(CvCity* pStartingCity, bool bJustChecking, bool bMajorFoundingCityState);
 
+	void SetCurrentVisibilityPlayer(PlayerTypes ePlayer);
+	PlayerTypes GetCurrentVisibilityPlayer() const;
+
 	//------------------------------------------------------------
 	PlayerTypes GetAutoPlayReturnPlayer() const { return m_eAIAutoPlayReturnPlayer;	}
 	//------------------------------------------------------------
@@ -893,6 +896,7 @@ protected:
 	PlayerTypes m_eObserverUIOverridePlayer;
 	PlayerTypes m_eWaitDiploPlayer;
 	TechTypes m_eTechAstronomy;
+	PlayerTypes m_eCurrentVisibilityPlayer;
 
 	bool m_bFOW;
 

--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -8474,6 +8474,7 @@ void CvPlot::setImprovementType(ImprovementTypes eNewValue, PlayerTypes eBuilder
 							{
 								iBestCityID = pLoopCity->GetID();
 								iBestCityDistance = iDistance;
+								pOwningCity = pLoopCity;
 							}
 						}
 					}
@@ -11411,7 +11412,7 @@ PlotVisibilityChangeResult CvPlot::changeVisibilityCount(TeamTypes eTeam, int iC
 		// Update tactical AI, let it know that the tile was made visible
 		if (!bOldMaxVisibility)
 		{
-			PlayerTypes eCurrentPlayer = GetCurrentPlayer();
+			PlayerTypes eCurrentPlayer = GC.getGame().GetCurrentVisibilityPlayer();
 			if (eCurrentPlayer != NO_PLAYER && GET_PLAYER(eCurrentPlayer).getTeam() == eTeam)
 				GET_PLAYER(eCurrentPlayer).GetTacticalAI()->UpdateVisibilityFromUnits(this);
 		}
@@ -11734,10 +11735,21 @@ void CvPlot::SetPlannedRouteState(PlayerTypes ePlayer, RoutePlanTypes eRoutePlan
 
 //	--------------------------------------------------------------------------------
 /// Current player's knowledge of other players' visibility count
+/// If the current player team is the same as eTeam, return the actual visibility count
 int CvPlot::GetKnownVisibilityCount(TeamTypes eTeam) const
 {
 	ASSERT_DEBUG(eTeam >= 0, "eTeam is expected to be non-negative (invalid Index)");
 	ASSERT_DEBUG(eTeam < MAX_TEAMS, "eTeam is expected to be within maximum bounds (invalid Index)");
+
+	PlayerTypes eCurrentPlayer = GC.getGame().GetCurrentVisibilityPlayer();
+	if (eCurrentPlayer != NO_PLAYER)
+	{
+		if (GET_PLAYER(eCurrentPlayer).getTeam() == eTeam)
+		{
+			return getVisibilityCount(eTeam);
+		}
+	}
+
 	return m_aiKnownVisibilityCount[eTeam];
 }
 
@@ -11745,7 +11757,7 @@ int CvPlot::GetKnownVisibilityCount(TeamTypes eTeam) const
 /// Is this plot visible to eTeam according to current player knowledge
 bool CvPlot::IsKnownVisibleToTeam(TeamTypes eTeam) const
 {
-	return m_aiKnownVisibilityCount[eTeam] > 0;
+	return GetKnownVisibilityCount(eTeam) > 0;
 }
 
 //	--------------------------------------------------------------------------------
@@ -11833,6 +11845,11 @@ bool CvPlot::setRevealed(TeamTypes eTeam, bool bNewValue, CvUnit* pUnit, bool bT
 		{
 			area()->changeNumRevealedTiles(eTeam, (bNewValue ? 1 : -1));
 		}
+
+		// Update tactical AI, let it know that the tile was revealed
+		PlayerTypes eCurrentPlayer = GC.getGame().GetCurrentVisibilityPlayer();
+		if (eCurrentPlayer != NO_PLAYER)
+			GET_PLAYER(eCurrentPlayer).GetTacticalAI()->UpdateVisibilityFromBorders(this);
 
 		// Natural Wonder
 		if(eTeam != BARBARIAN_TEAM && bNewValue && !GET_TEAM(eTeam).isObserver())
@@ -12090,11 +12107,6 @@ bool CvPlot::setRevealed(TeamTypes eTeam, bool bNewValue, CvUnit* pUnit, bool bT
 						}
 					}
 				}
-
-				// Update tactical AI, let it know that the tile was revealed
-				PlayerTypes eCurrentPlayer = GC.getGame().getActivePlayer();
-				if (eCurrentPlayer != NO_PLAYER)
-					GET_PLAYER(eCurrentPlayer).GetTacticalAI()->UpdateVisibilityFromBorders(this);
 
 				if (bEligibleForAchievement)
 				{

--- a/CvGameCoreDLL_Expansion2/CvTacticalAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTacticalAI.cpp
@@ -391,7 +391,7 @@ void CvTacticalAI::UpdateVisibilityFromUnits(CvPlot* pPlot)
 		{
 			PlayerTypes eTradeUnitOwner = GC.getGame().GetGameTrade()->GetOwnerFromID(*it);
 
-			if (eTradeUnitOwner != NO_PLAYER)
+			if (eTradeUnitOwner != NO_PLAYER && GET_PLAYER(eTradeUnitOwner).getTeam() != ePlayerTeam)
 				pPlot->IncreaseKnownVisibilityCount(GET_PLAYER(eTradeUnitOwner).getTeam(), NO_TEAM);
 		}
 	}

--- a/CvGameCoreDLL_Expansion2/CvUnitProductionAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnitProductionAI.cpp
@@ -187,7 +187,7 @@ int CvUnitProductionAI::CheckUnitBuildSanity(UnitTypes eUnit, bool bForOperation
 	if (!pkUnitEntry)
 		return SR_IMPOSSIBLE;
 
-	bool bCombat = (pkUnitEntry->GetCombat() > 0 || pkUnitEntry->GetRangedCombat() > 0);
+	bool bCombat = (pkUnitEntry->GetCombat() > 0 || pkUnitEntry->GetRangedCombat() > 0) && pkUnitEntry->GetDefaultUnitAIType() != UNITAI_EXPLORE;
 
 	CvPlayerAI& kPlayer = GET_PLAYER(m_pCity->getOwner());
 	if (!bFree && bForPurchase && !m_pCity->IsCanPurchase(/*bTestPurchaseCost*/ true, /*bTestTrainable*/ true, eUnit, NO_BUILDING, NO_PROJECT, YIELD_GOLD))
@@ -202,6 +202,12 @@ int CvUnitProductionAI::CheckUnitBuildSanity(UnitTypes eUnit, bool bForOperation
 
 	bool bDesperate = m_pCity->isUnderSiege();
 	if (!bFree && bDesperate && !bCombat)
+	{
+		return SR_STRATEGY;
+	}
+
+	// Don't build units in underdeveloped cities
+	if (m_pCity->GetCityBuildings()->GetNumBuildings() < 2 && !bDesperate && !bForPurchase)
 	{
 		return SR_STRATEGY;
 	}
@@ -256,10 +262,38 @@ int CvUnitProductionAI::CheckUnitBuildSanity(UnitTypes eUnit, bool bForOperation
 			return SR_IMPOSSIBLE;
 	}
 
+
+	int iNumExplorers = kPlayer.GetNumUnitsWithUnitAI(UNITAI_EXPLORE, true);
 	int iNumLandUnits = kPlayer.getNumMilitaryLandUnits() + kPlayer.GetNumUnitsInProduction(DOMAIN_LAND, true);
 	int iNumSeaUnits = kPlayer.getNumMilitarySeaUnits() + kPlayer.GetNumUnitsInProduction(DOMAIN_SEA, true);
+
+	UnitTypes eCurrentlyProducing = m_pCity->getProductionUnit();
+
+	if (eCurrentlyProducing != NO_UNIT)
+	{
+		CvUnitEntry* pkCurrentlyProducing = GC.getUnitInfo(eCurrentlyProducing);
+		if (pkCurrentlyProducing)
+		{
+			if (pkCurrentlyProducing->GetDomainType() == DOMAIN_LAND && pkCurrentlyProducing->GetDefaultUnitAIType() == UNITAI_EXPLORE)
+				iNumExplorers--;
+			else if (pkCurrentlyProducing->GetDomainType() == DOMAIN_LAND && (pkCurrentlyProducing->GetCombat() > 0 || pkCurrentlyProducing->GetRangedCombat() > 0))
+				iNumLandUnits--;
+			else if (pkCurrentlyProducing->GetDomainType() == DOMAIN_SEA && (pkCurrentlyProducing->GetCombat() > 0 || pkCurrentlyProducing->GetRangedCombat() > 0))
+				iNumSeaUnits--;
+		}
+	}
+
+	iNumLandUnits -= iNumExplorers;
+
 	int iNumTotalUnits = iNumLandUnits + iNumSeaUnits;
 	int iNumTotalUnitsToSupply = iNumTotalUnits - kPlayer.getNumUnitsSupplyFree();
+
+	if (bCombat && pkUnitEntry->GetDomainType() == DOMAIN_LAND && iNumLandUnits >= kPlayer.GetMilitaryAI()->GetRecommendLandArmySize())
+		return SR_UNITSUPPLY;
+	else if (bCombat && pkUnitEntry->GetDomainType() == DOMAIN_SEA && iNumSeaUnits >= kPlayer.GetMilitaryAI()->GetRecommendNavySize())
+		return SR_UNITSUPPLY;
+	else if (pkUnitEntry->GetDefaultUnitAIType() == UNITAI_EXPLORE && iNumExplorers >= kPlayer.GetEconomicAI()->GetExplorersNeeded())
+		return SR_UNITSUPPLY;
 
 	//only war with majors count
 	bool bAtWar = (kPlayer.GetMilitaryAI()->GetNumberCivsAtWarWith(false) > 0);
@@ -304,32 +338,6 @@ int CvUnitProductionAI::CheckUnitBuildSanity(UnitTypes eUnit, bool bForOperation
 				else
 					return SR_UNITSUPPLY;
 			}
-		}
-	}
-
-	//Let's check this against supply to keep our military numbers lean.
-	int iScale = 0;
-	if (bCombat && !bFree)
-	{
-		int iSupply = max(1, kPlayer.GetNumUnitsSupplied());
-		int iDemand = iNumTotalUnitsToSupply;
-		if (bAtWar || bForOperation)
-		{
-			//hard limit, don't go too far into negative supply
-			if (iSupply <= iDemand - 3)
-				return SR_UNITSUPPLY;
-
-			//reduce bonus once we're over the limit
-			iScale = MapToPercent(iDemand, iSupply + 3, iSupply - 1);
-		}
-		else
-		{
-			//reduce bonus once we're approaching the limit
-			iScale = MapToPercent(iDemand, iSupply, (iSupply * 2) / 3);
-
-			//don't exceed the limit
-			if (iSupply <= iDemand)
-				return SR_UNITSUPPLY;
 		}
 	}
 
@@ -522,11 +530,8 @@ int CvUnitProductionAI::CheckUnitBuildSanity(UnitTypes eUnit, bool bForOperation
 		if (eDomain == DOMAIN_LAND && pkUnitEntry->GetDefaultUnitAIType() == UNITAI_EXPLORE)
 		{
 			int iExplorersNeeded = kPlayer.GetEconomicAI()->GetExplorersNeeded();
-			int iExplorersHave = kPlayer.GetNumUnitsWithUnitAI(UNITAI_EXPLORE, true);
-			if (m_pCity->isProductionUnit() && m_pCity->getProductionUnit() == eUnit)
-				iExplorersHave--;
 
-			int iExploreBonus = iExplorersNeeded - iExplorersHave;
+			int iExploreBonus = iExplorersNeeded - iNumExplorers;
 			if (iExploreBonus > 0)
 			{
 				iBonus += iExploreBonus * 500;
@@ -534,7 +539,7 @@ int CvUnitProductionAI::CheckUnitBuildSanity(UnitTypes eUnit, bool bForOperation
 		}
 
 		//Need Sea Explorers?
-		if (EconomicAIHelpers::IsPotentialNavalExplorer(pkUnitEntry->GetDefaultUnitAIType()))
+		/*if (EconomicAIHelpers::IsPotentialNavalExplorer(pkUnitEntry->GetDefaultUnitAIType()))
 		{
 			int iExplorersNeeded = kPlayer.GetEconomicAI()->GetNavalExplorersNeeded(); //this will always return at least one!
 			int iExplorersHave = kPlayer.GetNumUnitsWithUnitAI(UNITAI_EXPLORE_SEA, true);
@@ -543,13 +548,13 @@ int CvUnitProductionAI::CheckUnitBuildSanity(UnitTypes eUnit, bool bForOperation
 			if (iExplorersNeeded > iExplorersHave + iExplorersIdle)
 				iBonus += 500;
 
-		}
+		}*/
 		//Naval Units Critically Needed?
 		if (eDomain == DOMAIN_SEA)
 		{
 			if(bCombat)
 			{
-				int iCurrent = kPlayer.GetMilitaryAI()->GetNumNavalUnits();
+				int iCurrent = iNumSeaUnits;
 				int iDesired = kPlayer.GetMilitaryAI()->GetRecommendNavySize();
 				int iValue = iDesired - iCurrent;
 
@@ -558,9 +563,6 @@ int CvUnitProductionAI::CheckUnitBuildSanity(UnitTypes eUnit, bool bForOperation
 					iBonus += 75;
 
 				iValue *= max(1, (int)kPlayer.GetCurrentEra());
-
-				if (iCurrent * 2 < iDesired)
-					iValue *= 2;
 
 				if (iValue > 0 && !kPlayer.isBarbarian())
 				{
@@ -603,7 +605,7 @@ int CvUnitProductionAI::CheckUnitBuildSanity(UnitTypes eUnit, bool bForOperation
 						iValue *= iWarValue;
 					}
 				}
-				iBonus += iValue;
+				iBonus += iValue * 30;
 			}
 		}
 		//Land Units Critically Needed?
@@ -611,7 +613,7 @@ int CvUnitProductionAI::CheckUnitBuildSanity(UnitTypes eUnit, bool bForOperation
 		{
 			if (bCombat)
 			{
-				int iCurrent = kPlayer.GetMilitaryAI()->GetNumLandUnits();
+				int iCurrent = iNumLandUnits;
 				int iDesired = kPlayer.GetMilitaryAI()->GetRecommendLandArmySize();
 				int iValue = iDesired - iCurrent;
 
@@ -673,7 +675,7 @@ int CvUnitProductionAI::CheckUnitBuildSanity(UnitTypes eUnit, bool bForOperation
 						iValue *= iWarValue;
 					}
 				}
-				iBonus += iValue;
+				iBonus += iValue * 30;
 			}
 		}
 
@@ -681,8 +683,8 @@ int CvUnitProductionAI::CheckUnitBuildSanity(UnitTypes eUnit, bool bForOperation
 		{
 			//if we can build an airforce do so, independent of other players
 			//just take care that it's approximately evenly split between attack and defense
-			int ourBombers = kPlayer.GetNumUnitsWithUnitAI(UNITAI_ATTACK_AIR, false);
-			int ourFighters = kPlayer.GetNumUnitsWithUnitAI(UNITAI_DEFENSE_AIR, false);
+			int ourBombers = kPlayer.GetNumUnitsWithUnitAI(UNITAI_ATTACK_AIR, true);
+			int ourFighters = kPlayer.GetNumUnitsWithUnitAI(UNITAI_DEFENSE_AIR, true);
 			int emptySlots = m_pCity->GetMaxAirUnits() - m_pCity->plot()->countNumAirUnits(kPlayer.getTeam(), true);
 
 			switch (pkUnitEntry->GetDefaultUnitAIType())
@@ -1359,7 +1361,7 @@ int CvUnitProductionAI::CheckUnitBuildSanity(UnitTypes eUnit, bool bForOperation
 				iBonus += 200;
 			}
 
-			if (eDomain == DOMAIN_LAND && pkUnitEntry->GetDefaultUnitAIType() != UNITAI_EXPLORE)
+			if (eDomain == DOMAIN_LAND)
 			{
 				if (m_pCity->GetGarrisonedUnit() == NULL)
 				{
@@ -1368,10 +1370,25 @@ int CvUnitProductionAI::CheckUnitBuildSanity(UnitTypes eUnit, bool bForOperation
 			}
 		}
 	}
+
 	//Tiny army? Eek!
-	if (iNumLandUnits <= (kPlayer.getNumCities() * 2) && pkUnitEntry->GetDomainType() == DOMAIN_LAND && pkUnitEntry->GetDefaultUnitAIType() != UNITAI_EXPLORE)
+	if (iNumLandUnits <= (kPlayer.getNumCities() * 2) && pkUnitEntry->GetDomainType() == DOMAIN_LAND)
 	{
 		if(bCombat)
+		{
+			iBonus += 300;
+		}
+		//Fewer civilians til we rectify this!
+		else
+		{
+			iBonus -= 300;
+		}
+	}
+
+	//Tiny navy? Eek!
+	if (iNumSeaUnits <= kPlayer.GetNumEffectiveCoastalCities() && pkUnitEntry->GetDomainType() == DOMAIN_SEA)
+	{
+		if (bCombat)
 		{
 			iBonus += 300;
 		}
@@ -1390,7 +1407,7 @@ int CvUnitProductionAI::CheckUnitBuildSanity(UnitTypes eUnit, bool bForOperation
 			iBonus -= 500;
 	}
 
-	if (bCombat && pkUnitEntry->GetDomainType() == DOMAIN_LAND && pkUnitEntry->GetDefaultUnitAIType() != UNITAI_EXPLORE)
+	if (bCombat)
 	{
 		static MilitaryAIStrategyTypes eStrategyBarbs = (MilitaryAIStrategyTypes)GC.getInfoTypeForString("MILITARYAISTRATEGY_ERADICATE_BARBARIANS");
 		static MilitaryAIStrategyTypes eStrategyBarbsCritical = (MilitaryAIStrategyTypes)GC.getInfoTypeForString("MILITARYAISTRATEGY_ERADICATE_BARBARIANS_CRITICAL");
@@ -1456,9 +1473,34 @@ int CvUnitProductionAI::CheckUnitBuildSanity(UnitTypes eUnit, bool bForOperation
 
 	if (!kPlayer.isMinorCiv() && !pkUnitEntry->IsNoSupply())
 	{
-		//Let's check this against supply to keep our military numbers lean.
 		if (bCombat && !bFree)
 		{
+			//Let's check this against supply to keep our military numbers lean.
+			int iScale = 0;
+			if (bCombat && !bFree)
+			{
+				int iSupply = max(1, kPlayer.GetNumUnitsSupplied());
+				int iDemand = iNumTotalUnitsToSupply;
+				if (bAtWar || bForOperation)
+				{
+					//hard limit, don't go too far into negative supply
+					if (iSupply <= iDemand - 3)
+						return SR_UNITSUPPLY;
+
+					//reduce bonus once we're over the limit
+					iScale = MapToPercent(iDemand, iSupply + 3, iSupply - 1);
+				}
+				else
+				{
+					//reduce bonus once we're approaching the limit
+					iScale = MapToPercent(iDemand, iSupply, (iSupply * 2) / 3);
+
+					//don't exceed the limit
+					if (iSupply <= iDemand)
+						return SR_UNITSUPPLY;
+				}
+			}
+
 			iBonus *= iScale;
 			iBonus /= 100;
 		}


### PR DESCRIPTION
Unit production/unit composition planning AI rework:

Rework AI army planning to make it split its total supply into land/naval units. Previously it would not take the maximum supply into account properly so it would sometimes decide that it needs more defensive land units than the total supply allows.

With this new system the function in CvMilitaryAI will decide the exact number of land/naval units it wants up to the supply limit.

Future consideration: could update the CvMilitaryAI functionality to plan out how many units it wants of every unit type/unit AI type.

Various other tweaks and fixes:

Fix crash when building Eki (or similar) outside owned borders.

Add functionality for the game to keep track of who the current player is in regards to known other player vision logic. Should hopefully work with simultaneous turns etc.

Fix GPTIs being built in deserts/snow/other poor yield plots when there are perfectly fine plots to put them where we weren't planning on doing anything useful anyway.