### PR TITLE
Auto-focus search in civilopedia

### DIFF
--- a/(2) Vox Populi/Core Files/Overrides/CivilopediaScreen.lua
+++ b/(2) Vox Populi/Core Files/Overrides/CivilopediaScreen.lua
@@ -9332,9 +9332,15 @@ function InputHandler( uiMsg, wParam, lParam )
 		if(not Controls.SearchFoundNothing:IsHidden()) then
 			if(wParam == Keys.VK_ESCAPE or wParam == Keys.VK_RETURN) then
 				Controls.SearchFoundNothing:SetHide(true);
+				Controls.SearchEditBox:TakeFocus()
 				return true;
 			end
 		else
+			if wParam == Keys.F and UIManager:GetControl() then
+				Controls.SearchEditBox:TakeFocus()
+				return true
+			end
+
 			if(wParam == Keys.VK_ESCAPE) then
 				OnClose();
 				return true;


### PR DESCRIPTION
Auto-focus search input when civilopedia is shown.
Auto-focus search input when ok clicked in notfound popup.
Auto-focus search input when ESC pressed in notfound popup (Clears input as a side effect).
Add `CTRL+F` bind to focus search input in civilopedia.