### PR TITLE
New Lua APIs to set/get strategies and diplomatic flavors ("Personas")

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.h
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.h
@@ -1758,6 +1758,30 @@ public:
 
 	void LogOpenEmbassy(PlayerTypes ePlayer);
 	void LogCloseEmbassy(PlayerTypes ePlayer);
+
+	// Vox Deorum: Personality values made public for Lua access via GetPersona/SetPersona
+	// These control the AI's diplomatic behavior and approach tendencies
+	unsigned char m_iVictoryCompetitiveness;
+	unsigned char m_iWonderCompetitiveness;
+	unsigned char m_iMinorCivCompetitiveness;
+	unsigned char m_iBoldness;
+	unsigned char m_iDiploBalance;
+	unsigned char m_iWarmongerHate;
+	unsigned char m_iDoFWillingness;
+	unsigned char m_iDenounceWillingness;
+	unsigned char m_iWorkWithWillingness;
+	unsigned char m_iWorkAgainstWillingness;
+	unsigned char m_iLoyalty;
+	unsigned char m_iForgiveness;
+	unsigned char m_iNeediness;
+	unsigned char m_iMeanness;
+	unsigned char m_iChattiness;
+	unsigned char m_aiMajorCivApproachBiases[NUM_CIV_APPROACHES];
+	unsigned char m_iMinorCivWarBias;
+	unsigned char m_iMinorCivHostileBias;
+	unsigned char m_iMinorCivNeutralBias;
+	unsigned char m_iMinorCivFriendlyBias;
+
 private:
 	/// Helper functions to return the Player and Team IDs more conveniently
 	inline PlayerTypes GetID() const { return (PlayerTypes)m_eID; }
@@ -1840,28 +1864,6 @@ private:
 
 	// Need a string member so that it doesn't go out of scope after translation
 	Localization::String m_strDiploText;
-
-	// Personality Values
-	unsigned char m_iVictoryCompetitiveness;
-	unsigned char m_iWonderCompetitiveness;
-	unsigned char m_iMinorCivCompetitiveness;
-	unsigned char m_iBoldness;
-	unsigned char m_iDiploBalance;
-	unsigned char m_iWarmongerHate;
-	unsigned char m_iDoFWillingness;
-	unsigned char m_iDenounceWillingness;
-	unsigned char m_iWorkWithWillingness;
-	unsigned char m_iWorkAgainstWillingness;
-	unsigned char m_iLoyalty;
-	unsigned char m_iForgiveness;
-	unsigned char m_iNeediness;
-	unsigned char m_iMeanness;
-	unsigned char m_iChattiness;
-	unsigned char m_aiMajorCivApproachBiases[NUM_CIV_APPROACHES];
-	unsigned char m_iMinorCivWarBias;
-	unsigned char m_iMinorCivHostileBias;
-	unsigned char m_iMinorCivNeutralBias;
-	unsigned char m_iMinorCivFriendlyBias;
 
 	// Key Players
 	PlayerTypes m_eMostValuableFriend;

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
@@ -27,6 +27,10 @@
 #include "../CvDealAI.h"
 #include "../CvGameCoreUtils.h"
 #include "../CvInternalGameCoreUtils.h"
+#include "../CvGrandStrategyAI.h"
+#include "../CvEconomicAI.h"
+#include "../CvMilitaryAI.h"
+#include "../CvCitySpecializationAI.h"
 #include "ICvDLLUserInterface.h"
 #include "CvDllInterfaces.h"
 #include "CvDllNetMessageExt.h"
@@ -1468,6 +1472,11 @@ void CvLuaPlayer::PushMethods(lua_State* L, int t)
 	Method(CountAllTerrain);
 	Method(CountAllWorkedTerrain);
 
+	// Vox Deorum: Methods to get/set AI personality values
+	Method(GetPersona);
+	Method(SetPersona);
+	Method(GetDiplomacyEvaluation);
+	
 #if defined(MOD_IMPROVEMENTS_EXTENSIONS)
 	Method(GetResponsibleForRouteCount);
 	Method(GetResponsibleForImprovementCount);
@@ -1537,6 +1546,13 @@ void CvLuaPlayer::PushMethods(lua_State* L, int t)
 	Method(SetInstantYieldNotificationDisabled);
 
 	Method(GetCompetitiveSpawnUnitType);
+	
+	Method(GetGrandStrategy);
+	Method(SetGrandStrategy);
+	Method(GetEconomicStrategies);
+	Method(SetEconomicStrategies);
+	Method(GetMilitaryStrategies);
+	Method(SetMilitaryStrategies);
 }
 //------------------------------------------------------------------------------
 void CvLuaPlayer::HandleMissingInstance(lua_State* L)
@@ -13378,10 +13394,25 @@ struct OpinionEval
 	}
 };
 
