### PR TITLE
Fusta using military supply fixed (issue 12223)

### DIFF
--- a/(2) Vox Populi/Database Changes/Civilizations/Venice.sql
+++ b/(2) Vox Populi/Database Changes/Civilizations/Venice.sql
@@ -121,8 +121,7 @@ SET
 	Combat = 14,
 	RangedCombat = 21,
 	"Range" = 1,
-	Moves = 5,
-	NoSupply = 1
+	Moves = 5
 WHERE Type = 'UNIT_FUSTA';
 
 INSERT INTO Unit_ClassUpgrades

--- a/(2) Vox Populi/Database Changes/Units/UnitSweeps.sql
+++ b/(2) Vox Populi/Database Changes/Units/UnitSweeps.sql
@@ -46,14 +46,15 @@ WHERE CombatClass IN (
 	'UNITCLASS_NUCLEAR_MISSILE'
 );
 
--- Air units and missiles don't cost supply
+-- Fusta, Air units and missiles don't cost supply
 UPDATE Units
 SET NoSupply = 1
 WHERE CombatClass IN (
 	SELECT Type FROM UnitCombatInfos WHERE IsAerial = 1
 ) OR Class IN (
 	'UNITCLASS_ROCKET_MISSILE',
-	'UNITCLASS_GUIDED_MISSILE'
+	'UNITCLASS_GUIDED_MISSILE',
+	'UNITCLASS_FUSTA'
 );
 
 -----------------------------------------------------------------


### PR DESCRIPTION
Moved the NoSupply = 1 of Fusta from Venice.sql to UnitSweeps.sql, to prevent the NoSupply = 0 from that .sql from overriding Venice.sql. 

Fixes #12223 