### PR TITLE
Add backwards compatibility to HandicapInfos

### DIFF
--- a/(1) Community Patch/Database Changes/Difficulty/CoreDifficultyChanges.xml
+++ b/(1) Community Patch/Database Changes/Difficulty/CoreDifficultyChanges.xml
@@ -16,7 +16,9 @@
 	- AITrainPercent
 	- AIWorldTrainPercent
 	- AIConstructPercent
+	- AIWorldConstructPercent
 	- AICreatePercent
+	- AIWorldCreatePercent
 -->
 <GameData>
 	<HandicapInfos>
@@ -786,7 +788,9 @@
 			<AITrainPercent>100</AITrainPercent>
 			<AIWorldTrainPercent>100</AIWorldTrainPercent>
 			<AIConstructPercent>100</AIConstructPercent>
+			<AIWorldConstructPercent>100</AIWorldConstructPercent>
 			<AICreatePercent>100</AICreatePercent>
+			<AIWorldCreatePercent>100</AIWorldCreatePercent>
 		</Row>
 	</HandicapInfos>
 </GameData>

--- a/(1) Community Patch/Database Changes/Difficulty/DifficultyTableChanges.sql
+++ b/(1) Community Patch/Database Changes/Difficulty/DifficultyTableChanges.sql
@@ -1,12 +1,12 @@
 -- Player Bonuses
 ALTER TABLE HandicapInfos ADD MapPlacementPriority integer DEFAULT 3;
-ALTER TABLE HandicapInfos ADD StartingGold integer DEFAULT 0;
+ALTER TABLE HandicapInfos ADD StartingGold integer DEFAULT 0; -- renamed from Gold
 ALTER TABLE HandicapInfos ADD HappinessDefaultCapital integer DEFAULT 0;
 ALTER TABLE HandicapInfos ADD EmpireSizeUnhappinessMod integer DEFAULT 0;
-ALTER TABLE HandicapInfos ADD MaintenanceFreeUnits integer DEFAULT 0;
-ALTER TABLE HandicapInfos ADD UnitSupplyBase integer DEFAULT 0;
-ALTER TABLE HandicapInfos ADD UnitSupplyPerCity integer DEFAULT 0;
-ALTER TABLE HandicapInfos ADD UnitSupplyPopulationPercent integer DEFAULT 0;
+ALTER TABLE HandicapInfos ADD MaintenanceFreeUnits integer DEFAULT 0; -- renamed from GoldFreeUnits
+ALTER TABLE HandicapInfos ADD UnitSupplyBase integer DEFAULT 0; -- renamed from ProductionFreeUnits
+ALTER TABLE HandicapInfos ADD UnitSupplyPerCity integer DEFAULT 0; -- renamed from ProductionFreeUnitsPerCity
+ALTER TABLE HandicapInfos ADD UnitSupplyPopulationPercent integer DEFAULT 0; -- renamed from ProductionFreeUnitsPopulationPercent
 ALTER TABLE HandicapInfos ADD UnitSupplyPerEraFlat integer DEFAULT 0;
 ALTER TABLE HandicapInfos ADD UnitSupplyPerEraModifier integer DEFAULT 0;
 ALTER TABLE HandicapInfos ADD UnitSupplyBonusPercent integer DEFAULT 0;
@@ -62,7 +62,7 @@ ALTER TABLE HandicapInfos ADD AIUnitSupplyPerCity integer DEFAULT 0;
 ALTER TABLE HandicapInfos ADD AIUnitSupplyPopulationPercent integer DEFAULT 0;
 ALTER TABLE HandicapInfos ADD AIUnitSupplyPerEraFlat integer DEFAULT 0;
 ALTER TABLE HandicapInfos ADD AIUnitSupplyPerEraModifier integer DEFAULT 0;
-ALTER TABLE HandicapInfos ADD AIUnitSupplyBonusPercent integer DEFAULT 0;
+ALTER TABLE HandicapInfos ADD AIUnitSupplyBonusPercent integer DEFAULT 0; -- renamed from AIUnitSupplyPercent
 ALTER TABLE HandicapInfos ADD AIImprovementCostPercent integer DEFAULT 100;
 ALTER TABLE HandicapInfos ADD AIUnitUpgradePerEraModifier integer DEFAULT 0;
 ALTER TABLE HandicapInfos ADD AIGrowthPerEraModifier integer DEFAULT 0;
@@ -116,11 +116,11 @@ ALTER TABLE HandicapInfos ADD CityStateCombatBonus integer DEFAULT 0;
 ALTER TABLE HandicapInfos ADD CityStateVisionBonus integer DEFAULT 0;
 
 -- Barbarians
-ALTER TABLE HandicapInfos ADD BonusVSBarbarians integer DEFAULT 0;
-ALTER TABLE HandicapInfos ADD AIBonusVSBarbarians integer DEFAULT 0;
-ALTER TABLE HandicapInfos ADD BarbarianCampGold integer DEFAULT 0;
+ALTER TABLE HandicapInfos ADD BonusVSBarbarians integer DEFAULT 0; -- renamed from BarbarianBonus
+ALTER TABLE HandicapInfos ADD AIBonusVSBarbarians integer DEFAULT 0; -- renamed from AIBarbarianBonus
+ALTER TABLE HandicapInfos ADD BarbarianCampGold integer DEFAULT 0; -- renamed from BarbCampGold
 ALTER TABLE HandicapInfos ADD AIBarbarianCampGold integer DEFAULT 0;
-ALTER TABLE HandicapInfos ADD BarbarianSpawnDelay integer DEFAULT 0;
+ALTER TABLE HandicapInfos ADD BarbarianSpawnDelay integer DEFAULT 0; -- renamed from BarbSpawnMod
 
 -- AI Behavior Modifiers
 -- Weighted Randomized Choices

