### PR TITLE
Various AI fixes

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvAStar.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAStar.cpp
@@ -1189,6 +1189,26 @@ int PathEndTurnCost(CvPlot* pToPlot, const CvPathNodeCacheData& kToNodeCacheData
 			iCost += (PATH_BASE_COST * pToPlot->getExtraMovePathCost());
 	}
 
+	// Explorers aren't banned from entering minor civ territory, but they should avoid it when possible
+	if (pUnit->AI_getUnitAIType() == UNITAI_EXPLORE)
+	{
+		TeamTypes ePlotTeam = pToPlot->getTeam();
+		if (ePlotTeam != NO_TEAM && ePlotTeam != eUnitTeam)
+		{
+			CvTeam& kMyTeam = GET_TEAM(eUnitTeam);
+			CvTeam& kTheirTeam = GET_TEAM(ePlotTeam);
+			if (kTheirTeam.isMinorCiv() && kMyTeam.isMajorCiv())
+			{
+				if (!pUnit->isHuman(ISHUMAN_AI_UNITS) && kMyTeam.isHasMet(ePlotTeam) && !pUnit->IsAngerFreeUnit())
+				{
+					// If we are friends etc we may go there
+					CvMinorCivAI* pMinorAI = GET_PLAYER(kTheirTeam.getLeaderID()).GetMinorCivAI();
+					if (!pMinorAI->IsPlayerHasOpenBorders(pUnit->getOwner()))
+						iCost += PATH_END_TURN_MISSIONARY_OTHER_TERRITORY;
+				}
+			}
+		}
+	}
 	if (pUnit->isHasPromotion((PromotionTypes)GD_INT_GET(PROMOTION_UNWELCOME_EVANGELIST)))
 	{
 		// Avoid being in a territory that we are not welcome in

--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
@@ -1859,7 +1859,7 @@ static vector<OptionWithScore<BuilderDirective>> FilterNonOptimalNoTwoAdjacentIm
 	return aNewDirectives;
 }
 
