### PR TITLE
Add bombardment highlight

### DIFF
--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.cpp
@@ -1623,15 +1623,28 @@ int CvLuaUnit::lCanRangeStrike(lua_State* L)
 	return BasicLuaMethod(L, &CvUnit::canRangeStrike);
 }
 //------------------------------------------------------------------------------
-//bool CanRangeStrikeAt(int iX, int iY)
+//bool CanRangeStrikeAt(int iX, int iY [, int sourceX, int sourceY, bool ignoreVision] )
 int CvLuaUnit::lCanEverRangeStrikeAt(lua_State* L)
 {
 	CvUnit* pkUnit = GetInstance(L);
 	const int x = lua_tointeger(L, 2);
 	const int y = lua_tointeger(L, 3);
 
-	const bool bResult = pkUnit->canEverRangeStrikeAt(x, y);
-	lua_pushboolean(L, bResult);
+	if ( lua_gettop(L) >= 5 )
+	{
+		const int sx = lua_tointeger(L, 4);
+		const int sy = lua_tointeger(L, 5);
+		const CvPlot* pTargetPlot = GC.getMap().plot(sx,sy) ;
+		const bool ignoreVision = luaL_optbool(L, 6, false) ; 
+		const bool bResult = pkUnit->canEverRangeStrikeAt(x, y, pTargetPlot, ignoreVision);
+		lua_pushboolean(L, bResult);
+	}
+	else 
+	{
+		const bool bResult = pkUnit->canEverRangeStrikeAt(x, y);
+		lua_pushboolean(L, bResult);
+	}
+
 	return 1;
 }
 

--- a/VPUI/Core/Highlights.xml
+++ b/VPUI/Core/Highlights.xml
@@ -11,6 +11,7 @@
 	<style name="GroupBorder" type="SplineBorder" width ="6" texture="spline_border_contour2.dds" color="255,128,0,200"/>
 	<style name="ValidFireTargetBorder" type="StaticTexture" texture="static_texture_highlight.dds"/>
 	<style name="FireRangeBorder" type="SplineBorder" width="6" texture="spline_border_contour2.dds" color="255,0,0,200"/>
+	<style name="RangedAttackPreview" type="SplineBorder" width ="2" texture="hex_contour1.dds" color="255,0,0,255" />
 	<style name="MovementRangeBorder" type="SplineBorder" width="6" texture="spline_border_contour2.dds" color="100,185,245,200"/>
 	<style name="AMRBorder" type="StaticTexture" texture="static_texture_highlight.dds"/>
 	<style name="TradeRoute" type="HexContour" width=".2" texture="hex_contour2.dds"/>


### PR DESCRIPTION
Adds plot highlighting showing which plots can be bombarded when [potentially] moving a ranged unit.

The highlight style is a thinner version of the normal ranged attack border, so it still looks decent when it occasionally overlaps with the movement border.

![20D850~1](https://github.com/user-attachments/assets/a6f02e57-8c57-4541-a3fb-bd31ad1ad8c4)
![20B356~1](https://github.com/user-attachments/assets/735b4cd3-7e5e-417c-ab0f-b38f7fcd4209)
