### PR TITLE
perf: Trade route from Buildings and Techs

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -688,6 +688,8 @@ CvPlayer::CvPlayer() :
 	, m_iFreeWCVotes()
 	, m_iVotesPerFollowingCityTimes100()
 	, m_iInfluenceGPExpend()
+	, m_iTradeRouteFromBuildings()
+	, m_iTradeRouteFromTechs()
 	, m_iFreeTradeRoute()
 	, m_iReligionDistance()
 	, m_iPressureMod()
@@ -1496,6 +1498,8 @@ void CvPlayer::uninit()
 	m_iFreeWCVotes = 0;
 	m_iVotesPerFollowingCityTimes100 = 0;
 	m_iInfluenceGPExpend = 0;
+	m_iTradeRouteFromBuildings = 0;
+	m_iTradeRouteFromTechs = 0;
 	m_iFreeTradeRoute = 0;
 	m_iReligionDistance = 0;
 	m_iPressureMod = 0;
@@ -15785,6 +15789,9 @@ void CvPlayer::processBuilding(BuildingTypes eBuilding, int iChange, bool bFirst
 
 	ChangeCityWorkingChange(pBuildingInfo->GetGlobalCityWorkingChange() * iChange);
 	ChangeCityAutomatonWorkersChange(pBuildingInfo->GetGlobalCityAutomatonWorkersChange() * iChange);
+
+	// Trade route num bonus
+	changeTradeRouteFromBuildings(pBuildingInfo->GetNumTradeRouteBonus() * iChange);
 
 	// Trade route gold modifier
 	GetTreasury()->ChangeCityConnectionTradeRouteGoldModifier(pBuildingInfo->GetCityConnectionTradeRouteModifier() * iChange);
@@ -34837,6 +34844,24 @@ void CvPlayer::changeInfluenceGPExpend(int iChange)
 	m_iInfluenceGPExpend += iChange;
 }
 
