### PR TITLE
9-30 Change How "Heal Every Turn" Abilities Work

### DIFF
--- a/(1) Community Patch/Database Changes/UnitPromotions/PromotionTableChanges.sql
+++ b/(1) Community Patch/Database Changes/UnitPromotions/PromotionTableChanges.sql
@@ -349,3 +349,6 @@ ALTER TABLE UnitPromotions_Features ADD IgnoreTerrainCostIn boolean DEFAULT 0;
 -- Likewise, the cost of crossing a river isn't ignored by this
 ALTER TABLE UnitPromotions_Terrains ADD IgnoreTerrainCostFrom boolean DEFAULT 0;
 ALTER TABLE UnitPromotions_Features ADD IgnoreTerrainCostFrom boolean DEFAULT 0;
+
+-- Additonal healing for a flat amount each turn regardless of action taken
+ALTER TABLE UnitPromotions ADD FlatHealRate integer DEFAULT 0;

--- a/(2) Vox Populi/Core Files/Overrides/CivilopediaScreen.lua
+++ b/(2) Vox Populi/Core Files/Overrides/CivilopediaScreen.lua
@@ -3492,6 +3492,8 @@ CivilopediaCategory[CategoryPromotions].SelectArticle = function( promotionID, s
 		AnalyzePromotion("CanMoveAfterAttacking");
 		--AnalyzePromotion("AlwaysHeal");
 		if thisPromotion.AlwaysHeal then sText = sText.."[NEWLINE][ICON_BULLET][COLOR_POSITIVE_TEXT]Heal Every Turn[ENDCOLOR]"; end
+		--AnalyzePromotion("FlatHealRate");
+		if thisPromotion.FlatHealRate > 0 then sText = sText.."[NEWLINE][ICON_BULLET][COLOR_POSITIVE_TEXT]Heals an additional "..string.format("%d", thisPromotion.FlatHealRate).." HP each turn regardless of action taken[ENDCOLOR]"; end
 		--AnalyzePromotion("HealOutsideFriendly");
 		if thisPromotion.HealOutsideFriendly then sText = sText.."[NEWLINE][ICON_BULLET][COLOR_POSITIVE_TEXT]Heals outside friendly territory[ENDCOLOR]"; end
 		AnalyzePromotion("HillsDoubleMove");

--- a/(2) Vox Populi/Database Changes/Text/en_US/UnitPromotions/NewPromotionText.xml
+++ b/(2) Vox Populi/Database Changes/Text/en_US/UnitPromotions/NewPromotionText.xml
@@ -3,7 +3,7 @@
 	<Language_en_US>
 		<!-- Air Repair -->
 		<Row Tag="TXT_KEY_PROMOTION_AIR_REPAIR_HELP">
-			<Text>Unit will [COLOR_POSITIVE_TEXT]Heal Every Turn[ENDCOLOR], even if it performs an action.</Text>
+			<Text>Unit will [COLOR_POSITIVE_TEXT]Heal an additional 10 HP[ENDCOLOR] each turn, regardless of action taken.</Text>
 		</Row>
 
 		<Row Tag="TXT_KEY_PROMOTION_AIR_LOGISTICS">

--- a/(2) Vox Populi/Database Changes/Text/en_US/UnitPromotions/PromotionTextChanges.sql
+++ b/(2) Vox Populi/Database Changes/Text/en_US/UnitPromotions/PromotionTextChanges.sql
@@ -141,7 +141,7 @@ WHERE Tag = 'TXT_KEY_PROMOTION_SUPPLY_HELP';
 
 -- March
 UPDATE Language_en_US
-SET Text = 'Unit will [COLOR_POSITIVE_TEXT]Heal Every Turn[ENDCOLOR], even if it performs an action.'
+SET Text = 'Unit will [COLOR_POSITIVE_TEXT]Heal an additional 10 HP[ENDCOLOR] each turn, regardless of action taken.'
 WHERE Tag = 'TXT_KEY_PROMOTION_MARCH_HELP';
 
 -- Blitz
@@ -284,7 +284,7 @@ SET Text = '+25% [ICON_STRENGTH] Combat Strength when defending.[NEWLINE]+5 HP w
 WHERE Tag = 'TXT_KEY_PROMOTION_SURVIVALISM_2_HELP';
 
 UPDATE Language_en_US
-SET Text = 'Unit will [COLOR_POSITIVE_TEXT]Heal Every Turn[ENDCOLOR], even if it performs an action.[NEWLINE][ICON_RAZING] Pillaging costs no [ICON_MOVES] Movement.'
+SET Text = 'Unit will [COLOR_POSITIVE_TEXT]Heal an additional 10 HP[ENDCOLOR] each turn, regardless of action taken.[NEWLINE][ICON_RAZING] Pillaging costs no [ICON_MOVES] Movement.'
 WHERE Tag = 'TXT_KEY_PROMOTION_SURVIVALISM_3_HELP';
 
 UPDATE Language_en_US

--- a/(2) Vox Populi/Database Changes/UnitPromotions/PromotionChanges.sql
+++ b/(2) Vox Populi/Database Changes/UnitPromotions/PromotionChanges.sql
@@ -67,7 +67,7 @@ UPDATE UnitPromotions SET OpenDefense = 15 WHERE RankList = 'FORMATION';
 
 UPDATE UnitPromotions SET FlankAttackModifier = 25, AOEDamageOnKill = 10 WHERE Type = 'PROMOTION_OVERRUN';
 
-UPDATE UnitPromotions SET AlwaysHeal = 1 WHERE RankList = 'MARCH';
+UPDATE UnitPromotions SET FlatHealRate = 10 WHERE RankList = 'MARCH';
 
 UPDATE UnitPromotions SET ExtraAttacks = 1, CanMoveAfterAttacking = 1 WHERE Type = 'PROMOTION_BLITZ';
 
@@ -192,7 +192,7 @@ SET
 	DefenseMod = 25
 WHERE Type IN ('PROMOTION_SURVIVALISM_1', 'PROMOTION_SURVIVALISM_2');
 
-UPDATE UnitPromotions SET AlwaysHeal = 1, FreePillageMoves = 1 WHERE Type = 'PROMOTION_SURVIVALISM_3';
+UPDATE UnitPromotions SET FlatHealRate = 10, FreePillageMoves = 1 WHERE Type = 'PROMOTION_SURVIVALISM_3';
 
 UPDATE UnitPromotions SET VisibilityChange = 1, EmbarkExtraVisibility = 1 WHERE Type = 'PROMOTION_TRAILBLAZER_1';
 UPDATE UnitPromotions SET MovesChange = 1, ExtraNavalMovement = 1, River = 1 WHERE Type = 'PROMOTION_TRAILBLAZER_2';

--- a/(3a) VP - EUI Compatibility Files/LUA/EUI_tooltip_library.lua
+++ b/(3a) VP - EUI Compatibility Files/LUA/EUI_tooltip_library.lua
@@ -1403,6 +1403,7 @@ if civBE_mode then
 		-- Healing
 		s = s .. ComposeUnitPerkFlagHelpText(filteredPerkIDTable, "TXT_KEY_UNITPERK_ALWAYS_HEAL", "AlwaysHeal", s == "", prefix);
 		s = s .. ComposeUnitPerkFlagHelpText(filteredPerkIDTable, "TXT_KEY_UNITPERK_HEAL_OUTSIDE_FRIENDLY_TERRITORY", "HealOutsideFriendlyTerritory", s == "", prefix);
+		s = s .. ComposeUnitPerkNumberHelpText(filteredPerkIDTable, "TXT_KEY_UNITPERK_FLAT_HEAL_RATE", "FlatHealRate", s == "", prefix);
 		s = s .. ComposeUnitPerkNumberHelpText(filteredPerkIDTable, "TXT_KEY_UNITPERK_ENEMY_HEAL_CHANGE", "EnemyHealChange", s == "", prefix);
 		s = s .. ComposeUnitPerkNumberHelpText(filteredPerkIDTable, "TXT_KEY_UNITPERK_NEUTRAL_HEAL_CHANGE", "NeutralHealChange", s == "", prefix);
 		s = s .. ComposeUnitPerkNumberHelpText(filteredPerkIDTable, "TXT_KEY_UNITPERK_FRIENDLY_HEAL_CHANGE", "FriendlyHealChange", s == "", prefix);

--- a/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
@@ -792,7 +792,7 @@ void CvHomelandAI::PlotHealMoves()
 			}
 
 			int iDamageThreshold = 25;
