### PR TITLE
[Balance] Increase Deity AI Base Supply

### DIFF
--- a/(2) Vox Populi/Database Changes/Difficulty/DifficultyChanges.xml
+++ b/(2) Vox Populi/Database Changes/Difficulty/DifficultyChanges.xml
@@ -627,7 +627,7 @@
 			<!-- AI Bonuses -->
 			<AIHappinessDefault>8</AIHappinessDefault>
 			<AIHappinessDefaultCapital>2</AIHappinessDefaultCapital>
-			<AIUnitSupplyBase>12</AIUnitSupplyBase>
+			<AIUnitSupplyBase>15</AIUnitSupplyBase>
 			<AIUnitSupplyPopulationPercent>20</AIUnitSupplyPopulationPercent>
 			<AIWorkRateModifier>70</AIWorkRateModifier>
 			<AIBuildingCostPercent>70</AIBuildingCostPercent>


### PR DESCRIPTION
Revised PR with reduced scope based on feedback on https://github.com/LoneGazebo/Community-Patch-DLL/pull/12192

Currently, its a bit too easy to conquer the Deity AI early in the game (first 3 ages) as it seems VP shifted too far from vanilla which gave too many early game bonuses (see recent Deity playthroughs on discord). I would propose the following to give the AI a bit more supply as it struggles to focus enough units to counter a human player (needs this especially after the naval rework as it builds ships too early and frequently now which wastes its limited supply).

Deity
- Increase AI base supply from 12 to 15

Requires a Project Overseer to approve out-of-congress balance change.