### PR TITLE
Add new minor poland color

### DIFF
--- a/(2) Vox Populi/Database Changes/NewColors.xml
+++ b/(2) Vox Populi/Database Changes/NewColors.xml
@@ -90,7 +90,15 @@
 			<Blue>0</Blue>
 			<Alpha>1</Alpha>
 		</Row>
-		<!-- Additionally, Austria and Persia's reds look too similar to Barbarians, and the same goes for brightened England, Mongolia and Morocco, so some manual adjustments were made. -->
+		<!-- Additionally, Austria, Poland, and Persia's reds look too similar to Barbarians, and the same goes for brightened England, Mongolia and Morocco, so some manual adjustments were made. -->
+		<!-- Poland is now #E78587 (pale red). -->
+		<Row>
+			<Type>COLOR_PLAYER_POLAND_MINOR_BACKGROUND</Type> <!-- RGB = 231/133/135, Original ≈ 246/5/0 -->
+			<Red>0.9023</Red>
+			<Green>0.5195</Green>
+			<Blue>0.5273</Blue>
+			<Alpha>1</Alpha>
+		</Row>
 		<!-- Austria is now #FFAEFF (lavender rose). -->
 		<Row>
 			<Type>COLOR_PLAYER_AUSTRIA_MINOR_BACKGROUND</Type> <!-- RGB = 255/174/255, Original ≈ 235/0/0 -->
@@ -343,7 +351,7 @@
 		<Row>
 			<Type>PLAYERCOLOR_MINOR_POLAND</Type>
 			<PrimaryColor>COLOR_PLAYER_MINOR_ICON</PrimaryColor>
-			<SecondaryColor>COLOR_PLAYER_POLAND_BACKGROUND</SecondaryColor>
+			<SecondaryColor>COLOR_PLAYER_POLAND_MINOR_BACKGROUND</SecondaryColor>
 			<TextColor>COLOR_PLAYER_PEACH_TEXT</TextColor>
 		</Row>
 		<Row>


### PR DESCRIPTION
In @RecursiveVision's recent minor civ color update, he changed the full-red colors so they wouldn't look identical to Barbarian colors (Austria, Persia), but he missed Poland.
<img width="535" height="313" alt="image" src="https://github.com/user-attachments/assets/54f2e2ab-b91e-44d5-9764-459bd6d64744" />
 
 Lightened to pale red -- chosen not to clash with the other updated colors (closest is probably england dusty rose, which is a more washed, grey color)
 
<img width="512" height="288" alt="image" src="https://github.com/user-attachments/assets/d3a3d01d-d550-4295-b73f-26c13148a97a" />

It was suggested here,
https://forums.civfanatics.com/threads/9-93-change-denmarks-minor-color-to-look-less-like-barbarians.701331
I think given the original logic of Recursive, which makes total sense, we don't need to vote on this.