+//------------------------------------------------------------------------------
+// Get the opinion table for a player towards another player
+// Parameters:
+//   1. Player instance (self)
+//   2. Target player ID (PlayerTypes)
+//   3. Force debug mode (boolean, optional) - if true, shows all hidden modifiers
+//------------------------------------------------------------------------------
 int CvLuaPlayer::lGetOpinionTable(lua_State* L)
 {
 	CvPlayerAI* pkPlayer = GetInstance(L);
 	PlayerTypes ePlayer = (PlayerTypes)lua_tointeger(L, 2);
+
+	// Check for optional third parameter to force debug mode
+	bool bForceDebugMode = false;
+	if (lua_gettop(L) >= 3 && lua_isboolean(L, 3))
+	{
+		bForceDebugMode = lua_toboolean(L, 3);
+	}
+
 	CvDiplomacyAI* pDiplo = pkPlayer->GetDiplomacyAI();
 
 	// Initialize variables
@@ -13391,14 +13422,14 @@ int CvLuaPlayer::lGetOpinionTable(lua_State* L)
 
 	bool bHuman = pkPlayer->isHuman();
 	bool bTeammate = pDiplo->IsTeammate(ePlayer);
-	bool bShowHiddenModifiers = GC.getGame().IsShowHiddenOpinionModifiers();
-	bool bShowAllValues = bHuman ? false : GC.getGame().IsShowAllOpinionValues();
+	bool bShowHiddenModifiers = bForceDebugMode || GC.getGame().IsShowHiddenOpinionModifiers();
+	bool bShowAllValues = bHuman ? false : (bForceDebugMode || GC.getGame().IsShowAllOpinionValues());
 	bool bHideDisputes = bShowHiddenModifiers ? false : pDiplo->ShouldHideDisputeMods(ePlayer);
 	bool bHideNegatives = bShowHiddenModifiers ? false : pDiplo->ShouldHideNegativeMods(ePlayer);
 	bool bPretendNoDisputes = GET_PLAYER(ePlayer).isHuman() && bHideDisputes && bHideNegatives && !GC.getGame().IsNoFakeOpinionModifiers();
 	bool bObserver = GET_PLAYER(ePlayer).isObserver() || !pkPlayer->isMajorCiv() || !GET_PLAYER(ePlayer).isMajorCiv() || !pkPlayer->isAlive() || !GET_PLAYER(ePlayer).isAlive() || GC.getGame().IsHideOpinionTable();
 	bool bUNActive = GC.getGame().IsUnitedNationsActive();
-	bool bJustMet = GC.getGame().IsDiploDebugModeEnabled() ? false : (GET_TEAM(pkPlayer->getTeam()).GetTurnsSinceMeetingTeam(GET_PLAYER(ePlayer).getTeam()) == 0); // Don't display certain modifiers if we just met them
+	bool bJustMet = (bForceDebugMode || GC.getGame().IsDiploDebugModeEnabled()) ? false : (GET_TEAM(pkPlayer->getTeam()).GetTurnsSinceMeetingTeam(GET_PLAYER(ePlayer).getTeam()) == 0); // Don't display certain modifiers if we just met them
 
 	CivApproachTypes eSurfaceApproach = pDiplo->GetSurfaceApproach(ePlayer);
 	CivApproachTypes eTrueApproach = pDiplo->GetCivApproach(ePlayer);
@@ -13565,7 +13596,7 @@ int CvLuaPlayer::lGetOpinionTable(lua_State* L)
 				kOpinion.m_iValue = 0;
 				CvString str;
 
-				if (bHuman || GC.getGame().IsDiploDebugModeEnabled())
+				if (bHuman || bForceDebugMode || GC.getGame().IsDiploDebugModeEnabled())
 				{
 					str = Localization::Lookup("TXT_KEY_DIPLO_PAST_WAR_BAD").toUTF8();
 				}
@@ -13587,10 +13618,10 @@ int CvLuaPlayer::lGetOpinionTable(lua_State* L)
 		}
 
 		// Special indicators
