### PR TITLE
Update CityStateStatusHelper.lua

### DIFF
--- a/(2) Vox Populi/LUA/CityStateStatusHelper.lua
+++ b/(2) Vox Populi/LUA/CityStateStatusHelper.lua
@@ -19,7 +19,10 @@ local kNegBarRange = 81;
 local kBarIconAtlas = "CITY_STATE_INFLUENCE_METER_ICON_ATLAS";
 local kBarIconNeutralIndex = 4;
 
-local iEmbassy = GameInfoTypes.IMPROVEMENT_EMBASSY
+tIsEmbassyImprovement = {}
+for row in DB.Query("select ID From Improvements where IsEmbassy=1") do
+	tIsEmbassyImprovement[row.ID] = true
+end
 
 -- The order of precedence in which the quest icons and tooltip points are displayed
 ktQuestsDisplayOrder = {
@@ -321,7 +324,14 @@ function GetCityStateStatusToolTip(iMajor, iMinor, bFullInfo)
 		strStatusTT = strStatusTT .. "[NEWLINE][NEWLINE]" .. Locale.ConvertTextKey("TXT_KEY_NEUTRAL_CSTATE_TT", strShortDescKey);
 	end
 	-- Embassy Check
-	if pMinor:GetImprovementCount(iEmbassy) > 0 then
+	local bIsEmbassyCheck = false
+	for k, v in pairs(tIsEmbassyImprovement) do
+		if pMinor:GetImprovementCount(k) > 0 then
+			bIsEmbassyCheck = true
+			break
+		end
+	end
+	if bIsEmbassyCheck then
 		strStatusTT = strStatusTT .. Locale.ConvertTextKey("TXT_KEY_CSTATE_CANNOT_EMBASSY");
 	else
 		strStatusTT = strStatusTT .. Locale.ConvertTextKey("TXT_KEY_CSTATE_CAN_EMBASSY");

--- a/(3a) EUI Compatibility Files/LUA/CityStateStatusHelper.lua
+++ b/(3a) EUI Compatibility Files/LUA/CityStateStatusHelper.lua
@@ -40,6 +40,11 @@ local newLine = civ5_mode and "[NEWLINE]" or "/n"
 
 local iEmbassy = GameInfoTypes.IMPROVEMENT_EMBASSY
 
+tIsEmbassyImprovement = {}
+for row in DB.Query("select ID From Improvements where IsEmbassy=1") do
+	tIsEmbassyImprovement[row.ID] = true
+end
+
 --[[
 local GetCityStateStatusRow = GetCityStateStatusRow
 local GetCityStateStatusType = GetCityStateStatusType
@@ -446,7 +451,14 @@ function GetCityStateStatusToolTip( majorPlayerID, minorPlayerID, isFullInfo )
 		-- Status
 		tip = tip .. " " .. GetCityStateStatusText( majorPlayerID, minorPlayerID )
 		table_insert( tips, tip )
-		if minorPlayer:GetImprovementCount(iEmbassy) > 0 then
+		local bIsEmbassyCheck = false
+		for k, v in pairs(tIsEmbassyImprovement) do
+			if minorPlayer:GetImprovementCount(k) > 0 then
+				bIsEmbassyCheck = true
+				break
+			end
+		end
+		if bIsEmbassyCheck then
 			table_insert( tips, L"TXT_KEY_CSTATE_CANNOT_EMBASSY")
 		else
 			table_insert( tips, L"TXT_KEY_CSTATE_CAN_EMBASSY")


### PR DESCRIPTION
City State status tooltip is not compatible with civs plopping unique embassies (improvements with column IsEmbassy=1) in CS territory. In detail, it displays "embassy available" erroneously when it should be not. I edited the relevant part and fixed the issue (I tested it in game).