-static vector<OptionWithScore<BuilderDirective>> FilterNoTwoAdjacentDirectives(vector<OptionWithScore<BuilderDirective>> aDirectives)
+static vector<OptionWithScore<BuilderDirective>> FilterNoTwoAdjacentDirectives(vector<OptionWithScore<BuilderDirective>> aDirectives, PlayerTypes ePlayer)
 {
 	vector<OptionWithScore<BuilderDirective>> aNewDirectives;
 	vector<OptionWithScore<BuilderDirective>> aNoTwoAdjacentDirectives;
@@ -1903,6 +1903,20 @@ static vector<OptionWithScore<BuilderDirective>> FilterNoTwoAdjacentDirectives(v
 				continue;
 
 			iNeighboringSameScore += it2->option.m_iScore;
+		}
+
+		// Check all adjacent tiles that are unowned to see if we could potentially build one there, use as tie-breaker
+		for (int iI = 1; iI < RING1_PLOTS; iI++)
+		{
+			CvPlot* pLoopPlot = iterateRingPlots(pPlot, iI);
+			if (!pLoopPlot)
+				continue;
+
+			if (pLoopPlot->getOwner() != NO_PLAYER)
+				continue;
+
+			if (pLoopPlot->canBuild(it->option.m_eBuild, ePlayer, false, false))
+				iNeighboringSameScore++;
 		}
 
 		int iNewScore = it->option.m_iScore - iNeighboringSameScore;
@@ -2079,7 +2093,7 @@ vector<OptionWithScore<BuilderDirective>> CvBuilderTaskingAI::GetImprovementDire
 
 	// Special handling for no-two-adjacent and great person improvements
 	aDirectives = FilterNonOptimalNoTwoAdjacentImprovements(aDirectives, true);
-	aDirectives = FilterNoTwoAdjacentDirectives(aDirectives);
+	aDirectives = FilterNoTwoAdjacentDirectives(aDirectives, ePlayer);
 	aDirectives = FilterNonOptimalNoTwoAdjacentImprovements(aDirectives, false);
 	UpdateGreatPersonDirectives(aDirectives);
 

--- a/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
@@ -377,7 +377,7 @@ CvPlot* CvHomelandAI::GetBestExploreTarget(const CvUnit* pUnit, int nMinCandidat
 		if (pUnit->getDomainType()==DOMAIN_LAND && pEvalPlot->isWater())
 			iRating /= 2;
 
-		int iPlotScore = (1000 * iRating) / max(1, it->iPathLength);
+		int iPlotScore = (1000 * iRating) / (it->iPathLength + 1);
 
 		iValidCandidates++;
 		if (iPlotScore > iBestPlotScore)

--- a/CvGameCoreDLL_Expansion2/CvMilitaryAI.h
+++ b/CvGameCoreDLL_Expansion2/CvMilitaryAI.h
@@ -208,7 +208,7 @@ public:
 	int GetNumberCivsAtWarWith(bool bIncludeMinor = true) const;
 	int GetRecommendedMilitarySize() const
 	{
-		return m_iRecDefensiveLandUnits + m_iRecOffensiveLandUnits + m_iRecOffensiveNavalUnits + m_iRecExplorerUnits;
+		return m_iRecLandUnits + m_iRecNavalUnits + m_iRecExplorerUnits;
 	};
 
 	int GetPowerOfStrongestBuildableUnit(DomainTypes eDomain);
@@ -263,11 +263,11 @@ public:
 
 	int GetRecommendLandArmySize() const
 	{
-		return m_iRecOffensiveLandUnits + m_iRecDefensiveLandUnits;
+		return m_iRecLandUnits;
 	};
 	int GetRecommendNavySize() const
 	{
-		return m_iRecOffensiveNavalUnits;
+		return m_iRecNavalUnits;
 	};
 	int GetRecommendedExplorers() const
 	{
@@ -337,13 +337,12 @@ private:
 	int m_iNumNavalUnits;
 	int m_iNumLandUnitsInArmies;
 	int m_iNumNavalUnitsInArmies;
-	int m_iRecOffensiveNavalUnits;
+	int m_iRecNavalUnits;
 	int m_iNumAirUnits;
 	int m_iNumAntiAirUnits;
 	int m_iBarbarianCampCount;
 	int m_iVisibleBarbarianCount;
-	int m_iRecOffensiveLandUnits;
-	int m_iRecDefensiveLandUnits;
+	int m_iRecLandUnits;
 	int m_iRecExplorerUnits;
 	int m_iNumFreeCarriers;
 

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -4632,6 +4632,10 @@ bool CvUnit::canEnterTerritory(TeamTypes eTeam, bool bEndTurn) const
 		if (IsAngerFreeUnit())
 			return true;
 
+		// Explorers occasionally need to go through minor civ territory to get out of dead ends
+		if (AI_getUnitAIType() == UNITAI_EXPLORE)
+			return true;
+
 		// If we are friends etc we may go there
 		CvMinorCivAI* pMinorAI = GET_PLAYER(kTheirTeam.getLeaderID()).GetMinorCivAI();
 		if (pMinorAI->IsPlayerHasOpenBorders(getOwner()))

--- a/CvGameCoreDLL_Expansion2/CvUnitProductionAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnitProductionAI.cpp
@@ -1056,6 +1056,11 @@ int CvUnitProductionAI::CheckUnitBuildSanity(UnitTypes eUnit, bool bForOperation
 		if (m_pCity->GetCityStrategyAI()->IsUsingCityStrategy(eEnoughSettlers))
 			return SR_BALANCE;
 
+		if (m_pCity->plot()->getNumUnitsOfAIType(UNITAI_SETTLE, m_pCity->getOwner()) > 0)
+		{
+			return SR_USELESS;
+		}
+
 		int iFlavorExpansion = kPlayer.GetGrandStrategyAI()->GetPersonalityAndGrandStrategy((FlavorTypes)GC.getInfoTypeForString("FLAVOR_EXPANSION"));
 
 		//we already checked ECONOMICAISTRATEGY_ENOUGH_EXPANSION, so we know we have a good settle plot


### PR DESCRIPTION
AI Explorers can enter city state territory if they really need to.

Fix AI explorers evaluating 1 and 2 turn paths the same.

Make AI workers better at planning out no-two-adjacent improvements near unowned plots.

Simplify and fix Military AI desired army/navy/explorer ratio.