### PR TITLE
Add functionality for homeland AI to distribute its workers

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvAStarNode.h
+++ b/CvGameCoreDLL_Expansion2/CvAStarNode.h
@@ -56,7 +56,8 @@ enum PathType
 	PT_CITY_CONNECTION_LAND,	//is there a road or railroad between two points
 	PT_CITY_CONNECTION_WATER,	//is there a sea connection between two points
 	PT_CITY_CONNECTION_MIXED,	//is there a mixed land/sea connection between two points
-	PT_WORKER_SEA_UNIT_SAFE,        //is it definitely safe for a worker to go between two points
+	PT_WORKER_LAND_UNIT_SAFE,   //is it definitely safe for a worker to go between two points
+	PT_WORKER_SEA_UNIT_SAFE,    //is it definitely safe for a work boat to go between two points
 	PT_AIR_REBASE,				//for aircraft, only plots with cities and carriers are allowed
 };
 

--- a/CvGameCoreDLL_Expansion2/CvHomelandAI.h
+++ b/CvGameCoreDLL_Expansion2/CvHomelandAI.h
@@ -177,6 +177,37 @@ private:
 	int m_iAuxData;
 };
 
+typedef std::tr1::unordered_set<int> CitySet;
+
+struct SWorkerRegion {
+	int m_iID;
+	int m_iCapitalX;
+	int m_iCapitalY;
+	CitySet m_aCities;
+	int m_iImprovementNeed;
+	std::vector<int> m_aCurrentWorkers;
+	int m_iWantedWorkers;
+
+	SWorkerRegion();
+	SWorkerRegion(CitySet aCities, int iImprovementNeed, int iCapitalX, int iCapitalY);
+
+	bool OwnsWorker(int iWorkerID) const;
+	bool ContainsCity(int iCityID) const;
+	static void ResetCounter();
+	
+	struct compareID {
+		bool operator()(const SWorkerRegion& lhs, const SWorkerRegion& rhs) const {
+			return lhs.m_iID < rhs.m_iID;
+		}
+	};
+
+	bool operator<(const SWorkerRegion& rhs) const;
+	bool operator==(const SWorkerRegion& rhs) const;
+
+private:
+	static int iIDCounter;
+};
+
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 //  CLASS:      CvHomelandAI
 //!  \brief		A player's AI to control units that are in reserve protecting their lands
@@ -256,6 +287,7 @@ private:
 //-------------------------------------
 
 	void PlanImprovements();
+	void PlanWorkerDistribution();
 	void PlotWorkerMoves();
 	void PlotWriterMoves();
 	void PlotArtistMoves();
@@ -326,6 +358,8 @@ private:
 	bool ExecuteGoldenAgeMove(CvUnit* pUnit);
 	bool IsValidExplorerEndTurnPlot(const CvUnit* pUnit, CvPlot* pPlot) const;
 	void ClearCurrentMoveUnits(AIHomelandMove eNextMove);
+	bool IsWorkerAtAllocatedRegion(const CvUnit* pUnit, const CvPlot* pPlot = NULL) const;
+	CvPlot* GetWorkerRegionTargetPlot(const CvUnit* pUnit) const;
 
 	// Logging functions
 	CvString GetLogFileName(CvString& playerName) const;
@@ -337,6 +371,7 @@ private:
 	list<int> m_greatPeopleForImprovements;
 	std::map<UnitAITypes,std::vector<std::pair<int,int>>> m_automatedTargetPlots; //for human units
 	bool m_bNeedsUpdate;
+	std::vector<SWorkerRegion> m_aWorkerRegions;
 
 	CHomelandUnitArray m_CurrentMoveUnits;
 


### PR DESCRIPTION
When an AI civilization becomes non-contiguous, the workers will previously be stuck in the region they are currently in, meaning that newly founded colonies will not get any tiles improved.

This commit adds functionality for the homeland AI to compute how many contiguous regions it has and how many improvements are needed to be built in them, and then distribute its workers among them.

Since this behavior may put the workers in danger, it will not be used for human automated workers, they will have to manually move their workers to their colonies.