### PR TITLE
fix: missing SAFE_DELETE_ARRAY calls

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvBeliefClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBeliefClasses.cpp
@@ -179,6 +179,71 @@ CvBeliefEntry::CvBeliefEntry() :
 /// Destructor
 CvBeliefEntry::~CvBeliefEntry()
 {
+	SAFE_DELETE_ARRAY(m_paiCityYieldChange);
+	SAFE_DELETE_ARRAY(m_paiHolyCityYieldChange);
+	SAFE_DELETE_ARRAY(m_paiYieldChangePerForeignCity);
+	SAFE_DELETE_ARRAY(m_paiYieldChangePerXForeignFollowers);
+	SAFE_DELETE_ARRAY(m_paiYieldChangePerXCityStateFollowers);
+	SAFE_DELETE_ARRAY(m_piYieldPerFollowingCity);
+	SAFE_DELETE_ARRAY(m_piYieldPerXFollowers);
+	SAFE_DELETE_ARRAY(m_piYieldPerOtherReligionFollower);
+	SAFE_DELETE_ARRAY(m_piResourceQuantityModifiers);
+
+	SAFE_DELETE_ARRAY(m_paiBuildingClassHappiness);
+
+	SAFE_DELETE_ARRAY(m_paiLakePlotYieldChange);
+
+	SAFE_DELETE_ARRAY(m_piGoldenAgeGreatPersonRateModifier);
+	SAFE_DELETE_ARRAY(m_piGreatPersonPoints);
+	SAFE_DELETE_ARRAY(m_piCapitalYieldChange);
+	SAFE_DELETE_ARRAY(m_piCoastalCityYieldChange);
+	SAFE_DELETE_ARRAY(m_piGreatWorkYieldChange);
+	SAFE_DELETE_ARRAY(m_piYieldFromKills);
+	SAFE_DELETE_ARRAY(m_piYieldFromRemoveHeresy);
+	SAFE_DELETE_ARRAY(m_piYieldFromBarbarianKills);
+
+	SAFE_DELETE_ARRAY(m_piResourceHappiness);
+	SAFE_DELETE_ARRAY(m_piYieldChangeAnySpecialist);
+	SAFE_DELETE_ARRAY(m_piYieldChangeTradeRoute);
+	SAFE_DELETE_ARRAY(m_piYieldChangeNaturalWonder);
+	SAFE_DELETE_ARRAY(m_piYieldChangeWorldWonder);
+	SAFE_DELETE_ARRAY(m_piYieldModifierNaturalWonder);
+	SAFE_DELETE_ARRAY(m_piMaxYieldModifierPerFollower);
+	SAFE_DELETE_ARRAY(m_piMaxYieldModifierPerFollowerPercent);
+	SAFE_DELETE_ARRAY(m_pbFaithPurchaseUnitSpecificEnabled);
+	SAFE_DELETE_ARRAY(m_pbFaithPurchaseUnitEraEnabled);
+    SAFE_DELETE_ARRAY(m_pbBuildingClassEnabled);
+
+	SAFE_DELETE_ARRAY(m_piYieldPerActiveTR);
+	SAFE_DELETE_ARRAY(m_piYieldPerConstruction);
+	SAFE_DELETE_ARRAY(m_piYieldPerWorldWonderConstruction);
+	SAFE_DELETE_ARRAY(m_piYieldPerPop);
+	SAFE_DELETE_ARRAY(m_piYieldPerGPT);
+	SAFE_DELETE_ARRAY(m_piYieldPerLux);
+
+	SAFE_DELETE_ARRAY(m_piYieldPerHeal);
+	SAFE_DELETE_ARRAY(m_piYieldPerBirth);
+	SAFE_DELETE_ARRAY(m_piYieldPerHolyCityBirth);
+	SAFE_DELETE_ARRAY(m_piYieldPerScience);
+	SAFE_DELETE_ARRAY(m_piYieldFromGPUse);
+	SAFE_DELETE_ARRAY(m_piYieldBonusGoldenAge);
+	SAFE_DELETE_ARRAY(m_piYieldFromSpread);
+	SAFE_DELETE_ARRAY(m_piYieldFromForeignSpread);
+	SAFE_DELETE_ARRAY(m_piYieldFromConquest);
+	SAFE_DELETE_ARRAY(m_piYieldFromPolicyUnlock);
+	SAFE_DELETE_ARRAY(m_piYieldFromEraUnlock);
+
+	SAFE_DELETE_ARRAY(m_piYieldFromConversion);
+	SAFE_DELETE_ARRAY(m_piYieldFromConversionExpo);
+	SAFE_DELETE_ARRAY(m_piYieldFromWLTKD);
+	SAFE_DELETE_ARRAY(m_piYieldFromProposal);
+	SAFE_DELETE_ARRAY(m_piYieldFromHost);
+	SAFE_DELETE_ARRAY(m_piYieldFromFaithPurchase);
+	SAFE_DELETE_ARRAY(m_piYieldFromKnownPantheons);
+	SAFE_DELETE_ARRAY(m_piMaxYieldPerFollower);
+	SAFE_DELETE_ARRAY(m_piMaxYieldPerFollowerPercent);
+	SAFE_DELETE_ARRAY(m_piImprovementVoteChange);
+
 	CvDatabaseUtility::SafeDelete2DArray(m_ppiImprovementYieldChanges);
 	CvDatabaseUtility::SafeDelete2DArray(m_ppiBuildingClassYieldChanges);
 	CvDatabaseUtility::SafeDelete2DArray(m_ppaiFeatureYieldChange);

--- a/CvGameCoreDLL_Expansion2/CvPolicyClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPolicyClasses.cpp
@@ -402,6 +402,7 @@ CvPolicyEntry::~CvPolicyEntry(void)
 	SAFE_DELETE_ARRAY(m_piCapitalYieldModifier);
 	SAFE_DELETE_ARRAY(m_piGreatWorkYieldChange);
 	SAFE_DELETE_ARRAY(m_piSpecialistExtraYield);
+	SAFE_DELETE_ARRAY(m_piImprovementCultureChange);
 	SAFE_DELETE_ARRAY(m_pabFreePromotion);
 	SAFE_DELETE_ARRAY(m_paiUnitCombatProductionModifiers);
 	SAFE_DELETE_ARRAY(m_paiUnitCombatFreeExperiences);
@@ -460,6 +461,8 @@ CvPolicyEntry::~CvPolicyEntry(void)
 	SAFE_DELETE_ARRAY(m_piArtYieldChanges);
 	SAFE_DELETE_ARRAY(m_piLitYieldChanges);
 	SAFE_DELETE_ARRAY(m_piMusicYieldChanges);
+	SAFE_DELETE_ARRAY(m_piRelicYieldChanges);
+	SAFE_DELETE_ARRAY(m_piFilmYieldChanges);
 	SAFE_DELETE_ARRAY(m_piYieldFromNonSpecialistCitizensTimes100);
 	SAFE_DELETE_ARRAY(m_piYieldModifierFromGreatWorks);
 	SAFE_DELETE_ARRAY(m_piYieldModifierFromActiveSpies);
@@ -470,6 +473,7 @@ CvPolicyEntry::~CvPolicyEntry(void)
 #if defined(HH_MOD_API_TRADEROUTE_MODIFIERS)
 	SAFE_DELETE_ARRAY(m_piInternationalRouteYieldModifiers);
 #endif 
+	SAFE_DELETE_ARRAY(m_piFlavorValue);
 	m_piUnitClassReplacements.clear();
 	CvDatabaseUtility::SafeDelete2DArray(m_ppiBuildingClassYieldModifiers);
 	CvDatabaseUtility::SafeDelete2DArray(m_ppiBuildingClassYieldChanges);

--- a/CvGameCoreDLL_Expansion2/CvTraitClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTraitClasses.cpp
@@ -308,6 +308,72 @@ CvTraitEntry::CvTraitEntry() :
 /// Destructor
 CvTraitEntry::~CvTraitEntry()
 {
+	SAFE_DELETE_ARRAY(m_paiExtraYieldThreshold);
+	SAFE_DELETE_ARRAY(m_paiYieldChange);
+	SAFE_DELETE_ARRAY(m_paiYieldChangeStrategicResources);
+	SAFE_DELETE_ARRAY(m_paiYieldChangeNaturalWonder);
+	SAFE_DELETE_ARRAY(m_paiYieldChangePerTradePartner);
+	SAFE_DELETE_ARRAY(m_paiYieldChangeIncomingTradeRoute);
+	SAFE_DELETE_ARRAY(m_paiYieldModifier);
+	SAFE_DELETE_ARRAY(m_piStrategicResourceQuantityModifier);
+	SAFE_DELETE_ARRAY(m_piResourceQuantityModifiers);
+	SAFE_DELETE_ARRAY(m_piNumFreeResourceOnWorldWonderCompletion);
+	SAFE_DELETE_ARRAY(m_piMovesChangeUnitCombats);
+	SAFE_DELETE_ARRAY(m_paiGAPToYield);
+	SAFE_DELETE_ARRAY(m_paiMountainRangeYield);
+	SAFE_DELETE_ARRAY(m_piMovesChangeUnitClasses);
+	
+	SAFE_DELETE_ARRAY(m_piMaintenanceModifierUnitCombats);
+
+	SAFE_DELETE_ARRAY(m_piYieldFromLevelUp);
+	SAFE_DELETE_ARRAY(m_piYieldFromHistoricEvent);
+	SAFE_DELETE_ARRAY(m_piYieldFromOwnPantheon);
+	SAFE_DELETE_ARRAY(m_piYieldFromXMilitaryUnits);
+
+	SAFE_DELETE_ARRAY(m_piYieldFromRouteMovement);
+	SAFE_DELETE_ARRAY(m_piYieldFromExport);
+	SAFE_DELETE_ARRAY(m_piYieldFromImport);
+	SAFE_DELETE_ARRAY(m_piYieldFromTilePurchase);
+	SAFE_DELETE_ARRAY(m_piYieldFromTileEarn);
+	SAFE_DELETE_ARRAY(m_piYieldFromCSAlly);
+	SAFE_DELETE_ARRAY(m_piYieldFromCSFriend);
+	SAFE_DELETE_ARRAY(m_piYieldFromSettle);
+	SAFE_DELETE_ARRAY(m_piYieldFromConquest);
+	SAFE_DELETE_ARRAY(m_piYieldFromCityDamageTimes100);
+
+	SAFE_DELETE_ARRAY(m_piNumPledgesDomainProdMod);
+	SAFE_DELETE_ARRAY(m_piDomainFreeExperienceModifier);
+	SAFE_DELETE_ARRAY(m_piGreatPersonProgressFromPolicyUnlock);
+
+	SAFE_DELETE_ARRAY(m_piFreeUnitClassesDOW);
+
+	SAFE_DELETE_ARRAY(m_piCapitalYieldChanges);
+	SAFE_DELETE_ARRAY(m_piCityYieldChanges);
+	SAFE_DELETE_ARRAY(m_piPermanentYieldChangeWLTKD);
+	SAFE_DELETE_ARRAY(m_piCoastalCityYieldChanges);
+	SAFE_DELETE_ARRAY(m_piGreatWorkYieldChanges);
+	SAFE_DELETE_ARRAY(m_piArtifactYieldChanges);
+	SAFE_DELETE_ARRAY(m_piArtYieldChanges);
+	SAFE_DELETE_ARRAY(m_piLitYieldChanges);
+	SAFE_DELETE_ARRAY(m_piMusicYieldChanges);
+	SAFE_DELETE_ARRAY(m_piSeaPlotYieldChanges);
+
+	SAFE_DELETE_ARRAY(m_piLuxuryYieldChanges);
+
+	SAFE_DELETE_ARRAY(m_piYieldFromKills);
+	SAFE_DELETE_ARRAY(m_piYieldFromBarbarianKills);
+	SAFE_DELETE_ARRAY(m_piYieldFromMinorDemand);
+	SAFE_DELETE_ARRAY(m_piYieldFromLuxuryResourceGain);
+	SAFE_DELETE_ARRAY(m_piYieldChangeTradeRoute);
+	SAFE_DELETE_ARRAY(m_piYieldChangeWorldWonder);
+
+	SAFE_DELETE_ARRAY(m_piGreatPersonCostReduction);
+	SAFE_DELETE_ARRAY(m_piGoldenAgeGreatPersonRateModifier);
+	SAFE_DELETE_ARRAY(m_piPerPuppetGreatPersonRateModifier);
+	SAFE_DELETE_ARRAY(m_piGreatPersonGWAM);
+
+	SAFE_DELETE_ARRAY(m_piGoldenAgeFromGreatPersonBirth);
+
 	CvDatabaseUtility::SafeDelete2DArray(m_ppiImprovementYieldChanges);
 	CvDatabaseUtility::SafeDelete2DArray(m_ppiPlotYieldChanges);
 	CvDatabaseUtility::SafeDelete2DArray(m_ppiBuildingClassYieldChanges);

--- a/CvGameCoreDLL_Expansion2/CvUnitClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnitClasses.cpp
@@ -198,6 +198,11 @@ CvUnitEntry::~CvUnitEntry(void)
 	SAFE_DELETE_ARRAY(m_piResourceQuantityExpended);
 	SAFE_DELETE_ARRAY(m_piProductionTraits);
 	SAFE_DELETE_ARRAY(m_piFlavorValue);
+	SAFE_DELETE_ARRAY(m_piProductionModifierBuildings);
+	SAFE_DELETE_ARRAY(m_piYieldOnBountyToKiller);
+	SAFE_DELETE_ARRAY(m_piYieldFromKills);
+	SAFE_DELETE_ARRAY(m_piYieldFromBarbarianKills);
+	SAFE_DELETE_ARRAY(m_piYieldOnCompletion);
 	SAFE_DELETE_ARRAY(m_pbFreePromotions);
 	SAFE_DELETE_ARRAY(m_paszEarlyArtDefineTags);
 	SAFE_DELETE_ARRAY(m_paszLateArtDefineTags);


### PR DESCRIPTION
I reviewed **CvUnitEntry**, **CvPromotionEntry**, **CvPolicyEntry**, **CvBuildingEntry**, **CvTraitEntry**, and **CvBeliefEntry**, and added missing SAFE_DELETE_ARRAY calls for some 1D array pointers.