### PR TITLE
Fix clang warnings

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
@@ -3368,10 +3368,12 @@ pair<int,int> CvBuilderTaskingAI::ScorePlotBuild(CvPlot* pPlot, ImprovementTypes
 				{
 					int iAdjacentTerrainYieldChange = pkImprovementInfo ? pkImprovementInfo->GetAdjacentTerrainYieldChanges(pAdjacentPlot->getTerrainType(), eYield) : 0;
 					if (iAdjacentTerrainYieldChange != 0)
+					{
 						if (bWorkingAdjacent)
 							iNewAdjacentWorkedYield += iAdjacentTerrainYieldChange;
 						else
 							iNewAdjacentUnworkedYield += iAdjacentTerrainYieldChange;
+					}
 				}
 
 				ImprovementTypes eAdjacentImprovement = GetPlannedImprovementInPlot(pAdjacentPlot, sState);
@@ -3391,20 +3393,24 @@ pair<int,int> CvBuilderTaskingAI::ScorePlotBuild(CvPlot* pPlot, ImprovementTypes
 
 						int iDeltaTruncatedYield = (fCurrentAdjacentImprovementYield + fAdjacentImprovementYield).Truncate() - fCurrentAdjacentImprovementYield.Truncate();
 						if (iDeltaTruncatedYield != 0)
+						{
 							if (bWorkingAdjacent)
 								iNewAdjacentWorkedYield += iDeltaTruncatedYield;
 							else
 								iNewAdjacentUnworkedYield += iDeltaTruncatedYield;
+						}
 
 						// How much extra yield an adjacent improvement will get if we create a resource
 						if (eResourceFromImprovement != NO_RESOURCE)
 						{
 							int iAdjacentResourceYieldChanges = pkAdjacentImprovementInfo->GetAdjacentResourceYieldChanges(eResourceFromImprovement, eYield);
 							if (iAdjacentResourceYieldChanges != 0)
+							{
 								if (bWorkingAdjacent)
 									iNewAdjacentWorkedYield += iAdjacentResourceYieldChanges;
 								else
 									iNewAdjacentUnworkedYield += iAdjacentResourceYieldChanges;
+							}
 						}
 
 						// How much extra yield an adjacent improvement will get if we create a feature (or keep the one that's here)
@@ -3413,10 +3419,12 @@ pair<int,int> CvBuilderTaskingAI::ScorePlotBuild(CvPlot* pPlot, ImprovementTypes
 							FeatureTypes eNewFeature = eFeatureFromImprovement != NO_FEATURE ? eFeatureFromImprovement : eFeature;
 							int iAdjacentFeatureYieldChanges = pkAdjacentImprovementInfo->GetAdjacentFeatureYieldChanges(eNewFeature, eYield);
 							if (iAdjacentFeatureYieldChanges != 0)
+							{
 								if (bWorkingAdjacent)
 									iNewAdjacentWorkedYield += iAdjacentFeatureYieldChanges;
 								else
 									iNewAdjacentUnworkedYield += iAdjacentFeatureYieldChanges;
+							}
 						}
 					}
 				}

--- a/CvGameCoreDLL_Expansion2/CvTacticalAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTacticalAI.cpp
@@ -1805,7 +1805,7 @@ void CvTacticalAI::PlotNavalEscortMoves()
 /// Win an attrition campaign with bombardments
 void CvTacticalAI::PlotAttritionAttacks(CvTacticalDominanceZone* pZone)
 {
-	pZone; //unused but can be inspected
+	(void)pZone; //unused but can be inspected
 	ClearCurrentMoveUnits(AI_TACTICAL_ATTRITION);
 
 	//todo: the targets are sorted in a very rough "how bad can they hit us" order
@@ -1819,7 +1819,7 @@ void CvTacticalAI::PlotAttritionAttacks(CvTacticalDominanceZone* pZone)
 /// Defeat enemy units by using our advantage in numbers
 void CvTacticalAI::PlotExploitFlanksMoves(CvTacticalDominanceZone* pZone)
 {
-	pZone; //unused but can be inspected
+	(void)pZone; //unused but can be inspected
 	ClearCurrentMoveUnits(AI_TACTICAL_FLANKATTACK);
 
 	for (CvTacticalTarget* pTarget = GetFirstZoneTarget(AI_TACTICAL_TARGET_ENEMY_COMBAT_UNIT, AL_MEDIUM); pTarget!=NULL; pTarget = GetNextZoneTarget(AL_MEDIUM))
@@ -1832,7 +1832,7 @@ void CvTacticalAI::PlotExploitFlanksMoves(CvTacticalDominanceZone* pZone)
 /// We have more overall strength than enemy, defeat his army first
 void CvTacticalAI::PlotSteamrollMoves(CvTacticalDominanceZone* pZone)
 {
-	pZone; //unused but can be inspected
+	(void)pZone; //unused but can be inspected
 	ClearCurrentMoveUnits(AI_TACTICAL_STEAMROLL);
 
 	// See if there are any kill attacks we can make.
@@ -1846,7 +1846,7 @@ void CvTacticalAI::PlotSteamrollMoves(CvTacticalDominanceZone* pZone)
 /// We should be strong enough to take out the city before the enemy can whittle us down with ranged attacks
 void CvTacticalAI::PlotSurgicalCityStrikeMoves(CvTacticalDominanceZone* pZone)
 {
-	pZone; //unused but can be inspected
+	(void)pZone; //unused but can be inspected
 	ClearCurrentMoveUnits(AI_TACTICAL_SURGICAL_STRIKE);
 
 	// Attack the city first
@@ -1873,7 +1873,7 @@ void CvTacticalAI::PlotHedgehogMoves(CvTacticalDominanceZone* pZone)
 /// Try to push back the invader
 void CvTacticalAI::PlotCounterattackMoves(CvTacticalDominanceZone* pZone)
 {
-	pZone; //unused but can be inspected
+	(void)pZone; //unused but can be inspected
 	ClearCurrentMoveUnits(AI_TACTICAL_COUNTERATTACK);
 
 	// Attack priority unit targets


### PR DESCRIPTION
Fixed some warnings, two others remain.
```
C:\Users\user\Documents\GitHub\Community-Patch-DLL\CvGameCoreDLL_Expansion2\CvCity.cpp(31916,11) : warning: 5 enumeration values not handled in switch: 'REASON_DEFAULT', 'REASON_UPGRADE', 'REASON_GIFT'... [-Wswitch]
 31916 |                         switch (eReason) {
       |                                 ^~~~~~~
C:\Users\user\Documents\GitHub\Community-Patch-DLL\CvGameCoreDLL_Expansion2\CvPlayer.cpp(17300,3) : warning: expression result unused [-Wunused-value]
 17300 |                         iFreeCulture;
       |                         ^~~~~~~~~~~~
```