### PR TITLE
clarify third alternative text to include paper

### DIFF
--- a/(2) Vox Populi/Database Changes/Text/en_US/Policies/PolicyTextChanges.sql
+++ b/(2) Vox Populi/Database Changes/Text/en_US/Policies/PolicyTextChanges.sql
@@ -944,7 +944,7 @@ SET Text = '[COLOR_POSITIVE_TEXT]Police State[ENDCOLOR]: +3 [ICON_HAPPINESS_1] L
 WHERE Tag = 'TXT_KEY_POLICY_POLICE_STATE_HELP';
 
 UPDATE Language_en_US
-SET Text = '[COLOR_POSITIVE_TEXT]Third Alternative[ENDCOLOR]: Quantity of Strategic Resources produced is increased by 100%. Reduces Unit [ICON_GOLD] Gold Maintenance costs by 25%.'
+SET Text = '[COLOR_POSITIVE_TEXT]Third Alternative[ENDCOLOR]: Quantity of Strategic Resources produced (including [ICON_RES_PAPER] Paper) is increased by 100%. Reduces Unit [ICON_GOLD] Gold Maintenance costs by 25%.'
 WHERE Tag = 'TXT_KEY_POLICY_THIRD_ALTERNATIVE_HELP';
 
 UPDATE Language_en_US


### PR DESCRIPTION
As suggested here 
https://forums.civfanatics.com/threads/9-103b-nerf-third-alternative-explicitly-state-its-paper-bonus.701539/#post-16908412

Added the icon for consistency