--- a/(2) Vox Populi/Database Changes/Difficulty/DifficultyChanges.xml
+++ b/(2) Vox Populi/Database Changes/Difficulty/DifficultyChanges.xml
@@ -16,7 +16,9 @@
 	- AITrainPercent
 	- AIWorldTrainPercent
 	- AIConstructPercent
+	- AIWorldConstructPercent
 	- AICreatePercent
+	- AIWorldCreatePercent
 -->
 <GameData>
 	<HandicapInfos>
@@ -712,7 +714,9 @@
 			<AITrainPercent>100</AITrainPercent>
 			<AIWorldTrainPercent>100</AIWorldTrainPercent>
 			<AIConstructPercent>100</AIConstructPercent>
+			<AIWorldConstructPercent>100</AIWorldConstructPercent>
 			<AICreatePercent>100</AICreatePercent>
+			<AIWorldCreatePercent>100</AIWorldCreatePercent>
 		</Row>
 	</HandicapInfos>
 </GameData>

--- a/CvGameCoreDLL_Expansion2/CvInfos.cpp
+++ b/CvGameCoreDLL_Expansion2/CvInfos.cpp
@@ -4489,6 +4489,50 @@ bool CvHandicapInfo::CacheResults(Database::Results& kResults, CvDatabaseUtility
 	m_iAIFriendlyApproachChangeFlat = kResults.GetInt("AIFriendlyApproachChangeFlat");
 	m_iAIFriendlyApproachChangePercent = kResults.GetInt("AIFriendlyApproachChangePercent");
 
+	// Add backwards compatibility for some renamed, previously used columns (as much as we reasonably can)
+	m_iStartingGold += kResults.GetInt("Gold");
+	m_iMaintenanceFreeUnits += kResults.GetInt("GoldFreeUnits");
+	m_iUnitSupplyBase += kResults.GetInt("ProductionFreeUnits");
+	m_iUnitSupplyPerCity += kResults.GetInt("ProductionFreeUnitsPerCity");
+	m_iUnitSupplyPopulationPercent += kResults.GetInt("ProductionFreeUnitsPopulationPercent");
+	m_iAIUnitSupplyBonusPercent += kResults.GetInt("AIUnitSupplyPercent");
+	m_iBonusVSBarbarians += kResults.GetInt("BarbarianBonus");
+	m_iAIBonusVSBarbarians += kResults.GetInt("AIBarbarianBonus");
+	m_iBarbarianCampGold += kResults.GetInt("BarbCampGold");
+	m_iBarbarianSpawnDelay += kResults.GetInt("BarbSpawnMod");
+
+	// The "per era modifier" affects a bunch of things in vanilla BNW - most of these are retained, some of the functionality is removed
+	// Omitted: production discount to World Wonders and two additional discounts the AI had to portions of unit maintenance costs
+	int iAIPerEraModifier = kResults.GetInt("AIPerEraModifier");
+	m_iAICivilianPerEraModifier += iAIPerEraModifier;
+	m_iAITrainPerEraModifier += iAIPerEraModifier;
+	m_iAIConstructPerEraModifier += iAIPerEraModifier;
+	m_iAICreatePerEraModifier += iAIPerEraModifier;
+	m_iAIGrowthPerEraModifier += iAIPerEraModifier;
+	m_iAIUnitUpgradePerEraModifier += iAIPerEraModifier;
+
+	// ... more complicated for multiplicative columns
+	int iNumCitiesUnhappinessMod = kResults.GetInt("NumCitiesUnhappinessMod");
+	if (iNumCitiesUnhappinessMod != 0)
+	{
+		m_iEmpireSizeUnhappinessMod = (iNumCitiesUnhappinessMod * (100 + m_iEmpireSizeUnhappinessMod) / 100) - 100;
+	}
+	int iRouteCostPercent = kResults.GetInt("RouteCostPercent");
+	if (iRouteCostPercent != 0)
+	{
+		// We can probably assume that if a modmod specified RouteCostPercent, they don't also have special tile improvements that cost maintenance
+		// Note that in vanilla BNW, ImprovementCostPercent is supposed to be the player version of AIWorkRateModifier - VP adds WorkRateModifier and repurposes this to be the maintenance cost
+		// A better fix here would be to separate cost from Roads and Tile Improvements
+		m_iImprovementCostPercent *= iRouteCostPercent;
+		m_iImprovementCostPercent /= 100;
+	}
+	int iAIUnhappinessPercent = kResults.GetInt("AIUnhappinessPercent");
+	if (iAIUnhappinessPercent != 0)
+	{
+		m_iAIPopulationUnhappinessMod = (iAIUnhappinessPercent * (100 + m_iAIPopulationUnhappinessMod) / 100) - 100;
+		m_iAIEmpireSizeUnhappinessMod = (iAIUnhappinessPercent * (100 + m_iAIEmpireSizeUnhappinessMod) / 100) - 100;
+	}
+
 	//Arrays
 	const char* szHandicapType = GetType();
 


### PR DESCRIPTION
~~Removes DifficultyChanges.sql, separating it into one file for the Ancient Ruins changes and five files for the triggered instant yields, one file for each difficulty.~~

~~This should now be way easier to modify for the end user compared to having to do math. And it's easy enough to read from the file if someone wants to do difficulty bonus related proposals.~~

Adds backwards compatibility to some renamed but previously used columns in the HandicapInfos table - if these normally unused columns are used by a modmod, their effects will stack with those of the new columns.

The columns unfortunately cannot be simply deleted by remaking the table, since remaking the table creates errors due to external code.