### PR TITLE
Combat panel fixes

### DIFF
--- a/(1) Community Patch/Core Files/Overrides/EnemyUnitPanel.lua
+++ b/(1) Community Patch/Core Files/Overrides/EnemyUnitPanel.lua
@@ -403,15 +403,19 @@ function UpdateCombatSimulator(pMyUnit, pTheirUnit, pMyCity, pTheirCity)
 				iTheirStrength = pTheirUnit:GetMaxDefenseStrength(pToPlot, pMyUnit, pFromPlot, false, iMyRangedSupportDamageInflicted);
 
 				iWithdrawChance = pTheirUnit:GetWithdrawChance(pMyUnit);
+				
+				if (iMyRangedSupportDamageInflicted > pTheirUnit:GetCurrHitPoints()) then
+					-- defender killed by RangedSupportFire, no melee combat necessary
+					iMyDamageInflicted = iMyRangedSupportDamageInflicted
+				else
+					iMyDamageInflicted, iTheirDamageInflicted = pMyUnit:GetMeleeCombatDamage(iMyStrength, iTheirStrength, false, pTheirUnit, iMyRangedSupportDamageInflicted);
+					iMyDamageInflicted = iMyDamageInflicted + iMyRangedSupportDamageInflicted;
+				end
+			else
+				-- attack on city
+				iMyDamageInflicted, iTheirDamageInflicted = pMyUnit:GetMeleeCombatDamageCity(iMyStrength, pTheirCity, false);
 			end
 
-			iMyDamageInflicted = pMyUnit:GetCombatDamage(iMyStrength, iTheirStrength, nil, false, false, not not pTheirCity, pTheirCity);
-			iMyDamageInflicted = iMyDamageInflicted + iMyRangedSupportDamageInflicted;
-
-			-- Embarked unit cannot deal damage
-			if not (pTheirUnit and pTheirUnit:IsEmbarked()) then
-				iTheirDamageInflicted = pMyUnit:GetCombatDamage(iTheirStrength, iMyStrength, nil, false, not not pTheirCity, false);
-			end
 		end
 	end
 

