### PR TITLE
Fix heap-use-after-free in TContainer::Remove

### DIFF
--- a/CvGameCoreDLL_Expansion2/TContainer.h
+++ b/CvGameCoreDLL_Expansion2/TContainer.h
@@ -127,9 +127,9 @@ bool TContainer<T>::Remove(int iID)
 
 	if (it!=m_items.end())
 	{
+		m_order.erase( std::remove(m_order.begin(), m_order.end(), it->second), m_order.end() );
 		delete m_items[it->first];
 		m_items.erase(it->first);
-		m_order.erase( std::remove(m_order.begin(), m_order.end(), it->second), m_order.end() );
 		return true;
 	}
 


### PR DESCRIPTION
`m_items.erase(it->first)` invalidates `it`, causing `it->second` to read (potentially) freed data. The solution is just to erase from `m_order` before `m_items`.