### PR TITLE
Add Lua APIs for AI decision introspection and control

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvEconomicAI.h
+++ b/CvGameCoreDLL_Expansion2/CvEconomicAI.h
@@ -170,6 +170,7 @@ public:
 	void SetUsingStrategy(EconomicAIStrategyTypes eStrategy, bool bValue);
 	int GetTurnStrategyAdopted(EconomicAIStrategyTypes eStrategy);
 	void SetTurnStrategyAdopted(EconomicAIStrategyTypes eStrategy, int iValue);
+	bool IsStrategyAllowed(EconomicAIStrategyTypes eStrategy, CvEconomicAIStrategyXMLEntry* pStrategy); // Vox Deorum: Check if strategy meets prereqs
 
 	void DoTurn();
 

--- a/CvGameCoreDLL_Expansion2/CvMilitaryAI.h
+++ b/CvGameCoreDLL_Expansion2/CvMilitaryAI.h
@@ -292,6 +292,8 @@ public:
 	}
 #endif
 
+	bool IsStrategyAllowed(MilitaryAIStrategyTypes eStrategy, CvMilitaryAIStrategyXMLEntry* pStrategy);
+
 private:
 
 	// Functions to process a turn

--- a/CvGameCoreDLL_Expansion2/CvPlayerAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayerAI.cpp
@@ -34,6 +34,7 @@
 #include "CvEnumMap.h"
 
 #include "CvDistanceMap.h"
+#include "CvConnectionService.h"
 
 // Include this after all other headers.
 #include "LintFree.h"
@@ -284,6 +285,11 @@ void CvPlayerAI::AI_unitUpdate(bool bUpdateHomelandAI)
 		GetTacticalAI()->Update();
 		GetHomelandAI()->Update(true);
 		GetTacticalAI()->CleanUp();
+	}
+
+	if (MOD_IPC_CHANNEL) {
+		// Process messages from the Connection Service
+		CvConnectionService::GetInstance().ProcessMessages();
 	}
 }
 

--- a/CvGameCoreDLL_Expansion2/CvPolicyAI.h
+++ b/CvGameCoreDLL_Expansion2/CvPolicyAI.h
@@ -37,7 +37,7 @@ public:
 	void AddFlavorWeights(FlavorTypes eFlavor, int iWeight, int iPropagationPercent);
 
 	// Choose a player's next policy purchase
-	int ChooseNextPolicy(CvPlayer* pPlayer);
+	int ChooseNextPolicy(CvPlayer* pPlayer, bool bIgnoreCost = false);
 	bool CanContinuePolicyBranch(PolicyBranchTypes ePolicyBranch);
 
 	// Ideology
@@ -48,6 +48,13 @@ public:
 
 	int WeighBranch(CvPlayer* pPlayer, PolicyBranchTypes eBranch);
 	int WeighPolicy(CvPlayer* pPlayer, PolicyTypes ePolicy);
+
+	// Vox Deorum: Get possible policies by calling ChooseNextPolicy and returning m_AdoptablePolicies
+	const CvWeightedVector<int>& GetAdoptablePolicies() const { return m_AdoptablePolicies; }
+
+	// Vox Deorum: Force next policy selection
+	void SetNextPolicy(int iPolicy) { m_iNextPolicy = iPolicy; }
+	int GetNextPolicy() const { return m_iNextPolicy; }
 
 private:
 	// Internal methods
@@ -74,6 +81,9 @@ private:
 	// Locally cached GlobalAIDefines
 	int m_iPolicyWeightPropagationLevels;
 	int m_iPolicyWeightPercentDropNewBranch;
+
+	// Vox Deorum: Forced next policy selection
+	int m_iNextPolicy;
 };
 FDataStream& operator<<(FDataStream&, const CvPolicyAI&);
 FDataStream& operator>>(FDataStream&, CvPolicyAI&);

--- a/CvGameCoreDLL_Expansion2/CvPolicyClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPolicyClasses.cpp
@@ -5099,10 +5099,10 @@ void CvPlayerPolicies::DoUnlockPolicyBranch(PolicyBranchTypes eBranchType)
 }
 
 /// can the player unlock eBranchType right now?