-		if (!bHuman && !bTeammate)
+		if (bForceDebugMode || (!bHuman && !bTeammate))
 		{
 			// Debug mode approach reveal
-			if (GC.getGame().IsDiploDebugModeEnabled())
+			if (bForceDebugMode || GC.getGame().IsDiploDebugModeEnabled())
 			{
 				Opinion kOpinion;
 				kOpinion.m_iValue = 0;
@@ -13685,7 +13716,7 @@ int CvLuaPlayer::lGetOpinionTable(lua_State* L)
 	// [PART 2A: HUMANS]			  //
 	//--------------------------------//
 
-	if (bHuman && !bObserver)
+	if (bForceDebugMode || (bHuman && !bObserver))
 	{
 		// DoF?
 		if (pDiplo->IsDoFAccepted(ePlayer))
@@ -15975,7 +16006,7 @@ int CvLuaPlayer::lGetOpinionTable(lua_State* L)
 			aOpinions.push_back(kOpinion);
 		}
 		// If not at war and debug mode is not enabled, a hint explaining the AI's current approach is displayed
-		else if (!GC.getGame().IsDiploDebugModeEnabled())
+		else if (!bForceDebugMode && !GC.getGame().IsDiploDebugModeEnabled())
 		{
 			Opinion kOpinion;
 			kOpinion.m_iValue = 0;
@@ -16117,6 +16148,316 @@ int CvLuaPlayer::lGetOpinionTable(lua_State* L)
 	}
 
 	return 1;
+}
+
+//------------------------------------------------------------------------------
+// Vox Deorum: GetDiplomacyEvaluation - Returns diplomatic evaluation information (top friend, ally, competitor, etc.)
+// Returns empty table if not a major civ
+//------------------------------------------------------------------------------
+int CvLuaPlayer::lGetDiplomacyEvaluation(lua_State* L)
+{
+	CvPlayerAI* pkPlayer = GetInstance(L);
+	PlayerTypes ePlayer = (PlayerTypes)lua_tointeger(L, 2);
+
+	lua_newtable(L);
+
+	// Return empty table if not a major civ
+	if (!pkPlayer->isMajorCiv() || !pkPlayer->isAlive())
+	{
+		return 1;
+	}
+
+	CvDiplomacyAI* pDiplo = pkPlayer->GetDiplomacyAI();
+	bool bUNActive = GC.getGame().IsUnitedNationsActive();
+
+	PlayerTypes eTopFriend = pDiplo->GetMostValuableFriend();
+	PlayerTypes eTopDP = pDiplo->GetMostValuableAlly();
+	PlayerTypes eTopCompetitor = pDiplo->GetBiggestCompetitor();
+	PlayerTypes eTopLeagueAlly = pDiplo->GetPrimeLeagueAlly();
+	PlayerTypes eTopLeagueRival = pDiplo->GetPrimeLeagueCompetitor();
+	CvString FriendStr;
+	CvString LeagueStr;
+	CvString EnemyStr;
+
+	FriendStr = Localization::Lookup("TXT_KEY_DIPLO_DEBUG_TOP_FRIEND").toUTF8();
+	FriendStr += " ";
+	if (eTopFriend == NO_PLAYER || !GET_PLAYER(eTopFriend).isAlive())
+	{
+		FriendStr += Localization::Lookup("TXT_KEY_DIPLO_DEBUG_TOP_CHOICE_NONE").toUTF8();
+	}
+	else
+	{
+		FriendStr += GET_PLAYER(eTopFriend).getCivilizationShortDescription();
+	}
+
+	if (GET_TEAM(pkPlayer->getTeam()).isDefensivePactTradingAllowed())
+	{
+		FriendStr += ", ";
+		FriendStr += Localization::Lookup("TXT_KEY_DIPLO_DEBUG_TOP_ALLY").toUTF8();
+		FriendStr += " ";
+		if (eTopDP == NO_PLAYER || !GET_PLAYER(eTopDP).isAlive())
+		{
+			FriendStr += Localization::Lookup("TXT_KEY_DIPLO_DEBUG_TOP_CHOICE_NONE").toUTF8();
+		}
+		else
+		{
+			FriendStr += GET_PLAYER(eTopDP).getCivilizationShortDescription();
+		}
+	}
+
+	CvLeague* pLeague = GC.getGame().GetGameLeagues()->GetActiveLeague();
+	if (pLeague != NULL)
+	{
+		LeagueStr = bUNActive ? Localization::Lookup("TXT_KEY_DIPLO_DEBUG_TOP_LEAGUE_ALLY_UN").toUTF8() : Localization::Lookup("TXT_KEY_DIPLO_DEBUG_TOP_LEAGUE_ALLY").toUTF8();
+		LeagueStr += " ";
+		if (eTopLeagueAlly == NO_PLAYER || !GET_PLAYER(eTopLeagueAlly).isAlive())
+		{
+			LeagueStr += Localization::Lookup("TXT_KEY_DIPLO_DEBUG_TOP_CHOICE_NONE").toUTF8();
+		}
+		else
+		{
+			LeagueStr += GET_PLAYER(eTopLeagueAlly).getCivilizationShortDescription();
+		}
+		LeagueStr += ", ";
+		LeagueStr += bUNActive ? Localization::Lookup("TXT_KEY_DIPLO_DEBUG_TOP_LEAGUE_COMPETITOR_UN").toUTF8() : Localization::Lookup("TXT_KEY_DIPLO_DEBUG_TOP_LEAGUE_COMPETITOR").toUTF8();
+		LeagueStr += " ";
+		if (eTopLeagueRival == NO_PLAYER || !GET_PLAYER(eTopLeagueRival).isAlive())
+		{
+			LeagueStr += Localization::Lookup("TXT_KEY_DIPLO_DEBUG_TOP_CHOICE_NONE").toUTF8();
+		}
+		else
+		{
+			LeagueStr += GET_PLAYER(eTopLeagueRival).getCivilizationShortDescription();
+		}
+	}
+
+	EnemyStr = Localization::Lookup("TXT_KEY_DIPLO_DEBUG_TOP_COMPETITOR").toUTF8();
+	EnemyStr += " ";
+	if (eTopCompetitor == NO_PLAYER || !GET_PLAYER(eTopCompetitor).isAlive())
+	{
+		EnemyStr += Localization::Lookup("TXT_KEY_DIPLO_DEBUG_TOP_CHOICE_NONE").toUTF8();
+	}
+	else
+	{
+		EnemyStr += GET_PLAYER(eTopCompetitor).getCivilizationShortDescription();
+	}
+
+	// Push strings to table array
+	int index = 1;
+
+	lua_pushinteger(L, index++);
+	lua_pushstring(L, FriendStr.c_str());
+	lua_settable(L, -3);
+
+	if (pLeague)
+	{
+		lua_pushinteger(L, index++);
+		lua_pushstring(L, LeagueStr.c_str());
+		lua_settable(L, -3);
+	}
+
+	lua_pushinteger(L, index++);
+	lua_pushstring(L, EnemyStr.c_str());
+	lua_settable(L, -3);
+
+	return 1;
+}
+
+//------------------------------------------------------------------------------
+// Vox Deorum: GetPersona - Get personality values for major civs
+int CvLuaPlayer::lGetPersona(lua_State* L)
+{
+			CvPlayerAI* pkPlayer = GetInstance(L);
+			CvDiplomacyAI* pDiplo = pkPlayer->GetDiplomacyAI();
+
+			if (!pDiplo)
+			{
+							lua_pushnil(L);
+							return 1;
+			}
+
+			// Create Lua table to return personality values
+			lua_newtable(L);
+
+			// Add personality values
+			lua_pushstring(L, "VictoryCompetitiveness");
+			lua_pushinteger(L, pDiplo->m_iVictoryCompetitiveness);
+			lua_settable(L, -3);
+
+			lua_pushstring(L, "WonderCompetitiveness");
+			lua_pushinteger(L, pDiplo->m_iWonderCompetitiveness);
+			lua_settable(L, -3);
+
+			lua_pushstring(L, "MinorCivCompetitiveness");
+			lua_pushinteger(L, pDiplo->m_iMinorCivCompetitiveness);
+			lua_settable(L, -3);
+
+			lua_pushstring(L, "Boldness");
+			lua_pushinteger(L, pDiplo->m_iBoldness);
+			lua_settable(L, -3);
+
+			lua_pushstring(L, "DiplomaticBalance");
+			lua_pushinteger(L, pDiplo->m_iDiploBalance);
+			lua_settable(L, -3);
+
+			lua_pushstring(L, "WarmongerHate");
+			lua_pushinteger(L, pDiplo->m_iWarmongerHate);
+			lua_settable(L, -3);
+
+			lua_pushstring(L, "Friendliness");
+			lua_pushinteger(L, pDiplo->m_iDoFWillingness);
+			lua_settable(L, -3);
+
+			lua_pushstring(L, "DenounceWillingness");
+			lua_pushinteger(L, pDiplo->m_iDenounceWillingness);
+			lua_settable(L, -3);
+
+			lua_pushstring(L, "WorkWithWillingness");
+			lua_pushinteger(L, pDiplo->m_iWorkWithWillingness);
+			lua_settable(L, -3);
+
+			lua_pushstring(L, "WorkAgainstWillingness");
+			lua_pushinteger(L, pDiplo->m_iWorkAgainstWillingness);
+			lua_settable(L, -3);
+
+			lua_pushstring(L, "Loyalty");
+			lua_pushinteger(L, pDiplo->m_iLoyalty);
+			lua_settable(L, -3);
+
+			lua_pushstring(L, "Forgiveness");
+			lua_pushinteger(L, pDiplo->m_iForgiveness);
+			lua_settable(L, -3);
+
+			lua_pushstring(L, "Neediness");
+			lua_pushinteger(L, pDiplo->m_iNeediness);
+			lua_settable(L, -3);
+
+			lua_pushstring(L, "Meanness");
+			lua_pushinteger(L, pDiplo->m_iMeanness);
+			lua_settable(L, -3);
+
+			lua_pushstring(L, "Chattiness");
+			lua_pushinteger(L, pDiplo->m_iChattiness);
+			lua_settable(L, -3);
+
+			// Add approach biases
+			lua_pushstring(L, "WarBias");
+			lua_pushinteger(L, pDiplo->m_aiMajorCivApproachBiases[CIV_APPROACH_WAR]);
+			lua_settable(L, -3);
+
+			lua_pushstring(L, "HostileBias");
+			lua_pushinteger(L, pDiplo->m_aiMajorCivApproachBiases[CIV_APPROACH_HOSTILE]);
+			lua_settable(L, -3);
+
+			lua_pushstring(L, "DeceptiveBias");
+			lua_pushinteger(L, pDiplo->m_aiMajorCivApproachBiases[CIV_APPROACH_DECEPTIVE]);
+			lua_settable(L, -3);
+
+			lua_pushstring(L, "GuardedBias");
+			lua_pushinteger(L, pDiplo->m_aiMajorCivApproachBiases[CIV_APPROACH_GUARDED]);
+			lua_settable(L, -3);
+
+			lua_pushstring(L, "AfraidBias");
+			lua_pushinteger(L, pDiplo->m_aiMajorCivApproachBiases[CIV_APPROACH_AFRAID]);
+			lua_settable(L, -3);
+
+			lua_pushstring(L, "FriendlyBias");
+			lua_pushinteger(L, pDiplo->m_aiMajorCivApproachBiases[CIV_APPROACH_FRIENDLY]);
+			lua_settable(L, -3);
+
+			lua_pushstring(L, "NeutralBias");
+			lua_pushinteger(L, pDiplo->m_aiMajorCivApproachBiases[CIV_APPROACH_NEUTRAL]);
+			lua_settable(L, -3);
+
+			// Add minor civ approach biases
+			lua_pushstring(L, "MinorCivWarBias");
+			lua_pushinteger(L, pDiplo->m_iMinorCivWarBias);
+			lua_settable(L, -3);
+
+			lua_pushstring(L, "MinorCivHostileBias");
+			lua_pushinteger(L, pDiplo->m_iMinorCivHostileBias);
+			lua_settable(L, -3);
+
+			lua_pushstring(L, "MinorCivNeutralBias");
+			lua_pushinteger(L, pDiplo->m_iMinorCivNeutralBias);
+			lua_settable(L, -3);
+
+			lua_pushstring(L, "MinorCivFriendlyBias");
+			lua_pushinteger(L, pDiplo->m_iMinorCivFriendlyBias);
+			lua_settable(L, -3);
+
+			return 1;
+}
+
+//------------------------------------------------------------------------------
+// Vox Deorum: SetPersona - Set personality values for major civs
+int CvLuaPlayer::lSetPersona(lua_State* L)
+{
+			CvPlayerAI* pkPlayer = GetInstance(L);
+			CvDiplomacyAI* pDiplo = pkPlayer->GetDiplomacyAI();
+
+			if (!pDiplo)
+							return 0;
+
+			// Check if argument is a table
+			if (!lua_istable(L, 2))
+			{
+							luaL_error(L, "SetPersona requires a table argument");
+							return 0;
+			}
+
+			// Helper macro to get value from table
+#define GET_TABLE_VALUE(key, var) \
+			{ \
+							lua_pushstring(L, key); \
+							lua_gettable(L, 2); \
+							if (lua_isnumber(L, -1)) \
+							{ \
+											int value = lua_tointeger(L, -1); \
+											if (value < 1) value = 1; \
+											if (value > 10) value = 10; \
+											if (value >= 0) var = value; \
+							} \
+							lua_pop(L, 1); \
+			}
+
+			// Set personality values (only if present in the table)
+			GET_TABLE_VALUE("VictoryCompetitiveness", pDiplo->m_iVictoryCompetitiveness);
+			GET_TABLE_VALUE("WonderCompetitiveness", pDiplo->m_iWonderCompetitiveness);
+			GET_TABLE_VALUE("MinorCivCompetitiveness", pDiplo->m_iMinorCivCompetitiveness);
+			GET_TABLE_VALUE("Boldness", pDiplo->m_iBoldness);
+
+			GET_TABLE_VALUE("DiploBalance", pDiplo->m_iDiploBalance);
+			GET_TABLE_VALUE("WarmongerHate", pDiplo->m_iWarmongerHate);
+			GET_TABLE_VALUE("Friendliness", pDiplo->m_iDoFWillingness);
+			GET_TABLE_VALUE("DenounceWillingness", pDiplo->m_iDenounceWillingness);
+			GET_TABLE_VALUE("WorkWithWillingness", pDiplo->m_iWorkWithWillingness);
+			GET_TABLE_VALUE("WorkAgainstWillingness", pDiplo->m_iWorkAgainstWillingness);
+			GET_TABLE_VALUE("Loyalty", pDiplo->m_iLoyalty);
+			GET_TABLE_VALUE("Forgiveness", pDiplo->m_iForgiveness);
+			GET_TABLE_VALUE("Neediness", pDiplo->m_iNeediness);
+			GET_TABLE_VALUE("Meanness", pDiplo->m_iMeanness);
+
+			GET_TABLE_VALUE("Chattiness", pDiplo->m_iChattiness);
+
+			// Set approach biases
+			GET_TABLE_VALUE("WarBias", pDiplo->m_aiMajorCivApproachBiases[CIV_APPROACH_WAR]);
+			GET_TABLE_VALUE("HostileBias", pDiplo->m_aiMajorCivApproachBiases[CIV_APPROACH_HOSTILE]);
+			GET_TABLE_VALUE("DeceptiveBias", pDiplo->m_aiMajorCivApproachBiases[CIV_APPROACH_DECEPTIVE]);
+			GET_TABLE_VALUE("GuardedBias", pDiplo->m_aiMajorCivApproachBiases[CIV_APPROACH_GUARDED]);
+			GET_TABLE_VALUE("AfraidBias", pDiplo->m_aiMajorCivApproachBiases[CIV_APPROACH_AFRAID]);
+			GET_TABLE_VALUE("FriendlyBias", pDiplo->m_aiMajorCivApproachBiases[CIV_APPROACH_FRIENDLY]);
+			GET_TABLE_VALUE("NeutralBias", pDiplo->m_aiMajorCivApproachBiases[CIV_APPROACH_NEUTRAL]);
+
+			// Set minor civ approach biases
+			GET_TABLE_VALUE("MinorCivWarBias", pDiplo->m_iMinorCivWarBias);
+			GET_TABLE_VALUE("MinorCivHostileBias", pDiplo->m_iMinorCivHostileBias);
+			GET_TABLE_VALUE("MinorCivNeutralBias", pDiplo->m_iMinorCivNeutralBias);
+			GET_TABLE_VALUE("MinorCivFriendlyBias", pDiplo->m_iMinorCivFriendlyBias);
+
+#undef GET_TABLE_VALUE
+
+			return 0;
 }
 
 //------------------------------------------------------------------------------
@@ -18721,4 +19062,259 @@ int CvLuaPlayer::lGetCompetitiveSpawnUnitType(lua_State* L)
 	UnitTypes eUnit = pPlayer->GetCompetitiveSpawnUnitType(bIncludeRanged, bIncludeShips, bIncludeRecon, bIncludeUUs, NULL, bNoResource, bMinorCivGift, bRandom, &seed, viUnitCombat);
 	lua_pushinteger(L, eUnit);
 	return 1;
+}
+
+// Vox Deorum added, allowing Lua scripts to change AI's grand strategies
+//------------------------------------------------------------------------------
+//int GetGrandStrategy();
+// Returns: grandStrategy, turnsSinceActive
+int CvLuaPlayer::lGetGrandStrategy(lua_State* L)
+{
+	CvPlayerAI* pkPlayer = GetInstance(L);
+	if (pkPlayer && pkPlayer->GetGrandStrategyAI())
+	{
+		AIGrandStrategyTypes eGrandStrategy = pkPlayer->GetGrandStrategyAI()->GetActiveGrandStrategy();
+		int iTurnsSinceActive = pkPlayer->GetGrandStrategyAI()->GetNumTurnsSinceActiveSet();
+		lua_pushinteger(L, (int)eGrandStrategy);
+		lua_pushinteger(L, iTurnsSinceActive);
+		return 2;
+	}
+	else
+	{
+		lua_pushinteger(L, NO_AIGRANDSTRATEGY);
+		lua_pushinteger(L, 0); // Return 0 turns if no grand strategy AI
+		return 2;
+	}
+}
+
+//------------------------------------------------------------------------------
+//void SetGrandStrategy(int eGrandStrategy);
+int CvLuaPlayer::lSetGrandStrategy(lua_State* L)
+{
+	CvPlayerAI* pkPlayer = GetInstance(L);
+	if (pkPlayer && pkPlayer->GetGrandStrategyAI())
+	{
+		const int iGrandStrategy = lua_tointeger(L, 2);
+		AIGrandStrategyTypes eGrandStrategy = (AIGrandStrategyTypes)iGrandStrategy;
+		// Should we refactor?
+		pkPlayer->GetGrandStrategyAI()->SetActiveGrandStrategy(eGrandStrategy);
+		pkPlayer->GetGrandStrategyAI()->SetNumTurnsSinceActiveSet(1);
+		pkPlayer->GetCitySpecializationAI()->SetSpecializationsDirty(SPECIALIZATION_UPDATE_NEW_GRAND_STRATEGY);
+
+		// Vox Deorum: Also set primary victory pursuit in diplomacy AI based on grand strategy
+		CvDiplomacyAI* pDiploAI = pkPlayer->GetDiplomacyAI();
+		if (pDiploAI)
+		{
+			// Get the grand strategy types
+			AIGrandStrategyTypes eConquest = (AIGrandStrategyTypes) GC.getInfoTypeForString("AIGRANDSTRATEGY_CONQUEST");
+			AIGrandStrategyTypes eCulture = (AIGrandStrategyTypes) GC.getInfoTypeForString("AIGRANDSTRATEGY_CULTURE");
+			AIGrandStrategyTypes eUnitedNations = (AIGrandStrategyTypes) GC.getInfoTypeForString("AIGRANDSTRATEGY_UNITED_NATIONS");
+			AIGrandStrategyTypes eSpaceship = (AIGrandStrategyTypes) GC.getInfoTypeForString("AIGRANDSTRATEGY_SPACESHIP");
+
+			// Map grand strategy to victory pursuit
+			VictoryPursuitTypes eNewPrimaryPursuit = NO_VICTORY_PURSUIT;
+			if (eGrandStrategy == eConquest)
+				eNewPrimaryPursuit = VICTORY_PURSUIT_DOMINATION;
+			else if (eGrandStrategy == eCulture)
+				eNewPrimaryPursuit = VICTORY_PURSUIT_CULTURE;
+			else if (eGrandStrategy == eUnitedNations)
+				eNewPrimaryPursuit = VICTORY_PURSUIT_DIPLOMACY;
+			else if (eGrandStrategy == eSpaceship)
+				eNewPrimaryPursuit = VICTORY_PURSUIT_SCIENCE;
+
+			// If we have a valid new primary pursuit
+			if (eNewPrimaryPursuit != NO_VICTORY_PURSUIT)
+			{
+				// Get current primary and secondary pursuits
+				VictoryPursuitTypes eCurrentPrimary = pDiploAI->GetPrimaryVictoryPursuit();
+				VictoryPursuitTypes eCurrentSecondary = pDiploAI->GetSecondaryVictoryPursuit();
+
+				// Only update if it's different from the current primary
+				if (eCurrentPrimary != eNewPrimaryPursuit)
+				{
+					// Set the new primary pursuit
+					pDiploAI->SetPrimaryVictoryPursuit(eNewPrimaryPursuit);
+
+					// Only set secondary if the old primary is different from the existing secondary
+					if (eCurrentSecondary != eCurrentPrimary)
+					{
+						pDiploAI->SetSecondaryVictoryPursuit(eCurrentPrimary);
+					}
+				}
+			}
+		}
+	}
+	return 0;
+}
+
+//------------------------------------------------------------------------------
+//array, array GetEconomicStrategies();
+// Returns two arrays: first with strategy IDs, second with corresponding active turns
+int CvLuaPlayer::lGetEconomicStrategies(lua_State* L)
+{
+	CvPlayerAI* pkPlayer = GetInstance(L);
+	lua_newtable(L); // Create the first array (strategy IDs)
+	lua_newtable(L); // Create the second array (active turns)
+	
+	if (pkPlayer && pkPlayer->GetEconomicAI())
+	{
+		int iCurrentTurn = GC.getGame().getGameTurn();
+		int iNumStrategies = pkPlayer->GetEconomicAI()->GetEconomicAIStrategies()->GetNumEconomicAIStrategies();
+		int iActiveCount = 0;
+		
+		for (int i = 0; i < iNumStrategies; i++)
+		{
+			EconomicAIStrategyTypes eStrategy = (EconomicAIStrategyTypes)i;
+			if (pkPlayer->GetEconomicAI()->IsUsingStrategy(eStrategy))
+			{
+				int iTurnAdopted = pkPlayer->GetEconomicAI()->GetTurnStrategyAdopted(eStrategy);
+				int iActiveTurns = (iTurnAdopted != -1) ? (iCurrentTurn - iTurnAdopted) : 0;
+				
+				iActiveCount++;
+				
+				// Add to strategy IDs array
+				lua_pushinteger(L, iActiveCount);
+				lua_pushinteger(L, i);
+				lua_settable(L, -4);
+				
+				// Add to active turns array
+				lua_pushinteger(L, iActiveCount);
+				lua_pushinteger(L, iActiveTurns);
+				lua_settable(L, -3);
+			}
+		}
+	}
+	
+	return 2;
+}
+
+//------------------------------------------------------------------------------
+//void SetEconomicStrategies(array enabledStrategies);
+// Takes an array of strategy IDs to enable, all others will be disabled
+int CvLuaPlayer::lSetEconomicStrategies(lua_State* L)
+{
+	CvPlayerAI* pkPlayer = GetInstance(L);
+	if (pkPlayer && pkPlayer->GetEconomicAI())
+	{
+		int iNumStrategies = pkPlayer->GetEconomicAI()->GetEconomicAIStrategies()->GetNumEconomicAIStrategies();
+		
+		// First, disable all strategies
+		for (int i = 0; i < iNumStrategies; i++)
+		{
+			EconomicAIStrategyTypes eStrategy = (EconomicAIStrategyTypes)i;
+			pkPlayer->GetEconomicAI()->SetUsingStrategy(eStrategy, false);
+		}
+		
+		// Check if argument is a table (array)
+		if (lua_istable(L, 2))
+		{
+			// Get array length
+			int iLen = lua_objlen(L, 2);
+			
+			// Enable strategies specified in the array
+			for (int i = 1; i <= iLen; i++)
+			{
+				lua_rawgeti(L, 2, i);
+				if (lua_isnumber(L, -1))
+				{
+					const int iStrategy = lua_tointeger(L, -1);
+					
+					// Validate strategy ID
+					if (iStrategy >= 0 && iStrategy < iNumStrategies)
+					{
+						EconomicAIStrategyTypes eStrategy = (EconomicAIStrategyTypes)iStrategy;
+						pkPlayer->GetEconomicAI()->SetUsingStrategy(eStrategy, true);
+					}
+				}
+				lua_pop(L, 1);
+			}
+		}
+	}
+	return 0;
+}
+
+//------------------------------------------------------------------------------
+//array, array GetMilitaryStrategies();
+// Returns two arrays: first with strategy IDs, second with corresponding active turns
+int CvLuaPlayer::lGetMilitaryStrategies(lua_State* L)
+{
+	CvPlayerAI* pkPlayer = GetInstance(L);
+	lua_newtable(L); // Create the first array (strategy IDs)
+	lua_newtable(L); // Create the second array (active turns)
+	
+	if (pkPlayer && pkPlayer->GetMilitaryAI())
+	{
+		int iCurrentTurn = GC.getGame().getGameTurn();
+		int iNumStrategies = pkPlayer->GetMilitaryAI()->GetMilitaryAIStrategies()->GetNumMilitaryAIStrategies();
+		int iActiveCount = 0;
+		
+		for (int i = 0; i < iNumStrategies; i++)
+		{
+			MilitaryAIStrategyTypes eStrategy = (MilitaryAIStrategyTypes)i;
+			if (pkPlayer->GetMilitaryAI()->IsUsingStrategy(eStrategy))
+			{
+				int iTurnAdopted = pkPlayer->GetMilitaryAI()->GetTurnStrategyAdopted(eStrategy);
+				int iActiveTurns = (iTurnAdopted != -1) ? (iCurrentTurn - iTurnAdopted) : 0;
+				
+				iActiveCount++;
+				
+				// Add to strategy IDs array
+				lua_pushinteger(L, iActiveCount);
+				lua_pushinteger(L, i);
+				lua_settable(L, -4);
+				
+				// Add to active turns array
+				lua_pushinteger(L, iActiveCount);
+				lua_pushinteger(L, iActiveTurns);
+				lua_settable(L, -3);
+			}
+		}
+	}
+	
+	return 2;
+}
+
+//------------------------------------------------------------------------------
+//void SetMilitaryStrategies(array enabledStrategies);
+// Takes an array of strategy IDs to enable, all others will be disabled
+int CvLuaPlayer::lSetMilitaryStrategies(lua_State* L)
+{
+	CvPlayerAI* pkPlayer = GetInstance(L);
+	if (pkPlayer && pkPlayer->GetMilitaryAI())
+	{
+		int iNumStrategies = pkPlayer->GetMilitaryAI()->GetMilitaryAIStrategies()->GetNumMilitaryAIStrategies();
+		
+		// First, disable all strategies
+		for (int i = 0; i < iNumStrategies; i++)
+		{
+			MilitaryAIStrategyTypes eStrategy = (MilitaryAIStrategyTypes)i;
+			pkPlayer->GetMilitaryAI()->SetUsingStrategy(eStrategy, false);
+		}
+		
+		// Check if argument is a table (array)
+		if (lua_istable(L, 2))
+		{
+			// Get array length
+			int iLen = lua_objlen(L, 2);
+			
+			// Enable strategies specified in the array
+			for (int i = 1; i <= iLen; i++)
+			{
+				lua_rawgeti(L, 2, i);
+				if (lua_isnumber(L, -1))
+				{
+					const int iStrategy = lua_tointeger(L, -1);
+					
+					// Validate strategy ID
+					if (iStrategy >= 0 && iStrategy < iNumStrategies)
+					{
+						MilitaryAIStrategyTypes eStrategy = (MilitaryAIStrategyTypes)iStrategy;
+						pkPlayer->GetMilitaryAI()->SetUsingStrategy(eStrategy, true);
+					}
+				}
+				lua_pop(L, 1);
+			}
+		}
+	}
+	return 0;
 }

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.h
@@ -1470,6 +1470,11 @@ protected:
 	LUAAPIEXTN(CountAllTerrain, int, iTerrainType);
 	LUAAPIEXTN(CountAllWorkedTerrain, int, iTerrainType);
 
