### PR TITLE
Fix Notifications table

### DIFF
--- a/(1) Community Patch/Community Patch.civ5proj
+++ b/(1) Community Patch/Community Patch.civ5proj
@@ -876,6 +876,11 @@
         <Type>UpdateDatabase</Type>
         <FileName>Database Changes\Remapper.sql</FileName>
       </Action>
+      <Action>
+        <Set>OnModActivated</Set>
+        <Type>UpdateDatabase</Type>
+        <FileName>Database Changes/Misc/NotificationsChanges.sql</FileName>
+      </Action>
     </ModActions>
     <ModContent>
       <Content>
@@ -970,6 +975,7 @@
     <Folder Include="Database Changes\Events" />
     <Folder Include="Database Changes\Minors" />
     <Folder Include="Database Changes\Mod Support" />
+    <Folder Include="Database Changes\Misc" />
     <Folder Include="Database Changes\Policies" />
     <Folder Include="Database Changes\Religions" />
     <Folder Include="Database Changes\Tech" />
@@ -2898,6 +2904,10 @@
       <ImportIntoVFS>False</ImportIntoVFS>
     </Content>
     <Content Include="Database Changes\GameSpeedTableChanges.sql">
+      <SubType>Lua</SubType>
+      <ImportIntoVFS>False</ImportIntoVFS>
+    </Content>
+    <Content Include="Database Changes\Misc\NotificationsChanges.sql">
       <SubType>Lua</SubType>
       <ImportIntoVFS>False</ImportIntoVFS>
     </Content>

--- a/(1) Community Patch/Database Changes/Misc/NotificationsChanges.sql
+++ b/(1) Community Patch/Database Changes/Misc/NotificationsChanges.sql
@@ -1,0 +1,17 @@
+UPDATE Notifications SET Urgent = 0 WHERE Urgent = 'false';
+UPDATE Notifications SET Urgent = 1 WHERE Urgent = 'true';
+
+CREATE TABLE Notifications_new (
+    ID INTEGER PRIMARY KEY AUTOINCREMENT,
+    NotificationType TEXT UNIQUE,
+    Welcomeness INTEGER DEFAULT 0,
+    Urgent boolean DEFAULT 0
+);
+
+INSERT INTO Notifications_new (ID, NotificationType, Welcomeness, Urgent)
+SELECT ID, NotificationType, Welcomeness, Urgent
+FROM Notifications;
+
+DROP TABLE Notifications;
+
+ALTER TABLE Notifications_new RENAME TO Notifications;


### PR DESCRIPTION
Fix an issue where the .Urgent column was defined as `bool` and contained mixed representations `('false', 'true', 0, 1)`. Civ engine treats bool columns as mixed-type fields, which leads to incorrect serialization/deserialization.
The column is migrated to boolean, and all existing data is normalized to integers to ensure consistent behavior.