### PR TITLE
vectorize the BonusFromAccomplishments

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvBuildingClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuildingClasses.cpp
@@ -1314,13 +1314,13 @@ bool CvBuildingEntry::CacheResults(Database::Results& kResults, CvDatabaseUtilit
 			bonusInfo.eUnitCombatType = (UnitCombatTypes)pResults->GetInt(4);
 			bonusInfo.iUnitProductionModifier = pResults->GetInt(5);
 
-			m_miBonusFromAccomplishments[iAccomplishment] = bonusInfo;
+			m_miBonusFromAccomplishments[iAccomplishment].push_back(bonusInfo);
 		}
 
 		pResults->Reset();
 
 		//Trim extra memory off container since this is mostly read-only.
-		std::map<int, AccomplishmentBonusInfo>(m_miBonusFromAccomplishments).swap(m_miBonusFromAccomplishments);
+		std::map<int, std::vector<AccomplishmentBonusInfo>>(m_miBonusFromAccomplishments).swap(m_miBonusFromAccomplishments);
 	}
 	// Building_ExtraPlayerInstancesFromAccomplishments 
 	// Table structure (BuildingType, AccomplishmentType, ExtraInstances)
@@ -4661,9 +4661,9 @@ std::map<int, std::map<int, int>> CvBuildingEntry::GetTechEnhancedYields() const
 	return m_miTechEnhancedYields;
 }
 
-std::map<int, AccomplishmentBonusInfo> CvBuildingEntry::GetBonusFromAccomplishments() const
+const std::map<int, std::vector<AccomplishmentBonusInfo>>& CvBuildingEntry::GetBonusFromAccomplishments() const
 {
-	return m_miBonusFromAccomplishments;
+    return m_miBonusFromAccomplishments;
 }
 
 std::map<int, std::map<int, int>> CvBuildingEntry::GetYieldChangesFromAccomplishments() const

--- a/CvGameCoreDLL_Expansion2/CvBuildingClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvBuildingClasses.h
@@ -655,7 +655,7 @@ public:
 	int* GetFeatureYieldChangeArray(int i) const;
 	int GetResourceYieldChangeGlobal(int iResource, int iYieldType) const;
 	std::map<int, std::map<int, int>> GetTechEnhancedYields() const;
-	std::map<int, AccomplishmentBonusInfo> GetBonusFromAccomplishments() const;
+	const std::map<int, std::vector<AccomplishmentBonusInfo>>& GetBonusFromAccomplishments() const;
 	std::map<int, std::map<int, int>> GetYieldChangesFromAccomplishments() const;
 	std::map<pair<GreatPersonTypes, EraTypes>, int> GetGreatPersonPointFromConstruction() const;
 	int GetImprovementYieldChange(int i, int j) const;
@@ -1107,7 +1107,7 @@ private:
 	int** m_ppaiFeatureYieldChange;
 	std::map<int, std::map<int, int>> m_ppiResourceYieldChangeGlobal;
 	std::map<int, std::map<int, int>> m_miTechEnhancedYields;
-	std::map<int, AccomplishmentBonusInfo> m_miBonusFromAccomplishments;
+	std::map<int, std::vector<AccomplishmentBonusInfo>> m_miBonusFromAccomplishments;
 	std::map<int, std::map<int, int>> m_miYieldChangesFromAccomplishments;
 	std::map<pair<GreatPersonTypes, EraTypes>, int> m_miGreatPersonPointFromConstruction;
 	CvDoubleYieldInfo* m_paYieldFromYield;

