### PR TITLE
Lost Codex PediaType from PEDIA_SCOUT to PEDIA_SCOUTING

### DIFF
--- a/(2) Vox Populi/Database Changes/UnitPromotions/NewPromotions.xml
+++ b/(2) Vox Populi/Database Changes/UnitPromotions/NewPromotions.xml
@@ -1201,7 +1201,7 @@
 			<Type>PROMOTION_LOST_CODEX</Type>
 			<Description>TXT_KEY_PROMOTION_LOST_CODEX</Description>
 			<Help>TXT_KEY_PROMOTION_LOST_CODEX_HELP</Help>
-			<PediaType>PEDIA_SCOUT</PediaType>
+			<PediaType>PEDIA_SCOUTING</PediaType>
 			<PediaEntry>TXT_KEY_PROMOTION_LOST_CODEX</PediaEntry>
 		</Row>
 		<Row>


### PR DESCRIPTION
A typo, PEDIA_SCOUT is not used anywhere.