### PR TITLE
Fix Clang compiler warnings

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvTacticalAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTacticalAI.cpp
@@ -11056,6 +11056,7 @@ bool TacticalAIHelpers::ExecuteUnitAssignments(PlayerTypes ePlayer, const std::v
 		{
 		case A_INITIAL:
 		case A_FINISH_TEMP:
+		case A_MOVE_DOUBLE:
 			continue; //skip this!
 			break;
 		case A_MOVE:

--- a/CvGameCoreDLL_Expansion2/CvUnit.h
+++ b/CvGameCoreDLL_Expansion2/CvUnit.h
@@ -623,7 +623,7 @@ public:
 	void RemoveFromSquad();
 	CvPlot* GetSquadCenterOfMass();
 	void DoSquadPlotAssignmentsByDomain(std::vector<CvUnit*> eligibleUnits, CvPlot* pDestPlot, std::map<CvUnit*, CvPlot*>& unitToPlotMap);
-	std::map<CvUnit*, CvPlot*> CvUnit::DoSquadPlotAssignments(CvPlot* pDestPlot, bool escort, bool computeOnly);
+	std::map<CvUnit*, CvPlot*> DoSquadPlotAssignments(CvPlot* pDestPlot, bool escort, bool computeOnly);
 	void DoSquadMovement(CvPlot* pDestPlot, bool escort);
 	void GetSquadMovementPreview(std::vector<CvPlot*>& pPlotList, CvPlot* pDestPlot);
 	bool IsUnitInActiveMoveMission();

--- a/CvGameCoreDLL_Expansion2/CvUnitProductionAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnitProductionAI.cpp
@@ -1636,6 +1636,9 @@ int CvUnitProductionAI::CheckUnitBuildSanity(UnitTypes eUnit, bool bForOperation
 				iBonus += iBonusValueFromStrategy;
 			else if (kPlayer.GetMilitaryAI()->IsUsingStrategy(eStrategyEnoughFighter))
 				return SR_BALANCE;
+			break;
+		default:
+			break;
 		}
 	}
 


### PR DESCRIPTION
- CvUnitProductionAI.cpp: Add missing break statement and default case for switch on UnitAIType (0de31cd909)
- CvTacticalAI.cpp: Add A_MOVE_DOUBLE case to assignment type switch (9b313a5a22)
- CvUnit.h: Remove extra CvUnit:: qualification from DoSquadPlotAssignments declaration (b36be6852d)