### PR TITLE
Fix debug log spam

### DIFF
--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaScopedInstance.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaScopedInstance.h
@@ -166,10 +166,10 @@ InstanceType* CvLuaScopedInstance<Derived, InstanceType>::GetInstance(lua_State*
 #endif
 	}
 #if defined(VPDEBUG)
-	else
+	else if (bErrorOnFail  || (lua_type(L, idx) != LUA_TNIL && lua_type(L, idx) != LUA_TNONE))
 	{
 		char szWarning[256];
-		sprintf_s(szWarning, "Warning: Expected table at index %d, got %s\n",
+		sprintf_s(szWarning, "Warning: Expected table or no value at index %d, got %s\n",
 			idx, lua_typename(L, lua_type(L, idx)));
 		OutputDebugString(szWarning);
 	}


### PR DESCRIPTION
Related to this: @azum4roll  Can you fix non-EUI and BNW UnitPanel.lua calling CanHandleAction with 0 instead of an instance?

const int iAction = lua_tointeger(L, 1);
CvPlot* pkPlot = CvLuaPlot::GetInstance(L, 2, false);
const bool bTestVisible = luaL_optbool(L, 3, 0);
const bool bResult = GetInstance()->canHandleAction(iAction, pkPlot, bTestVisible);


if(action.Visible and Game.CanHandleAction( iAction, 0, 1 ) ) then