### PR TITLE
Fix lint of CPK local variable names

### DIFF
--- a/(1) Community Patch/Community Patch.civ5proj
+++ b/(1) Community Patch/Community Patch.civ5proj
@@ -3354,7 +3354,7 @@
       <SubType>Lua</SubType>
       <ImportIntoVFS>True</ImportIntoVFS>
     </Content>
-    <Content Include="Kit\Args\CPK.Args.IsEmpty.lua">
+    <Content Include="Kit\Args\CPK.Args.Empty.lua">
       <SubType>Lua</SubType>
       <ImportIntoVFS>True</ImportIntoVFS>
     </Content>
@@ -3474,7 +3474,7 @@
       <SubType>Lua</SubType>
       <ImportIntoVFS>True</ImportIntoVFS>
     </Content>
-    <Content Include="Kit\Table\CPK.Table.IsEmpty.lua">
+    <Content Include="Kit\Table\CPK.Table.Empty.lua">
       <SubType>Lua</SubType>
       <ImportIntoVFS>True</ImportIntoVFS>
     </Content>

--- a/(1) Community Patch/Core Files/Overrides/Includes/TechHelpInclude.lua
+++ b/(1) Community Patch/Core Files/Overrides/Includes/TechHelpInclude.lua
@@ -4,15 +4,15 @@ local StringBuilder = CPK.Util.StringBuilder
 local AsPercentage = CPK.Misc.AsPercentage
 local Memoize1 = CPK.Cache.Memoize1
 
-local _lua_type = type
-local _lua_math_floor = math.floor
-local _lua_string_format = string.format
+local lua_type = type
+local lua_math_floor = math.floor
+local lua_string_format = string.format
 
-local _civ_locale_lookup = Locale.Lookup
-local _civ_locale_toupper = Locale.ToUpper
-local _civ_db_create_query = DB.CreateQuery
+local civ_locale_lookup = Locale.Lookup
+local civ_locale_toupper = Locale.ToUpper
+local civ_db_create_query = DB.CreateQuery
 
-local L = _civ_locale_lookup
+local L = civ_locale_lookup
 
 --- @param color string
 local function PrepareColor(color)
@@ -93,7 +93,7 @@ end
 --- @param map RowMapper<Row>
 --- @return Writer
 local function PrepareContent(sql, map)
-	local query = _civ_db_create_query(sql)
+	local query = civ_db_create_query(sql)
 
 	return function(text, type)
 		WriteContent(text, type, query(type), map)
@@ -130,7 +130,7 @@ end
 --- @param map RowMapper<Row>
 --- @return Writer
 local function PrepareSection(name, sql, map)
-	local query = _civ_db_create_query(sql)
+	local query = civ_db_create_query(sql)
 	name = Cyan(L(name))
 
 	return function(text, type)
