### PR TITLE
Fix enough settlers strategy condition

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvCityStrategyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCityStrategyAI.cpp
@@ -2669,6 +2669,20 @@ bool CityStrategyAIHelpers::IsTestCityStrategy_EnoughSettlers(CvCity* pCity)
 		return true;
 
 	int iNumSettlers = kPlayer.GetNumUnitsWithUnitAI(UNITAI_SETTLE, true);
+
+	UnitTypes eCurrentlyProducing = pCity->getProductionUnit();
+	if (eCurrentlyProducing != NO_UNIT)
+	{
+		CvUnitEntry* pkCurrentlyProducing = GC.getUnitInfo(eCurrentlyProducing);
+		if (pkCurrentlyProducing)
+		{
+			if (pkCurrentlyProducing->GetDefaultUnitAIType() == UNITAI_SETTLE)
+			{
+				iNumSettlers--;
+			}
+		}
+	}
+
 	if (iNumSettlers > 1)
 		return true;
 


### PR DESCRIPTION
AI would adopt the "stop building settlers" strategy as soon as they started building a settler. This meant that if the city did a reevaluation, it would stop building the settler. Could cause some AI players to build very few settlers.