### PR TITLE
Change default AI on Conquistador

### DIFF
--- a/(2) Vox Populi/Database Changes/Civilizations/Spain.sql
+++ b/(2) Vox Populi/Database Changes/Civilizations/Spain.sql
@@ -83,7 +83,7 @@ SET
 		)
 	),
 	Combat = (SELECT Combat FROM Units WHERE Type = 'UNIT_EXPLORER') + 6,
-	DefaultUnitAI = 'UNITAI_FAST_ATTACK',
+	DefaultUnitAI = 'UNITAI_EXPLORE',
 	Found = 1,
 	FoundMid = 1
 WHERE Type = 'UNIT_SPANISH_CONQUISTADOR';


### PR DESCRIPTION
I noticed Spain is using their entire military supply to build Conquistador and then upgrading into recon unit. 
<img width="140" height="567" alt="image" src="https://github.com/user-attachments/assets/b215c6ec-afb0-4260-999d-55fc5a1cfacb" />

This means they becomes completely unable to fight, with the exception of Naval Units which seem to be handled seperately. Possibly explains poor performance in test games.

Discussed with KungCheops and he says the production AI reads the DefaultUnitAI column to decide what to build.  In lieu of a more sophisticated change, we have to stop Spain AI from committing sudoku every single game on UU unlock.