### PR TITLE
Espionage QoL

### DIFF
--- a/(3a) VP - EUI Compatibility Files/LUA/CityBannerManager.lua
+++ b/(3a) VP - EUI Compatibility Files/LUA/CityBannerManager.lua
@@ -850,7 +850,7 @@ local function OnBannerClick( plotIndex )
 					local x, y = plot:GetX(), plot:GetY()
 					for _, spy in ipairs( g_activePlayer:GetEspionageSpies() ) do
 						if spy.CityX == x and spy.CityY == y then
-							hasSpy = spy.EstablishedSurveillance
+							hasSpy = spy.RevealCityScreen
 							break
 						end
 					end

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
@@ -16945,6 +16945,8 @@ int CvLuaPlayer::lGetEspionageSpies(lua_State* L)
 			CvCity* pCity = pPlot->getPlotCity();
 			if (pCity)
 			{
+				lua_pushboolean(L, pCity->GetCityEspionage()->GetRevealCityScreen( pkThisPlayer->GetID() ) );
+				lua_setfield(L,t,"RevealCityScreen");
 				lua_pushinteger(L, pkPlayerEspionage->CalcNetworkPointsPerTurn(pSpy->GetSpyState(), pCity, uiSpy));
 			}
 			else


### PR DESCRIPTION
Restores a currently broken EUI functionality which allows to directly open the city screen of another player's city by clicking the banner if a spy is present and has unlocked that action.