### PR TITLE
Squads improvements

### DIFF
--- a/(4a) Squads for VP/UI/Squads.lua
+++ b/(4a) Squads for VP/UI/Squads.lua
@@ -18,6 +18,7 @@ include( "SquadNames.lua" );
 
 
 local bHighlightSquadUnits = true;
+local bEscortNonCombatUnits = true;
 local SquadsEndMovementType = 0;
 
 SQUADS_MODE_NONE = 0;
@@ -30,11 +31,15 @@ local currentMode = SQUADS_MODE_NONE;
 
 local bIsBoxSelecting = false;
 local pSelectBoxStartPlot = nil;
+local bBoxSelectingLeftToRight = nil;
+local mapW, mapH = Map.GetGridSize();
 
 -- Options Logic
 function SquadsOptionChanged(optionKey, newValue)
     if optionKey == "HighlightSquadUnits" then
         bHighlightSquadUnits = newValue;
+    elseif optionKey == "EscortNonCombatUnits" then
+        bEscortNonCombatUnits = newValue;
     elseif optionKey == "SquadsEndMovementType" then
         SquadsEndMovementType = newValue;
 
@@ -118,14 +123,29 @@ function UpdateMouse(gridX, gridY)
 
 
             if bIsBoxSelecting then
-                --print(string.format("Start plot for box select: (%i,%i)", pSelectBoxStartPlot:GetX(), pSelectBoxStartPlot:GetY()))
-                --print(string.format("End plot for box select: (%i,%i)", currentPlot:GetX(), currentPlot:GetY()))
+                -- Determine box select direction across world wrap using mapW
+                if bBoxSelectingLeftToRight == nil and currentPlot:GetX() ~= pSelectBoxStartPlot:GetX() then
+                    if currentPlot:GetX() > pSelectBoxStartPlot:GetX() then
+                        if currentPlot:GetX() - pSelectBoxStartPlot:GetX() > mapW / 2 then
+                            bBoxSelectingLeftToRight = false;
+                        else
+                            bBoxSelectingLeftToRight = true;
+                        end
+                    else
+                        if pSelectBoxStartPlot:GetX() - currentPlot:GetX() > mapW / 2 then
+                            bBoxSelectingLeftToRight = true;
+                        else
+                            bBoxSelectingLeftToRight = false;
+                        end
+                    end
+                end
+                if currentPlot:GetX() == pSelectBoxStartPlot:GetX() then
+                    bBoxSelectingLeftToRight = nil
+                end
 
                 for i = 0, Map.GetNumPlots() - 1, 1 do
                     local pLoopPlot = Map.GetPlotByIndex(i);
-                    -- print(string.format("Checking (%i,%i)", pLoopPlot:GetX(), pLoopPlot:GetY()))
                     if IsInBoxSelectArea(pLoopPlot) then
-                        -- print("highlighting box select plot")
                         HighlightPlot(pLoopPlot, nil, "SquadsBoxSelect");
                     end
                 end
@@ -138,11 +158,14 @@ function UpdateMouse(gridX, gridY)
 
         HighlightSquadUnits(pPlayer, currentSquadNumber);
         Events.ClearHexHighlightStyle("SquadsGroupMovement");
-        -- Draw the movement preview shadow (2 rings worth)
-        HighlightPlot(currentPlot, nil, "SquadsGroupMovement");
-        for pLoopPlot in PlotAreaSpiralIterator(currentPlot, 2) do
-            -- TODO: only highlight tiles current squad units can end on
-            HighlightPlot(pLoopPlot, nil, "SquadsGroupMovement");
+        -- Draw the movement preview region
+        for unit in getSquadUnits(pPlayer, currentSquadNumber) do
+            local previewPlots = {unit:GetSquadMovementPreview(currentPlot)}
+            for i = 1, #previewPlots do
+                local plot = previewPlots[i]
+                HighlightPlot(plot, nil, "SquadsGroupMovement");
+            end
+            break;
         end
     end
 end
@@ -184,23 +207,46 @@ function IsInBoxSelectArea(pPlotToCheck)
         return false
     end
 