--- a/CvGameCoreDLL_Expansion2/CvBuildingProductionAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuildingProductionAI.cpp
@@ -567,11 +567,17 @@ int CvBuildingProductionAI::CheckBuildingBuildSanity(BuildingTypes eBuilding, in
 
 	if (!pkBuildingInfo->GetBonusFromAccomplishments().empty())
 	{
-		map<int, AccomplishmentBonusInfo> mBonusesFromAccomplishments = pkBuildingInfo->GetBonusFromAccomplishments();
-		map<int, AccomplishmentBonusInfo>::iterator it;
-		for (it = mBonusesFromAccomplishments.begin(); it != mBonusesFromAccomplishments.end(); it++)
+		for (std::map<int, std::vector<AccomplishmentBonusInfo>>::const_iterator it = pkBuildingInfo->GetBonusFromAccomplishments().begin(); it != pkBuildingInfo->GetBonusFromAccomplishments().end(); ++it)
 		{
-			iBonus += iHappinessValue + kPlayer.GetNumTimesAccomplishmentCompleted((AccomplishmentTypes)it->first) > 0 * it->second.iHappiness;
+			int iNum = kPlayer.GetNumTimesAccomplishmentCompleted((AccomplishmentTypes)it->first);
+			if (iNum > 0)
+			{
+				const std::vector<AccomplishmentBonusInfo>& vBonuses = it->second;
+				for (size_t i = 0; i < vBonuses.size(); i++)
+				{
+					iBonus += iHappinessValue + (iNum * vBonuses[i].iHappiness);
+				}
+			}
 		}
 	}
 
@@ -986,13 +992,21 @@ int CvBuildingProductionAI::CheckBuildingBuildSanity(BuildingTypes eBuilding, in
 			}
 			if (!pkBuildingInfo->GetBonusFromAccomplishments().empty())
 			{
-				map<int, AccomplishmentBonusInfo> mBonusesFromAccomplishments = pkBuildingInfo->GetBonusFromAccomplishments();
-				map<int, AccomplishmentBonusInfo>::iterator it;
-				for (it = mBonusesFromAccomplishments.begin(); it != mBonusesFromAccomplishments.end(); it++)
+				for (std::map<int, std::vector<AccomplishmentBonusInfo>>::const_iterator it = pkBuildingInfo->GetBonusFromAccomplishments().begin(); it != pkBuildingInfo->GetBonusFromAccomplishments().end(); ++it)
 				{
-					if (it->second.eDomainType == eTestDomain)
+					int iNum = kPlayer.GetNumTimesAccomplishmentCompleted((AccomplishmentTypes)it->first);
+					if (iNum > 0)
 					{
-						iTempBonus += m_pCity->getDomainFreeExperience(eTestDomain) + kPlayer.GetNumTimesAccomplishmentCompleted((AccomplishmentTypes)it->first) > 0 * it->second.iDomainXP;
+						const std::vector<AccomplishmentBonusInfo>& vBonuses = it->second;
+						for (size_t i = 0; i < vBonuses.size(); i++)
+						{
+							const AccomplishmentBonusInfo& bonusInfo = vBonuses[i];
+							if (bonusInfo.eDomainType == eTestDomain)
+							{
+								iTempBonus += m_pCity->getDomainFreeExperience(eTestDomain)
+									+ (iNum * bonusInfo.iDomainXP);
+							}
+						}
 					}
 				}
 			}
@@ -1047,13 +1061,21 @@ int CvBuildingProductionAI::CheckBuildingBuildSanity(BuildingTypes eBuilding, in
 				}
 				if (!pkBuildingInfo->GetBonusFromAccomplishments().empty())
 				{
-					map<int, AccomplishmentBonusInfo> mBonusesFromAccomplishments = pkBuildingInfo->GetBonusFromAccomplishments();
-					map<int, AccomplishmentBonusInfo>::iterator it;
-					for (it = mBonusesFromAccomplishments.begin(); it != mBonusesFromAccomplishments.end(); it++)
+					for (std::map<int, std::vector<AccomplishmentBonusInfo>>::const_iterator it = pkBuildingInfo->GetBonusFromAccomplishments().begin(); it != pkBuildingInfo->GetBonusFromAccomplishments().end(); ++it)
 					{
-						if (it->second.eUnitCombatType == eUnitCombatClass)
+						int iNum = kPlayer.GetNumTimesAccomplishmentCompleted((AccomplishmentTypes)it->first);
+						if (iNum > 0)
 						{
-							iTempBonus += m_pCity->getUnitCombatProductionModifier(eUnitCombatClass) + kPlayer.GetNumTimesAccomplishmentCompleted((AccomplishmentTypes)it->first) > 0 * it->second.iUnitProductionModifier;
+							const std::vector<AccomplishmentBonusInfo>& vBonuses = it->second;
+							for (size_t i = 0; i < vBonuses.size(); i++)
+							{
+								const AccomplishmentBonusInfo& bonusInfo = vBonuses[i];
+								if (bonusInfo.eUnitCombatType == eUnitCombatClass)
+								{
+									iTempBonus += m_pCity->getUnitCombatProductionModifier(eUnitCombatClass)
+										+ (iNum * bonusInfo.iUnitProductionModifier);
+								}
+							}
 						}
 					}
 				}

--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -14900,30 +14900,34 @@ void CvCity::processBuilding(BuildingTypes eBuilding, int iChange, bool bFirst, 
 			}
 		}
 