-bool CvPlayerPolicies::CanUnlockPolicyBranch(PolicyBranchTypes eBranchType)
+bool CvPlayerPolicies::CanUnlockPolicyBranch(PolicyBranchTypes eBranchType, bool bIgnoreCost)
 {
 	// Must have enough culture to spend a buy opening a new branch
-	if(GetPlayer()->getJONSCultureTimes100() < GetPlayer()->getNextPolicyCost() * 100)
+	if(!bIgnoreCost && GetPlayer()->getJONSCultureTimes100() < GetPlayer()->getNextPolicyCost() * 100)
 	{
 		if(GetPlayer()->GetNumFreePolicies() == 0)
 			return false;

--- a/CvGameCoreDLL_Expansion2/CvPolicyClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvPolicyClasses.h
@@ -1077,6 +1077,8 @@ public:
 	void FlavorUpdate();
 
 	CvPlayer* GetPlayer();
+	// Vox Deorum: Get PolicyAI for accessing adoptable policies
+	CvPolicyAI* GetPolicyAI() const { return m_pPolicyAI; }
 
 	// Accessor functions
 	bool HasPolicy(PolicyTypes eIndex) const;
@@ -1116,7 +1118,7 @@ public:
 
 	// Policy Branch Stuff
 	void DoUnlockPolicyBranch(PolicyBranchTypes eBranchType);
-	bool CanUnlockPolicyBranch(PolicyBranchTypes eBranchType);
+	bool CanUnlockPolicyBranch(PolicyBranchTypes eBranchType, bool bIgnoreCost = false);
 
 	bool IsPolicyBranchUnlocked(PolicyBranchTypes eBranchType) const;
 	void SetPolicyBranchUnlocked(PolicyBranchTypes eBranchType, bool bNewValue, bool bRevolution);

--- a/CvGameCoreDLL_Expansion2/CvTechAI.h
+++ b/CvGameCoreDLL_Expansion2/CvTechAI.h
@@ -42,13 +42,20 @@ public:
 
 	// Choose a player's next tech to research
 	TechTypes ChooseNextTech(CvPlayer *pPlayer, bool bFreeTech = false);
-	TechTypes RecommendNextTech(CvPlayer *pPlayer, TechTypes eIgnoreTech = NO_TECH);
+	TechTypes RecommendNextTech(CvPlayer *pPlayer, TechTypes eIgnoreTech = NO_TECH, TechTypes eAssumingTech = NO_TECH);
 
 	int GetWeight(TechTypes eTech);
 
 	float GetTechRatio();
 
 	void LogResearchCompleted(TechTypes eTech);
+
+	// Vox Deorum: Get the researchable techs after ChooseNextTech is called
+	const CvWeightedVector<int>& GetResearchableTechs() const { return m_ResearchableTechs; }
+
+	// Vox Deorum: Force next tech selection
+	void SetNextResearch(TechTypes eTech) { m_iNextResearch = eTech; }
+	TechTypes GetNextResearch() const { return m_iNextResearch; }
 
 private:
 	// Internal methods
@@ -66,6 +73,7 @@ private:
 	CvPlayerTechs* m_pCurrentTechs;
 	CvWeightedVector<int> m_TechAIWeights;
 	CvWeightedVector<int> m_ResearchableTechs;
+	TechTypes m_iNextResearch;  // Vox Deorum: Forced next research selection
 };
 
 FDataStream& operator<<(FDataStream&, const CvTechAI&);

--- a/CvGameCoreDLL_Expansion2/CvTechClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTechClasses.cpp
@@ -1433,7 +1433,8 @@ bool CvPlayerTechs::CanEverResearch(TechTypes eTech) const
 }
 
 /// Accessor: Is it possible to research this tech?
-bool CvPlayerTechs::CanResearch(TechTypes eTech, bool bTrade) const
+// Vox Deorum: Added eAssumingTech parameter to check researchability assuming a specific tech is already researched
+bool CvPlayerTechs::CanResearch(TechTypes eTech, bool bTrade, TechTypes eAssumingTech) const
 {
 	bool bFoundPossible = false;
 	bool bFoundValid = false;
@@ -1454,6 +1455,12 @@ bool CvPlayerTechs::CanResearch(TechTypes eTech, bool bTrade) const
 		return false;
 	}
 