+	// Vox Deorum: Methods to get/set AI personality values
+	static int lGetPersona(lua_State* L);
+	static int lSetPersona(lua_State* L);
+	static int lGetDiplomacyEvaluation(lua_State* L);
+	
 #if defined(MOD_IMPROVEMENTS_EXTENSIONS)
 	static int lGetResponsibleForRouteCount(lua_State* L);
 	static int lGetResponsibleForImprovementCount(lua_State* L);
@@ -1539,6 +1544,13 @@ protected:
 	static int lSetInstantYieldNotificationDisabled(lua_State* L);
 
 	LUAAPIEXTN(GetCompetitiveSpawnUnitType, int, bIncludeRanged, bIncludeShips, bIncludeRecon, bIncludeUUs, bNoResource, bMinorCivGift, bRandom, tUnitCombatIDs);
+	
+	static int lGetGrandStrategy(lua_State* L);
+	static int lSetGrandStrategy(lua_State* L);
+	static int lGetEconomicStrategies(lua_State* L);
+	static int lSetEconomicStrategies(lua_State* L);
+	static int lGetMilitaryStrategies(lua_State* L);
+	static int lSetMilitaryStrategies(lua_State* L);
 };
 
 namespace CvLuaArgs


### PR DESCRIPTION
New Lua APIs to enable LLMs tweak the in-game AI behaviors:
- Player::GetPersona
- Player::SetPersona
- Player::GetDiplomacyEvaluation (an always-frank version of the GetOpinionTable)
- Player::GetGrandStrategy
- Player::SetGrandStrategy
- Player::GetMilitaryStrategies
- Player::SetMilitaryStrategies
- Player::GetEconomicStrategies
- Player::SetEconomicStrategies