### PR TITLE
Fix cross-domain squads bugs

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvUnit.h
+++ b/CvGameCoreDLL_Expansion2/CvUnit.h
@@ -622,6 +622,7 @@ public:
 	void AssignToSquad(int iNewSquadNumber);
 	void RemoveFromSquad();
 	CvPlot* GetSquadCenterOfMass();
+	void DoSquadPlotAssignmentsByDomain(std::vector<CvUnit*> eligibleUnits, CvPlot* pDestPlot, std::map<CvUnit*, CvPlot*>& unitToPlotMap);
 	std::map<CvUnit*, CvPlot*> CvUnit::DoSquadPlotAssignments(CvPlot* pDestPlot, bool escort, bool computeOnly);
 	void DoSquadMovement(CvPlot* pDestPlot, bool escort);
 	void GetSquadMovementPreview(std::vector<CvPlot*>& pPlotList, CvPlot* pDestPlot);


### PR DESCRIPTION
* Fixes a bug where squad movement would fail when the oldest unit in a squad wasn't the same domain as the destination tile
* Fixes several related issues where squads with more than 1 domain type would choose incorrect destination tiles for squad movement
* Fixes several other edge cases where destination plot selection for squad movement was suboptimal