@@ -181,13 +181,13 @@ local buildingsSqlTemplate = [[
 
 local WriteWonders = PrepareSection(
 	'TXT_KEY_TECH_HELP_WONDERS_UNLOCKED',
-	_lua_string_format(buildingsSqlTemplate, '>'),
+	lua_string_format(buildingsSqlTemplate, '>'),
 	BulletAdj
 )
 
 local WriteBuildings = PrepareSection(
 	'TXT_KEY_TECH_HELP_BUILDINGS_UNLOCKED',
-	_lua_string_format(buildingsSqlTemplate, '<='),
+	lua_string_format(buildingsSqlTemplate, '<='),
 	BulletAdj
 )
 
@@ -304,7 +304,7 @@ local WriteAbilities = (function()
 	local function FillAbilityRemoveForestBonus(text, type, tech)
 		local prop = tech.FeatureProductionModifier
 
-		if _lua_type(prop) ~= 'number' then
+		if lua_type(prop) ~= 'number' then
 			return
 		end
 
@@ -325,7 +325,7 @@ local WriteAbilities = (function()
 		local baseChopYield = feature and feature.Production or 0
 		local gameChopYield = baseChopYield * percent / 100
 
-		local bonusChopYield = _lua_math_floor(gameChopYield * prop / 100)
+		local bonusChopYield = lua_math_floor(gameChopYield * prop / 100)
 
 		local str = ICON_BULLET
 				.. L('TXT_KEY_ABLTY_TECH_BOOST_CHOP', bonusChopYield)
@@ -364,7 +364,7 @@ local WriteAbilities = (function()
 		return function(text, type, tech)
 			local prop = tech[key]
 
-			if _lua_type(prop) == 'number' and prop > 0 then
+			if lua_type(prop) == 'number' and prop > 0 then
 				local str = ICON_BULLET .. L(txtKey, prop)
 				text:Append(str)
 			end
@@ -429,10 +429,10 @@ local WriteAbilities = (function()
 	for i = 1, len do
 		local ability = abilities[i]
 
-		if _lua_type(ability) == 'table' then
+		if lua_type(ability) == 'table' then
 			local str = ability[2]
 
-			if _lua_type(str) == 'string' then
+			if lua_type(str) == 'string' then
 				ability[2] = L(str)
 			end
 		end
@@ -447,14 +447,14 @@ local WriteAbilities = (function()
 		for i = 1, len do
 			local ability = abilities[i]
 
-			if _lua_type(ability) == 'function' then
+			if lua_type(ability) == 'function' then
 				ability(text, type, tech)
 			else
 				local prop = tech[ability[1]]
 				local str = ability[2]
 
-				local condA = _lua_type(prop) == 'boolean' and prop
-				local condB = _lua_type(prop) == 'number' and prop > 0
+				local condA = lua_type(prop) == 'boolean' and prop
+				local condB = lua_type(prop) == 'number' and prop > 0
 
 				if condA or condB then
 					text:Append(ICON_BULLET .. str)
@@ -531,7 +531,7 @@ local function GetYieldChangesSql()
 		local tag = select.tag
 		local src = select.src
 
-		sql:Append(_lua_string_format(template, tag, src))
+		sql:Append(lua_string_format(template, tag, src))
 	end
 
 	return 'SELECT * FROM (' .. sql:Concat(' UNION ALL ') .. [[
@@ -599,7 +599,7 @@ local GetTechById = Memoize1(function(techId)
 end)
 
 local GetTechNameById = Memoize1(function(techId)
-	return _civ_locale_toupper(L(GetTechById(techId).Description))
+	return civ_locale_toupper(L(GetTechById(techId).Description))
 end)
 
 GetShortHelpTextForTech = Memoize1(function(techId)
@@ -630,14 +630,14 @@ local function GetHelpForUnstartedTech(techId, cost)
 			.. (help == '' and '' or (NL .. help))
 end
 
---- @param techId TechId
+--- @param techId integer
 --- @param player Player
 --- @return number
 local function GetTechProgressById(techId, player)
 	local progress = 0
 
-	local a = _lua_type(player.GetResearchProgressTimes100) == 'function'
-	local b = _lua_type(player.GetResearchProgress) == 'function'
+	local a = lua_type(player.GetResearchProgressTimes100) == 'function'
+	local b = lua_type(player.GetResearchProgress) == 'function'
 
 	if a then
 		progress = player:GetResearchProgressTimes100(techId) / 100
@@ -648,7 +648,7 @@ local function GetTechProgressById(techId, player)
 	return progress
 end
 
---- @param techId TechId? # Technology Id
+--- @param techId integer? # Technology Id
 --- @param isShort boolean? # Shall help text be short (Without tech name and player info)
 --- @param playerId PlayerId? # Relative playerId, if none specified then active
 --- @return string

--- a/(1) Community Patch/Kit/Args/CPK.Args.Each.lua
+++ b/(1) Community Patch/Kit/Args/CPK.Args.Each.lua
@@ -1,4 +1,4 @@
-local _lua_select = select
+local lua_select = select
 
 --- Calls the specified function on each variadic argument.
 --- Uses two strategies internally:
@@ -10,15 +10,15 @@ local _lua_select = select
 --- @param ... Arg # Zero or more arguments
 --- @return Arg ... # Returns the original arguments
 local function ArgsEach(fn, ...)
-	local len = _lua_select('#', ...)
+	local len = lua_select('#', ...)
 
 	if len <= 8 then
 		local tmp = nil
 		-- O(n^2), acceptable for small length
 		for i = 1, len do
-			-- Very crucial to not do `fn(_lua_select(i, ...))`
+			-- Very crucial to not do `fn(select(i, ...))`
 			-- because select returns multiple values
-			tmp = _lua_select(i, ...)
+			tmp = lua_select(i, ...)
 			fn(tmp)
 		end
 	else

--- a/(1) Community Patch/Kit/Args/CPK.Args.Empty.lua
+++ b/(1) Community Patch/Kit/Args/CPK.Args.Empty.lua
@@ -1,11 +1,11 @@
-local _lua_select = select
+local lua_select = select
 
 --- Checks whether no arguments were passed.
 --- @param ... any # Zero or more arguments
 --- @return boolean # true if no arguments were passed, false otherwise
 --- @nodiscard
-local function ArgsIsEmpty(...)
-	return _lua_select('#', ...) == 0
+local function ArgsEmpty(...)
+	return lua_select('#', ...) == 0
 end
 
-CPK.Args.IsEmpty = ArgsIsEmpty
+CPK.Args.Empty = ArgsEmpty

--- a/(1) Community Patch/Kit/Args/CPK.Args.Pack.lua
+++ b/(1) Community Patch/Kit/Args/CPK.Args.Pack.lua
@@ -1,4 +1,4 @@
-local _lua_select = select
+local lua_select = select
 
 --- Packs variable arguments into a table.
 --- <br> Stores arguments in numeric keys and adds field `n` with the count.
@@ -10,7 +10,7 @@ local _lua_select = select
 --- @nodiscard
 --- @see table.pack
 local function ArgsPack(...)
-	return { n = _lua_select('#', ...), ... }
+	return { n = lua_select('#', ...), ... }
 end
 
 CPK.Args.Pack = ArgsPack

--- a/(1) Community Patch/Kit/Args/CPK.Args.Size.lua
+++ b/(1) Community Patch/Kit/Args/CPK.Args.Size.lua
@@ -1,7 +1,7 @@
-local _lua_select = select
+local lua_select = select
 
 local function ArgsSize(...)
-	return _lua_select('#', ...)
+	return lua_select('#', ...)
 end
 
 CPK.Args.Size = ArgsSize

--- a/(1) Community Patch/Kit/Args/CPK.Args.Unpack.lua
+++ b/(1) Community Patch/Kit/Args/CPK.Args.Unpack.lua
@@ -1,5 +1,5 @@
 ---@diagnostic disable-next-line: deprecated
-local _lua_unpack = table.unpack or unpack
+local lua_unpack = table.unpack or unpack
 
 --- Unpacks specified table using it's property `n` or length
 --- @generic T
@@ -9,7 +9,7 @@ local _lua_unpack = table.unpack or unpack
 --- @see unpack
 --- @see table.unpack
 local function ArgsUnpack(args)
-	return _lua_unpack(args, 1, args.n or #args)
+	return lua_unpack(args, 1, args.n or #args)
 end
 
 CPK.Args.Unpack = ArgsUnpack

--- a/(1) Community Patch/Kit/Assert/CPK.Assert.Error.lua
+++ b/(1) Community Patch/Kit/Assert/CPK.Assert.Error.lua
@@ -1,5 +1,5 @@
-local _lua_error = error
-local _lua_tostring = tostring
+local lua_error = error
+local lua_tostring = tostring
 
 --- Throws assertion error: `Got <got> where <exp> expected. <mes>`
 --- @param got string? # Actual type or value name.
@@ -7,14 +7,14 @@ local _lua_tostring = tostring
 --- @param mes string? # Extra message for context.
 --- @param lvl integer? # Error level (default 2).
 local function AssertError(got, exp, mes, lvl)
-	got = got == nil and 'unknown' or _lua_tostring(got)
-	exp = exp == nil and 'unknown' or _lua_tostring(exp)
-	mes = mes == nil and '' or (' ' .. _lua_tostring(mes))
+	got = got == nil and 'unknown' or lua_tostring(got)
+	exp = exp == nil and 'unknown' or lua_tostring(exp)
+	mes = mes == nil and '' or (' ' .. lua_tostring(mes))
 	lvl = lvl == nil and 2 or lvl
 
 	local str = 'Got ' .. got .. ' where ' .. exp .. ' expected.' .. mes
 
-	_lua_error(str, lvl)
+	lua_error(str, lvl)
 end
 
 CPK.Assert.Error = AssertError

--- a/(1) Community Patch/Kit/Assert/CPK.Assert.Prepare.lua
+++ b/(1) Community Patch/Kit/Assert/CPK.Assert.Prepare.lua
@@ -1,4 +1,4 @@
-local _lua_type = type
+local lua_type = type
 local AssertError = CPK.Assert.Error
 
 --- Creates a function that asserts the value matches the specified Lua type using a provided test function.
@@ -24,7 +24,7 @@ local function AssertPrepare(exp, tst)
 	--- @param lvl? integer # An optional level of error. For common asserts level should be 3.
 	return function(val, mes, lvl)
 		if not tst(val) then
-			AssertError(_lua_type(val), exp, mes, lvl or 3)
+			AssertError(lua_type(val), exp, mes, lvl or 3)
 		end
 	end
 end

--- a/(1) Community Patch/Kit/CPK.lua
+++ b/(1) Community Patch/Kit/CPK.lua
@@ -14,17 +14,17 @@
 		VERBOSE = false,
 	}
 
-	local _lua_type = type
-	local _lua_next = next
-	local _lua_error = error
-	local _lua_tostring = tostring
+	local lua_type = type
+	local lua_next = next
+	local lua_error = error
+	local lua_tostring = tostring
 
-	local _lua_string_match = string.match
-	local _lua_table_insert = table.insert
-	local _lua_table_concat = table.concat
+	local lua_string_match = string.match
+	local lua_table_insert = table.insert
+	local lua_table_concat = table.concat
 
-	local _lua_getmetatable = getmetatable
-	local _lua_setmetatable = setmetatable
+	local lua_getmetatable = getmetatable
+	local lua_setmetatable = setmetatable
 
 	local EmulateInclude = (function()
 		local function GetAvailablePaths()
@@ -42,7 +42,7 @@
 			end
 
 			-- We are not inside Civ5 Lua but somewhere else...
-			local hasOs = os and _lua_type(os.getenv) == 'function'
+			local hasOs = os and lua_type(os.getenv) == 'function'
 
 			if not hasOs then
 				error('Error in include emulation: Cannot determine OS')
@@ -60,7 +60,7 @@
 			end
 
 			for line in stream:lines() do
-				_lua_table_insert(files, line)
+				lua_table_insert(files, line)
 			end
 
 			return files
@@ -68,7 +68,7 @@
 
 		--- @param filename string
 		local function GetCandidatePath(filename)
-			for _, path in _lua_next, GetAvailablePaths(), nil do
+			for _, path in lua_next, GetAvailablePaths(), nil do
 				if string.sub(path, - #filename) == filename then
 					return path
 				end
@@ -83,7 +83,7 @@
 				filename = filename .. '.lua'
 			end
 
-			if _lua_type(dofile) ~= 'function' then
+			if lua_type(dofile) ~= 'function' then
 				error('Error in include emulation: dofile is not a function')
 			end
 
@@ -101,7 +101,7 @@
 		end
 	end)()
 
-	local _civ_include = include or EmulateInclude
+	local civ_include = include or EmulateInclude
 
 	-- If include is not set, then set global emulated version of include
 	if not include then
@@ -121,14 +121,14 @@
 	--- @param filename string
 	--- @return nil
 	local function Import(filename)
-		local type = _lua_type(filename)
+		local type = lua_type(filename)
 
 		if type ~= 'string' then
 			local message = 'Failed to include file because filename is not string but ' .. type '.'
-			_lua_error(message)
+			lua_error(message)
 		end
 
-		local included = _civ_include(filename)
+		local included = civ_include(filename)
 
 		if #included == 1 then
 			Info('Included file "' .. filename .. '"')
@@ -142,21 +142,21 @@
 					.. '\n\t' .. 'Please verify if specified file is registered in VFS.'
 					.. '\n\t' .. 'Please verify if specified file exists.'
 
-			_lua_error(message)
+			lua_error(message)
 		end
 
 		local tokens = {}
 
-		for _, path in _lua_next, included, nil do
-			_lua_table_insert(tokens, '"' .. path .. '"')
+		for _, path in lua_next, included, nil do
+			lua_table_insert(tokens, '"' .. path .. '"')
 		end
 
 		local message = failed
 				.. ' Filename is not unique enough. Multiple candidates found: {'
-				.. '\n\t' .. _lua_table_concat(tokens, ',\n\t')
+				.. '\n\t' .. lua_table_concat(tokens, ',\n\t')
 				.. '\n}'
 
-		_lua_error(message)
+		lua_error(message)
 	end
 
 	local Node = {}
@@ -167,11 +167,11 @@
 	Module.Node = Node
 
 	local function Error(lvl, mes)
-		if _lua_type(mes) == 'table' then
-			mes = _lua_table_concat(mes, '\n\t')
+		if lua_type(mes) == 'table' then
+			mes = lua_table_concat(mes, '\n\t')
 		end
 
-		_lua_error(mes, lvl)
+		lua_error(mes, lvl)
 	end
 	Node.Error = Error
 
@@ -180,7 +180,7 @@
 	--- @param key any
 	--- @return boolean
 	local function IsValidKey(key)
-		return _lua_type(key) == 'string' and _lua_string_match(key, keyPattern)
+		return lua_type(key) == 'string' and lua_string_match(key, keyPattern)
 	end
 	Module.IsValidKey = IsValidKey
 
@@ -194,17 +194,17 @@
 	--- @param val any
 	--- @return nil
 	local function GetNode(val)
-		if _lua_type(val) ~= 'table' then
+		if lua_type(val) ~= 'table' then
 			return nil
 		end
 
-		local node = _lua_getmetatable(val)
+		local node = lua_getmetatable(val)
 
 		if node == nil then
 			return nil
 		end
 
-		local meta = _lua_getmetatable(node)
+		local meta = lua_getmetatable(node)
 
 		if meta ~= Node then
 			return nil
@@ -224,12 +224,12 @@
 	--- @param val any
 	--- @return string
 	local function GetInfo(val)
-		return '(' .. _lua_type(val) .. ') ' .. _lua_tostring(val)
+		return '(' .. lua_type(val) .. ') ' .. lua_tostring(val)
 	end
 	Node.GetInfo = GetInfo
 
 	function Node.New(name)
-		local node = _lua_setmetatable({}, Node)
+		local node = lua_setmetatable({}, Node)
 
 		node.name = name
 		node.parent = node
@@ -253,15 +253,15 @@
 		local this = self
 
 		if name ~= nil then
-			_lua_table_insert(path, name)
+			lua_table_insert(path, name)
 		end
 
 		while not this:IsRoot() do
 			this = this.parent
-			_lua_table_insert(path, 1, this.name)
+			lua_table_insert(path, 1, this.name)
 		end
 
-		return _lua_table_concat(path, '.')
+		return lua_table_concat(path, '.')
 	end
 
 	--- @param name? string
@@ -324,7 +324,7 @@
 		end
 
 		self.children[key] = val
-		Info('Assigned ' .. _lua_type(val) .. ' ' .. self:GetPath(key))
+		Info('Assigned ' .. lua_type(val) .. ' ' .. self:GetPath(key))
 	end
 
 	--- @param key string
@@ -368,7 +368,7 @@
 		child = self.children[key]
 
 		if child ~= nil then
-			Info('Resolved ' .. _lua_type(child) .. ' ' .. pathname)
+			Info('Resolved ' .. lua_type(child) .. ' ' .. pathname)
 			return child
 		end
 
@@ -383,22 +383,22 @@
 	--- @param name? string
 	--- @return table
 	function Module.New(name)
-		local module = _lua_setmetatable({}, Node.New(name))
+		local module = lua_setmetatable({}, Node.New(name))
 
 		return module
 	end
 
-	_lua_setmetatable(Module --[[@as table]], {
+	lua_setmetatable(Module --[[@as table]], {
 		__call = Module.New
 	})
 
-	local kit = Module.New('CPK')
+	local M = Module.New
+
+	local kit = M('CPK')
 
 	kit.Module = Module
 	kit.Import = Import
 	kit.Var = Var
-
-	local M = Module
 
 	kit.Args = M()  -- Variadic Arguments
 	kit.Assert = M() -- Assertion utilities

--- a/(1) Community Patch/Kit/Cache/CPK.Cache.Memoize0.lua
+++ b/(1) Community Patch/Kit/Cache/CPK.Cache.Memoize0.lua
@@ -1,4 +1,4 @@
-local _lua_setmetatable = setmetatable
+local lua_setmetatable = setmetatable
 
 --- Creates a memoized version of a nullary (zero-argument) function.
 --- <br> The result of the first call is cached and reused on subsequent calls.
@@ -7,7 +7,7 @@ local _lua_setmetatable = setmetatable
 --- @param cache table? # Optional table to use as cache. If omitted, a weak-valued table is used.
 --- @return Fn # A memoized version of the original function.
 local function Memoize0(fn, cache)
-	local c = cache or _lua_setmetatable({}, { __mode = 'v' })
+	local c = cache or lua_setmetatable({}, { __mode = 'v' })
 
 	return function(...)
 		local val = c[1]

--- a/(1) Community Patch/Kit/Cache/CPK.Cache.Memoize1.lua
+++ b/(1) Community Patch/Kit/Cache/CPK.Cache.Memoize1.lua
@@ -1,4 +1,4 @@
-local _lua_setmetatable = setmetatable
+local lua_setmetatable = setmetatable
 
 local Identity = CPK.FP.Identity
 local Memoize = CPK.Cache.Memoize
@@ -14,7 +14,7 @@ local Memoize = CPK.Cache.Memoize
 local function Memoize1(fn, cache, hash)
 	return Memoize(
 		fn,
-		cache or _lua_setmetatable({}, { __mode = 'v' }),
+		cache or lua_setmetatable({}, { __mode = 'v' }),
 		hash or Identity
 	)
 end

--- a/(1) Community Patch/Kit/FP/CPK.FP.Compose.lua
+++ b/(1) Community Patch/Kit/FP/CPK.FP.Compose.lua
@@ -1,4 +1,4 @@
-local _lua_select = select
+local lua_select = select
 
 --- Composes the specified functions.
 --- Creates a function that executes the specified functions from last to first,
@@ -19,7 +19,7 @@ local _lua_select = select
 --- @nodiscard
 local function Compose(...)
 	local fns = { ... }
-	local len = _lua_select('#', ...)
+	local len = lua_select('#', ...)
 
 	local function Call(i, ...)
 		local fn = fns[i]

--- a/(1) Community Patch/Kit/FP/CPK.FP.Pipe.lua
+++ b/(1) Community Patch/Kit/FP/CPK.FP.Pipe.lua
@@ -1,4 +1,4 @@
-local _lua_select = select
+local lua_select = select
 
 --- Pipes the specified functions, creating a function that executes them in sequence.
 --- Each function's output is passed as input to the next function.
@@ -18,7 +18,7 @@ local _lua_select = select
 --- @nodiscard
 local function Pipe(...)
 	local fns = { ... }
-	local len = _lua_select('#', ...)
+	local len = lua_select('#', ...)
 
 	local function Call(i, ...)
 		local fn = fns[i]

--- a/(1) Community Patch/Kit/Misc/CPK.Misc.AsPercentage.lua
+++ b/(1) Community Patch/Kit/Misc/CPK.Misc.AsPercentage.lua
@@ -1,4 +1,4 @@
-local _lua_math_floor = math.floor
+local lua_math_floor = math.floor
 
 --- Converts a ratio (e.g., 0.25) into a display-friendly percentage (e.g. 25).
 --- Rounds down to whole number if no decimal part is needed,
@@ -15,10 +15,10 @@ local _lua_math_floor = math.floor
 --- @param ratio number # Ratio (e.g., 0.25 = 25%)
 --- @return number # Integer or 1-decimal-place float
 local function AsPercentage(ratio)
-	local num = _lua_math_floor(ratio * 1000) / 10
+	local num = lua_math_floor(ratio * 1000) / 10
 
 	return num % 1 == 0
-			and _lua_math_floor(num)
+			and lua_math_floor(num)
 			or num
 end
 

--- a/(1) Community Patch/Kit/String/CPK.String.Distance.lua
+++ b/(1) Community Patch/Kit/String/CPK.String.Distance.lua
@@ -1,27 +1,27 @@
-local _lua_math_min = math.min
-local _lua_math_huge = math.huge
-local _lua_string_len = string.len
-local _lua_string_byte = string.byte
+local lua_math_min = math.min
+local lua_math_huge = math.huge
+local lua_string_len = string.len
+local lua_string_byte = string.byte
 
-local _civ_locale_len = Locale.Length
-local _civ_locale_cmp = Locale.Compare
-local _civ_locale_sub = Locale.Substring
-local _civ_locale_isascii = Locale.IsASCII
+local civ_locale_len = Locale.Length
+local civ_locale_cmp = Locale.Compare
+local civ_locale_sub = Locale.Substring
+local civ_locale_isascii = Locale.IsASCII
 
 local AssertIsNumber = CPK.Assert.IsNumber
 local AssertIsString = CPK.Assert.IsString
 
-local LenUtf8 = _civ_locale_len
-local LenAscii = _lua_string_len
+local LenUtf8 = civ_locale_len
+local LenAscii = lua_string_len
 
 --- @type fun(charA: string, charB: string): boolean
 local function EqlUtf8(charA, charB)
-	return _civ_locale_cmp(charA, charB) == 0
+	return civ_locale_cmp(charA, charB) == 0
 end
 
 --- @type fun(str: string, i: integer): string
 local function SubUtf8(str, i)
-	return _civ_locale_sub(str, i, 1)
+	return civ_locale_sub(str, i, 1)
 end
 
 --- @type fun(charA: integer, charB: integer): boolean
@@ -32,7 +32,7 @@ end
 --- ASCII byte extraction
 --- @type fun(str: string, i: integer): integer
 local function SubAscii(str, i)
-	return _lua_string_byte(str, i)
+	return lua_string_byte(str, i)
 end
 
 --- Calculates Damerau–Levenshtein edit distance between two strings.
@@ -57,7 +57,7 @@ function CPK.String.Distance(strA, strB, max)
 	AssertIsString(strB)
 
 	if max == nil then
-		max = _lua_math_huge
+		max = lua_math_huge
 	end
 
 	AssertIsNumber(max)
@@ -70,7 +70,7 @@ function CPK.String.Distance(strA, strB, max)
 	local Eql, Sub, Len
 
 	-- Pick strategy once: ASCII uses byte ops, UTF-8 uses Locale
-	if _civ_locale_isascii(strA) and _civ_locale_isascii(strB) then
+	if civ_locale_isascii(strA) and civ_locale_isascii(strB) then
 		Eql, Sub, Len = EqlAscii, SubAscii, LenAscii
 	else
 		Eql, Sub, Len = EqlUtf8, SubUtf8, LenUtf8
@@ -113,7 +113,7 @@ function CPK.String.Distance(strA, strB, max)
 			local cost = Eql(charA, charB) and 0 or 1
 
 			-- Standard Levenshtein recurrence:
-			local dist = _lua_math_min(
+			local dist = lua_math_min(
 				currRow[iB] + 1,   -- deletion
 				nextRow[iB - 1] + 1, -- insertion
 				currRow[iB - 1] + cost -- substitution
@@ -122,7 +122,7 @@ function CPK.String.Distance(strA, strB, max)
 			-- Damerau transposition check
 			if iA > 1 and iB > 1 then
 				if Eql(charA, prevB) and Eql(prevA, charB) then
-					dist = _lua_math_min(dist, (prevRow[iB - 2] or 0) + 1)
+					dist = lua_math_min(dist, (prevRow[iB - 2] or 0) + 1)
 				end
 			end
 

--- a/(1) Community Patch/Kit/Table/CPK.Table.Copy.lua
+++ b/(1) Community Patch/Kit/Table/CPK.Table.Copy.lua
@@ -1,7 +1,7 @@
-local _lua_next = next
-local _lua_type = type
-local _lua_setmetatable = setmetatable
-local _lua_getmetatable = getmetatable
+local lua_next = next
+local lua_type = type
+local lua_setmetatable = setmetatable
+local lua_getmetatable = getmetatable
 
 local IsNil = CPK.Type.IsNil
 local IsTable = CPK.Type.IsTable
@@ -51,7 +51,7 @@ local function TableCopy(tbl, meta)
 
 	local copy = {}
 
-	for key, val in _lua_next, tbl, nil do
+	for key, val in lua_next, tbl, nil do
 		copy[key] = val
 	end
 
@@ -60,16 +60,16 @@ local function TableCopy(tbl, meta)
 	end
 
 	if IsTable(meta) then
-		return _lua_setmetatable(copy, meta --[[@as metatable]])
+		return lua_setmetatable(copy, meta --[[@as metatable]])
 	end
 
 	if IsBoolean(meta) then
 		return meta
-				and _lua_setmetatable(copy, _lua_getmetatable(tbl))
+				and lua_setmetatable(copy, lua_getmetatable(tbl))
 				or copy
 	end
 
-	return AssertError(_lua_type(meta), 'boolean, table, nil')
+	return AssertError(lua_type(meta), 'boolean, table, nil')
 end
 
 CPK.Table.Copy = TableCopy

--- a/(1) Community Patch/Kit/Table/CPK.Table.Empty.lua
+++ b/(1) Community Patch/Kit/Table/CPK.Table.Empty.lua
@@ -1,4 +1,4 @@
-local _lua_next = next
+local lua_next = next
 
 local AssertIsTable = CPK.Assert.IsTable
 
@@ -9,29 +9,29 @@ local AssertIsTable = CPK.Assert.IsTable
 ---
 --- ```lua
 --- -- Examples
---- local IsEmpty = CPK.Table.IsEmpty
+--- local TableEmpty = CPK.Table.Empty
 ---
 --- -- empty table
 --- local t1 = {}
---- print(IsEmpty(t1)) -- true
+--- print(TableEmpty(t1)) -- true
 ---
 --- -- non-empty table
 --- local t2 = { a = 1 }
---- print(IsEmpty(t2)) -- false
+--- print(TableEmpty(t2)) -- false
 --- ```
 ---
 --- @param tbl table # The table to check if it is empty.
 --- @return boolean # `true` if the table is empty, `false` otherwise.
 --- @nodiscard
-local function IsEmpty(tbl)
+local function TableEmpty(tbl)
 	AssertIsTable(tbl)
 
 	-- Iterate over the table to check if it has any elements
-	for _, _ in _lua_next, tbl, nil do
+	for _, _ in lua_next, tbl, nil do
 		return false
 	end
 
 	return true
 end
 
-CPK.Table.IsEmpty = IsEmpty
+CPK.Table.Empty = TableEmpty

--- a/(1) Community Patch/Kit/Table/CPK.Table.Merge.lua
+++ b/(1) Community Patch/Kit/Table/CPK.Table.Merge.lua
@@ -1,7 +1,7 @@
-local _lua_next = next
+local lua_next = next
 
 local ArgsEach = CPK.Args.Each
-local ArgsIsEmpty = CPK.Args.IsEmpty
+local ArgsEmpty = CPK.Args.Empty
 
 local AssertError = CPK.Assert.Error
 local AssertIsTable = CPK.Assert.IsTable
@@ -27,7 +27,7 @@ local AssertIsTable = CPK.Assert.IsTable
 --- @return table
 --- @nodiscard
 local function TableMerge(...)
-	if ArgsIsEmpty(...) then
+	if ArgsEmpty(...) then
 		AssertError(
 			'0 arguments',
 			'at least 1 argument of type table',
@@ -44,7 +44,7 @@ local function TableMerge(...)
 
 		AssertIsTable(tbl, 'Argument at #' .. idx .. ' is not table')
 
-		for key, val in _lua_next, tbl, nil do
+		for key, val in lua_next, tbl, nil do
 			res[key] = val
 		end
 	end, ...)

--- a/(1) Community Patch/Kit/Type/CPK.Type.IsBoolean.lua
+++ b/(1) Community Patch/Kit/Type/CPK.Type.IsBoolean.lua
@@ -1,4 +1,4 @@
-local _lua_type = type
+local lua_type = type
 
 --- Checks if the type of the specified value is `"boolean"`.
 ---
@@ -16,7 +16,7 @@ local _lua_type = type
 --- @return boolean # `true` if the value is a boolean, `false` otherwise.
 --- @nodiscard
 local function IsBoolean(val)
-	return _lua_type(val) == 'boolean'
+	return lua_type(val) == 'boolean'
 end
 
 CPK.Type.IsBoolean = IsBoolean

--- a/(1) Community Patch/Kit/Type/CPK.Type.IsCallable.lua
+++ b/(1) Community Patch/Kit/Type/CPK.Type.IsCallable.lua
@@ -1,5 +1,5 @@
-local _lua_type = type
-local _lua_getmetatable = getmetatable
+local lua_type = type
+local lua_getmetatable = getmetatable
 
 --- Checks if the specified value is callable.
 --- A value is considered callable if it is a function or if it is a table with a `__call` method in its metatable.
@@ -20,16 +20,16 @@ local _lua_getmetatable = getmetatable
 --- @return boolean # `true` if the value is callable, `false` otherwise.
 --- @nodiscard
 local function IsCallable(val)
-	local t = _lua_type(val)
+	local t = lua_type(val)
 
 	if t == 'function' then
 			return true
 	end
 
 	if t == 'table' then
-			local mt = _lua_getmetatable(val)
+			local mt = lua_getmetatable(val)
 
-			return _lua_type(mt) == 'table' and _lua_type(mt.__call) == 'function'
+			return lua_type(mt) == 'table' and lua_type(mt.__call) == 'function'
 	end
 
 	return false

--- a/(1) Community Patch/Kit/Type/CPK.Type.IsFunction.lua
+++ b/(1) Community Patch/Kit/Type/CPK.Type.IsFunction.lua
@@ -1,4 +1,4 @@
-local _lua_type = type
+local lua_type = type
 
 --- Checks if the type of the specified value is `"function"`.
 ---
@@ -16,7 +16,7 @@ local _lua_type = type
 --- @return boolean # `true` if the value is a function, `false` otherwise.
 --- @nodiscard
 local function IsFunction(val)
-	return _lua_type(val) == 'function'
+	return lua_type(val) == 'function'
 end
 
 CPK.Type.IsFunction = IsFunction

--- a/(1) Community Patch/Kit/Type/CPK.Type.IsNumber.lua
+++ b/(1) Community Patch/Kit/Type/CPK.Type.IsNumber.lua
@@ -1,4 +1,4 @@
-local _lua_type = type
+local lua_type = type
 
 --- Checks if the type of the specified value is `"number"`.
 ---
@@ -16,7 +16,7 @@ local _lua_type = type
 --- @return boolean # `true` if the value is a number, `false` otherwise.
 --- @nodiscard
 local function IsNumber(val)
-	return _lua_type(val) == "number"
+	return lua_type(val) == "number"
 end
 
 CPK.Type.IsNumber = IsNumber

--- a/(1) Community Patch/Kit/Type/CPK.Type.IsString.lua
+++ b/(1) Community Patch/Kit/Type/CPK.Type.IsString.lua
@@ -1,4 +1,4 @@
-local _lua_type = type
+local lua_type = type
 
 --- Checks if the type of the specified value is `"string"`.
 ---
@@ -16,7 +16,7 @@ local _lua_type = type
 --- @return boolean # `true` if the value is a string, `false` otherwise.
 --- @nodiscard
 local function IsString(val)
-	return _lua_type(val) == "string"
+	return lua_type(val) == "string"
 end
 
 CPK.Type.IsString = IsString

--- a/(1) Community Patch/Kit/Type/CPK.Type.IsTable.lua
+++ b/(1) Community Patch/Kit/Type/CPK.Type.IsTable.lua
@@ -1,4 +1,4 @@
-local _lua_type = type
+local lua_type = type
 
 --- Checks if the type of the specified value is `"table"`.
 ---
@@ -16,7 +16,7 @@ local _lua_type = type
 --- @return boolean # `true` if the value is a table, `false` otherwise.
 --- @nodiscard
 local function IsTable(val)
-	return _lua_type(val) == "table"
+	return lua_type(val) == "table"
 end
 
 CPK.Type.IsTable = IsTable

--- a/(1) Community Patch/Kit/Type/CPK.Type.IsThread.lua
+++ b/(1) Community Patch/Kit/Type/CPK.Type.IsThread.lua
@@ -1,4 +1,4 @@
-local _lua_type = type
+local lua_type = type
 
 --- Checks if the type of the specified value is `"thread"`.
 ---
@@ -16,7 +16,7 @@ local _lua_type = type
 --- @return boolean # `true` if the value is a thread, `false` otherwise.
 --- @nodiscard
 local function IsThread(val)
-	return _lua_type(val) == "thread"
+	return lua_type(val) == "thread"
 end
 
 CPK.Type.IsThread = IsThread

--- a/(1) Community Patch/Kit/Type/CPK.Type.IsUserdata.lua
+++ b/(1) Community Patch/Kit/Type/CPK.Type.IsUserdata.lua
@@ -1,11 +1,11 @@
-local _lua_type = type
+local lua_type = type
 
 --- Checks if the type of the specified value is `"userdata"`.
 --- @param val any # The value to check.
 --- @return boolean # `true` if the value is userdata, `false` otherwise.
 --- @nodiscard
 local function IsUserdata(val)
-	return _lua_type(val) == "userdata"
+	return lua_type(val) == "userdata"
 end
 
 CPK.Type.IsUserdata = IsUserdata

--- a/(1) Community Patch/Kit/UI/Control/CPK.UI.Control.Create.lua
+++ b/(1) Community Patch/Kit/UI/Control/CPK.UI.Control.Create.lua
@@ -1,5 +1,5 @@
-local _lua_error = error
-local _lua_tostring = tostring
+local lua_error = error
+local lua_tostring = tostring
 
 local AssertIsTable = CPK.Assert.IsTable
 local AssertIsString = CPK.Assert.IsString
@@ -30,17 +30,17 @@ local function ControlCreate(name, parent)
 
 	ContextPtr:BuildInstanceForControl(name, instance, parent)
 
-	local str = _lua_tostring(instance)
+	local str = lua_tostring(instance)
 
 	--- NULL control created
 	if str:match(': 00000000$') then
 		parent:ReleaseChild(instance)
 
-		_lua_error(
+		lua_error(
 			'Failed to create ' .. name .. ' control instance.'
 			.. '\n\t<Instance Name="' .. name .. '" />'
 			.. ' was not found in related XML file.'
-			.. '\n\tPlease verify file: ' .. _lua_tostring(StateName) .. '.xml'
+			.. '\n\tPlease verify file: ' .. lua_tostring(StateName) .. '.xml'
 		)
 	end
 

--- a/(1) Community Patch/Kit/UI/Control/CPK.UI.Control.Disable.lua
+++ b/(1) Community Patch/Kit/UI/Control/CPK.UI.Control.Disable.lua
@@ -1,10 +1,10 @@
-local _lua_type = type
+local lua_type = type
 
 local ArgsEach = CPK.Args.Each
 
 --- @param control Control
 local function ControlDisableOne(control)
-	if control ~= nil and _lua_type(control.SetDisabled) == 'function' then
+	if control ~= nil and lua_type(control.SetDisabled) == 'function' then
 		control:SetDisabled(true)
 	end
 end

--- a/(1) Community Patch/Kit/UI/Control/CPK.UI.Control.Enable.lua
+++ b/(1) Community Patch/Kit/UI/Control/CPK.UI.Control.Enable.lua
@@ -1,10 +1,10 @@
-local _lua_type = type
+local lua_type = type
 
 local ArgsEach = CPK.Args.Each
 
 --- @param control Control
 local function ControlEnableOne(control)
-	if control ~= nil and _lua_type(control.SetDisabled) == 'function' then
+	if control ~= nil and lua_type(control.SetDisabled) == 'function' then
 		control:SetDisabled(false)
 	end
 end

--- a/(1) Community Patch/Kit/UI/Control/CPK.UI.Control.IsKind.lua
+++ b/(1) Community Patch/Kit/UI/Control/CPK.UI.Control.IsKind.lua
@@ -1,4 +1,4 @@
-local _lua_getmetatable = getmetatable
+local lua_getmetatable = getmetatable
 
 local Curry = CPK.FP.Curry
 local AssertIsTable = CPK.Assert.IsTable
@@ -27,7 +27,7 @@ local ControlIsKind = Curry(2, function(kind, control)
 	AssertIsString(kind)
 	AssertIsTable(control)
 
-	local base = _lua_getmetatable(control)
+	local base = lua_getmetatable(control)
 	local name = nil
 
 	repeat

--- a/(1) Community Patch/Kit/UI/Control/CPK.UI.Control.Kind.lua
+++ b/(1) Community Patch/Kit/UI/Control/CPK.UI.Control.Kind.lua
@@ -1,4 +1,4 @@
-local _lua_getmetatable = getmetatable
+local lua_getmetatable = getmetatable
 local AssertIsTable = CPK.Assert.IsTable
 
 --- The kinds of UI controls available in the game.
@@ -51,7 +51,7 @@ local AssertIsTable = CPK.Assert.IsTable
 local function ControlKind(control)
 	AssertIsTable(control)
 
-	local meta = _lua_getmetatable(control)
+	local meta = lua_getmetatable(control)
 	return meta.CTypeName
 end
 


### PR DESCRIPTION
Functionally nothing changed, just variables renamed.

1. Fixes CPK local declaration variable names _(underscore prefix conflicts with Emmylua(unused) lint rule, so if such var is unused it won't be reported...)._
2. Normalized some function names.