### PR TITLE
Modify population consumption logic for (non)settlers

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -29797,8 +29797,8 @@ CvUnit* CvCity::CreateUnit(UnitTypes eUnitType, UnitAITypes eAIType, UnitCreatio
 	if (MOD_BALANCE_SETTLERS_CONSUME_POPULATION)
 	{
 		const CvUnitEntry& kUnitInfo = pUnit->getUnitInfo();
-		bool bSettler = kUnitInfo->IsFound() || kUnitInfo->IsFoundMid() || kUnitInfo->IsFoundLate() || kUnitInfo->IsFoundAbroad();
-		if (kUnitInfo->IsFoodProduction() && getPopulation() > 1 && bSettler)
+		bool bSettler = kUnitInfo.IsFound() || kUnitInfo.IsFoundMid() || kUnitInfo.IsFoundLate() || kUnitInfo.IsFoundAbroad();
+		if (kUnitInfo.IsFoodProduction() && getPopulation() > 1 && bSettler)
 			changePopulation(-1);
 	}
 


### PR DESCRIPTION
This code is intended to reduce pop when making settler units, but actually it reduces pop when making any unit that converts food to production (which in some mods can be combat units).

The new check, copied from code above, tightens it to require the bSettler is also satisfied.

I think this use of `CvUnitEntry* pkUnitInfo = pUnit->getUnitInfo();` is correct? Reduces the number of calls.