### PR TITLE
Slightly Increase the High Level AI Early Game Bonuses

### DIFF
--- a/(2) Vox Populi/Database Changes/Difficulty/DifficultyChanges.xml
+++ b/(2) Vox Populi/Database Changes/Difficulty/DifficultyChanges.xml
@@ -544,14 +544,14 @@
 			<AIUnitCostPercent>75</AIUnitCostPercent>
 			<AIUnitUpgradePercent>60</AIUnitUpgradePercent>
 			<AIGrowthPercent>100</AIGrowthPercent>
-			<AITrainPercent>75</AITrainPercent>
-			<AITrainPerEraModifier>-9</AITrainPerEraModifier>
+			<AITrainPercent>70</AITrainPercent>
+			<AITrainPerEraModifier>-8</AITrainPerEraModifier>
 			<AIWorldTrainPercent>100</AIWorldTrainPercent>
-			<AIConstructPercent>75</AIConstructPercent>
-			<AIConstructPerEraModifier>-9</AIConstructPerEraModifier>
+			<AIConstructPercent>70</AIConstructPercent>
+			<AIConstructPerEraModifier>-8</AIConstructPerEraModifier>
 			<AIWorldConstructPercent>100</AIWorldConstructPercent>
-			<AICreatePercent>75</AICreatePercent>
-			<AICreatePerEraModifier>-9</AICreatePerEraModifier>
+			<AICreatePercent>70</AICreatePercent>
+			<AICreatePerEraModifier>-8</AICreatePerEraModifier>
 			<AIWorldCreatePercent>100</AIWorldCreatePercent>
 			<AIFreeXP>25</AIFreeXP>
 			<AIFreeXPPercentVSHuman>80</AIFreeXPPercentVSHuman>
@@ -627,21 +627,21 @@
 			<!-- AI Bonuses -->
 			<AIHappinessDefault>8</AIHappinessDefault>
 			<AIHappinessDefaultCapital>2</AIHappinessDefaultCapital>
-			<AIUnitSupplyBase>12</AIUnitSupplyBase>
+			<AIUnitSupplyBase>15</AIUnitSupplyBase>
 			<AIUnitSupplyPopulationPercent>20</AIUnitSupplyPopulationPercent>
 			<AIWorkRateModifier>70</AIWorkRateModifier>
 			<AIBuildingCostPercent>70</AIBuildingCostPercent>
 			<AIUnitCostPercent>70</AIUnitCostPercent>
 			<AIUnitUpgradePercent>50</AIUnitUpgradePercent>
 			<AIGrowthPercent>100</AIGrowthPercent>
-			<AITrainPercent>70</AITrainPercent>
-			<AITrainPerEraModifier>-10</AITrainPerEraModifier>
+			<AITrainPercent>60</AITrainPercent>
+			<AITrainPerEraModifier>-8</AITrainPerEraModifier>
 			<AIWorldTrainPercent>100</AIWorldTrainPercent>
-			<AIConstructPercent>70</AIConstructPercent>
-			<AIConstructPerEraModifier>-10</AIConstructPerEraModifier>
+			<AIConstructPercent>60</AIConstructPercent>
+			<AIConstructPerEraModifier>-8</AIConstructPerEraModifier>
 			<AIWorldConstructPercent>100</AIWorldConstructPercent>
-			<AICreatePercent>70</AICreatePercent>
-			<AICreatePerEraModifier>-10</AICreatePerEraModifier>
+			<AICreatePercent>60</AICreatePercent>
+			<AICreatePerEraModifier>-8</AICreatePerEraModifier>
 			<AIWorldCreatePercent>100</AIWorldCreatePercent>
 			<AIFreeXP>30</AIFreeXP>
 			<AIFreeXPPercentVSHuman>100</AIFreeXPPercentVSHuman>


### PR DESCRIPTION
Currently, its a bit too easy to conquer the Deity AI early in the game (first 3 ages) as it seems VP shifted too far from vanilla which gave too many early game bonuses (see recent Deity playthroughs on discord). I would propose the following to give the AI a bit more supply (needs this especially after the naval rework as it builds ships too early and frequently now) and adjust building/combat unit/non-world project cost so that it starts lower but scales a bit slower to help them build up a little faster while keeping about the same late game discount.

Deity
- Increase AI base supply from 12 to 15
- Update AI building/combat unit/non-world project cost from 70% to 60%
- Update AI building/combat unit/non-world project cost per era from 10% to 8%

Immortal
- Update AI building/combat unit/non-world project cost from 75% to 70%
- Update AI building/combat unit/non-world project cost per era from 9% to 8%