### PR TITLE
(9-67) Bastion Fort Takes City Strike Strength From Military Base

### DIFF
--- a/(2) Vox Populi/Database Changes/City/Buildings/BuildingChanges.sql
+++ b/(2) Vox Populi/Database Changes/City/Buildings/BuildingChanges.sql
@@ -845,7 +845,6 @@ WHERE BuildingClass = 'BUILDINGCLASS_ARSENAL';
 UPDATE Buildings
 SET
 	PrereqTech = 'TECH_RADAR',
-	RangedStrikeModifier = 10,
 	CitySupplyModifier = 5,
 	HealRateChange = 20,
 	DistressFlatReduction = 1,

--- a/(2) Vox Populi/Database Changes/City/Buildings/NewBuildings.xml
+++ b/(2) Vox Populi/Database Changes/City/Buildings/NewBuildings.xml
@@ -702,6 +702,7 @@
 			<Strategy>TXT_KEY_BUILDING_BASTION_FORT_STRATEGY</Strategy>
 			<PrereqTech>TECH_NAVIGATION</PrereqTech>
 			<CityIndirectFire>true</CityIndirectFire>
+			<RangedStrikeModifier>10</RangedStrikeModifier>
 			<CitySupplyModifier>10</CitySupplyModifier>
 			<HealRateChange>5</HealRateChange>
 			<EmpireSizeModifierReduction>-5</EmpireSizeModifierReduction>

--- a/(2) Vox Populi/Database Changes/City/Buildings/PreBuildingChanges.sql
+++ b/(2) Vox Populi/Database Changes/City/Buildings/PreBuildingChanges.sql
@@ -260,6 +260,7 @@ SET
 	PrereqTech = (SELECT PrereqTech FROM Buildings WHERE Type = 'BUILDING_BASTION_FORT'),
 	FreeStartEra = (SELECT FreeStartEra FROM Buildings WHERE Type = 'BUILDING_BASTION_FORT'),
 	CityIndirectFire = (SELECT CityIndirectFire FROM Buildings WHERE Type = 'BUILDING_BASTION_FORT'),
+	RangedStrikeModifier = (SELECT RangedStrikeModifier FROM Buildings WHERE Type = 'BUILDING_BASTION_FORT'),
 	CitySupplyModifier = (SELECT CitySupplyModifier FROM Buildings WHERE Type = 'BUILDING_BASTION_FORT'),
 	HealRateChange = (SELECT HealRateChange FROM Buildings WHERE Type = 'BUILDING_BASTION_FORT'),
 	EmpireSizeModifierReduction = (SELECT EmpireSizeModifierReduction FROM Buildings WHERE Type = 'BUILDING_BASTION_FORT'),


### PR DESCRIPTION
Proposal thread: https://forums.civfanatics.com/threads/9-67-bastion-fort-takes-city-strike-strength-from-military-base.701463/

RangedStrikeModifier added on NewBuildings.xml, requires update to Russia's Ostrog UB in PreBuildingChanges.sql.

Tested with IGE: base Bastion Fort, Military base and Russia's Ostrog ranged strike strength.