-    -- Box drawn from bottom left to top right
-    if currentPlot:GetX() >= pSelectBoxStartPlot:GetX() and currentPlot:GetY() >= pSelectBoxStartPlot:GetY() then
-        return pPlotToCheck:GetX() >= pSelectBoxStartPlot:GetX() and pPlotToCheck:GetX() <= currentPlot:GetX() and 
-               pPlotToCheck:GetY() >= pSelectBoxStartPlot:GetY() and pPlotToCheck:GetY() <= currentPlot:GetY();
-    -- Box drawn from top left to bottom right
-    elseif currentPlot:GetX() >= pSelectBoxStartPlot:GetX() and currentPlot:GetY() <= pSelectBoxStartPlot:GetY() then
-        return pPlotToCheck:GetX() >= pSelectBoxStartPlot:GetX() and pPlotToCheck:GetX() <= currentPlot:GetX() and 
-               pPlotToCheck:GetY() <= pSelectBoxStartPlot:GetY() and pPlotToCheck:GetY() >= currentPlot:GetY();
-    -- Box drawn from top right to bottom left
-    elseif currentPlot:GetX() <= pSelectBoxStartPlot:GetX() and currentPlot:GetY() <= pSelectBoxStartPlot:GetY() then
-        return pPlotToCheck:GetX() <= pSelectBoxStartPlot:GetX() and pPlotToCheck:GetX() >= currentPlot:GetX() and 
-               pPlotToCheck:GetY() <= pSelectBoxStartPlot:GetY() and pPlotToCheck:GetY() >= currentPlot:GetY();
-    -- Box drawn from bottom right to top left
-    elseif currentPlot:GetX() <= pSelectBoxStartPlot:GetX() and currentPlot:GetY() >= pSelectBoxStartPlot:GetY() then
-        return pPlotToCheck:GetX() <= pSelectBoxStartPlot:GetX() and pPlotToCheck:GetX() >= currentPlot:GetX() and 
-               pPlotToCheck:GetY() >= pSelectBoxStartPlot:GetY() and pPlotToCheck:GetY() <= currentPlot:GetY();
+    local startX, startY = pSelectBoxStartPlot:GetX(), pSelectBoxStartPlot:GetY()
+    local endX, endY = currentPlot:GetX(), currentPlot:GetY()
+    local checkX, checkY = pPlotToCheck:GetX(), pPlotToCheck:GetY()
+
+    -- Determine box bounds in Y direction
+    local minY, maxY = startY, endY
+    if currentPlot:GetY() < pSelectBoxStartPlot:GetY() then
+        minY, maxY = endY, startY
     end
+
+    -- Check if Y is within bounds
+    if checkY < minY or checkY > maxY then
+        return false
+    end
+
+    -- Determine box bounds in X direction, accounting for world wrap
+    local minX, maxX
+    -- This can happen when the box select crosses its original x location
+    if bBoxSelectingLeftToRight == nil then
+        minX, maxX = math.min(startX, endX), math.max(startX, endX)
+    elseif bBoxSelectingLeftToRight then
+        minX, maxX = startX, endX
+        if minX > maxX then
+            maxX = maxX + mapW
+        end
+    else
+        minX, maxX = endX, startX
+        if minX > maxX then
+            maxX = maxX + mapW
+        end
+    end
+
+    -- Adjust checkX for wrapping
+    if checkX < minX then
+        checkX = checkX + mapW
+    end
+
+    -- Check if X is within bounds
+    return checkX >= minX and checkX <= maxX
+
 end
 
 
@@ -239,6 +285,7 @@ function DoBoxSelect()
             end
         end
     end
+    bBoxSelectingLeftToRight = nil;
     return bUnitsSelected;
 end
 
@@ -279,6 +326,7 @@ LuaEvents.SQUADS_MANAGE_UNITS_MODE_LEFT_CLICK_UP.Add(HandleLeftClickUp);
 function HandleRightClickDown(wParam, lParam)
     bIsBoxSelecting = true;
     pSelectBoxStartPlot = currentPlot;
+    bBoxSelectingLeftToRight = nil;
 end
 
 LuaEvents.SQUADS_MANAGE_UNITS_MODE_RIGHT_CLICK_DOWN.Add(HandleRightClickDown);
@@ -346,7 +394,7 @@ function HandleMoveSquad(wParam, lParam)
         local bMovedSquad = false;
         for unit in getSquadUnits(pPlayer, currentSquadNumber) do
             unit:SetSquadEndMovementType(SquadsEndMovementType);
-            unit:DoSquadMovement(currentPlot);
+            unit:DoSquadMovement(currentPlot, bEscortNonCombatUnits);
             bMovedSquad = true;
             break;
         end
