### PR TITLE
Various fixes/refactorings

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
@@ -1313,7 +1313,8 @@ bool CvBuilderTaskingAI::ExecuteWorkerMove(CvUnit* pUnit, BuilderDirective aDire
 			UNREACHABLE();
 		case BuilderDirective::BUILD_IMPROVEMENT_ON_RESOURCE:
 		case BuilderDirective::BUILD_IMPROVEMENT:
-		case BuilderDirective::REPAIR:
+		case BuilderDirective::REPAIR_IMPROVEMENT:
+		case BuilderDirective::REPAIR_ROUTE:
 		case BuilderDirective::BUILD_ROUTE:
 		case BuilderDirective::REMOVE_FEATURE:
 		case BuilderDirective::REMOVE_ROAD:
@@ -1355,8 +1356,11 @@ bool CvBuilderTaskingAI::ExecuteWorkerMove(CvUnit* pUnit, BuilderDirective aDire
 				case BuilderDirective::BUILD_IMPROVEMENT:
 					strLog += "On plot,";
 					break;
-				case BuilderDirective::REPAIR:
+				case BuilderDirective::REPAIR_IMPROVEMENT:
 					strLog += "Repairing,";
+					break;
+				case BuilderDirective::REPAIR_ROUTE:
+					strLog += "Repairing route,";
 					break;
 				case BuilderDirective::BUILD_ROUTE:
 					strLog += "Building route,";
@@ -1371,16 +1375,13 @@ bool CvBuilderTaskingAI::ExecuteWorkerMove(CvUnit* pUnit, BuilderDirective aDire
 
 				if (eMission == CvTypes::getMISSION_BUILD())
 				{
-					if (aDirective.m_eDirectiveType == BuilderDirective::REPAIR)
+					if (aDirective.m_eDirectiveType == BuilderDirective::REPAIR_IMPROVEMENT)
 					{
-						if (pPlot->IsImprovementPillaged())
-						{
-							strLog += "Repairing improvement";
-						}
-						else
-						{
-							strLog += "Repairing route";
-						}
+						strLog += "Repairing improvement";
+					}
+					else if (aDirective.m_eDirectiveType == BuilderDirective::REPAIR_ROUTE)
+					{
+						strLog += "Repairing route";
 					}
 					else if (aDirective.m_eDirectiveType == BuilderDirective::BUILD_ROUTE)
 					{
@@ -2093,7 +2094,7 @@ void CvBuilderTaskingAI::AddImprovingPlotsDirective(vector<OptionWithScore<Build
 	if (eExistingImprovement != NO_IMPROVEMENT)
 	{
 		// Do we have a special improvement here? (great person improvement, gifted improvement from major civ)
-		if (pPlot->HasSpecialImprovement() || (m_pPlayer->isOption(PLAYEROPTION_SAFE_AUTOMATION) && m_pPlayer->isHuman()))
+		if (PlotHasSpecialImprovement(pPlot) || (m_pPlayer->isOption(PLAYEROPTION_SAFE_AUTOMATION) && m_pPlayer->isHuman()))
 		{
 			if (m_bLogging)
 			{
@@ -2579,7 +2580,7 @@ void CvBuilderTaskingAI::AddRepairImprovementDirective(vector<OptionWithScore<Bu
 
 	if (iScore > 0)
 	{
-		aDirectives.push_back(OptionWithScore<BuilderDirective>(BuilderDirective(BuilderDirective::REPAIR, m_eRepairBuild, NO_RESOURCE, false, pPlot->getX(), pPlot->getY(), iScore, iPotentialScore), iScore));
+		aDirectives.push_back(OptionWithScore<BuilderDirective>(BuilderDirective(BuilderDirective::REPAIR_IMPROVEMENT, m_eRepairBuild, NO_RESOURCE, false, pPlot->getX(), pPlot->getY(), iScore, iPotentialScore), iScore));
 	}
 }
 
@@ -2598,7 +2599,7 @@ void CvBuilderTaskingAI::AddRepairRouteDirective(vector<OptionWithScore<BuilderD
 
 	if (iValue > 0)
 	{
-		aDirectives.push_back(OptionWithScore<BuilderDirective>(BuilderDirective(BuilderDirective::REPAIR, m_eRepairBuild, NO_RESOURCE, false, pPlot->getX(), pPlot->getY(), iValue, 0), iValue));
+		aDirectives.push_back(OptionWithScore<BuilderDirective>(BuilderDirective(BuilderDirective::REPAIR_ROUTE, m_eRepairBuild, NO_RESOURCE, false, pPlot->getX(), pPlot->getY(), iValue, 0), iValue));
 	}
 }
 
@@ -2711,6 +2712,44 @@ bool CvBuilderTaskingAI::ShouldBuilderConsiderPlot(CvUnit* pUnit, CvPlot* pPlot)
 	}
 
 	return true;
+}
+
+//	--------------------------------------------------------------------------------
+/// Does this plot have a special improvement that we shouldn't remove?
+bool CvBuilderTaskingAI::PlotHasSpecialImprovement(const CvPlot* pPlot) const
+{
+	// Gifted improvements (if we are a minor civ)
+	if (m_pPlayer->isMinorCiv())
+	{
+		if (pPlot->IsImprovedByGiftFromMajor())
+		{
+			return true;
+		}
+	}
+
+	if (m_pPlayer->isHuman())
+	{
+		// Great person improvements
+		ImprovementTypes eImprovement = pPlot->getImprovementType();
+		if (eImprovement != NO_IMPROVEMENT)
+		{
+			CvImprovementEntry* pImprovementInfo = GC.getImprovementInfo(eImprovement);
+			//Works like GP improvement.
+			if (pImprovementInfo && pImprovementInfo->IsCreatedByGreatPerson())
+			{
+				return true;
+			}
+
+			//Don't delete landmarks!
+			ImprovementTypes eLandmark = (ImprovementTypes)GC.getInfoTypeForString("IMPROVEMENT_LANDMARK");
+			if (eLandmark != NO_IMPROVEMENT && eImprovement == eLandmark)
+			{
+				return true;
+			}
+		}
+	}
+
+	return false;
 }
 
 /// Return the weight of this resource
@@ -2898,8 +2937,11 @@ pair<int,int> CvBuilderTaskingAI::ScorePlotBuild(CvPlot* pPlot, ImprovementTypes
 	int iSecondaryScore = 0;
 	int iPotentialScore = 0;
 
+	const bool bIsBuild = eBuild != NO_BUILD;
+	const bool bIsRepair = bIsBuild ? pkBuildInfo->isRepair() : false;
+
 	// Not building anything has some inherent value
-	if (eBuild == NO_BUILD && eImprovement != NO_IMPROVEMENT)
+	if (!bIsBuild && eImprovement != NO_IMPROVEMENT)
 		iSecondaryScore += 100;
 
 	const CvCity* pOwningCity = pPlot->getEffectiveOwningCity();
@@ -3054,7 +3096,7 @@ pair<int,int> CvBuilderTaskingAI::ScorePlotBuild(CvPlot* pPlot, ImprovementTypes
 
 	if (bIsWithinWorkRange)
 	{
-		if (eBuild != NO_BUILD)
+		if (bIsBuild)
 			UpdateProjectedPlotYields(pPlot, eBuild, eForceCityConnection);
 		else
 			UpdateCurrentPlotYields(pPlot);
@@ -3157,7 +3199,7 @@ pair<int,int> CvBuilderTaskingAI::ScorePlotBuild(CvPlot* pPlot, ImprovementTypes
 
 		int iYieldModifier = GetYieldBaseModifierTimes100(eYield);
 		int iNewYieldTimes100 = 0;
-		int iProjectedNewYieldsTimes100 = eBuild != NO_BUILD ? 100 * m_aiProjectedPlotYields[ui] : 100 * m_aiCurrentPlotYields[ui];
+		int iProjectedNewYieldsTimes100 = bIsBuild ? 100 * m_aiProjectedPlotYields[ui] : 100 * m_aiCurrentPlotYields[ui];
 
 		if (bIsWithinWorkRange)
 		{
@@ -3387,10 +3429,10 @@ pair<int,int> CvBuilderTaskingAI::ScorePlotBuild(CvPlot* pPlot, ImprovementTypes
 					if (pkAdjacentImprovementInfo)
 					{
 						// How much extra yield we give to adjacent tiles with a certain improvement
-						fraction fAdjacentImprovementYield = pkAdjacentImprovementInfo->GetYieldPerXAdjacentImprovement(eYield, eImprovement);
+						fraction fAdjacentImprovementYield = eImprovement != NO_IMPROVEMENT ? pkAdjacentImprovementInfo->GetYieldPerXAdjacentImprovement(eYield, eImprovement) : 0;
 						fraction fCurrentAdjacentImprovementYield = GetCurrentAdjacencyScoreFromImprovementsAndTerrain(pAdjacentPlot, *pkAdjacentImprovementInfo, eYield, sState);
 
-						if (eBuild == NO_BUILD)
+						if (!bIsBuild)
 							fCurrentAdjacentImprovementYield -= fAdjacentImprovementYield;
 
 						int iDeltaTruncatedYield = (fCurrentAdjacentImprovementYield + fAdjacentImprovementYield).Truncate() - fCurrentAdjacentImprovementYield.Truncate();
@@ -3651,7 +3693,15 @@ pair<int,int> CvBuilderTaskingAI::ScorePlotBuild(CvPlot* pPlot, ImprovementTypes
 			}
 		}
 
-		int iPenalty = pkImprovementInfo && pkImprovementInfo->IsCreatedByGreatPerson() ? 1000 : 100;
+		int iPenalty = 100;
+		if (pkImprovementInfo && pkImprovementInfo->IsCreatedByGreatPerson())
+		{
+			// No penalty for repairing/keeping GP improvements
+			if (!bIsBuild || bIsRepair)
+				iPenalty = 0;
+			else
+				iPenalty = 1000;
+		}
 
 		if (bBenefitsFromRoads && eForceCityConnection == NO_ROUTE)
 			iSecondaryScore -= iPenalty;
@@ -3660,7 +3710,7 @@ pair<int,int> CvBuilderTaskingAI::ScorePlotBuild(CvPlot* pPlot, ImprovementTypes
 	}
 
 	// Don't build on antiquity sites
-	if (eResource != NO_RESOURCE && eBuild != NO_BUILD)
+	if (eResource != NO_RESOURCE && bIsBuild)
 	{
 		static const BuildTypes eDigBuild = (BuildTypes)GC.getInfoTypeForString("BUILD_ARCHAEOLOGY_DIG");
 		if (m_pPlayer->canBuild(pPlot, eDigBuild) && eDigBuild != eBuild)
@@ -3693,7 +3743,12 @@ pair<int,int> CvBuilderTaskingAI::ScorePlotBuild(CvPlot* pPlot, ImprovementTypes
 		if (iDefenseBuildValue > 0)
 			iSecondaryScore += iDefenseBuildValue;
 		else
-			iYieldScore /= 2; //de-emphasize yields if we're not close to the border
+		{
+			//de-emphasize yields for forts if we're not close to the border (they look ugly when spammed)
+			bool bIsFort = strncmp(pkImprovementInfo->GetType(), "IMPROVEMENT_FORT", 64) == 0;
+			if (bIsFort)
+				iYieldScore /= 2;
+		}
 	}
 
 	// How many tiles will be covered by an encampment bonus (or similar)
@@ -3739,7 +3794,7 @@ pair<int,int> CvBuilderTaskingAI::ScorePlotBuild(CvPlot* pPlot, ImprovementTypes
 	}
 
 	// Currently this is only for human player recommendations.
-	if (bIsCultureBomb && eBuild != NO_BUILD)
+	if (bIsCultureBomb && bIsBuild)
 	{
 		int iStealScore = 0;
 		int iRange = pkImprovementInfo->GetCultureBombRadius();
@@ -3891,7 +3946,7 @@ pair<int,int> CvBuilderTaskingAI::ScorePlotBuild(CvPlot* pPlot, ImprovementTypes
 	{
 		int iTileClaimChance = 0;
 		int iTileWorkableChance = 0;
-		if (eBuild != NO_BUILD)
+		if (bIsBuild)
 		{
 			iTileWorkableChance = GetResourceSpawnWorkableChance(pPlot, iTileClaimChance);
 		}
@@ -4392,8 +4447,11 @@ void CvBuilderTaskingAI::LogDirective(BuilderDirective directive, int iWeight, b
 	case BuilderDirective::BUILD_IMPROVEMENT:
 		strLog += "BUILD_IMPROVEMENT,";
 		break;
-	case BuilderDirective::REPAIR:
-		strLog += "REPAIR,";
+	case BuilderDirective::REPAIR_IMPROVEMENT:
+		strLog += "REPAIR_IMPROVEMENT,";
+		break;
+	case BuilderDirective::REPAIR_ROUTE:
+		strLog += "REPAIR_ROUTE,";
 		break;
 	case BuilderDirective::BUILD_ROUTE:
 		strLog += "BUILD_ROUTE,";
@@ -4429,29 +4487,27 @@ void CvBuilderTaskingAI::LogDirective(BuilderDirective directive, int iWeight, b
 		strLog += ",";
 	}
 
-	if(directive.m_eDirectiveType == BuilderDirective::REPAIR)
+	if(directive.m_eDirectiveType == BuilderDirective::REPAIR_IMPROVEMENT)
 	{
 		CvPlot* pPlot = GC.getMap().plot(directive.m_sX, directive.m_sY);
-		if(pPlot->IsImprovementPillaged())
+		if(pPlot->getImprovementType() != NO_IMPROVEMENT)
 		{
-			if(pPlot->getImprovementType() != NO_IMPROVEMENT)
+			CvImprovementEntry* pkImprovementInfo = GC.getImprovementInfo(pPlot->getImprovementType());
+			if(pkImprovementInfo)
 			{
-				CvImprovementEntry* pkImprovementInfo = GC.getImprovementInfo(pPlot->getImprovementType());
-				if(pkImprovementInfo)
-				{
-					strLog += pkImprovementInfo->GetType();
-				}
+				strLog += pkImprovementInfo->GetType();
 			}
 		}
-		else
+	}
+	else if (directive.m_eDirectiveType == BuilderDirective::REPAIR_ROUTE)
+	{
+		CvPlot* pPlot = GC.getMap().plot(directive.m_sX, directive.m_sY);
+		if (pPlot->getRouteType() != NO_ROUTE)
 		{
-			if(pPlot->getRouteType() != NO_ROUTE)
+			CvRouteInfo* pkRouteInfo = GC.getRouteInfo(pPlot->getRouteType());
+			if (pkRouteInfo)
 			{
-				CvRouteInfo* pkRouteInfo = GC.getRouteInfo(pPlot->getRouteType());
-				if(pkRouteInfo)
-				{
-					strLog += pkRouteInfo->GetType();
-				}
+				strLog += pkRouteInfo->GetType();
 			}
 		}
 	}

--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.h
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.h
@@ -24,7 +24,8 @@ struct BuilderDirective
 		BUILD_IMPROVEMENT_ON_RESOURCE, // enabling a special resource
 		BUILD_IMPROVEMENT,			   // improving a tile
 		BUILD_ROUTE,				   // build a route on a tile
-		REPAIR,						   // repairing a pillaged route or improvement
+		REPAIR_IMPROVEMENT,			   // repairing a pillaged improvement
+		REPAIR_ROUTE,				   // repairing a pillaged route
 		REMOVE_FEATURE,				   // remove a feature to improve production
 		REMOVE_ROAD,				   // remove a road from a plot
 		KEEP_IMPROVEMENT,			   // will not actually be executed but needed for planning
@@ -195,6 +196,8 @@ protected:
 	void SetupExtraXAdjacentPlotsForBuild(BuildTypes eBuild, ImprovementTypes eImprovement, int iAdjacencyRequirement);
 
 	void UpdateCanalPlots();
+
+	bool PlotHasSpecialImprovement(const CvPlot* pPlot) const;
 
 	PlotPair GetPlotPair(int iPlotId1, int iPlotId2);
 

--- a/CvGameCoreDLL_Expansion2/CvCultureClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCultureClasses.cpp
@@ -204,6 +204,8 @@ CvString CvGameCulture::GetGreatWorkTooltip(int iIndex, PlayerTypes eOwner) cons
 			iBaseValueTimes100 = 0;
 		}
 
+		iAddedValue = 0;
+
 		iBaseValueTimes100 += GET_PLAYER(eOwner).GetGreatWorkYieldChange(eYield) * 100;
 		iBaseValueTimes100 += GET_PLAYER(eOwner).GetPlayerTraits()->GetGreatWorkYieldChanges(eYield) * 100;
 		if (pCity)
@@ -6319,7 +6321,7 @@ int CvCityCulture::GetThemingBonusMultiplierTimes10000() const
 {
 	CvPlayer* pPlayer = m_pCity->GetPlayer();
 	int iMultiplier = 100 + pPlayer->GetPlayerPolicies()->GetNumericModifier(POLICYMOD_THEMING_BONUS);
-	iMultiplier *= 100 + m_pCity->isCapital() ? pPlayer->GetPlayerTraits()->GetCapitalThemingBonusModifier() : 0;
+	iMultiplier *= 100 + (m_pCity->isCapital() ? pPlayer->GetPlayerTraits()->GetCapitalThemingBonusModifier() : 0);
 	return iMultiplier;
 }
 

--- a/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
@@ -2921,6 +2921,12 @@ void CvHomelandAI::ExecuteWorkerMoves()
 		CvUnit* pBuilder = aDistanceWeightedDirectives.front().option.first;
 		BuilderDirective eDirective = aDistanceWeightedDirectives.front().option.second;
 
+		// Need to save the state of the plot in case we finish the improvement this turn
+		CvPlot* pDirectivePlot = GC.getMap().plot(eDirective.m_sX, eDirective.m_sY);
+		ImprovementTypes eOldImprovement = !pDirectivePlot->IsImprovementPillaged() ? pDirectivePlot->getImprovementType() : NO_IMPROVEMENT;
+		FeatureTypes eOldFeature = pDirectivePlot->getFeatureType();
+		ResourceTypes eOldResource = pDirectivePlot->getResourceType(m_pPlayer->getTeam());
+
 		// We may have planned an improvement that we can't build yet, but should still update other plots as if we've built it
 		// E.g. if we're planning to build an improvement with a no-two-adjacent requirement, we still want to build other improvements next to it.
 		bool bCanBuild = pBuilder->canBuild(GC.getMap().plot(eDirective.m_sX, eDirective.m_sY), eDirective.m_eBuild);
@@ -2980,21 +2986,59 @@ void CvHomelandAI::ExecuteWorkerMoves()
 		if (allWorkers.size() > processedWorkers.size())
 		{
 			// We may want to recalculate some of the other directive scores
-			CvPlot* pDirectivePlot = GC.getMap().plot(eDirective.m_sX, eDirective.m_sY);
 			CvBuildInfo* pkBuildInfo = GC.getBuildInfo(eDirective.m_eBuild);
-			ImprovementTypes eOldImprovement = !pDirectivePlot->IsImprovementPillaged() ? pDirectivePlot->getImprovementType() : NO_IMPROVEMENT;
 			ImprovementTypes eImprovement = (ImprovementTypes)pkBuildInfo->getImprovement();
+			RouteTypes eRoute = (RouteTypes)pkBuildInfo->getRoute();
 
-			if (eImprovement == NO_IMPROVEMENT && (pkBuildInfo->isRepair() || !pDirectivePlot->IsImprovementPillaged()))
+			bool bFinishedBuilding = false;
+			switch (eDirective.m_eDirectiveType)
+			{
+			case BuilderDirective::BUILD_IMPROVEMENT:
+			case BuilderDirective::BUILD_IMPROVEMENT_ON_RESOURCE:
+				bFinishedBuilding = pDirectivePlot->getImprovementType() == eImprovement;
+				break;
+			case BuilderDirective::BUILD_ROUTE:
+				bFinishedBuilding = pDirectivePlot->getRouteType() == eRoute;
+				break;
+			case BuilderDirective::KEEP_IMPROVEMENT:
+				UNREACHABLE();
+				break;
+			case BuilderDirective::REMOVE_FEATURE:
+				bFinishedBuilding = pDirectivePlot->getFeatureType() == NO_FEATURE;
+				break;
+			case BuilderDirective::REMOVE_ROAD:
+				bFinishedBuilding = pDirectivePlot->getRouteType() == NO_ROUTE;
+				break;
+			case BuilderDirective::REPAIR_IMPROVEMENT:
+				bFinishedBuilding = !pDirectivePlot->IsImprovementPillaged();
+				break;
+			case BuilderDirective::REPAIR_ROUTE:
+				bFinishedBuilding = !pDirectivePlot->IsRoutePillaged();
+				break;
+			}
+
+			if (eImprovement == NO_IMPROVEMENT && eDirective.m_eDirectiveType == BuilderDirective::REPAIR_IMPROVEMENT)
 				eImprovement = pDirectivePlot->getImprovementType();
 
 			CvImprovementEntry* pkImprovementInfo = eImprovement != NO_IMPROVEMENT ? GC.getImprovementInfo(eImprovement) : NULL;
 			CvImprovementEntry* pkOldImprovementInfo = eOldImprovement != NO_IMPROVEMENT ? GC.getImprovementInfo(eOldImprovement) : NULL;
 
+			if (GC.getLogging() && GC.getAILogging())
+			{
+				if (pkImprovementInfo && pkOldImprovementInfo && pkOldImprovementInfo->IsCreatedByGreatPerson())
+				{
+					CvString strLogString;
+					CvString strTemp = pkOldImprovementInfo->GetDescription();
+					CvString strTemp2 = pkImprovementInfo->GetDescription();
+					strLogString.Format("Planning to replace Great Person improvement %s with %s", strTemp.GetCString(), strTemp2.GetCString());
+					LogHomelandMessage(strLogString);
+				}
+			}
+
 			vector<BuilderDirective> aNewBuilderDirectives;
 
 			const CvCity* pOwningCity = pDirectivePlot->getEffectiveOwningCity();
-			if (!pOwningCity && eImprovement == NO_IMPROVEMENT)
+			if (!pOwningCity && eImprovement != NO_IMPROVEMENT)
 			{
 				// If we are performing a culture bomb, find which city will be owning the plot
 				bool bIsCultureBomb = pkImprovementInfo ? pkImprovementInfo->GetCultureBombRadius() > 0 : false;
@@ -3028,12 +3072,11 @@ void CvHomelandAI::ExecuteWorkerMoves()
 
 			// Resource considerations
 			bool bResourceStateChanged = false;
-			const ResourceTypes eResource = pDirectivePlot->getResourceType(m_pPlayer->getTeam());
 			if (bCanBuild)
 			{
 				const ResourceTypes eResourceFromImprovement = pkImprovementInfo ? (ResourceTypes)pkImprovementInfo->GetResourceFromImprovement() : NO_RESOURCE;
 				const ResourceTypes eResourceFromOldImprovement = pkOldImprovementInfo ? (ResourceTypes)pkOldImprovementInfo->GetResourceFromImprovement() : NO_RESOURCE;
-				const ResourceTypes eNaturalResource = eResourceFromOldImprovement == NO_RESOURCE ? eResource : NO_RESOURCE;
+				const ResourceTypes eNaturalResource = eResourceFromOldImprovement == NO_RESOURCE ? eOldResource : NO_RESOURCE;
 
 				bool bOldCreatedResource = eResourceFromOldImprovement != NO_RESOURCE;
 				bool bOldConnectedResource = eNaturalResource != NO_RESOURCE && pkOldImprovementInfo && pkOldImprovementInfo->IsConnectsResource(eNaturalResource);
@@ -3061,14 +3104,20 @@ void CvHomelandAI::ExecuteWorkerMoves()
 
 				if (eCreatedResource != NO_RESOURCE)
 				{
-					int iResourceAmount = eResourceFromImprovement != NO_RESOURCE ? pkImprovementInfo->GetResourceQuantityFromImprovement() : pDirectivePlot->getNumResource();
-					sState.mExtraResources[eResource] += iResourceAmount;
+					if (!bFinishedBuilding)
+					{
+						int iResourceAmount = eResourceFromImprovement != NO_RESOURCE ? pkImprovementInfo->GetResourceQuantityFromImprovement() : pDirectivePlot->getNumResource();
+						sState.mExtraResources[eOldResource] += iResourceAmount;
+					}
 					bResourceStateChanged = true;
 				}
 				if (eRemovedResource != NO_RESOURCE)
 				{
-					int iResourceAmount = eResourceFromOldImprovement != NO_RESOURCE ? pkOldImprovementInfo->GetResourceQuantityFromImprovement() : pDirectivePlot->getNumResource();
-					sState.mExtraResources[eResource] -= iResourceAmount;
+					if (!bFinishedBuilding)
+					{
+						int iResourceAmount = eResourceFromOldImprovement != NO_RESOURCE ? pkOldImprovementInfo->GetResourceQuantityFromImprovement() : pDirectivePlot->getNumResource();
+						sState.mExtraResources[eOldResource] -= iResourceAmount;
+					}
 					bResourceStateChanged = true;
 				}
 			}
@@ -3079,7 +3128,7 @@ void CvHomelandAI::ExecuteWorkerMoves()
 			FeatureTypes eFeature = eFeatureFromImprovement;
 			if (eFeature == NO_FEATURE)
 			{
-				eFeature = pDirectivePlot->getFeatureType();
+				eFeature = eOldFeature;
 				if (eFeature != NO_FEATURE && pkBuildInfo->isFeatureRemove(eFeature))
 				{
 					eFeature = NO_FEATURE;
@@ -3088,22 +3137,25 @@ void CvHomelandAI::ExecuteWorkerMoves()
 
 			if (bCanBuild)
 			{
-				if (!MOD_BALANCE_VP && eFeature != pDirectivePlot->getFeatureType())
+				if (eFeature != eOldFeature)
 				{
-					sState.mChangedPlotFeatures[pDirectivePlot->GetPlotIndex()] = eFeature;
+					if (!bFinishedBuilding)
+						sState.mChangedPlotFeatures[pDirectivePlot->GetPlotIndex()] = eFeature;
+
 					bFeatureStateChanged = true;
 				}
 			}
 
 			// Improvement considerations
 			bool bImprovementStateChanged = false;
-			if (bCanBuild)
+			if (bCanBuild && (eDirective.m_eDirectiveType == BuilderDirective::BUILD_IMPROVEMENT || 
+							  eDirective.m_eDirectiveType == BuilderDirective::BUILD_IMPROVEMENT_ON_RESOURCE || 
+				              eDirective.m_eDirectiveType == BuilderDirective::REPAIR_IMPROVEMENT))
 			{
-				if ((eImprovement != NO_IMPROVEMENT && eImprovement != pDirectivePlot->getImprovementType()) || (pkBuildInfo->isRepair() && pDirectivePlot->IsImprovementPillaged()))
-				{
+				if (!bFinishedBuilding)
 					sState.mChangedPlotImprovements[pDirectivePlot->GetPlotIndex()].second = eImprovement;
-					bImprovementStateChanged = true;
-				}
+
+				bImprovementStateChanged = true;
 			}
 
 			// Defense considerations
@@ -3112,7 +3164,6 @@ void CvHomelandAI::ExecuteWorkerMoves()
 			{
 				if (bImprovementStateChanged)
 				{
-					ImprovementTypes eOldImprovement = pDirectivePlot->getImprovementType();
 					CvImprovementEntry* pkOldImprovementInfo = eOldImprovement != NO_IMPROVEMENT ? GC.getImprovementInfo(eOldImprovement) : NULL;
 
 					int iOldDefenseModifier = pkOldImprovementInfo ? pkOldImprovementInfo->GetDefenseModifier() : 0;
@@ -3138,7 +3189,7 @@ void CvHomelandAI::ExecuteWorkerMoves()
 				if (bImprovementStateChanged)
 				{
 					ImprovementTypes eBonusImprovement = m_pPlayer->GetPlayerTraits()->GetCombatBonusImprovementType();
-					if (eBonusImprovement == eImprovement)
+					if (eBonusImprovement == eImprovement || eBonusImprovement == eOldImprovement)
 					{
 						bCombatBonusStateChanged = true;
 					}
@@ -3147,12 +3198,9 @@ void CvHomelandAI::ExecuteWorkerMoves()
 
 			// Road considerations
 			bool bRouteStateChanged = false;
-			if (pkBuildInfo->getRoute() != NO_ROUTE || (pkBuildInfo->isRepair() && pDirectivePlot->IsRoutePillaged() && (pDirectivePlot->getImprovementType() == NO_IMPROVEMENT || !pDirectivePlot->IsImprovementPillaged())))
+			if (bCanBuild && (eDirective.m_eDirectiveType == BuilderDirective::BUILD_ROUTE || eDirective.m_eDirectiveType == BuilderDirective::REPAIR_ROUTE))
 			{
-				if (pDirectivePlot->getRouteType() == NO_ROUTE || pDirectivePlot->IsRoutePillaged())
-				{
-					bRouteStateChanged = true;
-				}
+				bRouteStateChanged = true;
 			}
 
 			for (vector<OptionWithScore<pair<CvUnit*, BuilderDirective>>>::iterator it = aDistanceWeightedDirectives.begin(); it != aDistanceWeightedDirectives.end(); ++it)
@@ -3220,7 +3268,7 @@ void CvHomelandAI::ExecuteWorkerMoves()
 				if (eOtherImprovement != NO_IMPROVEMENT && bResourceStateChanged && !bDirectiveUpdated)
 				{
 					// Connecting a resource may reduce or increase the value of connecting more instances of the same resource
-					if (pOtherPlot->getResourceType(m_pPlayer->getTeam()) == eResource || (pkOtherImprovementInfo && pkOtherImprovementInfo->GetResourceFromImprovement() == eResource))
+					if (pOtherPlot->getResourceType(m_pPlayer->getTeam()) == eOldResource || (pkOtherImprovementInfo && pkOtherImprovementInfo->GetResourceFromImprovement() == eOldResource))
 					{
 						pair<int, int> pScore = pBuilderTaskingAI->ScorePlotBuild(pOtherPlot, eOtherImprovement, eOtherDirective.m_eBuild, sState);
 
@@ -3239,16 +3287,14 @@ void CvHomelandAI::ExecuteWorkerMoves()
 
 				if (bFeatureStateChanged && !bDirectiveUpdated)
 				{
-					// This is only used for vanilla Celts, removing forests will cause faith reduction in cities on certain thresholds
-					CvPlot* pOtherPlot = GC.getMap().plot(eOtherDirective.m_sX, eOtherDirective.m_sY);
-
-					if (pOtherPlot->getFeatureType() == pDirectivePlot->getFeatureType())
+					// This is only used for vanilla Celts, removing/improving forests will cause faith reduction in cities on certain thresholds
+					if (pOtherPlot->getFeatureType() == eOldFeature)
 					{
 						FeatureTypes eFeatureFromOtherImprovement = pkOtherImprovementInfo ? pkOtherImprovementInfo->GetCreatedFeature() : NO_FEATURE;
 						FeatureTypes eOtherFeature = pkOtherBuildInfo && pkOtherBuildInfo->isFeatureRemove(pOtherPlot->getFeatureType()) ? NO_FEATURE : pOtherPlot->getFeatureType();
 						eOtherFeature = eFeatureFromOtherImprovement != NO_FEATURE ? eFeatureFromOtherImprovement : eOtherFeature;
 
-						if (eOtherFeature != pOtherPlot->getFeatureType())
+						if (eOtherFeature != pOtherPlot->getFeatureType() || eOtherImprovement != NO_IMPROVEMENT)
 						{
 							pair<int, int> pScore = pBuilderTaskingAI->ScorePlotBuild(pOtherPlot, eOtherImprovement, eOtherDirective.m_eBuild, sState);
 

--- a/CvGameCoreDLL_Expansion2/CvMilitaryAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvMilitaryAI.cpp
@@ -314,6 +314,7 @@ void CvMilitaryAI::Reset()
 	m_iRecDefensiveLandUnits = 0;
 	m_iRecOffensiveLandUnits = 0;
 	m_iRecOffensiveNavalUnits = 0;
+	m_iRecExplorerUnits = 0;
 	m_eLandDefenseState = NO_DEFENSE_STATE;
 	m_eNavalDefenseState = NO_DEFENSE_STATE;
 	m_iNumberOfTimesOpsBuildSkippedOver = 0;
@@ -558,6 +559,10 @@ CvUnit* CvMilitaryAI::BuyEmergencyUnit(UnitAITypes eUnitType, CvCity* pCity)
 			}
 		}
 	}
+
+	// AI unit promotions have already been processed, so we need to do it explicitly here
+	if (pUnit)
+		pUnit->AI_promote();
 
 	if (pUnit)
 	{
@@ -1544,7 +1549,7 @@ void CvMilitaryAI::LogDeficitScrapUnit(CvUnit* pUnit, bool bGifted)
 
 		if(pUnit->getDomainType() == DOMAIN_LAND)
 		{
-			strTemp.Format("Num Land Units: %d, In Armies %d, Rec Size: %d, ", m_iNumLandUnits, m_iNumLandUnitsInArmies, m_iRecOffensiveLandUnits + m_iRecDefensiveLandUnits);
+			strTemp.Format("Num Land Units: %d, In Armies %d, Rec Size: %d, ", m_iNumLandUnits, m_iNumLandUnitsInArmies, m_iRecOffensiveLandUnits + m_iRecDefensiveLandUnits + m_iRecExplorerUnits);
 		}
 		else
 		{
@@ -1752,7 +1757,11 @@ void CvMilitaryAI::SetRecommendedArmyNavySize()
 
 	int iTotalWeight = iTotalOffenseWeight + iLandDefenseWeight + iNavalDefenseWeight;
 
-	iMaxPossibleUnits -= m_pPlayer->GetEconomicAI()->GetExplorersNeeded();
+	// Limit explorers to 1/4 of total supply
+	int iExplorersNeeded = min(iMaxPossibleUnits / 4, m_pPlayer->GetEconomicAI()->GetExplorersNeeded());
+	m_iRecExplorerUnits = iExplorersNeeded;
+
+	iMaxPossibleUnits -= iExplorersNeeded;
 
 	// We don't want to max out our supply cap
 	//if (iMaxPossibleUnits * 10 > iTotalWeight)

--- a/CvGameCoreDLL_Expansion2/CvMilitaryAI.h
+++ b/CvGameCoreDLL_Expansion2/CvMilitaryAI.h
@@ -208,7 +208,7 @@ public:
 	int GetNumberCivsAtWarWith(bool bIncludeMinor = true) const;
 	int GetRecommendedMilitarySize() const
 	{
-		return m_iRecDefensiveLandUnits + m_iRecOffensiveLandUnits + m_iRecOffensiveNavalUnits;
+		return m_iRecDefensiveLandUnits + m_iRecOffensiveLandUnits + m_iRecOffensiveNavalUnits + m_iRecExplorerUnits;
 	};
 
 	int GetPowerOfStrongestBuildableUnit(DomainTypes eDomain);
@@ -269,6 +269,10 @@ public:
 	int GetRecommendNavySize() const
 	{
 		return m_iRecOffensiveNavalUnits;
+	};
+	int GetRecommendedExplorers() const
+	{
+		return m_iRecExplorerUnits;
 	};
 	int GetNumLandUnits() const
 	{
@@ -345,6 +349,7 @@ private:
 	int m_iVisibleBarbarianCount;
 	int m_iRecOffensiveLandUnits;
 	int m_iRecDefensiveLandUnits;
+	int m_iRecExplorerUnits;
 	int m_iNumFreeCarriers;
 
 	//new unit counters

--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -9120,45 +9120,6 @@ void CvPlot::SetImprovedByGiftFromMajor(bool bValue)
 }
 
 //	--------------------------------------------------------------------------------
-/// Does this plot have a special improvement that we shouldn't remove?
-bool CvPlot::HasSpecialImprovement() const
-{
-	// Gifted improvements (if we are a minor civ)
-	if (getOwner() != NO_PLAYER)
-	{
-		CvPlayer* pOwner = &GET_PLAYER(getOwner());
-		if (pOwner->isMinorCiv())
-		{
-			if (IsImprovedByGiftFromMajor())
-			{
-				return true;
-			}
-		}
-
-		// Great person improvements
-		ImprovementTypes eImprovement = getImprovementType();
-		if (eImprovement != NO_IMPROVEMENT)
-		{
-			CvImprovementEntry* pImprovementInfo = GC.getImprovementInfo(eImprovement);
-			//Works like GP improvement.
-			if (pImprovementInfo && pImprovementInfo->IsCreatedByGreatPerson())
-			{
-				return true;
-			}
-
-			//Don't delete landmarks!
-			ImprovementTypes eLandmark = (ImprovementTypes)GC.getInfoTypeForString("IMPROVEMENT_LANDMARK");
-			if (eLandmark != NO_IMPROVEMENT && eImprovement == eLandmark)
-			{
-				return true;
-			}
-		}
-	}
-
-	return false;
-}
-
-//	--------------------------------------------------------------------------------
 bool CvPlot::IsBarbarianCampNotConverting() const
 {
 	return m_bBarbCampNotConverting;

--- a/CvGameCoreDLL_Expansion2/CvPlot.h
+++ b/CvGameCoreDLL_Expansion2/CvPlot.h
@@ -509,8 +509,6 @@ public:
 	bool IsImprovedByGiftFromMajor() const;
 	void SetImprovedByGiftFromMajor(bool bValue);
 
-	bool HasSpecialImprovement() const;
-
 	// Who built the improvement in this plot?
 	PlayerTypes GetPlayerThatBuiltImprovement() const;
 	void SetPlayerThatBuiltImprovement(PlayerTypes eBuilder);

--- a/CvGameCoreDLL_Expansion2/CvUnitProductionAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnitProductionAI.cpp
@@ -289,7 +289,7 @@ int CvUnitProductionAI::CheckUnitBuildSanity(UnitTypes eUnit, bool bForOperation
 		return SR_UNITSUPPLY;
 	else if (bCombat && pkUnitEntry->GetDomainType() == DOMAIN_SEA && iNumSeaUnits >= kPlayer.GetMilitaryAI()->GetRecommendNavySize())
 		return SR_UNITSUPPLY;
-	else if (pkUnitEntry->GetDefaultUnitAIType() == UNITAI_EXPLORE && iNumExplorers >= kPlayer.GetEconomicAI()->GetExplorersNeeded())
+	else if (pkUnitEntry->GetDefaultUnitAIType() == UNITAI_EXPLORE && iNumExplorers >= kPlayer.GetMilitaryAI()->GetRecommendedExplorers())
 		return SR_UNITSUPPLY;
 
 	//only war with majors count
@@ -526,7 +526,7 @@ int CvUnitProductionAI::CheckUnitBuildSanity(UnitTypes eUnit, bool bForOperation
 		//Need Explorers?
 		if (eDomain == DOMAIN_LAND && pkUnitEntry->GetDefaultUnitAIType() == UNITAI_EXPLORE)
 		{
-			int iExplorersNeeded = kPlayer.GetEconomicAI()->GetExplorersNeeded();
+			int iExplorersNeeded = kPlayer.GetMilitaryAI()->GetRecommendedExplorers();
 
 			int iExploreBonus = iExplorersNeeded - iNumExplorers;
 			if (iExploreBonus > 0)


### PR DESCRIPTION
Move function only used in CvBuilderTaskingAI to CvBuilderTaskingAI (from CvPlot).

Don't apply negative modifier for repairing Great Person improvements on top of existing/planned roads.

Allow AI players to replace Great Person improvements and Landmarks.

Change defensive improvement downprioritization in safe territory to only apply to forts.

Fix several possible bugs in HomelandAI when evaluating improvements on the same turn as another improvement was finished.

Fix minor bug with improvement planning regarding forests for vanilla Celts.

Limit maximum scouting units for AIs to 1/4 of total supply.

Fix theming bonus being set to 0 in almost all cases.

Fix great work tooltip.

Fix emergency units bought by military AI not getting promoted on the same turn as they are bought.