-			if (pUnit->AI_getUnitAIType() == UNITAI_EXPLORE_SEA && pUnit->healRate(pUnit->plot()) == 0)
+			if (pUnit->AI_getUnitAIType() == UNITAI_EXPLORE_SEA && pUnit->ActualHealRate(pUnit->plot(), false) == 0)
 				iDamageThreshold = pUnit->GetMaxHitPoints() - 50;
 
 			// We are not particularly damaged
@@ -911,7 +911,7 @@ void CvHomelandAI::PlotSentryMoves()
 				continue;
 
 			// Very important sentry points (forts and workers) we don't want to leave unguarded
-			if (pSentry->atPlot(*pTarget) && m_TargetedSentryPoints[iI].GetAuxIntData() < 500 && (pSentry->getDamage() == 0 || !pSentry->canHeal(pSentry->plot())))
+			if (pSentry->atPlot(*pTarget) && m_TargetedSentryPoints[iI].GetAuxIntData() < 500 && (pSentry->getDamage() == 0 || pSentry->ActualHealRate(pSentry->plot()) == 0))
 			{
 				//check our immediate neighbors if we can increase our visibility significantly
 				int iBestCount = 1;

--- a/CvGameCoreDLL_Expansion2/CvPromotionClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPromotionClasses.cpp
@@ -212,6 +212,7 @@ CvPromotionEntry::CvPromotionEntry():
 	m_bMustSetUpToRangedAttack(false),
 	m_bRangedSupportFire(false),
 	m_bAlwaysHeal(false),
+	m_iFlatHealRate(0),
 	m_bHealOutsideFriendly(false),
 	m_bRiverDoubleMove(false),
 	m_bIgnoreTerrainCost(false),
@@ -463,6 +464,7 @@ bool CvPromotionEntry::CacheResults(Database::Results& kResults, CvDatabaseUtili
 	m_bMustSetUpToRangedAttack = kResults.GetBool("MustSetUpToRangedAttack");
 	m_bRangedSupportFire= kResults.GetBool("RangedSupportFire");
 	m_bAlwaysHeal = kResults.GetBool("AlwaysHeal");
+	m_iFlatHealRate = kResults.GetInt("FlatHealRate");
 	m_bHealOutsideFriendly = kResults.GetBool("HealOutsideFriendly");
 	m_bRiverDoubleMove = kResults.GetBool("RiverDoubleMove");
 	m_bIgnoreTerrainCost = kResults.GetBool("IgnoreTerrainCost");
@@ -2344,6 +2346,12 @@ bool CvPromotionEntry::IsRangedSupportFire() const
 bool CvPromotionEntry::IsAlwaysHeal() const
 {
 	return m_bAlwaysHeal;
+}
+
+/// Accessor: Unit heals an extra flat amount each turn regardless of action taken
+int CvPromotionEntry::GetFlatHealRate() const
+{
+	return m_iFlatHealRate;
 }
 
 /// Accessor: Unit can heal outside friendly territory (naval units)

--- a/CvGameCoreDLL_Expansion2/CvPromotionClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvPromotionClasses.h
@@ -232,6 +232,7 @@ public:
 	bool IsMustSetUpToRangedAttack() const;
 	bool IsRangedSupportFire() const;
 	bool IsAlwaysHeal() const;
+	int GetFlatHealRate() const;
 	bool IsHealOutsideFriendly() const;
 	bool IsRiverDoubleMove() const;
 
@@ -528,6 +529,7 @@ protected:
 	bool m_bMustSetUpToRangedAttack;
 	bool m_bRangedSupportFire;
 	bool m_bAlwaysHeal;
+	int m_iFlatHealRate;
 	bool m_bHealOutsideFriendly;
 	bool m_bRiverDoubleMove;
 	bool m_bIgnoreTerrainCost;

--- a/CvGameCoreDLL_Expansion2/CvUnit.h
+++ b/CvGameCoreDLL_Expansion2/CvUnit.h
@@ -415,6 +415,8 @@ public:
 	int GetDanger(const CvPlot* pAtPlot=NULL) const;
 	int GetDanger(const CvPlot* pAtPlot, const UnitIdContainer& unitsToIgnore, int iExtraDamage) const;
 
+	int ActualHealRate(const CvPlot* pPlot, bool bCheckMovement = true) const;
+
 	const CvPlot* getAirliftFromPlot(const CvPlot* pPlot) const;
 	const CvPlot* getAirliftToPlot(const CvPlot* pPlot, bool bIncludeCities) const;
 
@@ -1165,6 +1167,9 @@ public:
 	int getAlwaysHealCount() const;
 	bool isAlwaysHeal() const;
 	void changeAlwaysHealCount(int iChange);
+
+	int GetFlatHealRate() const;
+	void ChangeFlatHealRate(int iChange);
 
 	int getHealOutsideFriendlyCount() const;
 	bool isHealOutsideFriendly() const;
@@ -2112,6 +2117,7 @@ protected:
 	std::map<PromotionTypes, int> m_TurnPromotionGained;
 	int m_iRangedSupportFireCount;
 	int m_iAlwaysHealCount;
+	int m_iFlatHealRate;
 	int m_iHealOutsideFriendlyCount;
 	int m_iRiverDoubleMoveCount;
 	int m_iEmbarkFlatCostCount;
@@ -2544,6 +2550,7 @@ SYNC_ARCHIVE_VAR(SYNC_ARCHIVE_VAR_TYPE(std::map<PromotionTypes, int>), m_Promoti
 SYNC_ARCHIVE_VAR(SYNC_ARCHIVE_VAR_TYPE(std::map<PromotionTypes, int>), m_TurnPromotionGained)
 SYNC_ARCHIVE_VAR(int, m_iRangedSupportFireCount)
 SYNC_ARCHIVE_VAR(int, m_iAlwaysHealCount)
+SYNC_ARCHIVE_VAR(int, m_iFlatHealRate)
 SYNC_ARCHIVE_VAR(int, m_iHealOutsideFriendlyCount)
 SYNC_ARCHIVE_VAR(int, m_iRiverDoubleMoveCount)
 SYNC_ARCHIVE_VAR(int, m_iEmbarkFlatCostCount)

--- a/CvGameCoreDLL_Expansion2/CvUnitMission.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnitMission.cpp
@@ -1099,7 +1099,7 @@ bool CvUnitMission::CanStartMission(CvUnit* hUnit, int iMission, int iData1, int
 	}
 	else if(iMission == CvTypes::getMISSION_HEAL())
 	{
-		if(hUnit->IsHurt() && hUnit->canHeal(pPlot, false)) //next turn is also ok
+		if(hUnit->IsHurt() && hUnit->ActualHealRate(pPlot, false) > 0) //next turn is also ok
 		{
 			return true;
 		}

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.cpp
@@ -1454,7 +1454,7 @@ int CvLuaUnit::lCanHeal(lua_State* L)
 {
 	CvUnit* pkUnit = GetInstance(L);
 	CvPlot* pkPlot = CvLuaPlot::GetInstance(L, 2);
-	const bool bResult = pkUnit->IsHurt() && pkUnit->canHeal(pkPlot);
+	const bool bResult = pkUnit->IsHurt() && pkUnit->ActualHealRate(pkPlot) > 0;
 
 	lua_pushboolean(L, bResult);
 	return 1;


### PR DESCRIPTION
Add new UnitPromotions integer column FlatHealRate. Units with this promotion property heal a flat extra amount each turn regardless of action taken.

Replace AlwaysHeal=1 with FlatHealRate=10 for relevant promotions (march, skirmisher march, air repair, survivalism 3).

Remove healRate call from canHeal function and add new ActualHealRate function in CvPlayer.

Replace all calls to both healRate and canHeal with ActualHealRate since that is what we actually care about in all cases. Should improve a lot of AI behavior related to healing, like thinking it could heal when it couldn't.

Should give a performance increase since we no longer call healRate when we don't need to.