@@ -387,7 +435,7 @@ function OnUnitSelectionChange(iPlayerID, iUnitID, i, j, k, isSelected)
         return 
     end
 
-    -- Events.ClearHexHighlights();
+    Events.ClearHexHighlights();
     if (isSelected) then
         local pPlayer = Players[iPlayerID];
         local pUnit = pPlayer:GetUnitByID(iUnitID);
@@ -409,7 +457,7 @@ Events.UnitSelectionChanged.Add( OnUnitSelectionChange );
 
 
 function HighlightSquadUnits(pPlayer, squadNumber)
-    _highlightSquadUnits(pPlayer, squadNumber, false);
+    _highlightSquadUnits(pPlayer, squadNumber, true);
 end
 
 function _highlightSquadUnits(pPlayer, squadNumber, clearOldHighlights)

--- a/(4a) Squads for VP/UI/Squads.xml
+++ b/(4a) Squads for VP/UI/Squads.xml
@@ -155,13 +155,14 @@
         <Image Anchor="C,B" Offset="0,110" Texture="HorizontalTrim.dds" Size="1027.5"/>
 
         <!-- Options Panel -->
-        <Grid ID="OptionsPanel" Anchor="R,C" Size="350,300" Color="White.256" Style="Grid9DetailSix140" Padding="5,10" Offset="-338,0" Hidden="true" ConsumeMouse="1" >
+        <Grid ID="OptionsPanel" Anchor="R,C" Size="350,350" Color="White.256" Style="Grid9DetailSix140" Padding="5,10" Offset="-338,0" Hidden="true" ConsumeMouse="1" >
             <Stack Anchor="C,C" Padding="0" Offset="0,5" StackGrowth="Bottom" ID="MainStack" >
                 <CheckBox Anchor="L,T"  TextAnchorSide="Right" Offset="-25,0" TextOffset="40,0" IsChecked="0" ID="HighlightSquadUnitsCheckBox" String="TXT_KEY_SQUADS_OPTION_HIGHLIGHT" />
                 <CheckBox Anchor="L,T"  TextAnchorSide="Right" Offset="-25,0" TextOffset="40,0" IsChecked="0" ID="FlagsNumberCheckBox" String="TXT_KEY_SQUADS_OPTION_FLAGS_NUMBER" />
+                <CheckBox Anchor="L,T"  TextAnchorSide="Right" Offset="-25,0" TextOffset="40,0" IsChecked="1" ID="EscortCheckBox" String="TXT_KEY_SQUADS_OPTION_ESCORT" ToolTip="TXT_KEY_SQUADS_OPTION_ESCORT_TT" />
                 <Label Anchor="L,T"  TextAnchorSide="Right" Offset="-25,0" TextOffset="40,0" String=" " />
                 <Label Anchor="L,T"  TextAnchorSide="Right" Offset="-25,0" TextOffset="40,0" String="TXT_KEY_SQUADS_MOVEMENT_END_TYPE" />
-                <RadioButton RadioGroup="SquadsEndMoveMode" Anchor="L,T"  TextAnchorSide="Right" Offset="-25,0" TextOffset="40,0" IsChecked="0" ID="AlertOnArrivalRadioButton" String="TXT_KEY_SQUADS_MOVEMENT_END_TYPE_ALERT_ON_ARRIVAL" />
+                <RadioButton RadioGroup="SquadsEndMoveMode" Anchor="L,T"  TextAnchorSide="Right" Offset="-25,15" TextOffset="40,0" IsChecked="0" ID="AlertOnArrivalRadioButton" String="TXT_KEY_SQUADS_MOVEMENT_END_TYPE_ALERT_ON_ARRIVAL" />
                 <RadioButton RadioGroup="SquadsEndMoveMode" Anchor="L,T"  TextAnchorSide="Right" Offset="-25,0" TextOffset="40,0" IsChecked="0" ID="WakeOnUnitArrivalRadioButton" String="TXT_KEY_SQUADS_MOVEMENT_END_TYPE_WAKE_ON_UNIT_ARRIVAL" />
                 <RadioButton RadioGroup="SquadsEndMoveMode" Anchor="L,T"  TextAnchorSide="Right" Offset="-25,0" TextOffset="40,0" IsChecked="0" ID="WakeOnSquadArrivalRadioButton" String="TXT_KEY_SQUADS_MOVEMENT_END_TYPE_WAKE_ON_SQUAD_ARRIVAL" />
                 <Box Anchor="C,T" Size="210,1" Color="0,0,0,0" />

