### PR TITLE
(9-39a) implementation

### DIFF
--- a/(2) Vox Populi/Database Changes/Civilizations/Greece.sql
+++ b/(2) Vox Populi/Database Changes/Civilizations/Greece.sql
@@ -17,14 +17,13 @@ SET
 			)
 		)
 	),
-	Combat = (SELECT Combat FROM Units WHERE Type = 'UNIT_SPEARMAN') + 2
+	Combat = (SELECT Combat FROM Units WHERE Type = 'UNIT_SPEARMAN') + 1
 WHERE Type = 'UNIT_GREEK_HOPLITE';
 
 INSERT INTO Unit_FreePromotions
 	(UnitType, PromotionType)
 VALUES
-	('UNIT_GREEK_HOPLITE', 'PROMOTION_ADJACENT_BONUS'),
-	('UNIT_GREEK_HOPLITE', 'PROMOTION_SPAWN_GENERALS_II');
+	('UNIT_GREEK_HOPLITE', 'PROMOTION_ADJACENT_BONUS');
 
 ----------------------------------------------------------
 -- Unique Unit: Klepht (Commando)

--- a/(2) Vox Populi/Database Changes/Text/en_US/Civilizations/CivilizationTextChanges.sql
+++ b/(2) Vox Populi/Database Changes/Text/en_US/Civilizations/CivilizationTextChanges.sql
@@ -366,7 +366,7 @@ SET Text = '[ICON_INFLUENCE] Influence degrades at half and recovers at twice th
 WHERE Tag = 'TXT_KEY_TRAIT_CITY_STATE_FRIENDSHIP';
 
 UPDATE Language_en_US
-SET Text = 'The {TXT_KEY_UNIT_GREEK_HOPLITE} is the Greek unique unit, replacing the {TXT_KEY_UNIT_SPEARMAN}. It is stronger when adjacent to more owned land units, and generates[ICON_GREAT_GENERAL] Great Generals faster through combat.'
+SET Text = 'The {TXT_KEY_UNIT_GREEK_HOPLITE} is the Greek unique unit, replacing the {TXT_KEY_UNIT_SPEARMAN}. It is stronger when adjacent to more owned land units, and these other units don''t need to be next to the enemy in order to boost the {TXT_KEY_UNIT_GREEK_HOPLITE}''s strength.'
 WHERE Tag = 'TXT_KEY_UNIT_GREEK_HOPLITE_STRATEGY';
 
 --------------------

--- a/(2) Vox Populi/Database Changes/Text/en_US/UnitPromotions/PromotionTextChanges.sql
+++ b/(2) Vox Populi/Database Changes/Text/en_US/UnitPromotions/PromotionTextChanges.sql
@@ -583,7 +583,7 @@ SET Text = 'Unity'
 WHERE Tag = 'TXT_KEY_PROMOTION_DISCIPLINE';
 
 UPDATE Language_en_US
-SET Text = '+10% [ICON_STRENGTH] Combat Strength.[NEWLINE]+15% [ICON_STRENGTH] Combat Strength per [COLOR_POSITIVE_TEXT]Adjacent Owned Land Unit[ENDCOLOR].'
+SET Text = '+15% [ICON_STRENGTH] Combat Strength per [COLOR_POSITIVE_TEXT]Adjacent Owned Land Unit[ENDCOLOR].'
 WHERE Tag = 'TXT_KEY_PROMOTION_DISCIPLINE_HELP';
 
 -- Bonus vs Mounted (50)

--- a/(2) Vox Populi/Database Changes/UnitPromotions/PromotionChanges.sql
+++ b/(2) Vox Populi/Database Changes/UnitPromotions/PromotionChanges.sql
@@ -842,7 +842,6 @@ UPDATE UnitPromotions SET NukeImmune = 1 WHERE Type = 'PROMOTION_SHIELDED_SILO';
 UPDATE UnitPromotions SET ExtraWithdrawal = 100 WHERE Type = 'PROMOTION_WITHDRAW_BEFORE_MELEE';
 
 -- Hoplite: Unity
-UPDATE UnitPromotions SET CombatPercent = 10 WHERE Type = 'PROMOTION_ADJACENT_BONUS';
 INSERT INTO UnitPromotions_CombatModPerAdjacentUnitCombat
 	(PromotionType, UnitCombatType, Modifier)
 SELECT
@@ -874,7 +873,7 @@ VALUES
 -- Companion Cavalry: Great Generals I
 UPDATE UnitPromotions SET GreatGeneralModifier = 50 WHERE Type = 'PROMOTION_SPAWN_GENERALS_I';
 
--- Hoplite, Samurai: Great Generals II
+-- Samurai: Great Generals II
 UPDATE UnitPromotions SET GreatGeneralModifier = 100 WHERE Type = 'PROMOTION_SPAWN_GENERALS_II';
 
 -- Companion Cavalry: Transfer Movement to General


### PR DESCRIPTION
Proposal's thread: https://forums.civfanatics.com/threads/9-39a-greek-hoplite-nerf-alternative.701513/

Strategy text edited; no longer mentions extra Great General generation, and has a more useful info for those using the Hoplite for the first time.

Tested with IGE: unit CS, combat modifiers, promotion tooltip, Great General generation vs major civs.