### PR TITLE
CPK: Add string distance function and FuzzyTrie stub

### DIFF
--- a/(1) Community Patch/Community Patch.civ5proj
+++ b/(1) Community Patch/Community Patch.civ5proj
@@ -998,6 +998,7 @@
     <Folder Include="Kit\Assert" />
     <Folder Include="Kit\FP" />
     <Folder Include="Kit\Cache" />
+    <Folder Include="Kit\String" />
     <Folder Include="Kit\Table" />
     <Folder Include="Kit\Type" />
     <Folder Include="Kit\UI" />
@@ -3465,6 +3466,10 @@
       <SubType>Lua</SubType>
       <ImportIntoVFS>True</ImportIntoVFS>
     </Content>
+    <Content Include="Kit\String\CPK.String.Distance.lua">
+      <SubType>Lua</SubType>
+      <ImportIntoVFS>True</ImportIntoVFS>
+    </Content>
     <Content Include="Kit\Table\CPK.Table.Copy.lua">
       <SubType>Lua</SubType>
       <ImportIntoVFS>True</ImportIntoVFS>
@@ -3554,6 +3559,10 @@
       <ImportIntoVFS>True</ImportIntoVFS>
     </Content>
     <Content Include="Kit\UI\Control\CPK.UI.Control.Show.lua">
+      <SubType>Lua</SubType>
+      <ImportIntoVFS>True</ImportIntoVFS>
+    </Content>
+    <Content Include="Kit\Util\CPK.Util.FuzzyTrie.lua">
       <SubType>Lua</SubType>
       <ImportIntoVFS>True</ImportIntoVFS>
     </Content>