--- a/(4a) Squads for VP/UI/SquadsOptions.lua
+++ b/(4a) Squads for VP/UI/SquadsOptions.lua
@@ -10,6 +10,7 @@ local SquadsOptions = Modding.OpenUserData( "Squads Options", 1 );
 -- Defaults
 local HighlightSquadUnits = true;
 local ShowSquadNumberUnderFlag = true;
+local EscortNonCombatUnits = true;
 local SquadsEndMovementType = 0;
 
 -- UI handlers
@@ -44,6 +45,12 @@ function HandleHighlightSquadUnitsCheckbox()
     LuaEvents.SQUADS_OPTIONS_CHANGED("HighlightSquadUnits", HighlightSquadUnits)
 end
 Controls.HighlightSquadUnitsCheckBox:RegisterCheckHandler(HandleHighlightSquadUnitsCheckbox);
+
+function HandleEscortNonCombatUnitsCheckbox()
+    EscortNonCombatUnits = not EscortNonCombatUnits;
+    LuaEvents.SQUADS_OPTIONS_CHANGED("EscortNonCombatUnits", EscortNonCombatUnits)
+end
+Controls.EscortCheckBox:RegisterCheckHandler(HandleEscortNonCombatUnitsCheckbox);
 
 function HandleFlagsNumberCheckBox()
     ShowSquadNumberUnderFlag = not ShowSquadNumberUnderFlag;
@@ -89,6 +96,13 @@ if _hsu ~= nil then
 end
 LuaEvents.SQUADS_OPTIONS_CHANGED("HighlightSquadUnits", HighlightSquadUnits)
 Controls.HighlightSquadUnitsCheckBox:SetCheck(HighlightSquadUnits);
+
+local _encu = SquadsOptions.GetValue("EscortNonCombatUnits");
+if _encu ~= nil then
+    EscortNonCombatUnits = _encu == 1;
+end
+LuaEvents.SQUADS_OPTIONS_CHANGED("EscortNonCombatUnits", EscortNonCombatUnits)
+Controls.EscortCheckBox:SetCheck(EscortNonCombatUnits);
 
 local _ssnuf = SquadsOptions.GetValue("ShowSquadNumberUnderFlag");
 if _ssnuf ~= nil then

--- a/(4a) Squads for VP/XML/Squads_EN_US.xml
+++ b/(4a) Squads for VP/XML/Squads_EN_US.xml
@@ -30,6 +30,12 @@
         <Row Tag="TXT_KEY_SQUADS_OPTION_FLAGS_NUMBER">
             <Text>Display Squad Number on Unit Flags</Text>
         </Row>
+        <Row Tag="TXT_KEY_SQUADS_OPTION_ESCORT">
+            <Text>Escort non-combat units</Text>
+        </Row>
+        <Row Tag="TXT_KEY_SQUADS_OPTION_ESCORT_TT">
+            <Text>During squad movement, combat units that start on the same tile as non combat units will escort them, linking their movement until the destination is reached or another move order is issued.</Text>
+        </Row>
         <Row Tag="TXT_KEY_SQUADS_MOVEMENT_END_TYPE">
             <Text>Squad Movement End Behavior:</Text>
         </Row>

--- a/CvGameCoreDLL_Expansion2/CvUnit.h
+++ b/CvGameCoreDLL_Expansion2/CvUnit.h
@@ -220,6 +220,7 @@ public:
 		MOVEFLAG_PRETEND_CANALS					= 0x10000000, //pretend ships can move one tile inland to see if a canal would make sense
 	    MOVEFLAG_IGNORE_STACKING_NEUTRAL		= 0x20000000, // stacking rules (with neutral units) don't apply (on turn end plots)
 		MOVEFLAG_CONTINUE_TO_CLOSEST_PLOT		= 0x40000000, //if the target plot is occupied go to the closest available plot instead
+		MOVEFLAG_KEEP_LINK                      = 0x80000000, //if flag is present, will not break unit link upon issuance of a new move mission
 
 		//seems we are running out of bits, be careful when adding new flags ... maybe we can finally recycle the unused ones above?
 
