### PR TITLE
Two small fixes for TechTree.lua

### DIFF
--- a/(3a) EUI Compatibility Files/ImprovedTechTree/TechTree.lua
+++ b/(3a) EUI Compatibility Files/ImprovedTechTree/TechTree.lua
@@ -262,7 +262,7 @@ local function RefreshDisplayOfSpecificTech( tech )
 	--print("RefreshDisplayOfSpecificTech afw Stuff done")
 	-- Rebuild the small buttons if needed
 	if g_NeedsFullRefresh then
-		AddSmallButtonsToTechButton( thisTechButton, tech, g_maxSmallButtons, 45, g_activePlayerID)
+		AddSmallButtonsToTechButton( thisTechButton, tech, g_maxSmallButtons, 45, 1, g_activePlayerID)
 	end
 	if g_EspionageViewMode then
 		thisTechButton.TechButton:SetDisabled(true);
@@ -612,6 +612,8 @@ local function InitActivePlayerData(OverridePlayer)
 	g_activeTeamID = g_activePlayer:GetTeam()
 	g_activeTeam = Teams[g_activeTeamID]
 	g_activeTeamTechs = g_activeTeam:GetTeamTechs()
+
+	GatherInfoAboutUniqueStuff( g_activeCivType )
 
 	g_NeedsFullRefresh = true
 	return RefreshDisplay("Init")


### PR DESCRIPTION
The tech tree would not properly display [the icons for unlocked stuff]

- the call to `AddSmallButtonsToTechButton` was missing an argument

but still with that fixed the icons for buildings, improvements and units were missing...

- `GatherInfoAboutUniqueStuff( g_activeCivType )` in `TechButtonInclude.lua` needs to be called somewhere to fill the `ValidXXXBuilds` tables - I restored the call to the location it was before....