+	// Vox Deorum: Don't check the assuming tech itself
+	if(eAssumingTech != NO_TECH && eTech == eAssumingTech)
+	{
+		return false;
+	}
+
 	bFoundPossible = false;
 	bFoundValid = false;
 
@@ -1465,7 +1472,8 @@ bool CvPlayerTechs::CanResearch(TechTypes eTech, bool bTrade) const
 		{
 			bFoundPossible = true;
 
-			if(GET_TEAM(m_pPlayer->getTeam()).GetTeamTechs()->HasTech(ePrereq))
+			// Vox Deorum: Check if we have the prereq OR if it's the tech we're assuming
+			if(GET_TEAM(m_pPlayer->getTeam()).GetTeamTechs()->HasTech(ePrereq) || ePrereq == eAssumingTech)
 			{
 				if(!bTrade || !GET_TEAM(m_pPlayer->getTeam()).GetTeamTechs()->IsNoTradeTech(ePrereq))
 				{
@@ -1487,7 +1495,8 @@ bool CvPlayerTechs::CanResearch(TechTypes eTech, bool bTrade) const
 		TechTypes ePrereq = (TechTypes)pkTechEntry->GetPrereqAndTechs(iI);
 		if(ePrereq != NO_TECH)
 		{
-			if(!GET_TEAM(m_pPlayer->getTeam()).GetTeamTechs()->HasTech(ePrereq))
+			// Vox Deorum: Check if we have the prereq OR if it's the tech we're assuming
+			if(!GET_TEAM(m_pPlayer->getTeam()).GetTeamTechs()->HasTech(ePrereq) && ePrereq != eAssumingTech)
 			{
 				return false;
 			}

--- a/CvGameCoreDLL_Expansion2/CvTechClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvTechClasses.h
@@ -256,7 +256,7 @@ public:
 	void SetGSPriorities();
 	bool IsResearch() const;
 	bool CanEverResearch(TechTypes eTech) const;
-	bool CanResearch(TechTypes eTech, bool bTrade = false) const;
+	bool CanResearch(TechTypes eTech, bool bTrade = false, TechTypes eAssumingTech = NO_TECH) const;
 	bool CanResearchForFree(TechTypes eTech) const;
 	TechTypes GetCurrentResearch() const;
 	bool IsCurrentResearchRepeat() const;

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaGame.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaGame.cpp
@@ -29,6 +29,7 @@
 #include "../CvGameTextMgr.h"
 #include "../CvReplayMessage.h"
 #include "../cvStopWatch.h"
+#include "../CvPreGame.h"
 
 #pragma warning(disable:4800 ) //forcing value to bool 'true' or 'false'
 
@@ -92,6 +93,7 @@ void CvLuaGame::RegisterMembers(lua_State* L)
 	Method(CanTrainNukes);
 
 	Method(GetCurrentEra);
+	Method(GetMapScriptName);
 
 	Method(GetDiploResponse);
 
@@ -773,6 +775,15 @@ int CvLuaGame::lCanTrainNukes(lua_State* L)
 int CvLuaGame::lGetCurrentEra(lua_State* L)
 {
 	return BasicLuaMethod(L, &CvGame::getCurrentEra);
+}
+//------------------------------------------------------------------------------
+//string GetMapScriptName();
+//Allow most in-game Lua scripts since they don't have access to PreGame anymore.
+int CvLuaGame::lGetMapScriptName(lua_State* L)
+{
+	const CvString& mapScriptName = CvPreGame::mapScriptName();
+	lua_pushstring(L, mapScriptName.c_str());
+	return 1;
 }
 //------------------------------------------------------------------------------
 //string GetDiploResponse(leaderType, responseType)

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaGame.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaGame.h
@@ -73,6 +73,7 @@ protected:
 	static int lCanTrainNukes(lua_State* L);
 
 	static int lGetCurrentEra(lua_State* L);
+	static int lGetMapScriptName(lua_State* L);
 	static int lGetDiploResponse(lua_State* L);
 
 	static int lGetActiveTeam(lua_State* L);

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.h
@@ -1545,12 +1545,25 @@ protected:
 
 	LUAAPIEXTN(GetCompetitiveSpawnUnitType, int, bIncludeRanged, bIncludeShips, bIncludeRecon, bIncludeUUs, bNoResource, bMinorCivGift, bRandom, tUnitCombatIDs);
 	
+	static int lGetPossibleTechs(lua_State* L);
+	static int lGetPossiblePolicies(lua_State* L);
+	static int lSetNextResearch(lua_State* L);  // Vox Deorum: Force next tech selection
+	static int lGetNextResearch(lua_State* L);  // Vox Deorum: Get forced next tech
+	static int lSetNextPolicy(lua_State* L);    // Vox Deorum: Force next policy selection
+	static int lGetNextPolicy(lua_State* L);    // Vox Deorum: Get forced next policy
+
+	static int lGetPossibleEconomicStrategies(lua_State* L);
+	static int lGetPossibleMilitaryStrategies(lua_State* L);
 	static int lGetGrandStrategy(lua_State* L);
 	static int lSetGrandStrategy(lua_State* L);
 	static int lGetEconomicStrategies(lua_State* L);
 	static int lSetEconomicStrategies(lua_State* L);
 	static int lGetMilitaryStrategies(lua_State* L);
 	static int lSetMilitaryStrategies(lua_State* L);
+
+	// Vox Deorum: Tactical zone APIs
+	static int lGetNumTacticalZones(lua_State* L);
+	static int lGetTacticalZone(lua_State* L);
 };
 
 namespace CvLuaArgs

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.cpp
@@ -16,6 +16,7 @@
 #include "CvLuaUnit.h"
 #include "../CvMinorCivAI.h"
 #include "../CvUnitCombat.h"
+#include "../CvTacticalAnalysisMap.h"
 
 #pragma warning(disable:4800 ) //forcing value to bool 'true' or 'false'
 
@@ -638,6 +639,7 @@ void CvLuaUnit::PushMethods(lua_State* L, int t)
 	Method(GetAIOperationInfo);
 	Method(GetMissionInfo);
 	Method(GetDanger);
+	Method(GetTacticalZoneID);
 #endif
 
 	Method(AddMessage);
@@ -6739,6 +6741,33 @@ int CvLuaUnit::lGetDanger(lua_State* L)
 	int iDanger = pUnit->GetDanger();
 
 	lua_pushinteger(L, iDanger);
+	return 1;
+}
+
+// Vox Deorum: Returns the tactical zone ID for this unit's current position
+// Optional parameter: PlayerID to get zone from a different player's perspective
+int CvLuaUnit::lGetTacticalZoneID(lua_State* L)
+{
+	CvUnit* pUnit = GetInstance(L);
+
+	// Check for optional PlayerID parameter
+	PlayerTypes ePlayer = pUnit->getOwner();
+	if (lua_gettop(L) >= 2)
+	{
+		ePlayer = (PlayerTypes)lua_tointeger(L, 2);
+	}
+
+	CvTacticalDominanceZone* pZone = GET_PLAYER(ePlayer).GetTacticalAI()->GetTacticalAnalysisMap()->GetZoneByPlot(pUnit->plot());
+
+	if (pZone)
+	{
+		lua_pushinteger(L, pZone->GetZoneID());
+	}
+	else
+	{
+		lua_pushinteger(L, -1);
+	}
+
 	return 1;
 }
 

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.h
@@ -639,6 +639,7 @@ protected:
 	static int lGetAIOperationInfo(lua_State* L);
 	static int lGetMissionInfo(lua_State* L);
 	static int lGetDanger(lua_State* L);
+	static int lGetTacticalZoneID(lua_State* L);
 #endif
 
 	LUAAPIEXTN(AddMessage, void, sMessage, iNotifyPlayer);


### PR DESCRIPTION
Expose tech/policy AI recommendations and strategy prerequisites to Lua for LLM-enhanced decision making. Add helper methods to check strategy prerequisites across Economic, Military, Policy, and Tech AI systems. Enable querying possible techs/policies and forcing AI selections.

Key additions:
- GetPossibleTechs/GetPossiblePolicies APIs with cost-ignoring variants
- SetNextResearch/SetNextPolicy for AI decision override
- IsStrategyAllowed helpers for Economic/Military AI
- GetTacticalZone API for tactical analysis
- GetMapScriptName for Lua access to map info
- Serialization support for forced selections