### PR TITLE
Revert dynamic_cast to static_cast in CvDllUnit.cpp

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvDllUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDllUnit.cpp
@@ -206,7 +206,7 @@ void CvDllUnit::GetPosition(int& iX, int& iY) const
 //------------------------------------------------------------------------------
 bool CvDllUnit::CanSwapWithUnitHere(ICvPlot1* pPlot) const
 {
-	CvPlot* pkPlot = (NULL != pPlot)? dynamic_cast<CvDllPlot*>(pPlot)->GetInstance() : NULL;
+	CvPlot* pkPlot = (NULL != pPlot)? static_cast<CvDllPlot*>(pPlot)->GetInstance() : NULL;
 	ASSERT(pkPlot != NULL);
 	if(pkPlot != NULL)
 		return m_pUnit->CanSwapWithUnitHere(*pkPlot);
@@ -216,8 +216,8 @@ bool CvDllUnit::CanSwapWithUnitHere(ICvPlot1* pPlot) const
 //------------------------------------------------------------------------------
 bool CvDllUnit::CanEmbarkOnto(ICvPlot1* pOriginPlot, ICvPlot1* pTargetPlot, bool bOverrideEmbarkedCheck) const
 {
-	CvPlot* pkOriginPlot = (NULL != pOriginPlot)? dynamic_cast<CvDllPlot*>(pOriginPlot)->GetInstance() : NULL;
-	CvPlot* pkTargetPlot = (NULL != pTargetPlot)? dynamic_cast<CvDllPlot*>(pTargetPlot)->GetInstance() : NULL;
+	CvPlot* pkOriginPlot = (NULL != pOriginPlot)? static_cast<CvDllPlot*>(pOriginPlot)->GetInstance() : NULL;
+	CvPlot* pkTargetPlot = (NULL != pTargetPlot)? static_cast<CvDllPlot*>(pTargetPlot)->GetInstance() : NULL;
 	ASSERT(pkOriginPlot != NULL);
 	ASSERT(pkTargetPlot != NULL);
 
@@ -229,8 +229,8 @@ bool CvDllUnit::CanEmbarkOnto(ICvPlot1* pOriginPlot, ICvPlot1* pTargetPlot, bool
 //------------------------------------------------------------------------------
 bool CvDllUnit::CanDisembarkOnto(ICvPlot1* pOriginPlot, ICvPlot1* pTargetPlot, bool bOverrideEmbarkedCheck) const
 {
-	CvPlot* pkOriginPlot = (NULL != pOriginPlot)? dynamic_cast<CvDllPlot*>(pOriginPlot)->GetInstance() : NULL;
-	CvPlot* pkTargetPlot = (NULL != pTargetPlot)? dynamic_cast<CvDllPlot*>(pTargetPlot)->GetInstance() : NULL;
+	CvPlot* pkOriginPlot = (NULL != pOriginPlot)? static_cast<CvDllPlot*>(pOriginPlot)->GetInstance() : NULL;
+	CvPlot* pkTargetPlot = (NULL != pTargetPlot)? static_cast<CvDllPlot*>(pTargetPlot)->GetInstance() : NULL;
 	ASSERT(pkOriginPlot != NULL);
 	ASSERT(pkTargetPlot != NULL);
 	if(pkOriginPlot != NULL && pkTargetPlot != NULL)
@@ -291,7 +291,7 @@ int CvDllUnit::MovesLeft() const
 //------------------------------------------------------------------------------
 bool CvDllUnit::CanMoveInto(ICvPlot1* pPlot, byte bMoveFlags) const
 {
-	CvPlot* pkPlot = (NULL != pPlot)? dynamic_cast<CvDllPlot*>(pPlot)->GetInstance() : NULL;
+	CvPlot* pkPlot = (NULL != pPlot)? static_cast<CvDllPlot*>(pPlot)->GetInstance() : NULL;
 	if(pkPlot != NULL)
 		return m_pUnit->canMoveInto(*pkPlot, bMoveFlags);
 	else
@@ -300,7 +300,7 @@ bool CvDllUnit::CanMoveInto(ICvPlot1* pPlot, byte bMoveFlags) const
 //------------------------------------------------------------------------------
 TeamTypes CvDllUnit::GetDeclareWarMove(ICvPlot1* pPlot) const
 {
-	CvPlot* pkPlot = (NULL != pPlot)? dynamic_cast<CvDllPlot*>(pPlot)->GetInstance() : NULL;
+	CvPlot* pkPlot = (NULL != pPlot)? static_cast<CvDllPlot*>(pPlot)->GetInstance() : NULL;
 	if(pkPlot != NULL)
 		return m_pUnit->GetDeclareWarMove(*pkPlot);
 	else


### PR DESCRIPTION
Complete the fix from PR #10730 which missed this file.

Reference: https://github.com/LoneGazebo/Community-Patch-DLL/pull/10730
Reference: https://github.com/Hello71/Community-Patch-DLL/commit/310e9626620866948a0c32f5782349ad4db58aed

dynamic_cast was incorrectly introduced in commit 4fbe2bf2c (cppcoreguidelines) to satisfy clang-tidy, but this pulls in RTTI which the DLL interface system is designed to avoid. The original Firaxis code used static_cast.