### PR TITLE
Fix Squads Bug - Incorrectly Loading "Arrival Mode" user option

### DIFF
--- a/(4a) Squads for VP/UI/Squads.xml
+++ b/(4a) Squads for VP/UI/Squads.xml
@@ -161,7 +161,7 @@
                 <CheckBox Anchor="L,T"  TextAnchorSide="Right" Offset="-25,0" TextOffset="40,0" IsChecked="0" ID="FlagsNumberCheckBox" String="TXT_KEY_SQUADS_OPTION_FLAGS_NUMBER" />
                 <Label Anchor="L,T"  TextAnchorSide="Right" Offset="-25,0" TextOffset="40,0" String=" " />
                 <Label Anchor="L,T"  TextAnchorSide="Right" Offset="-25,0" TextOffset="40,0" String="TXT_KEY_SQUADS_MOVEMENT_END_TYPE" />
-                <RadioButton RadioGroup="SquadsEndMoveMode" Anchor="L,T"  TextAnchorSide="Right" Offset="-25,0" TextOffset="40,0" IsChecked="1" ID="AlertOnArrivalRadioButton" String="TXT_KEY_SQUADS_MOVEMENT_END_TYPE_ALERT_ON_ARRIVAL" />
+                <RadioButton RadioGroup="SquadsEndMoveMode" Anchor="L,T"  TextAnchorSide="Right" Offset="-25,0" TextOffset="40,0" IsChecked="0" ID="AlertOnArrivalRadioButton" String="TXT_KEY_SQUADS_MOVEMENT_END_TYPE_ALERT_ON_ARRIVAL" />
                 <RadioButton RadioGroup="SquadsEndMoveMode" Anchor="L,T"  TextAnchorSide="Right" Offset="-25,0" TextOffset="40,0" IsChecked="0" ID="WakeOnUnitArrivalRadioButton" String="TXT_KEY_SQUADS_MOVEMENT_END_TYPE_WAKE_ON_UNIT_ARRIVAL" />
                 <RadioButton RadioGroup="SquadsEndMoveMode" Anchor="L,T"  TextAnchorSide="Right" Offset="-25,0" TextOffset="40,0" IsChecked="0" ID="WakeOnSquadArrivalRadioButton" String="TXT_KEY_SQUADS_MOVEMENT_END_TYPE_WAKE_ON_SQUAD_ARRIVAL" />
                 <Box Anchor="C,T" Size="210,1" Color="0,0,0,0" />


### PR DESCRIPTION
Fixes a bug where the `SquadsEndMoveMode` option, when loading, ignored the user saved option and always loaded the default of "Alert on Arrival".

I don't know what caused this to change, but the way it used to work is the `RegisterCheckHandler()` event for the default radio button used to fire first, then the code that loaded the saved option value, which would call `SetCheck()` on the right one.

The way it works now is the opposite: first the option is loaded, then the default xml option is enabled, which triggers the check handler and overwrites it with the default.
The fix is to remove a default check value in the xml so that it no longer overwrites the user-loaded value. 

I had concerns that having no checked radio button in a radio button group would lead to undefined behavior, but apparently the game does first check if there's nothing enabled and enables the first option in that case only, so both the initial and user loading cases work now.

Closes #11726