--- a/(1) Community Patch/Kit/String/CPK.String.Distance.lua
+++ b/(1) Community Patch/Kit/String/CPK.String.Distance.lua
@@ -1,0 +1,157 @@
+local _lua_math_min = math.min
+local _lua_math_huge = math.huge
+local _lua_string_len = string.len
+local _lua_string_byte = string.byte
+
+local _civ_locale_len = Locale.Length
+local _civ_locale_cmp = Locale.Compare
+local _civ_locale_sub = Locale.Substring
+local _civ_locale_isascii = Locale.IsASCII
+
+local AssertIsNumber = CPK.Assert.IsNumber
+local AssertIsString = CPK.Assert.IsString
+
+local LenUtf8 = _civ_locale_len
+local LenAscii = _lua_string_len
+
+--- @type fun(charA: string, charB: string): boolean
+local function EqlUtf8(charA, charB)
+	return _civ_locale_cmp(charA, charB) == 0
+end
+
+--- @type fun(str: string, i: integer): string
+local function SubUtf8(str, i)
+	return _civ_locale_sub(str, i, 1)
+end
+
+--- @type fun(charA: integer, charB: integer): boolean
+local function EqlAscii(charA, charB)
+	return charA == charB
+end
+
+--- ASCII byte extraction
+--- @type fun(str: string, i: integer): integer
+local function SubAscii(str, i)
+	return _lua_string_byte(str, i)
+end
+
+--- Calculates Damerau–Levenshtein edit distance between two strings.
+--- <br> Supports both ASCII and UTF-8 strings via Locale.
+--- <br> Uses dynamic programming with row reuse/sliding window for efficiency.
+--- <br> Use max parameter to specify fast cutoff to not calculate full distance.
+--- ```lua
+--- -- Example
+--- local StringDistance = CPK.String.Distance
+--- Distance('kitten', 'kiten') -- 1
+--- Distance('piktish', 'pcitish') -- 2
+--- Distance('warroir', 'warrior') -- 2
+--- Distance('Źdźbło', 'Zdżblo') -- 3
+--- Distance('bżęczyszczykiewić', 'brzęczyszczykiewicz') -- 4
+--- ```
+--- @param strA string
+--- @param strB string
+--- @param max? integer # Optional cutoff: if distance > max, returns max + 1
+--- @return integer # Distance or max + 1
+function CPK.String.Distance(strA, strB, max)
+	AssertIsString(strA)
+	AssertIsString(strB)
+
+	if max == nil then
+		max = _lua_math_huge
+	end
+
+	AssertIsNumber(max)
+
+	-- Fast exact match check
+	if strA == strB then
+		return 0
+	end
+
+	local Eql, Sub, Len
+
+	-- Pick strategy once: ASCII uses byte ops, UTF-8 uses Locale
+	if _civ_locale_isascii(strA) and _civ_locale_isascii(strB) then
+		Eql, Sub, Len = EqlAscii, SubAscii, LenAscii
+	else
+		Eql, Sub, Len = EqlUtf8, SubUtf8, LenUtf8
+	end
+
+	local lenA, lenB = Len(strA), Len(strB)
+
+	-- Ensure lenA >= lenB, (this should reduce memory usage)
+	if lenA < lenB then
+		strA, lenA, strB, lenB = strB, lenB, strA, lenA
+	end
+
+	-- Cutoff: lengths differ more than max, skip full calculation
+	if lenA - lenB > max then
+		return max + 1
+	end
+
+	-- Cutoff: if shorter string is empty, distance is length of longer
+	if lenB == 0 then
+		return lenA
+	end
+
+	local prevA, prevB
+	local prevRow, currRow, nextRow = {}, {}, {}
+
+	for iB = 0, lenB do
+		currRow[iB] = iB
+	end
+
+	for iA = 1, lenA do
+		local rmin = iA -- row minimum value
+		local charA = Sub(strA, iA)
+
+		nextRow[0] = iA
+
+		for iB = 1, lenB do
+			local charB = Sub(strB, iB)
+
+			-- Substitution cost
+			local cost = Eql(charA, charB) and 0 or 1
+
+			-- Standard Levenshtein recurrence:
+			local dist = _lua_math_min(
+				currRow[iB] + 1,   -- deletion
+				nextRow[iB - 1] + 1, -- insertion
+				currRow[iB - 1] + cost -- substitution
+			)
+
+			-- Damerau transposition check
+			if iA > 1 and iB > 1 then
+				if Eql(charA, prevB) and Eql(prevA, charB) then
+					dist = _lua_math_min(dist, (prevRow[iB - 2] or 0) + 1)
+				end
+			end
+
+			nextRow[iB] = dist
+
+			if dist < rmin then
+				rmin = dist
+			end
+
+			-- Reuse already extracted char instead of another Sub call
+			prevB = charB
+		end
+
+		if rmin > max then
+			return max + 1
+		end
+
+		-- Reuse already extracted char instead of another Sub call
+		prevA = charA
+
+		-- Slide/Reuse window
+		prevRow, currRow, nextRow = currRow, nextRow, prevRow
+	end
+
+	local final = currRow[lenB]
+
+	if final > max then
+		return max + 1
+	end
+
+	return final
+end

--- a/(1) Community Patch/Kit/Util/CPK.Util.FuzzyTrie.lua
+++ b/(1) Community Patch/Kit/Util/CPK.Util.FuzzyTrie.lua
@@ -1,0 +1,18 @@
+local _lua_setmetatable = setmetatable
+
+local Distance = CPK.String.Distance
+
+local FuzzyTrie = {}
+
+--- @class FuzzyTrie
+FuzzyTrie.__index = {}
+
+function FuzzyTrie.New()
+	error('Not implemented')
+end
+
+function FuzzyTrie.__index:Search(sentence)
+	error('Not implemented')
+end
+
+CPK.Util.FuzzyTrie = FuzzyTrie


### PR DESCRIPTION
Adding some building blocks for better Civilopedia search:
* _CPK.String.Distance_ – Damerau–Levenshtein distance between two strings. Supports a max cutoff so we don’t waste time on strings that are too different.
* _CPK.Util.FuzzyTrie_ – Stub for a trie-based fuzzy search. Will let us store and look up phrases/words efficiently.

_P.S. Distance calculation is kinda hot. Right now it’s pure Lua, but we could speed it up a lot if we implement it in C++ and expose it to Lua._