### PR TITLE
Resolve Happiness Tooltip Rendering Issues in Non-English Locales

### DIFF
--- a/(1) Community Patch/Core Files/Overrides/Includes/InfoTooltipInclude.lua
+++ b/(1) Community Patch/Core Files/Overrides/Includes/InfoTooltipInclude.lua
@@ -1878,7 +1878,14 @@ function GetHelpTextForBuilding(eBuilding, bExcludeName, _, bNoMaintenance, pCit
 		AddTooltipNonZero(tYieldLines, "TXT_KEY_PRODUCTION_BUILDING_HAPPINESS", iHappinessTotal);
 		AddTooltipNonZeroSigned(tYieldLines, "TXT_KEY_PRODUCTION_BUILDING_UNHAPPINESS", kBuildingInfo.Unhappiness);
 	else
-		AddTooltipNonZero(tYieldLines, "TXT_KEY_PRODUCTION_BUILDING_HAPPINESS", iHappinessTotal + kBuildingInfo.Unhappiness);
+		iHappinessTotal = iHappinessTotal + kBuildingInfo.Unhappiness;
+		local happinessLocaleKey = "TXT_KEY_PRODUCTION_BUILDING_HAPPINESS";
+		local displayNumber = iHappinessTotal;
+		if (iHappinessTotal < 0) then
+			happinessLocaleKey = "TXT_KEY_PRODUCTION_BUILDING_UNHAPPINESS";
+			displayNumber = -iHappinessTotal;
+		end
+		AddTooltipNonZero(tYieldLines, happinessLocaleKey, displayNumber);
 	end
 
 	-- Only show modified number in city view

--- a/(1) Community Patch/Database Changes/Text/en_US/UI/CoreUITextChanges.sql
+++ b/(1) Community Patch/Database Changes/Text/en_US/UI/CoreUITextChanges.sql
@@ -103,11 +103,6 @@ UPDATE Language_en_US
 SET Text = 'Resources Required: {1_NumResource} {2_ResIcon} {3_Res:textkey}'
 WHERE Tag = 'TXT_KEY_PRODUCTION_RESOURCES_REQUIRED';
 
--- Building
-UPDATE Language_en_US
-SET Text = '{1: number "''[ICON_HAPPINESS_1] Happiness: ''#;''[ICON_HAPPINESS_3] Unhappiness '':#"}'
-WHERE Tag = 'TXT_KEY_PRODUCTION_BUILDING_HAPPINESS';
-
 UPDATE Language_en_US
 SET Text = '[ICON_STRENGTH] City Strength: {2_Sign}{1_Num}'
 WHERE Tag = 'TXT_KEY_PRODUCTION_BUILDING_DEFENSE';


### PR DESCRIPTION
### Overview
This PR addresses a UI bug where building happiness tooltips would fail to display or render incorrectly in certain localized versions of the game (specifically reported in the Korean locale).

### The Problem
Commit ef20092 attempted to simplify the happiness tooltip by using a single XML key with positive/negative number formatting (#;#). While efficient in English, this approach is incompatible with the game engine's handling of multi-byte characters.

When the parser encounters Korean characters wrapped in literal delimiters ('') within a formatting block, it fails to align bytes correctly, causing the entire tooltip line to disappear.

### The Solution
I have partially reverted the happiness logic in InfoTooltipInclude.lua to use Lua-side branching:

VP Path: Maintains the current separation of Happiness and Unhappiness lines.

Standard Path: Restores the if (iHappinessTotal < 0) check to explicitly switch between HAPPINESS and UNHAPPINESS keys.

This ensures that the UI remains robust regardless of the language setting and fixes the regression introduced 3 months ago.

### Related Issue
Fixes #12338