+int CvPlayer::GetTradeRouteFromBuildings() const
+{
+	return m_iTradeRouteFromBuildings;
+}
+void CvPlayer::changeTradeRouteFromBuildings(int iChange)
+{
+	m_iTradeRouteFromBuildings += iChange;
+}
+
+int CvPlayer::GetTradeRouteFromTechs() const
+{
+	return m_iTradeRouteFromTechs;
+}
+void CvPlayer::changeTradeRouteFromTechs(int iChange)
+{
+	m_iTradeRouteFromTechs += iChange;
+}
+
 int CvPlayer::GetFreeTradeRoute() const
 {
 	return m_iFreeTradeRoute;
@@ -43319,6 +43344,8 @@ void CvPlayer::Serialize(Player& player, Visitor& visitor)
 	visitor(player.m_iFreeWCVotes);
 	visitor(player.m_iVotesPerFollowingCityTimes100);
 	visitor(player.m_iInfluenceGPExpend);
+	visitor(player.m_iTradeRouteFromBuildings);
+	visitor(player.m_iTradeRouteFromTechs);
 	visitor(player.m_iFreeTradeRoute);
 	visitor(player.m_iReligionDistance);
 	visitor(player.m_iPressureMod);

--- a/CvGameCoreDLL_Expansion2/CvPlayer.h
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.h
@@ -1855,6 +1855,12 @@ public:
 	int GetInfluenceGPExpend() const;
 	void changeInfluenceGPExpend(int iChange);
 
+	int GetTradeRouteFromBuildings() const;
+	void changeTradeRouteFromBuildings(int iChange);
+
+	int GetTradeRouteFromTechs() const;
+	void changeTradeRouteFromTechs(int iChange);
+
 	int GetFreeTradeRoute() const;
 	void changeFreeTradeRoute(int iChange);
 
@@ -3143,6 +3149,8 @@ protected:
 	int m_iFreeWCVotes;
 	int m_iVotesPerFollowingCityTimes100;
 	int m_iInfluenceGPExpend;
+	int m_iTradeRouteFromBuildings;
+	int m_iTradeRouteFromTechs;
 	int m_iFreeTradeRoute;
 	int m_iReligionDistance;
 	int m_iPressureMod;
@@ -3953,6 +3961,8 @@ SYNC_ARCHIVE_VAR(int, m_iGoldInternalTrade)
 SYNC_ARCHIVE_VAR(int, m_iFreeWCVotes)
 SYNC_ARCHIVE_VAR(int, m_iVotesPerFollowingCityTimes100)
 SYNC_ARCHIVE_VAR(int, m_iInfluenceGPExpend)
+SYNC_ARCHIVE_VAR(int, m_iTradeRouteFromBuildings)
+SYNC_ARCHIVE_VAR(int, m_iTradeRouteFromTechs)
 SYNC_ARCHIVE_VAR(int, m_iFreeTradeRoute)
 SYNC_ARCHIVE_VAR(int, m_iReligionDistance)
 SYNC_ARCHIVE_VAR(int, m_iPressureMod)

--- a/CvGameCoreDLL_Expansion2/CvTeam.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTeam.cpp
@@ -7905,6 +7905,7 @@ void CvTeam::processTech(TechTypes eTech, int iChange, bool bNoBonus)
 			kPlayer.changeWorkerSpeedModifier(pTech->GetWorkerSpeedModifier() * iChange);
 			kPlayer.ChangeInfluenceSpreadModifier(pTech->GetInfluenceSpreadModifier() * iChange);
 			kPlayer.ChangeExtraVotesPerDiplomat(pTech->GetExtraVotesPerDiplomat() * iChange);
+			kPlayer.changeTradeRouteFromTechs(pTech->GetNumInternationalTradeRoutesChange() * iChange);
 
 			if (kPlayer.isMajorCiv())
 			{

--- a/CvGameCoreDLL_Expansion2/CvTradeClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTradeClasses.cpp
@@ -5260,51 +5260,8 @@ uint CvPlayerTrade::GetNumTradeRoutesPossible() const
 	if (m_pPlayer->getCivilizationType() == NO_CIVILIZATION)
 		return 0;
 
-	CvPlayerTechs* pMyPlayerTechs = m_pPlayer->GetPlayerTechs();
-	CvTeamTechs* pMyTeamTechs = GET_TEAM(GET_PLAYER(m_pPlayer->GetID()).getTeam()).GetTeamTechs();
-	CvTechEntry* pTechInfo = NULL; 
-
-	CvTechXMLEntries* pMyPlayerTechEntries = pMyPlayerTechs->GetTechs();
-	ASSERT(pMyPlayerTechEntries);
-	if (pMyPlayerTechEntries == NULL)
-		return 0;
-
-	for(int iTechLoop = 0; iTechLoop < pMyPlayerTechEntries->GetNumTechs(); iTechLoop++)
-	{
-		TechTypes eTech = (TechTypes)iTechLoop;
-		if (!pMyTeamTechs->HasTech(eTech))
-		{
-			continue;
-		}
-
-		pTechInfo = pMyPlayerTechEntries->GetEntry(eTech);
-		ASSERT(pTechInfo, "null tech entry");
-		if (pTechInfo)
-		{
-			iNumRoutes += pTechInfo->GetNumInternationalTradeRoutesChange();
-		}
-	}
-
-	int iLoop = 0;
-	for (CvCity* pLoopCity = m_pPlayer->firstCity(&iLoop); pLoopCity != NULL; pLoopCity = m_pPlayer->nextCity(&iLoop))
-	{
-		const std::vector<BuildingTypes>& vBuildings = pLoopCity->GetCityBuildings()->GetAllBuildingsHere();
-		for (size_t i = 0; i < vBuildings.size(); i++)
-		{
-			CvBuildingEntry* pBuildingEntry = GC.GetGameBuildings()->GetEntry(vBuildings[i]);
-			if (pBuildingEntry)
-			{
-				if (pLoopCity->GetCityBuildings()->GetNumBuilding((BuildingTypes)pBuildingEntry->GetID()))
-				{
-					int iNumRouteBonus = pBuildingEntry->GetNumTradeRouteBonus();
-					if (iNumRouteBonus != 0)
-					{
-						iNumRoutes += iNumRouteBonus * pLoopCity->GetCityBuildings()->GetNumBuilding(vBuildings[i]);
-					}
-				}
-			}
-		}
-	}
+	iNumRoutes += m_pPlayer->GetTradeRouteFromBuildings();
+	iNumRoutes += m_pPlayer->GetTradeRouteFromTechs();
 
 	CorporationTypes eCorporation = m_pPlayer->GetCorporations()->GetFoundedCorporation();
 	if (eCorporation != NO_CORPORATION)


### PR DESCRIPTION
Cached the number of trade routes provided by Buildings and Technologies to reduce redundant calculations and slightly improve performance.