@@ -628,9 +629,13 @@ public:
 	int  GetSquadNumber() const;
 	void AssignToSquad(int iNewSquadNumber);
 	void RemoveFromSquad();
-	void DoSquadMovement(CvPlot* pDestPlot);
+	CvPlot* GetSquadCenterOfMass();
+	std::map<CvUnit*, CvPlot*> CvUnit::DoSquadPlotAssignments(CvPlot* pDestPlot, bool escort, bool computeOnly);
+	void DoSquadMovement(CvPlot* pDestPlot, bool escort);
+	void GetSquadMovementPreview(std::vector<CvPlot*>& pPlotList, CvPlot* pDestPlot);
 	bool IsUnitInActiveMoveMission();
 	bool IsSquadMoving();
+	bool SquadHasLink();
 	void TryEndSquadMovement();
 	void SetSquadDestination(CvPlot* pDestPlot = NULL);
 	bool HasSquadDestination();

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.cpp
@@ -210,6 +210,7 @@ void CvLuaUnit::PushMethods(lua_State* L, int t)
 	Method(RemoveFromSquad);
 	Method(DoSquadMovement);
 	Method(SetSquadEndMovementType);
+	Method(GetSquadMovementPreview);
 
 	Method(Range);
 	Method(NukeDamageLevel);
@@ -2663,13 +2664,14 @@ int CvLuaUnit::lRemoveFromSquad(lua_State* L)
 	return 0;
 }
 //------------------------------------------------------------------------------
-// void DoSquadMovement(CvPlot* pDestPlot)
+// void DoSquadMovement(CvPlot* pDestPlot, bool escort)
 int CvLuaUnit::lDoSquadMovement(lua_State* L)
 {
 	CvUnit* pkUnit = GetInstance(L);
 	CvPlot* pkDestPlot = CvLuaPlot::GetInstance(L, 2);
+	const int bEscort = lua_toboolean(L, 3);
 
-	pkUnit->DoSquadMovement(pkDestPlot);
+	pkUnit->DoSquadMovement(pkDestPlot, bEscort);
 	return 0;
 }
 //------------------------------------------------------------------------------
@@ -2681,6 +2683,30 @@ int CvLuaUnit::lSetSquadEndMovementType(lua_State* L)
 
 	pkUnit->SetSquadEndMovementType(iNewValue);
 	return 0;
+}
+//------------------------------------------------------------------------------
+// GetSquadMovementPreview(CvPlot* pDestPlot)
+int CvLuaUnit::lGetSquadMovementPreview(lua_State* L)
+{
+	CvUnit* pkUnit = GetInstance(L);
+    CvPlot* pkDestPlot = CvLuaPlot::GetInstance(L, 2);
+
+    std::vector<CvPlot*> pPlotList;
+    pkUnit->GetSquadMovementPreview(pPlotList, pkDestPlot);
+
+    int iReturnValues = 0;
+
+	for (std::vector<CvPlot*>::iterator it = pPlotList.begin(); it != pPlotList.end(); ++it)
+	{
+		CvPlot* pkPlot = *it;
+		if (pkPlot)
+		{
+			CvLuaPlot::Push(L, pkPlot);
+			iReturnValues++;
+		}
+	}
+
+    return iReturnValues;
 }
 //------------------------------------------------------------------------------
 //int GetRange();

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.h
@@ -205,6 +205,7 @@ protected:
 	static int lRemoveFromSquad(lua_State* L);
 	static int lDoSquadMovement(lua_State* L);
 	static int lSetSquadEndMovementType(lua_State* L);
+	static int lGetSquadMovementPreview(lua_State* L);
 
 	static int lRange(lua_State* L);
 	static int lNukeDamageLevel(lua_State* L);


### PR DESCRIPTION
* During group movement, non-combat units will now be escorted by combat units on the same starting tile, linking their movement until the destination is reached or another move order is issued. This behavior is configurable in the squads options menu and enabled by default.
* Group movement destination tiles now have an accurate preview instead of a generic 2 tile radius ring.
* Improved group movement destination tile selection logic. Units now select tiles that have a better grouping around the selected destination.
* Fixed an issue where embarked units were not routed to the same tiles as naval units when available and such tiles would be closer to the target destination.
* Fixed an issue where non-combat units were sometimes routed to the destination tile while no combat units in the squad were.
* Fixed an issue where box select did not work correctly around the map world wrap.