--- a/CvGameCoreDLL_Expansion2/CvGame.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGame.cpp
@@ -13468,7 +13468,8 @@ CombatPredictionTypes CvGame::GetCombatPrediction(const CvUnit* pAttackingUnit, 
 	int iRangedSupportDamageInflicted = 0;
 	if (pAttackingUnit->isRangedSupportFire()) 
 	{
-		iRangedSupportDamageInflicted = pAttackingUnit->GetRangeCombatDamage(pDefendingUnit, NULL, false);
+		int iUnusedReferenceVariable = 0;
+		iRangedSupportDamageInflicted = pAttackingUnit->GetRangeCombatDamage(pDefendingUnit, NULL, 0, iUnusedReferenceVariable, false);
 	}
 
 	int iAttackingStrength = pAttackingUnit->GetMaxAttackStrength(pFromPlot, pToPlot, pDefendingUnit, false, false);
@@ -13479,9 +13480,8 @@ CombatPredictionTypes CvGame::GetCombatPrediction(const CvUnit* pAttackingUnit, 
 
 	int iDefenderStrength = pDefendingUnit->GetMaxDefenseStrength(pToPlot, pAttackingUnit, pFromPlot, false, false, iRangedSupportDamageInflicted);
 
-	//iMyDamageInflicted = pMyUnit:GetCombatDamage(iMyStrength, iTheirStrength, pMyUnit:GetDamage() + iTheirFireSupportCombatDamage, false, false, false);
-	int iAttackingDamageInflicted = pAttackingUnit->getCombatDamage(iAttackingStrength, iDefenderStrength, false, false, false);
-	int iDefenderDamageInflicted  = pDefendingUnit->getCombatDamage(iDefenderStrength, iAttackingStrength, false, false, false);
+	int iDefenderDamageInflicted = 0; // passed by reference
+	int iAttackingDamageInflicted = pAttackingUnit->getMeleeCombatDamage(iAttackingStrength, iDefenderStrength, iDefenderDamageInflicted, false, pDefendingUnit, iRangedSupportDamageInflicted);
 	//iTheirDamageInflicted = iTheirDamageInflicted + iTheirFireSupportCombatDamage;
 
 	int iAttackerMaxHitPoints = pAttackingUnit->GetMaxHitPoints();

--- a/CvGameCoreDLL_Expansion2/CvGameCoreStructs.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGameCoreStructs.cpp
@@ -185,7 +185,6 @@ CvCombatInfo::CvCombatInfo() :
 		m_pCities[i] = NULL;
 		m_iFinalDamage[i] = 0;
 		m_iDamageInflicted[i] = 0;
-		m_iFearDamageInflicted[i] = 0;
 		m_iExperienceChange[i] = 0;
 		m_iMaxExperienceAllowed[i] = 0;
 		m_bInBorders[i] = false;
@@ -215,7 +214,6 @@ CvCombatInfo& CvCombatInfo::operator=(const CvCombatInfo& rhs)
 
 		m_iFinalDamage[i] = rhs.m_iFinalDamage[i];
 		m_iDamageInflicted[i] = rhs.m_iDamageInflicted[i];
-		m_iFearDamageInflicted[i] = rhs.m_iFearDamageInflicted[i];
 
 		m_iExperienceChange[i] = rhs.m_iExperienceChange[i];
 		m_iMaxExperienceAllowed[i] = rhs.m_iMaxExperienceAllowed[i];
@@ -404,18 +402,6 @@ void CvCombatInfo::setFinalDamage(BattleUnitTypes unitType, int iFinalDamage)
 {
 	checkBattleUnitType(unitType);
 	m_iFinalDamage[unitType] = iFinalDamage;
-}
-
-
-int CvCombatInfo::getFearDamageInflicted(BattleUnitTypes unitType) const
-{
-	checkBattleUnitType(unitType);
-	return m_iFearDamageInflicted[unitType];
-}
-void CvCombatInfo::setFearDamageInflicted(BattleUnitTypes unitType, int iDamage)
-{
-	checkBattleUnitType(unitType);
-	m_iFearDamageInflicted[unitType] = iDamage;
 }
 
 int CvCombatInfo::getExperience(BattleUnitTypes unitType) const

--- a/CvGameCoreDLL_Expansion2/CvGameCoreStructs.h
+++ b/CvGameCoreDLL_Expansion2/CvGameCoreStructs.h
@@ -333,9 +333,6 @@ public:
 	int getFinalDamage(BattleUnitTypes unitType) const;
 	void setFinalDamage(BattleUnitTypes unitType, int iFinalDamage);
 
-	int getFearDamageInflicted(BattleUnitTypes unitType) const;
-	void setFearDamageInflicted(BattleUnitTypes unitType, int iDamage);
-
 	int getExperience(BattleUnitTypes unitType) const;
 	void setExperience(BattleUnitTypes unitType, int iExperience);
 
@@ -381,7 +378,6 @@ protected:
 
 	int			m_iFinalDamage[BATTLE_UNIT_COUNT];				//!< The units final damage value
 	int			m_iDamageInflicted[BATTLE_UNIT_COUNT];			//!< How much damage this unit inflicts on the opponent
-	int			m_iFearDamageInflicted[BATTLE_UNIT_COUNT];		//!< How much fear damage this unit inflicts on the opponent
 
 	int			m_iExperienceChange[BATTLE_UNIT_COUNT];			//!< How much experience does this unit get from battle
 	int			m_iMaxExperienceAllowed[BATTLE_UNIT_COUNT];		//!< Maximum experience this unit is allowed

--- a/CvGameCoreDLL_Expansion2/CvTacticalAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTacticalAI.cpp
@@ -6229,19 +6229,23 @@ int TacticalAIHelpers::GetSimulatedDamageFromAttackOnUnit(const CvUnit* pDefende
 			iDamage += pAttacker->GetRangeCombatDamage(pDefender, NULL, 0, iUnusedReferenceVariable, false, iExtraDefenderDamage,
 							pDefenderPlot, pAttackerPlot, bIgnoreUnitAdjacencyBoni, bQuickAndDirty);
 
-		int iAttackerStrength = pAttacker->GetMaxAttackStrength(pAttackerPlot, pDefenderPlot, pDefender, bIgnoreUnitAdjacencyBoni, bQuickAndDirty);
-		//do not override defender flanking/general bonus (it is known during combat simulation)
-		int iDefenderStrength = pDefender->GetMaxDefenseStrength(pDefenderPlot, pAttacker, pAttackerPlot, false, bQuickAndDirty, iDamage + iExtraDefenderDamage);
+		// no melee attack if the RangedSupportFire has killed the defender
+		if (pDefender->GetCurrHitPoints() > iDamage + iExtraDefenderDamage)
+		{
+			int iAttackerStrength = pAttacker->GetMaxAttackStrength(pAttackerPlot, pDefenderPlot, pDefender, bIgnoreUnitAdjacencyBoni, bQuickAndDirty);
+			//do not override defender flanking/general bonus (it is known during combat simulation)
+			int iDefenderStrength = pDefender->GetMaxDefenseStrength(pDefenderPlot, pAttacker, pAttackerPlot, false, bQuickAndDirty, iDamage + iExtraDefenderDamage);
 
-		//just assume the unit can attack from its current location - modifiers might be different, but thats acceptable
-		iDamage += pAttacker->getMeleeCombatDamage(
-			iAttackerStrength,
-			iDefenderStrength,
-			iAttackerDamage,
-			false, pDefender,
-			iDamage + iExtraDefenderDamage);
+			//just assume the unit can attack from its current location - modifiers might be different, but thats acceptable
+			iDamage += pAttacker->getMeleeCombatDamage(
+				iAttackerStrength,
+				iDefenderStrength,
+				iAttackerDamage,
+				false, pDefender,
+				iDamage + iExtraDefenderDamage);
 
-		iDamage += (pAttacker->hasMoved() || pAttacker->plot() != pAttackerPlot) ? 0 : pAttacker->GetTileDamageIfNotMoved();
+			iDamage += (pAttacker->hasMoved() || pAttacker->plot() != pAttackerPlot) ? 0 : pAttacker->GetTileDamageIfNotMoved();
+		}
 	}
 
 	return iDamage;

--- a/CvGameCoreDLL_Expansion2/CvUnit.h
+++ b/CvGameCoreDLL_Expansion2/CvUnit.h
@@ -298,7 +298,9 @@ public:
 
 	bool IsAngerFreeUnit() const;
 
-	int getCombatDamage(int iStrength, int iOpponentStrength, bool bIncludeRand, bool bAttackerIsCity, bool bDefenderIsCity) const;
+	int getCombatDamage(int iStrength, int iOpponentStrength, bool bIncludeRand, bool bAttackerIsCity, bool bDefenderIsCity, const CvUnit* pkOtherUnit, bool bIsAirCombat) const;
+	int getMeleeCombatDamageCity(int iStrength, const CvCity* pCity, int& iSelfDamageInflicted, int iGarrisonMaxHP, int& iGarrisonDamage, bool bIncludeRand) const;
+	int getMeleeCombatDamage(int iStrength, int iOpponentStrength, int& iSelfDamageInflicted, bool bIncludeRand, const CvUnit* pkOtherUnit, int iExtraDefenderDamage = 0) const;
 	void move(CvPlot& targetPlot, bool bShow);
 	bool jumpToNearestValidPlot();
 	bool jumpToNearestValidPlotWithinRange(int iRange, CvPlot* pStartPlot=NULL);
@@ -364,10 +366,10 @@ public:
 #if defined(MOD_BALANCE_CORE)
 	void ChangeCannotBeCapturedCount(int iChange);
 	bool GetCannotBeCaptured();
-	int getForcedDamageValue();
+	int getForcedDamageValue() const;
 	void ChangeForcedDamageValue(int iChange);
 
-	int getChangeDamageValue();
+	int getChangeDamageValue() const;
 	void ChangeChangeDamageValue(int iChange);
 
 	int getPromotionDuration(PromotionTypes eIndex) const;
@@ -715,9 +717,11 @@ public:
 	int GetMaxRangedCombatStrength(const CvUnit* pOtherUnit, const CvCity* pCity, bool bAttacking, 
 									const CvPlot* pMyPlot = NULL, const CvPlot* pOtherPlot = NULL, 
 									bool bIgnoreUnitAdjacencyBoni = false, bool bQuickAndDirty = false, int iAssumeExtraDamage = 0) const;
-	int GetAirCombatDamage(const CvUnit* pDefender, const CvCity* pCity, bool bIncludeRand, int iAssumeExtraDamage = 0, 
+	int GetAirCombatDamage(const CvUnit* pDefender, const CvCity* pCity, int iGarrisonMaxHP, int& iGarrisonDamage, bool bIncludeRand,
+									int iAssumeExtraDefenderDamage = 0,
 									const CvPlot* pTargetPlot = NULL, const CvPlot* pFromPlot = NULL, bool bQuickAndDirty = false) const;
-	int GetRangeCombatDamage(const CvUnit* pDefender, const CvCity* pCity, bool bIncludeRand, int iAssumeExtraDamage = 0, 
+	int GetRangeCombatDamage(const CvUnit* pDefender, const CvCity* pCity, int iGarrisonMaxHP, int& iGarrisonDamage, bool bIncludeRand,
+									int iAssumeExtraDefenderDamage = 0,
 									const CvPlot* pTargetPlot = NULL, const CvPlot* pFromPlot = NULL, 
 									bool bIgnoreUnitAdjacencyBoni = false, bool bQuickAndDirty = false) const;
 	int GetRangeCombatSplashDamage(const CvPlot* pTargetPlot) const;

--- a/CvGameCoreDLL_Expansion2/CvUnit.h
+++ b/CvGameCoreDLL_Expansion2/CvUnit.h
@@ -298,7 +298,6 @@ public:
 
 	bool IsAngerFreeUnit() const;
 
-	int getCombatDamage(int iStrength, int iOpponentStrength, bool bIncludeRand, bool bAttackerIsCity, bool bDefenderIsCity, const CvUnit* pkOtherUnit, bool bIsAirCombat) const;
 	int getMeleeCombatDamageCity(int iStrength, const CvCity* pCity, int& iSelfDamageInflicted, int iGarrisonMaxHP, int& iGarrisonDamage, bool bIncludeRand) const;
 	int getMeleeCombatDamage(int iStrength, int iOpponentStrength, int& iSelfDamageInflicted, bool bIncludeRand, const CvUnit* pkOtherUnit, int iExtraDefenderDamage = 0) const;
 	void move(CvPlot& targetPlot, bool bShow);

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.h
@@ -54,6 +54,8 @@ protected:
 	static int lJumpToNearestValidPlot(lua_State* L);
 
 	static int lGetCombatDamage(lua_State* L);
+	static int lGetMeleeCombatDamage(lua_State* L);
+	static int lGetMeleeCombatDamageCity(lua_State* L);
 	static int lGetFireSupportUnit(lua_State* L);
 
 	static int lCanAutomate(lua_State* L);


### PR DESCRIPTION
- Fix incorrect combat panel predictions and tactical AI calculations when one or both units of a melee battle are killed (#11761)
- Combat panel now shows 0 self damage if a unit with a pre-ranged attack (Impi, GDR) is predicted to kill the defender with the ranged attack
- Combat panel and tactical AI now take into account flat damage reductions (cities and units)