-		// Building Yield Change with Technology
+		// Building Bonuses from Accomplishments
 		if (!pBuildingInfo->GetBonusFromAccomplishments().empty())
 		{
-			map<int, AccomplishmentBonusInfo> mBonusFromAccomplishments = pBuildingInfo->GetBonusFromAccomplishments();
-			map<int, AccomplishmentBonusInfo>::iterator it;
-			for (it = mBonusFromAccomplishments.begin(); it != mBonusFromAccomplishments.end(); ++it)
+			const std::map<int, std::vector<AccomplishmentBonusInfo>>& mBonusFromAccomplishments = pBuildingInfo->GetBonusFromAccomplishments();
+			for (std::map<int, std::vector<AccomplishmentBonusInfo>>::const_iterator it = mBonusFromAccomplishments.begin(); it != mBonusFromAccomplishments.end(); ++it)
 			{
-				int iNumAccomplishmentCompleted = GET_PLAYER(getOwner()).GetNumTimesAccomplishmentCompleted((AccomplishmentTypes)it->first);
+				int iNumAccomplishmentCompleted =
+					GET_PLAYER(getOwner()).GetNumTimesAccomplishmentCompleted((AccomplishmentTypes)it->first);
+			
 				if (iNumAccomplishmentCompleted > 0)
 				{
-					AccomplishmentBonusInfo bonusInfo = it->second;
-					// apply bonuses for completed accomplishments
-					ChangeBaseHappinessFromBuildings(bonusInfo.iHappiness * iNumAccomplishmentCompleted * iChange);
-					if (bonusInfo.eDomainType != NO_DOMAIN)
+					const std::vector<AccomplishmentBonusInfo>& vBonuses = it->second;
+					for (size_t i = 0; i < vBonuses.size(); i++)
 					{
-						changeDomainFreeExperience(bonusInfo.eDomainType, bonusInfo.iDomainXP * iNumAccomplishmentCompleted * iChange);
-					}
-					if (bonusInfo.eUnitCombatType != NO_UNITCOMBAT)
-					{
-						changeUnitCombatProductionModifier(bonusInfo.eUnitCombatType, bonusInfo.iUnitProductionModifier * iNumAccomplishmentCompleted* iChange);
+						const AccomplishmentBonusInfo& bonusInfo = vBonuses[i];
+			
+						ChangeBaseHappinessFromBuildings(bonusInfo.iHappiness * iNumAccomplishmentCompleted * iChange);
+			
+						if (bonusInfo.eDomainType != NO_DOMAIN)
+							changeDomainFreeExperience(bonusInfo.eDomainType,
+								bonusInfo.iDomainXP * iNumAccomplishmentCompleted * iChange);
+			
+						if (bonusInfo.eUnitCombatType != NO_UNITCOMBAT)
+							changeUnitCombatProductionModifier(bonusInfo.eUnitCombatType,
+								bonusInfo.iUnitProductionModifier * iNumAccomplishmentCompleted * iChange);
 					}
 				}
-				// for future accomplishments, we store a list of the accomplishments for which bonuses are given.
-				// when one of the accomplishments is completed later, we apply the bonuses by looping through the city buildings directly
+			
 				AddToAccomplishmentsWithBonuses((AccomplishmentTypes)it->first);
 			}
 		}

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -37633,19 +37633,31 @@ void CvPlayer::CompleteAccomplishment(AccomplishmentTypes eAccomplishment)
 				for (size_t iI = 0; iI < vCityBuildings.size(); iI++)
 				{
 					CvBuildingEntry* pkBuildingInfo = GC.getBuildingInfo(vCityBuildings[iI]);
-					if (pkBuildingInfo->GetBonusFromAccomplishments().count(eAccomplishment) > 0)
+					const std::map<int, std::vector<AccomplishmentBonusInfo>>& bonusMap = pkBuildingInfo->GetBonusFromAccomplishments();
+					std::map<int, std::vector<AccomplishmentBonusInfo>>::const_iterator it = bonusMap.find(eAccomplishment);
+					if (it != bonusMap.end())
 					{
-						AccomplishmentBonusInfo bonusInfo = pkBuildingInfo->GetBonusFromAccomplishments()[eAccomplishment];
-						// apply the bonuses
-						pLoopCity->ChangeBaseHappinessFromBuildings(bonusInfo.iHappiness);
-						if (bonusInfo.eDomainType != NO_DOMAIN)
-						{
-							pLoopCity->changeDomainFreeExperience(bonusInfo.eDomainType, bonusInfo.iDomainXP);
-						}
-						if (bonusInfo.eUnitCombatType != NO_UNITCOMBAT)
-						{
-							pLoopCity->changeUnitCombatProductionModifier(bonusInfo.eUnitCombatType, bonusInfo.iUnitProductionModifier);
-						}
+					    const std::vector<AccomplishmentBonusInfo>& vBonuses = it->second;
+					    for (size_t iBonus = 0; iBonus < vBonuses.size(); iBonus++)
+					    {
+					        const AccomplishmentBonusInfo& bonusInfo = vBonuses[iBonus];
+					        // apply the bonuses
+					        pLoopCity->ChangeBaseHappinessFromBuildings(bonusInfo.iHappiness);
+					        if (bonusInfo.eDomainType != NO_DOMAIN)
+					        {
+					            pLoopCity->changeDomainFreeExperience(
+					                bonusInfo.eDomainType,
+					                bonusInfo.iDomainXP
+					            );
+					        }
+					        if (bonusInfo.eUnitCombatType != NO_UNITCOMBAT)
+					        {
+					            pLoopCity->changeUnitCombatProductionModifier(
+					                bonusInfo.eUnitCombatType,
+					                bonusInfo.iUnitProductionModifier
+					            );
+					        }
+					    }
 					}
 				}
 			}


### PR DESCRIPTION
addresses #12539
note also I found there was an operator precedence bug in the building production AI (manual says > happens after *)

I got in a bit of a knife-fight with the msvc compiler. Clang was happy but something about the pkBuildingInfo-> reference stopped it getting the right iterator with auto&. My python brain doesn't understand this, but if someone looks and sees I did it in a weird way, please correct it.

In game, it appears to be working fine.
