### PR TITLE
 Tactical AI tuneup and fixes 

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvDangerPlots.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDangerPlots.cpp
@@ -874,6 +874,13 @@ int CvDangerPlotContents::GetDanger(const CvUnit* pUnit, const UnitIdContainer& 
 			//todo: consider whether the enemy units would block each other from attacking?
 			int iDamage = TacticalAIHelpers::GetSimulatedDamageFromAttackOnUnit(pUnit, pAttacker, m_pPlot, bOutOfRange ? NULL : pAttacker->plot(), iAttackerDamage, false, iExtraDamage, true);
 
+			//assume units will do AoE damage on move once per turn
+			int iAoEDamage = pAttacker->getAoEDamageOnMove();
+			if (iAoEDamage > 0)
+			{
+				iDamage += iAoEDamage;
+			}
+
 			if (!m_pPlot->IsKnownVisibleToTeam(pAttacker->getTeam()))
 				iDamage = (iDamage * 80) / 100; //there's a chance they won't spot us
 

--- a/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
@@ -282,6 +282,10 @@ CvPlot* CvHomelandAI::GetBestExploreTarget(const CvUnit* pUnit, int nMinCandidat
 		{
 			if (pLoopUnit->AI_getUnitAIType() != UNITAI_EXPLORE && pLoopUnit->AI_getUnitAIType() != UNITAI_EXPLORE_SEA)
 				continue;
+
+			//these units only explore near owned cities
+			if (pLoopUnit->getUnitCombatType() != (UnitCombatTypes)GC.getInfoTypeForString("UNITCOMBAT_RECON", true) && !pLoopUnit->IsGainsXPFromScouting())
+				continue;
 		}
 
 		int iLoopX = pLoopUnit->getX();
@@ -361,7 +365,7 @@ CvPlot* CvHomelandAI::GetBestExploreTarget(const CvUnit* pUnit, int nMinCandidat
 		int iRating = EconomicAIHelpers::ScoreExplorePlot(pEvalPlot, m_pPlayer, pUnit->getDomainType(), pUnit->isEmbarked(), bCanPopGoody);
 
 		int iNearbyPenalty = 0;
-
+		bool bSkip = false;
 		// Add a bonus based on how far away all other explorers are from this plot
 		for (std::vector<pair<int, int>>::iterator it = vOtherExplorerCoordinates.begin(); it != vOtherExplorerCoordinates.end(); ++it)
 		{
@@ -369,11 +373,15 @@ CvPlot* CvHomelandAI::GetBestExploreTarget(const CvUnit* pUnit, int nMinCandidat
 
 			if (iDistToOther == 0)
 			{
+				bSkip = true;
 				break;
 			}
 
 			iNearbyPenalty += 100 / iDistToOther;
 		}
+
+		if (bSkip)
+			continue;
 
 		iRating -= iNearbyPenalty;
 
@@ -448,22 +456,51 @@ void CvHomelandAI::FindHomelandTargets()
 			// If the city needs a garrison, it has been handled already by tactical AI
 			if(pCity != NULL && m_pPlayer->GetID() == pCity->getOwner() && !pCity->NeedsGarrison())
 			{
-				int iEstimatedCityStrengthNoGarrison = pCity->getStrengthValue();
-				CvUnit* pGarrisonedUnit = pCity->GetGarrisonedUnit();
-				if (pGarrisonedUnit)
-				{
-					int iStrengthFromGarrison = (max(pGarrisonedUnit->GetBaseCombatStrength(), pGarrisonedUnit->GetBaseRangedCombatStrength()) * 100) /
-						(pGarrisonedUnit->getDomainType() == DOMAIN_LAND ? /*500 in CP, 200 in VP*/GD_INT_GET(CITY_STRENGTH_LAND_UNIT_DIVISOR) : /*500 in CP, 400 in VP*/ GD_INT_GET(CITY_STRENGTH_NAVAL_UNIT_DIVISOR));
+				int iNearbyUnowned = 0;
 
-					iEstimatedCityStrengthNoGarrison -= (iStrengthFromGarrison * 100);
+				// This city may be exposed
+				for (int iJ = RING2_PLOTS; iJ < RING3_PLOTS; iJ++)
+				{
+					CvPlot* pNearbyPlot = iterateRingPlots(pLoopPlot, iJ);
+					if (pNearbyPlot && pNearbyPlot->getTeam() != eTeam)
+					{
+						if (pNearbyPlot->getOwner() != NO_PLAYER)
+							iNearbyUnowned = 6;
+						else
+							iNearbyUnowned++;
+
+						if (iNearbyUnowned > 5)
+							break;
+					}
 				}
-				if (bBonusFromGarrisons || (bBonusFromCityStrength && iEstimatedCityStrengthNoGarrison < GD_INT_GET(CITY_STRENGTH_THRESHOLD_FOR_BONUSES) * 100))
+
+				if (iNearbyUnowned > 5)
 				{
 					newTarget.SetTargetType(AI_HOMELAND_TARGET_CITY);
 					newTarget.SetTargetX(pLoopPlot->getX());
 					newTarget.SetTargetY(pLoopPlot->getY());
-					newTarget.SetAuxIntData(pCity->getThreatValue());
+					newTarget.SetAuxIntData(70);
 					m_TargetedCities.push_back(newTarget);
+				}
+				else
+				{
+					int iEstimatedCityStrengthNoGarrison = pCity->getStrengthValue();
+					CvUnit* pGarrisonedUnit = pCity->GetGarrisonedUnit();
+					if (pGarrisonedUnit)
+					{
+						int iStrengthFromGarrison = (max(pGarrisonedUnit->GetBaseCombatStrength(), pGarrisonedUnit->GetBaseRangedCombatStrength()) * 100) /
+							(pGarrisonedUnit->getDomainType() == DOMAIN_LAND ? /*500 in CP, 200 in VP*/GD_INT_GET(CITY_STRENGTH_LAND_UNIT_DIVISOR) : /*500 in CP, 400 in VP*/ GD_INT_GET(CITY_STRENGTH_NAVAL_UNIT_DIVISOR));
+
+						iEstimatedCityStrengthNoGarrison -= (iStrengthFromGarrison * 100);
+					}
+					if (bBonusFromGarrisons || (bBonusFromCityStrength && iEstimatedCityStrengthNoGarrison < GD_INT_GET(CITY_STRENGTH_THRESHOLD_FOR_BONUSES) * 100))
+					{
+						newTarget.SetTargetType(AI_HOMELAND_TARGET_CITY);
+						newTarget.SetTargetX(pLoopPlot->getX());
+						newTarget.SetTargetY(pLoopPlot->getY());
+						newTarget.SetAuxIntData(30);
+						m_TargetedCities.push_back(newTarget);
+					}
 				}
 			}
 			// ... antiquity site?
@@ -577,7 +614,7 @@ void CvHomelandAI::AssignHomelandMoves()
 	ExecuteUnitGift();
 
 	//civilian and military
-	PlotHealMoves();
+	PlotHealMoves(true);
 
 	PlotOpportunisticSettlementMoves();
 	PlotExplorerMoves();
@@ -610,6 +647,7 @@ void CvHomelandAI::AssignHomelandMoves()
 	PlotUpgradeMoves();
 	PlotOpportunityAttacks();
 	PlotGarrisonMoves();
+	PlotHealMoves(false);
 	PlotSentryMoves();
 	PlotSentryNavalMoves();
 	PlotPatrolMoves();
@@ -773,7 +811,7 @@ void CvHomelandAI::PlotGarrisonMoves()
 
 
 /// Find out which units would like to heal
-void CvHomelandAI::PlotHealMoves()
+void CvHomelandAI::PlotHealMoves(bool bConservative)
 {
 	ClearCurrentMoveUnits(AI_HOMELAND_MOVE_HEAL);
 
@@ -795,6 +833,9 @@ void CvHomelandAI::PlotHealMoves()
 			int iDamageThreshold = 25;
 			if (pUnit->AI_getUnitAIType() == UNITAI_EXPLORE_SEA && pUnit->ActualHealRate(pUnit->plot(), false) == 0)
 				iDamageThreshold = pUnit->GetMaxHitPoints() - 50;
+
+			if (!bConservative)
+				iDamageThreshold = 0;
 
 			// We are not particularly damaged
 			if (pUnit->getDamage() <= iDamageThreshold)
@@ -3189,7 +3230,9 @@ static bool IsBestDirectiveForPlot(BuilderDirective eDirective, CvPlayer* pPlaye
 			continue;
 
 		int iOtherDirectiveScore = eOtherDirective.GetPotentialScore();
-		if (iOtherDirectiveScore > iDirectiveScore)
+
+		// special case for scrubbing fallout, always do that first
+		if (iOtherDirectiveScore > iDirectiveScore || (pkOtherBuildInfo && pkOtherBuildInfo->isFeatureRemove(FEATURE_FALLOUT) && (!pkBuildInfo || !pkBuildInfo->isFeatureRemove(FEATURE_FALLOUT))))
 		{
 			if (eOtherDirective.m_eBuild != NO_BUILD && !pPlayer->canBuild(pPlot, eOtherDirective.m_eBuild, true))
 				continue;
@@ -4058,29 +4101,52 @@ void CvHomelandAI::ExecuteHeals()
 		if (!pUnit)
 			continue;
 
-		//this is not optimal, ideally we would decide on a target plot and then pillage along the way if possible
-		//but it should be good enough
-		CvPlot* pBestPlot = TacticalAIHelpers::FindClosestSafePlotForHealing(pUnit, true);
-		if (!pBestPlot)
-			pBestPlot = TacticalAIHelpers::FindClosestSafePlotForHealing(pUnit, false);
-		if (!pBestPlot)
-			pBestPlot = TacticalAIHelpers::FindSafestPlotInReach(pUnit, true);
-
-		// Check if we can pillage this tile for free
-		if (pUnit->hasFreePillageMove())
+		for (int iI = 0; iI < 3 && pUnit->canMove(); iI++)
 		{
+			//this is not optimal, ideally we would decide on a target plot and then pillage along the way if possible
+			//but it should be good enough
+			pair<CvPlot*, int> pBestPlot = TacticalAIHelpers::FindClosestSafePlotForHealing(pUnit, true);
+			if (!pBestPlot.first)
+				pBestPlot = TacticalAIHelpers::FindClosestSafePlotForHealing(pUnit, false);
+			if (!pBestPlot.first)
+				pBestPlot = TacticalAIHelpers::FindSafestPlotInReach(pUnit, true);
+
+			if (pBestPlot.first == pUnit->plot())
+			{
+				break;
+			}
+
+			int iUsedMoves = 0;
+
+			// Check if we can pillage this tile for free
+			if (pUnit->hasFreePillageMove() || pBestPlot.second > GD_INT_GET(MOVE_DENOMINATOR))
+			{
+				if (pUnit->shouldPillage(pUnit->plot(), true))
+				{
+					pUnit->PushMission(CvTypes::getMISSION_PILLAGE());
+					if (!pUnit->hasFreePillageMove())
+						iUsedMoves++;
+				}
+			}
+
+			// if possible, pillage both improvement and road
+			if (pUnit->hasFreePillageMove() || pBestPlot.second > (1 + iUsedMoves) * GD_INT_GET(MOVE_DENOMINATOR))
+			{
+				if (pUnit->shouldPillage(pUnit->plot(), true))
+				{
+					pUnit->PushMission(CvTypes::getMISSION_PILLAGE());
+					if (!pUnit->hasFreePillageMove())
+						iUsedMoves++;
+				}
+			}
+
+			if (pBestPlot.first && pBestPlot.first != pUnit->plot())
+				pUnit->PushMission(CvTypes::getMISSION_MOVE_TO(), pBestPlot.first->getX(), pBestPlot.first->getY(), CvUnit::MOVEFLAG_ABORT_IF_NEW_ENEMY_REVEALED);
 			if (pUnit->shouldPillage(pUnit->plot(), true))
 				pUnit->PushMission(CvTypes::getMISSION_PILLAGE());
 			if (pUnit->shouldPillage(pUnit->plot(), true)) // if possible, pillage both improvement and road
 				pUnit->PushMission(CvTypes::getMISSION_PILLAGE());
 		}
-
-		if (pBestPlot && pBestPlot!=pUnit->plot())
-			pUnit->PushMission(CvTypes::getMISSION_MOVE_TO(), pBestPlot->getX(), pBestPlot->getY());
-		if (pUnit->shouldPillage(pUnit->plot(), true))
-			pUnit->PushMission(CvTypes::getMISSION_PILLAGE());
-		if (pUnit->shouldPillage(pUnit->plot(), true)) // if possible, pillage both improvement and road
-			pUnit->PushMission(CvTypes::getMISSION_PILLAGE());
 		if (pUnit->canMove())
 			pUnit->PushMission(CvTypes::getMISSION_SKIP());
 		UnitProcessed(pUnit->GetID());
@@ -4092,28 +4158,38 @@ typedef CvWeightedVector<CvPlot*> WeightedPlotVector;
 /// Moves units to the hex with the lowest danger
 void CvHomelandAI::ExecuteMovesToSafestPlot(CvUnit* pUnit)
 {
-	CvPlot* pBestPlot = TacticalAIHelpers::FindSafestPlotInReach(pUnit, true);
-	if (!pBestPlot)
-		return;
-
-	pUnit->PushMission(CvTypes::getMISSION_MOVE_TO(), pBestPlot->getX(), pBestPlot->getY());
-
-	//a bit tricky: we know that we should be able to reach the best plot
-	//but maybe the mission is aborted (new enemy discovered etc)
-	//can happen for AI civilians ...
-
-	for (int iLimit = 0; iLimit<9; iLimit++) //failsafe so we don't get stuck ...
+	CvPlot* pBestPlot = NULL;
+	for (int iI = 0; iI < 3 && pUnit->canMove(); iI++)
 	{
-		pBestPlot = TacticalAIHelpers::FindSafestPlotInReach(pUnit, true);
+		pBestPlot = TacticalAIHelpers::FindSafestPlotInReach(pUnit, true).first;
+		if (!pBestPlot)
+			return;
 
-		//can we move?
-		if (!pBestPlot || pUnit->plot() == pBestPlot || !pUnit->canMove())
-			break;
+		pUnit->PushMission(CvTypes::getMISSION_MOVE_TO(), pBestPlot->getX(), pBestPlot->getY(), CvUnit::MOVEFLAG_ABORT_IF_NEW_ENEMY_REVEALED);
 
-		pUnit->PushMission(CvTypes::getMISSION_MOVE_TO(), pBestPlot->getX(), pBestPlot->getY());
-	} 
+		//a bit tricky: we know that we should be able to reach the best plot
+		//but maybe the mission is aborted (new enemy discovered etc)
+		//can happen for AI civilians ...
 
-	//important, else we can't end the turn
+		for (int iLimit = 0; iLimit < 9; iLimit++) //failsafe so we don't get stuck ...
+		{
+			pBestPlot = TacticalAIHelpers::FindSafestPlotInReach(pUnit, true).first;
+
+			//can we move?
+			if (!pBestPlot || pUnit->plot() == pBestPlot || !pUnit->canMove())
+				break;
+
+			pUnit->PushMission(CvTypes::getMISSION_MOVE_TO(), pBestPlot->getX(), pBestPlot->getY());
+
+			if (pBestPlot == pUnit->plot())
+			{
+				break;
+			}
+		}
+	}
+
+	if (pUnit->canMove())
+		pUnit->PushMission(CvTypes::getMISSION_SKIP());
 	UnitProcessed(pUnit->GetID());
 
 	if(GC.getLogging() && GC.getAILogging() && pBestPlot)
@@ -5054,7 +5130,7 @@ void CvHomelandAI::ExecuteProphetMoves()
 				int iFlags = CvUnit::MOVEFLAG_NO_ENEMY_TERRITORY | CvUnit::MOVEFLAG_ABORT_IF_NEW_ENEMY_REVEALED;
 				if (!pTargetCity || !ExecuteMoveToTarget(pUnit, pTargetCity->plot(), iFlags, true))
 				{
-					CvPlot*	pSafePlot = TacticalAIHelpers::FindSafestPlotInReach(pUnit, true);
+					CvPlot*	pSafePlot = TacticalAIHelpers::FindSafestPlotInReach(pUnit, true).first;
 					ExecuteMoveToTarget(pUnit, pSafePlot, CvUnit::MOVEFLAG_NO_ENEMY_TERRITORY, true);
 				}
 			}
@@ -5930,7 +6006,7 @@ bool CvHomelandAI::MoveCivilianToGarrison(CvUnit* pUnit)
 bool CvHomelandAI::MoveCivilianToSafety(CvUnit* pUnit)
 {
 	// Now loop through the sorted score list and go to the best one we can reach in one turn.
-	CvPlot* pBestPlot = TacticalAIHelpers::FindSafestPlotInReach(pUnit,true);
+	CvPlot* pBestPlot = TacticalAIHelpers::FindSafestPlotInReach(pUnit,true).first;
 	if(pBestPlot != NULL)
 	{
 		if(pUnit->atPlot(*pBestPlot))
@@ -6666,6 +6742,14 @@ bool CvHomelandAI::IsValidExplorerEndTurnPlot(const CvUnit* pUnit, CvPlot* pPlot
 			return false;
 	}
 
+	//AI controlled non-explorers should not explore too far
+	if (pUnit->getDomainType() == DOMAIN_LAND && !m_pPlayer->isHuman(ISHUMAN_AI_UNITS) && pUnit->getUnitCombatType() != (UnitCombatTypes)GC.getInfoTypeForString("UNITCOMBAT_RECON", true) && !pUnit->IsGainsXPFromScouting())
+	{
+		CvCity* pClosestCity = m_pPlayer->GetClosestCity(pPlot, 6, true);
+		if (!pClosestCity)
+			return false;
+	}
+
 	int iFlags = CvUnit::MOVEFLAG_DESTINATION;
 	if (pPlot->isVisibleEnemyDefender(pUnit))
 		// don't bump into enemies
@@ -6792,7 +6876,7 @@ bool CvHomelandAI::MoveToTargetButDontEndTurn(CvUnit* pUnit, CvPlot* pTargetPlot
 		// Embarked and in danger? We need to do something!
 		if (pUnit->isEmbarked())
 		{
-			pTargetPlot = TacticalAIHelpers::FindSafestPlotInReach(pUnit, true);
+			pTargetPlot = TacticalAIHelpers::FindSafestPlotInReach(pUnit, true).first;
 			if (pTargetPlot)
 				pUnit->PushMission(CvTypes::getMISSION_MOVE_TO(), pTargetPlot->getX(), pTargetPlot->getY());
 			else

--- a/CvGameCoreDLL_Expansion2/CvHomelandAI.h
+++ b/CvGameCoreDLL_Expansion2/CvHomelandAI.h
@@ -259,7 +259,7 @@ private:
 	// Routines to manage identifying and implementing homeland moves
 	void PlotExplorerMoves();
 	void PlotFirstTurnSettlerMoves();
-	void PlotHealMoves();
+	void PlotHealMoves(bool bConservative);
 	void PlotMovesToSafety();
 
 	void PlotOpportunisticSettlementMoves();

--- a/CvGameCoreDLL_Expansion2/CvTacticalAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTacticalAI.cpp
@@ -2139,10 +2139,11 @@ void CvTacticalAI::ReviewUnassignedUnits()
 				pUnit->setTacticalMove(AI_TACTICAL_UNASSIGNED);
 
 			//there shouldn't be any danger but just in case
-			CvPlot* pSafePlot = pUnit->GetDanger() > pUnit->ActualHealRate(pUnit->plot(), false) ? TacticalAIHelpers::FindSafestPlotInReach(pUnit, true) : NULL;
+			CvPlot* pSafePlot = pUnit->GetDanger() > pUnit->ActualHealRate(pUnit->plot()) ? TacticalAIHelpers::FindSafestPlotInReach(pUnit, true).first : NULL;
 			if (pSafePlot)
 			{
-				bool bUpgraded = false;
+				pUnit->PushMission(CvTypes::getMISSION_MOVE_TO(), pSafePlot->getX(), pSafePlot->getY());
+
 				if (pUnit->CanUpgradeRightNow(false) && !pUnit->IsHurt())
 				{
 					// Don't upgrade if we will go over supply
@@ -2151,14 +2152,10 @@ void CvTacticalAI::ReviewUnassignedUnits()
 						CvUnit* pNewUnit = pUnit->DoUpgrade();
 						if (pNewUnit)
 						{
-							bUpgraded = true;
 							pNewUnit->SetTurnProcessed(true);
 						}
 					}
 				}
-
-				if (!bUpgraded)
-					pUnit->PushMission(CvTypes::getMISSION_MOVE_TO(), pSafePlot->getX(), pSafePlot->getY());
 
 				if (!pUnit->canMove())
 					pUnit->SetTurnProcessed(true);
@@ -2248,7 +2245,7 @@ void CvTacticalAI::PlotArmyMovesEscort(CvArmyAI* pThisArmy)
 			if ( pCivilian->GetDanger() > 0 )
 			{
 				//try to move to safety
-				CvPlot* pBetterPlot = TacticalAIHelpers::FindSafestPlotInReach(pCivilian,true);
+				CvPlot* pBetterPlot = TacticalAIHelpers::FindSafestPlotInReach(pCivilian,true).first;
 				if (pBetterPlot)
 				{
 					ExecuteMoveToPlot(pCivilian,pBetterPlot);
@@ -2467,7 +2464,7 @@ void CvTacticalAI::PlotArmyMovesEscort(CvArmyAI* pThisArmy)
 				{
 					if (pCivilian->GetDanger(pTurnTarget) == INT_MAX)
 					{
-						CvPlot* pAlternativeTarget = TacticalAIHelpers::FindSafestPlotInReach(pCivilian, true, true);
+						CvPlot* pAlternativeTarget = TacticalAIHelpers::FindSafestPlotInReach(pCivilian, true, true).first;
 						if (pAlternativeTarget)
 							pTurnTarget = pAlternativeTarget;
 					}
@@ -2996,7 +2993,7 @@ bool CvTacticalAI::ExecutePillage(CvPlot* pTargetPlot)
 				if (!TacticalAIHelpers::IsOtherPlayerCitadel(pUnit->plot(), m_pPlayer->GetID(), true))
 				{
 					if (!pUnit->shouldPillage(pUnit->plot()))
-						pSafePlot = TacticalAIHelpers::FindSafestPlotInReach(pUnit, true);
+						pSafePlot = TacticalAIHelpers::FindSafestPlotInReach(pUnit, true).first;
 				}
 
 				if (pSafePlot)
@@ -3044,7 +3041,7 @@ void CvTacticalAI::ExecutePlunderTradeUnit(CvPlot* pTargetPlot)
 		}
 		else if (MoveToEmptySpaceNearTarget(pUnit, pTargetPlot, NO_DOMAIN, 23))
 		{
-			TacticalAIHelpers::PerformRangedOpportunityAttack(pUnit, false);
+			TacticalAIHelpers::PerformRangedOpportunityAttack(pUnit);
 			//don't run away
 			UnitProcessed(pUnit->GetID());
 		}
@@ -3444,9 +3441,10 @@ bool CvTacticalAI::PositionUnitsAroundTarget(const vector<CvUnit*>& vUnits, CvPl
 		{
 			//units are not typically hurt but this is convenient function to move out of danger
 			//MoveToSafestPlot() may cause units to run too far
-			CvPlot* pPlot = TacticalAIHelpers::FindClosestSafePlotForHealing(pUnit, false);
+			CvPlot* pPlot = TacticalAIHelpers::FindClosestSafePlotForHealing(pUnit, false).first;
 			//second chance for emergencies
-			if (!pPlot) pPlot = TacticalAIHelpers::FindSafestPlotInReach(pUnit, false, false);
+			if (!pPlot)
+				pPlot = TacticalAIHelpers::FindSafestPlotInReach(pUnit, false, false).first;
 			if (pPlot)
 				pUnit->PushMission(CvTypes::getMISSION_MOVE_TO(), pPlot->getX(), pPlot->getY(), 0, false, false, MISSIONAI_TACTMOVE);
 		}
@@ -3652,33 +3650,37 @@ void CvTacticalAI::ExecuteMovesToSafestPlot(CvUnit* pUnit)
 	if (!pUnit)
 		return;
 
-	//see if we can do damage before retreating
-	if (pUnit->canMoveAfterAttacking() && (pUnit->getMoves()>GD_INT_GET(MOVE_DENOMINATOR) || pUnit->IsFreeAttackMoves()) && pUnit->canRangeStrike())
-		TacticalAIHelpers::PerformRangedOpportunityAttack(pUnit,true);
+	CvPlot* pUnitPlot = pUnit->plot();
 
 	//so easy
-	CvPlot* pBestPlot = TacticalAIHelpers::FindSafestPlotInReach(pUnit, true, true);
-	if (pBestPlot != NULL)
+	pair<CvPlot*, int> pBestPlotMove = TacticalAIHelpers::FindSafestPlotInReach(pUnit, true, true);
+	if (pBestPlotMove.first)
 	{
 		//check if we need to bump somebody else
-		CvUnit* pBumpUnit = pUnit->GetPotentialUnitToPushOut(*pBestPlot);
+		CvUnit* pBumpUnit = pUnit->GetPotentialUnitToPushOut(*pBestPlotMove.first);
 		if (pBumpUnit)
 		{
-			if (pUnit->PushBlockingUnitOutOfPlot(*pBestPlot))
+			if (pUnit->PushBlockingUnitOutOfPlot(*pBestPlotMove.first))
 			{
 				UnitProcessed(pUnit->GetID());
 				return;
 			}
 		}
 
+		int iMovesRemaining = pBestPlotMove.second;
+
 		//pillage before retreat, if we have movement points to spare
-		if ((pUnit->hasFreePillageMove() || pUnit->getMoves()>GD_INT_GET(MOVE_DENOMINATOR)) && pBestPlot->isAdjacent(pUnit->plot()) && pUnit->shouldPillage(pUnit->plot()))
+		if ((pUnit->hasFreePillageMove() || iMovesRemaining > GD_INT_GET(MOVE_DENOMINATOR)) && pUnit->shouldPillage(pUnitPlot))
+		{
 			pUnit->PushMission(CvTypes::getMISSION_PILLAGE());
+			if (!pUnit->hasFreePillageMove())
+				iMovesRemaining -= GD_INT_GET(MOVE_DENOMINATOR);
+		}
 
 		//typical citadel case
-		if (pUnit->plot() == pBestPlot)
+		if (pUnitPlot == pBestPlotMove.first)
 		{
-			if (pUnit->GetCurrHitPoints()>pUnit->GetMaxHitPoints()/2)
+			if (pUnit->GetCurrHitPoints() > pUnit->GetMaxHitPoints() * 3 / 5)
 				TacticalAIHelpers::PerformRangedOpportunityAttack(pUnit);
 
 			//make sure the unit stays put!
@@ -3687,24 +3689,24 @@ void CvTacticalAI::ExecuteMovesToSafestPlot(CvUnit* pUnit)
 		else
 		{
 			//try to do some damage if we have movement points to spare
-			if (pBestPlot->isAdjacent(pUnit->plot()) && (pUnit->getMoves() > GD_INT_GET(MOVE_DENOMINATOR) || pUnit->IsFreeAttackMoves()) && pUnit->canRangeStrike() && pUnit->canMoveAfterAttacking())
-				TacticalAIHelpers::PerformRangedOpportunityAttack(pUnit, true);
+			if ((iMovesRemaining > GD_INT_GET(MOVE_DENOMINATOR) || pUnit->IsFreeAttackMoves()) && pUnit->canRangeStrike() && pUnit->canMoveAfterAttacking())
+				TacticalAIHelpers::PerformRangedOpportunityAttack(pUnit, false, iMovesRemaining);
 
 			// Move to the lowest danger value found
-			pUnit->PushMission(CvTypes::getMISSION_MOVE_TO(), pBestPlot->getX(), pBestPlot->getY(), 0, false, false, MISSIONAI_TACTMOVE);
+			pUnit->PushMission(CvTypes::getMISSION_MOVE_TO(), pBestPlotMove.first->getX(), pBestPlotMove.first->getY(), 0, false, false, MISSIONAI_TACTMOVE);
+
+			//pillage after retreat, if we have movement points to spare
+			if (pUnit->shouldPillage(pUnitPlot, false, true) && (pUnit->getMoves() > GD_INT_GET(MOVE_DENOMINATOR) || pUnit->IsFreeAttackMoves() || !pUnit->canRangeStrike()))
+				pUnit->PushMission(CvTypes::getMISSION_PILLAGE());
 
 			//see if we can do damage after retreating
 			if (pUnit->canMove() && pUnit->canRangeStrike())
-				TacticalAIHelpers::PerformRangedOpportunityAttack(pUnit, true);
-
-			//pillage after retreat, if we have movement points to spare
-			if (pUnit->shouldPillage(pUnit->plot(), false, true))
-				pUnit->PushMission(CvTypes::getMISSION_PILLAGE());
+				TacticalAIHelpers::PerformRangedOpportunityAttack(pUnit);
 		}
 
 		UnitProcessed(pUnit->GetID());
 	}
-	else if (pUnit->GetDanger() < min(pUnit->GetCurrHitPoints() + pUnit->ActualHealRate(pUnit->plot()), pUnit->GetMaxHitPoints()))
+	else if (pUnit->GetDanger() < min(pUnit->GetCurrHitPoints() + pUnit->ActualHealRate(pUnitPlot), pUnit->GetMaxHitPoints()))
 	{
 		//do nothing and hope for the best
 		pUnit->PushMission(CvTypes::getMISSION_SKIP());
@@ -3722,9 +3724,9 @@ void CvTacticalAI::ExecuteMovesToSafestPlot(CvUnit* pUnit)
 		}
 
 		//try to go home
-		if(pUnit->plot()->getOwner() != pUnit->getOwner())
+		if(pUnitPlot->getOwner() != pUnit->getOwner())
 		{
-			CvCity* pClosestCity = m_pPlayer->GetClosestCityByPathLength(pUnit->plot());
+			CvCity* pClosestCity = m_pPlayer->GetClosestCityByPathLength(pUnitPlot);
 			if (m_pPlayer->isMinorCiv())
 				pClosestCity = m_pPlayer->getCapitalCity();
 
@@ -3748,7 +3750,7 @@ void CvTacticalAI::ExecuteHeals(bool bFirstPass)
 		if (!pUnit)
 			continue;
 
-		CvPlot* pBetterPlot = NULL;
+		pair<CvPlot*, int> pBetterPlotMove = make_pair(static_cast<CvPlot*>(NULL), 0);
 
 		//need to split from army?
 		if (pUnit->getArmyID() != -1)
@@ -3766,27 +3768,12 @@ void CvTacticalAI::ExecuteHeals(bool bFirstPass)
 			}
 		}
 
-		//ranged attack before fleeing for fast units
-		if (pUnit->canMoveAfterAttacking() && (pUnit->getMoves() > 3*GD_INT_GET(MOVE_DENOMINATOR) || pUnit->IsFreeAttackMoves()) && pUnit->canRangeStrike())
-			TacticalAIHelpers::PerformRangedOpportunityAttack(pUnit);
-
 		//find a suitable spot for healing
 		if (pUnit->getDomainType() == DOMAIN_LAND)
 		{
-			//why not pillage some tiles?
-			if (pUnit->shouldPillage(pUnit->plot()))
-			{
-				pUnit->PushMission(CvTypes::getMISSION_PILLAGE());
-				if (GC.getLogging() && GC.getAILogging())
-				{
-					CvString strMsg;
-					strMsg.Format("Heal: pillage with %s, X: %d, Y: %d", pUnit->getName().GetCString(), pUnit->getX(), pUnit->getY());
-					LogTacticalMessage(strMsg);
-				}
-			}
-			else if (pUnit->GetDamageAoEFortified() > 0 && pUnit->canFortify(pUnit->plot()) &&
-				pUnit->getDamage() >= pUnit->ActualHealRate(pUnit->plot(), false) && pUnit->GetDanger() < pUnit->GetCurrHitPoints() &&
-				pUnit->plot()->GetNumEnemyUnitsAdjacent(pUnit->getTeam(), pUnit->getDomainType()) > 0)
+			if (pUnit->GetDamageAoEFortified() > 0 && pUnit->canFortify(pUnit->plot()) &&
+				pUnit->GetDanger() < pUnit->GetCurrHitPoints() + pUnit->ActualHealRate(pUnit->plot()) &&
+				pUnit->plot()->GetNumEnemyUnitsAdjacent(pUnit->getTeam(), pUnit->getDomainType()) > 1)
 			{
 				//units with area damage if fortified should fortify as much as possible if near enemies
 				pUnit->PushMission(CvTypes::getMISSION_FORTIFY());
@@ -3794,10 +3781,9 @@ void CvTacticalAI::ExecuteHeals(bool bFirstPass)
 				continue;
 			}
 
-			//land unit on land should move away from danger
-			if (pUnit->GetDanger() > 0 && !pUnit->isEmbarked() && !pUnit->IsGarrisoned())
+			//try opportunistic attacks if there is only one nearby unit
+			if (pUnit->GetDanger() > 0 && !pUnit->isEmbarked())
 			{
-				//unless we can eliminate the danger!
 				std::vector<CvUnit*> vAttackers = m_pPlayer->GetPossibleAttackers(*pUnit->plot(),m_pPlayer->getTeam());
 				if (vAttackers.size() == 1 && TacticalAIHelpers::KillLoneEnemyIfPossible(pUnit, vAttackers[0]))
 				{
@@ -3811,7 +3797,7 @@ void CvTacticalAI::ExecuteHeals(bool bFirstPass)
 				}
 			}
 
-			pBetterPlot = TacticalAIHelpers::FindClosestSafePlotForHealing(pUnit);
+			pBetterPlotMove = TacticalAIHelpers::FindClosestSafePlotForHealing(pUnit);
 		}
 		else if (pUnit->getDomainType()==DOMAIN_SEA)
 		{
@@ -3844,20 +3830,24 @@ void CvTacticalAI::ExecuteHeals(bool bFirstPass)
 					}
 				}
 
-				pBetterPlot = TacticalAIHelpers::FindClosestSafePlotForHealing(pUnit);
+				pBetterPlotMove = TacticalAIHelpers::FindClosestSafePlotForHealing(pUnit);
 			}
 		}
 
 		//now finally do something
-		if (pBetterPlot)
+		if (pBetterPlotMove.first)
 		{
-			if (pBetterPlot != pUnit->plot())
+			if (pBetterPlotMove.first != pUnit->plot())
 			{
-				CvUnit* pPushUnit = pUnit->GetPotentialUnitToPushOut(*pBetterPlot);
+				//ranged attack before fleeing for fast units
+				if (pUnit->canMoveAfterAttacking() && (pBetterPlotMove.second > GD_INT_GET(MOVE_DENOMINATOR) || pUnit->IsFreeAttackMoves()) && pUnit->canRangeStrike())
+					TacticalAIHelpers::PerformRangedOpportunityAttack(pUnit, false, pBetterPlotMove.second);
+
+				CvUnit* pPushUnit = pUnit->GetPotentialUnitToPushOut(*pBetterPlotMove.first);
 				if (pPushUnit)
-					pUnit->PushBlockingUnitOutOfPlot(*pBetterPlot);
+					pUnit->PushBlockingUnitOutOfPlot(*pBetterPlotMove.first);
 				else //plot should be free
-					ExecuteMoveToPlot(pUnit, pBetterPlot);
+					ExecuteMoveToPlot(pUnit, pBetterPlotMove.first);
 			}
 			else
 				//this is required to flush the previous mission!
@@ -3884,9 +3874,9 @@ void CvTacticalAI::ExecuteHeals(bool bFirstPass)
 			//at least try to flee if we're not needed
 			if (!pUnit->IsCoveringFriendlyCivilian())
 			{
-				pBetterPlot = TacticalAIHelpers::FindSafestPlotInReach(pUnit, true);
-				if (pBetterPlot && pBetterPlot != pUnit->plot())
-					ExecuteMoveToPlot(pUnit, pBetterPlot);
+				pBetterPlotMove = TacticalAIHelpers::FindSafestPlotInReach(pUnit, true);
+				if (pBetterPlotMove.first && pBetterPlotMove.first != pUnit->plot())
+					ExecuteMoveToPlot(pUnit, pBetterPlotMove.first);
 			}
 
 			if (!pUnit->canMove())
@@ -4020,7 +4010,7 @@ int CvTacticalAI::ExecuteMoveToPlot(CvUnit* pUnit, CvPlot* pTarget, bool bSetPro
 			if (bSetProcessed && !bAlreadyThere && pUnit->canMove() && pUnit->getArmyID()==-1)
 			{
 				//try to go to a better place if we're sure the unit will not be moved again this turn
-				pTarget = TacticalAIHelpers::FindSafestPlotInReach(pUnit, true);
+				pTarget = TacticalAIHelpers::FindSafestPlotInReach(pUnit, true).first;
 				if (pTarget)
 					pUnit->PushMission(CvTypes::getMISSION_MOVE_TO(), pTarget->getX(), pTarget->getY(), 0 /*no approximate flags*/, false, false, MISSIONAI_TACTMOVE, pTarget);
 			}
@@ -5796,7 +5786,7 @@ bool TacticalAIHelpers::PerformOpportunityAttack(CvUnit* pUnit, bool bAllowMovem
 }
 
 //see if we can hit anything from our current plot - with or without moving
-bool TacticalAIHelpers::PerformRangedOpportunityAttack(CvUnit* pUnit, bool bAllowMovement)
+bool TacticalAIHelpers::PerformRangedOpportunityAttack(CvUnit* pUnit, bool bAllowMovement, int bSaveMovement)
 {
 	if (!pUnit || !pUnit->IsCanAttackRanged() || !pUnit->canMove() || pUnit->isDelayedDeath())
 		return false;
@@ -5811,7 +5801,7 @@ bool TacticalAIHelpers::PerformRangedOpportunityAttack(CvUnit* pUnit, bool bAllo
 		//no loop needed, there is only one unit anyway
 		set<int> dummy;
 		gTargetPlot = pUnit->plot();
-		vector<STacticalAssignment> vAssignments = TacticalAIHelpers::FindBestUnitAssignments(vector<CvUnit*>(1, pUnit), pUnit->plot(), AL_LOW, gTactPosStorage, dummy, false, !bAllowMovement);
+		vector<STacticalAssignment> vAssignments = TacticalAIHelpers::FindBestUnitAssignments(vector<CvUnit*>(1, pUnit), pUnit->plot(), AL_LOW, gTactPosStorage, dummy, false, !bAllowMovement, bSaveMovement);
 		if (vAssignments.empty())
 			return false;
 
@@ -5875,16 +5865,16 @@ bool TacticalAIHelpers::PerformRangedOpportunityAttack(CvUnit* pUnit, bool bAllo
 	}
 }
 
-CvPlot* TacticalAIHelpers::FindSafestPlotInReach(const CvUnit* pUnit, bool bAllowEmbark, bool bConsiderPush)
+pair<CvPlot*, int> TacticalAIHelpers::FindSafestPlotInReach(const CvUnit* pUnit, bool bAllowEmbark, bool bConsiderPush)
 {
 	//use rebase moves for aircraft!
 	if (!pUnit || pUnit->getDomainType() == DOMAIN_AIR)
-		return NULL;
+		return make_pair(static_cast<CvPlot*>(NULL), 0);
 
-	vector<OptionWithScore<CvPlot*>> aCityList;
-	vector<OptionWithScore<CvPlot*>> aZeroDangerList;
-	vector<OptionWithScore<CvPlot*>> aCoverList;
-	vector<OptionWithScore<CvPlot*>> aDangerList;
+	vector<OptionWithScore<pair<CvPlot*, int>>> aCityList;
+	vector<OptionWithScore<pair<CvPlot*, int>>> aZeroDangerList;
+	vector<OptionWithScore<pair<CvPlot*, int>>> aCoverList;
+	vector<OptionWithScore<pair<CvPlot*, int>>> aDangerList;
 
 	//special behavior for cities and citadels - don't run even if there is a "safe" plot somewhere else
 	CvPlot* pCurrentPlot = pUnit->plot();
@@ -5892,7 +5882,7 @@ CvPlot* TacticalAIHelpers::FindSafestPlotInReach(const CvUnit* pUnit, bool bAllo
 								(pUnit->IsCombatUnit() && TacticalAIHelpers::IsPlayerCitadel(pCurrentPlot, pUnit->getOwner()) && pUnit->getDomainType() == DOMAIN_LAND);
 	if (bIsInCityOrCitadelNow && !pUnit->isProjectedToDieNextTurn() && pUnit->canEndTurnAtPlot(pCurrentPlot))
 		if (pUnit->AI_getUnitAIType()!=UNITAI_CITY_BOMBARD || pUnit->GetDanger(pCurrentPlot)<pUnit->GetCurrHitPoints())
-			return pCurrentPlot;
+			return make_pair(pCurrentPlot, pUnit->getMoves());
 
 	//for current plot
 	int iCurrentHealRate = pUnit->ActualHealRate(pUnit->plot());
@@ -5900,7 +5890,7 @@ CvPlot* TacticalAIHelpers::FindSafestPlotInReach(const CvUnit* pUnit, bool bAllo
 
 	//don't run if we are needed
 	if (pUnit->IsCoveringFriendlyCivilian() && pUnit->GetDanger(pCurrentPlot)<pUnit->GetCurrHitPoints()*2)
-		return pCurrentPlot;
+		return make_pair(pCurrentPlot, pUnit->getMoves());
 
 	//embarkation allowed for now, we sort it out below
 	ReachablePlots eligiblePlots = pUnit->GetAllPlotsInReachThisTurn(); 
@@ -6014,27 +6004,26 @@ CvPlot* TacticalAIHelpers::FindSafestPlotInReach(const CvUnit* pUnit, bool bAllo
 		}
 
 		//discourage water tiles for land units
-		//note that zero danger status has already been established, this is only for sorting now
-		if (bIsZeroDanger && bWrongDomain)
+		if (bWrongDomain)
 			iScore += 250;
 
 		if(bIsInCityOrCitadel)
 		{
-			aCityList.push_back( OptionWithScore<CvPlot*>(pPlot,iScore) );
+			aCityList.push_back( OptionWithScore<pair<CvPlot*, int>>(make_pair(pPlot, it->iMovesLeft),iScore) );
 		}
 		else if(bIsInCover) //mostly relevant for civilians
 		{
-			aCoverList.push_back( OptionWithScore<CvPlot*>(pPlot,iScore) );
+			aCoverList.push_back( OptionWithScore<pair<CvPlot*, int>>(make_pair(pPlot, it->iMovesLeft),iScore) );
 		}
 		else if(bIsZeroDanger)
 		{
 			//if danger is zero, look at distance to closest owned city instead
 			//idea: could also look at number of plots reachable from pPlot to avoid dead ends
-			aZeroDangerList.push_back( OptionWithScore<CvPlot*>(pPlot, bIsInTerritory ? iCityDistance : iCityDistance*2) );
+			aZeroDangerList.push_back( OptionWithScore<pair<CvPlot*, int>>(make_pair(pPlot, it->iMovesLeft), bIsInTerritory ? -iCityDistance : -iCityDistance*2) );
 		}
 		else if(!bWouldEmbark || bAllowEmbark)
 		{
-			aDangerList.push_back( OptionWithScore<CvPlot*>(pPlot,iScore) );
+			aDangerList.push_back( OptionWithScore<pair<CvPlot*, int>>(make_pair(pPlot, it->iMovesLeft),iScore) );
 		}
 	}
 
@@ -6049,8 +6038,8 @@ CvPlot* TacticalAIHelpers::FindSafestPlotInReach(const CvUnit* pUnit, bool bAllo
 		return aCityList.back().option;
 	else if (aCoverList.size() > 0)
 	{
-		CvPlot* pPlot = aCoverList.back().option;
-		CvUnit* pDefender = pPlot->getBestDefender(pUnit->getOwner());
+		pair<CvPlot*, int> pPlotMove = aCoverList.back().option;
+		CvUnit* pDefender = pPlotMove.first->getBestDefender(pUnit->getOwner());
 		if (pDefender && pDefender != pUnit)
 		{
 			//taking cover only works if the defender will not move away!
@@ -6062,14 +6051,14 @@ CvPlot* TacticalAIHelpers::FindSafestPlotInReach(const CvUnit* pUnit, bool bAllo
 				pDefender->SetTurnProcessed(true);
 			}
 		}
-		return pPlot;
+		return pPlotMove;
 	}
 	else if (aZeroDangerList.size()>0)
 		return aZeroDangerList.back().option;
 	else if (aDangerList.size()>0)
 		return aDangerList.back().option;
 
-	return NULL;
+	return make_pair(static_cast<CvPlot*>(NULL), 0);
 }
 
 void CTacticalUnitArray::push_back(const CvTacticalUnit& unit)
@@ -6157,26 +6146,26 @@ bool TacticalAIHelpers::IsCloseToContestedBorder(CvPlayer* pPlayer, CvPlot* pPlo
 	return bResult;
 }
 
-CvPlot* TacticalAIHelpers::FindClosestSafePlotForHealing(CvUnit* pUnit, bool bConservative)
+pair<CvPlot*, int> TacticalAIHelpers::FindClosestSafePlotForHealing(CvUnit* pUnit, bool bConservative)
 {
 	if (!pUnit)
-		return NULL;
+		return make_pair(static_cast<CvPlot*>(NULL), 0);
 
 	//first see if the current plot is good
 	int iCurrentHealRate = pUnit->ActualHealRate(pUnit->plot());
 	if (pUnit->GetDanger() == 0 && iCurrentHealRate > 5 && !pUnit->isAlwaysHeal())
-		return pUnit->plot();
+		return make_pair(pUnit->plot(), pUnit->getMoves());
 
 	//check if we can outheal the damage
 	if (iCurrentHealRate > 5 && iCurrentHealRate > pUnit->GetDanger() && !pUnit->isAlwaysHeal())
-		return pUnit->plot();
+		return make_pair(pUnit->plot(), pUnit->getMoves());
 
 	//doesn't get much safer than in a city
 	//also garrisons should not run away!
 	if (pUnit->plot()->isCity() && pUnit->getDomainType() == DOMAIN_LAND)
-		return pUnit->plot();
+		return make_pair(pUnit->plot(), pUnit->getMoves());
 
-	std::vector<SPlotWithScore> vCandidates;
+	std::vector<OptionWithScore<pair<CvPlot*, int>>> vCandidates;
 	ReachablePlots eligiblePlots = pUnit->GetAllPlotsInReachThisTurn(); //embarkation allowed for now, we sort it out below
 	for (ReachablePlots::iterator it = eligiblePlots.begin(); it != eligiblePlots.end(); ++it)
 	{
@@ -6219,6 +6208,11 @@ CvPlot* TacticalAIHelpers::FindClosestSafePlotForHealing(CvUnit* pUnit, bool bCo
 
 		int iDanger = min(pUnit->GetDanger(pPlot),10000); //handle INT_MAX for civilians
 		int iHealRate = pUnit->ActualHealRate(pPlot, false);
+
+		// a heal now is about as good as two heals next turn
+		if (pPlot == pUnit->plot() && !pUnit->hasMoved() && !pUnit->isAlwaysHeal())
+			iHealRate *= 2;
+
 		int iFriends = pPlot->GetNumFriendlyUnitsAdjacent(pUnit->getTeam(), NO_DOMAIN, true, pUnit);
 
 		//sometimes we want to ignore pillage health, it's a one-time effect and may lead into dead ends
@@ -6241,7 +6235,7 @@ CvPlot* TacticalAIHelpers::FindClosestSafePlotForHealing(CvUnit* pUnit, bool bCo
 		{
 			//tiebreaker
 			iScore -= plotDistance(pPlot->getX(), pPlot->getY(), pUnit->getX(), pUnit->getY()) * 2 - GET_PLAYER(pUnit->getOwner()).GetCityDistancePathLength(pPlot);
-			vCandidates.push_back(SPlotWithScore(pPlot, iScore));
+			vCandidates.push_back(OptionWithScore<pair<CvPlot*, int>>(make_pair(pPlot, it->iMovesLeft), iScore));
 		}
 	}
 
@@ -6249,10 +6243,10 @@ CvPlot* TacticalAIHelpers::FindClosestSafePlotForHealing(CvUnit* pUnit, bool bCo
 	{
 		std::stable_sort(vCandidates.begin(), vCandidates.end());
 		//how to tell whether it's safe enough?
-		return vCandidates.back().pPlot;
+		return vCandidates.back().option;
 	}
 
-	return NULL;
+	return make_pair(static_cast<CvPlot*>(NULL), 0);
 }
 
 std::vector<CvPlot*> TacticalAIHelpers::GetPlotsForRangedAttack(const CvPlot* pTarget, const CvUnit* pUnit, int iRange, bool bCheckOccupied)
@@ -6828,7 +6822,8 @@ bool ScoreAttackDamage(const CvTacticalPlot& tactPlot, const CvUnit* pUnit, cons
 
 	const CvPlot* pUnitPlot = assumedPlot.getPlot();
 	const CvPlot* pTestPlot = tactPlot.getPlot();
-	bool bScoreReduction = false;
+	bool bMajorScoreReduction = false;
+	bool bMinorScoreReduction = false;
 
 	//AL_LOW, AL_MEDIUM, AL_HIGH, AL_BRAVEHEART
 	//braveheart allows attacks for which you need luck to survive
@@ -6887,11 +6882,11 @@ bool ScoreAttackDamage(const CvTacticalPlot& tactPlot, const CvUnit* pUnit, cons
 
 		//prefer ranged attacks over melee attacks (except if it's a kill, see below)
 		if (iDamageReceived > 0)
-			bScoreReduction = true;
+			bMajorScoreReduction = true;
 
 		//special: if there are multiple enemy units around, try to attack those first
 		if (tactPlot.getNumAdjacentEnemies(CvTacticalPlot::TD_BOTH) > 1 && pUnit->AI_getUnitAIType() != UNITAI_CITY_BOMBARD)
-			bScoreReduction = true;
+			bMinorScoreReduction = true;
 
 		//if there is a chance that the enemy will be killed during the sim, we want to know
 		if (iDamageDealt * 3 > iPrevHitPoints * 2)
@@ -6945,7 +6940,7 @@ bool ScoreAttackDamage(const CvTacticalPlot& tactPlot, const CvUnit* pUnit, cons
 
 		//don't be distracted by attacks on barbarians or melee units in other domain when there are real enemies around
 		if (pEnemy->getOwner() == BARBARIAN_PLAYER || (!pEnemy->IsCanAttackRanged() && pEnemy->getDomainType() != pUnit->getDomainType()))
-			bScoreReduction = true;
+			bMinorScoreReduction = true;
 
 		//if there is a chance that the enemy will be killed during the sim, we want to know
 		if (iDamageDealt >= iPrevHitPoints - 10)
@@ -6977,7 +6972,8 @@ bool ScoreAttackDamage(const CvTacticalPlot& tactPlot, const CvUnit* pUnit, cons
 		if (tactPlot.isEnemyCity()) //city capture
 		{
 			bIsKill = pUnit->IsCanAttackWithMove(); //only melee can capture/kill a city!
-			bScoreReduction = false;
+			bMajorScoreReduction = false;
+			bMinorScoreReduction = false;
 
 			//ranged units can't capture, so discourage the attack
 			if (pUnit->IsCanAttackRanged())
@@ -6995,7 +6991,8 @@ bool ScoreAttackDamage(const CvTacticalPlot& tactPlot, const CvUnit* pUnit, cons
 		else //enemy unit killed
 		{
 			bIsKill = true;
-			bScoreReduction = false;
+			bMajorScoreReduction = false;
+			bMinorScoreReduction = false;
 
 			if (pTestPlot->getNumUnits() > 1 && !pTestPlot->isNeutralUnit(pUnit->getOwner(), false, false))
 				iExtraScore += 20; //even more points for a double kill
@@ -7019,6 +7016,35 @@ bool ScoreAttackDamage(const CvTacticalPlot& tactPlot, const CvUnit* pUnit, cons
 						}
 					}
 				}
+			}
+
+			bool bYieldBonus = false;
+			CvUnit* pEnemy = tactPlot.getEnemyUnit();
+			if (pEnemy->IsCombatUnit())
+			{
+				bYieldBonus = pUnit->GetGoldenAgeValueFromKills() > 0;
+
+				if (!bYieldBonus)
+				{
+					UnitTypes eUnitType = pUnit->getUnitType();
+					CvUnitEntry* pkUnitInfo = GC.getUnitInfo(eUnitType);
+
+					for (int iI = 0; iI < NUM_YIELD_TYPES; iI++)
+					{
+						YieldTypes eYield = (YieldTypes)iI;
+
+						bYieldBonus = pUnit->getYieldFromBarbarianKills(eYield)
+							|| pkUnitInfo->GetYieldFromBarbarianKills(eYield)
+							|| pUnit->getYieldFromKills(eYield)
+							|| pkUnitInfo->GetYieldFromKills(eYield);
+
+						if (bYieldBonus)
+							break;
+					}
+				}
+
+				if (bYieldBonus)
+					iExtraScore += 1000;
 			}
 
 			if (pUnit->IsCanAttackRanged())
@@ -7113,8 +7139,10 @@ bool ScoreAttackDamage(const CvTacticalPlot& tactPlot, const CvUnit* pUnit, cons
 	//todo: normalize damage done by max hp to balance between city attacks and unit attacks?
 	//todo: score by net damage? so subtract damage taken?
 	result.iBonusScore = iDamageDealt + iExtraScore;
-	if (bScoreReduction)
+	if (bMajorScoreReduction)
 		result.iBonusScore /= 2;
+	else if (bMinorScoreReduction)
+		result.iBonusScore = result.iBonusScore * 3 / 4;
 
 	result.iSelfDamage = iDamageReceived;
 	result.iDamage = iDamageDealt;
@@ -7246,11 +7274,10 @@ int ScorePlotForVisibility(const CvUnit* pUnit, const CvTacticalPlot& testPlot)
 {
 	int iVisiblityScore = 0;
 
-	if (pUnit->IsCanAttackRanged())
+	if (pUnit->IsCanAttackRanged() && !pUnit->IsRangeAttackIgnoreLOS())
 	{
 		//ignore range 1, we can always see those plots!
 		//also ignore range 4+, this is too far and we don't have those plots cached
-
 		if (pUnit->GetRange() > 1)
 			iVisiblityScore += testPlot.getNumVisiblePlotsRange2();
 		if (pUnit->GetRange() > 2)
@@ -7527,9 +7554,13 @@ STacticalAssignment ScorePlotForCombatUnitMove(const SUnitStats& unit, const CvT
 	//even for intermediate plots, so as not to bias against them
 	if (assumedPosition.haveEnemies())
 	{
+		int iEnemyDistance = !pUnit->IsCanAttackRanged() || pUnit->IsRangeAttackIgnoreLOS() || pUnit->GetRange() < 2
+			? testPlot.getEnemyDistance(eRelevantDomain)
+			: testPlot.getRangedAttackEnemyDistance(eRelevantDomain);
+
 		iPlotScore = pUnit->getDomainType() != DOMAIN_SEA
-			? iPlotScoreForEnemyDistanceLandAttack[eMoveStrategy][testPlot.getEnemyDistance(eRelevantDomain)]
-			: iPlotScoreForEnemyDistanceSeaAttack[eMoveStrategy][testPlot.getEnemyDistance(eRelevantDomain)];
+			? iPlotScoreForEnemyDistanceLandAttack[eMoveStrategy][iEnemyDistance]
+			: iPlotScoreForEnemyDistanceSeaAttack[eMoveStrategy][iEnemyDistance];
 
 		if (testPlot.getPlot()->isFriendlyCity(*pUnit))
 			iPlotScore = 12;
@@ -7644,7 +7675,7 @@ STacticalAssignment ScorePlotForCombatUnitMove(const SUnitStats& unit, const CvT
 	}
 
 	//consider visibility as well
-	iDangerScore += ScorePlotForVisibility(pUnit, testPlot);
+	iDangerScore += ScorePlotForVisibility(pUnit, testPlot) * 3;
 
 	//final score
 	//danger values (typically negative!) are mostly useful as tiebreaker
@@ -8034,6 +8065,9 @@ CvTacticalPlot::CvTacticalPlot(const CvPlot* plot, PlayerTypes ePlayer, const ve
 	aiEnemyCombatUnitsAdjacent[TD_BOTH] = 0;
 	aiEnemyCombatUnitsAdjacent[TD_LAND] = 0;
 	aiEnemyCombatUnitsAdjacent[TD_SEA] = 0;
+	aiRangedAttackEnemyDistance[TD_BOTH] = TACTICAL_COMBAT_MAX_TARGET_DISTANCE;
+	aiRangedAttackEnemyDistance[TD_LAND] = TACTICAL_COMBAT_MAX_TARGET_DISTANCE;
+	aiRangedAttackEnemyDistance[TD_SEA] = TACTICAL_COMBAT_MAX_TARGET_DISTANCE;
 
 	//enemy distance alone is not enough
 	//there may be multiple enemy combat units but we only care about the best defender
@@ -8143,6 +8177,9 @@ void CvTacticalPlot::resetVolatileProperties()
 	aiEnemyCombatUnitsAdjacent[TD_BOTH] = 0;
 	aiEnemyCombatUnitsAdjacent[TD_LAND] = 0;
 	aiEnemyCombatUnitsAdjacent[TD_SEA] = 0;
+	aiRangedAttackEnemyDistance[TD_BOTH] = TACTICAL_COMBAT_MAX_TARGET_DISTANCE;
+	aiRangedAttackEnemyDistance[TD_LAND] = TACTICAL_COMBAT_MAX_TARGET_DISTANCE;
+	aiRangedAttackEnemyDistance[TD_SEA] = TACTICAL_COMBAT_MAX_TARGET_DISTANCE;
 }
 
 bool CvTacticalPlot::isBlockedByNonSimUnit(eTactPlotDomain eDomain, bool bMustBeFriendly) const
@@ -8376,6 +8413,16 @@ unsigned char CvTacticalPlot::getEnemyDistance(eTactPlotDomain eDomain) const
 void CvTacticalPlot::setEnemyDistance(eTactPlotDomain eDomain, int iDistance)
 {
 	aiEnemyDistance[eDomain] = static_cast<unsigned char>(iDistance);
+}
+
+unsigned char CvTacticalPlot::getRangedAttackEnemyDistance(eTactPlotDomain eDomain) const
+{
+	return aiRangedAttackEnemyDistance[eDomain];
+}
+
+void CvTacticalPlot::setRangedAttackEnemyDistance(eTactPlotDomain eDomain, int iDistance)
+{
+	aiRangedAttackEnemyDistance[eDomain] = static_cast<unsigned char>(iDistance);
 }
 
 bool CvTacticalPlot::checkEdgePlotsForSurprises(const CvTacticalPosition& currentPosition, vector<int>& landEnemies, vector<int>& seaEnemies)
@@ -9199,11 +9246,11 @@ bool CvTacticalPosition::addFinishMovesIfAcceptable(bool bEarlyFinish, int& iBad
 		const CvTacticalPlot& tactPlot = getTactPlot(unit.iPlotIndex);
 		STacticalAssignment nextAssignment = ScorePlotForMove(unit, tactPlot, 0, *this, EM_FINAL);
 
-		if (bReturnToStartPositions)
-		{
-			if (unit.pUnit->plot()->GetPlotIndex() != tactPlot.getPlotIndex())
-				return false;
-		}
+		if (bReturnToStartPositions && unit.pUnit->plot()->GetPlotIndex() != tactPlot.getPlotIndex())
+			return false;
+
+		if (unit.iMovesLeft < nSaveMovement)
+			return false;
 
 		bool bAccept = (nextAssignment.Score() > TACTICAL_COMBAT_IMPOSSIBLE_SCORE);
 		if (!bAccept)
@@ -9468,13 +9515,19 @@ void CvTacticalPosition::refreshVolatilePlotProperties(bool bInitial)
 			gCitadels.push_back(it->getPlotIndex());
 	}
 
+	// Some teams have bonus sight range in certain circumstances
+	TeamTypes eTeam = !availableUnits.empty() ? availableUnits[0].pUnit->getTeam() : NO_TEAM;
+
 	//distance transform
 	for (vector<CvTacticalPlot>::iterator it = tactPlots.begin(); it != tactPlots.end(); ++it)
 	{
+		const CvPlot* pSourcePlot = it->getPlot();
+		const CvPlot* pTargetPlot;
 		//pt1
 		for (size_t i = 0; i < gLandEnemies.size(); i++)
 		{
-			int iDistance = plotDistance(*GC.getMap().plotByIndexUnchecked(gLandEnemies[i]), *it->getPlot());
+			pTargetPlot = GC.getMap().plotByIndexUnchecked(gLandEnemies[i]);
+			int iDistance = plotDistance(*pSourcePlot, *pTargetPlot);
 			if (iDistance < it->getEnemyDistance(CvTacticalPlot::TD_BOTH))
 				it->setEnemyDistance(CvTacticalPlot::TD_BOTH, iDistance);
 			if (iDistance < it->getEnemyDistance(CvTacticalPlot::TD_LAND))
@@ -9483,13 +9536,24 @@ void CvTacticalPosition::refreshVolatilePlotProperties(bool bInitial)
 			{
 				it->setNumAdjacentEnemies(CvTacticalPlot::TD_BOTH, it->getNumAdjacentEnemies(CvTacticalPlot::TD_BOTH) + 1);
 				it->setNumAdjacentEnemies(CvTacticalPlot::TD_LAND, it->getNumAdjacentEnemies(CvTacticalPlot::TD_LAND) + 1);
+			}
+			if (iDistance < it->getRangedAttackEnemyDistance(CvTacticalPlot::TD_BOTH))
+			{
+				if (pSourcePlot->canSeePlot(pTargetPlot, eTeam, iDistance, NO_DIRECTION))
+					it->setRangedAttackEnemyDistance(CvTacticalPlot::TD_BOTH, iDistance);
+			}
+			if (iDistance < it->getRangedAttackEnemyDistance(CvTacticalPlot::TD_LAND))
+			{
+				if (pSourcePlot->canSeePlot(pTargetPlot, eTeam, iDistance, NO_DIRECTION))
+					it->setRangedAttackEnemyDistance(CvTacticalPlot::TD_LAND, iDistance);
 			}
 		}
 
 		//pt2
 		for (size_t i = 0; i < gSeaEnemies.size(); i++)
 		{
-			int iDistance = plotDistance(*GC.getMap().plotByIndexUnchecked(gSeaEnemies[i]), *it->getPlot());
+			pTargetPlot = GC.getMap().plotByIndexUnchecked(gSeaEnemies[i]);
+			int iDistance = plotDistance(*pSourcePlot, *pTargetPlot);
 			if (iDistance < it->getEnemyDistance(CvTacticalPlot::TD_BOTH))
 				it->setEnemyDistance(CvTacticalPlot::TD_BOTH, iDistance);
 			if (iDistance < it->getEnemyDistance(CvTacticalPlot::TD_SEA))
@@ -9499,12 +9563,23 @@ void CvTacticalPosition::refreshVolatilePlotProperties(bool bInitial)
 				it->setNumAdjacentEnemies(CvTacticalPlot::TD_BOTH, it->getNumAdjacentEnemies(CvTacticalPlot::TD_BOTH) + 1);
 				it->setNumAdjacentEnemies(CvTacticalPlot::TD_SEA, it->getNumAdjacentEnemies(CvTacticalPlot::TD_SEA) + 1);
 			}
+			if (iDistance < it->getRangedAttackEnemyDistance(CvTacticalPlot::TD_BOTH))
+			{
+				if (pSourcePlot->canSeePlot(pTargetPlot, eTeam, iDistance, NO_DIRECTION))
+					it->setRangedAttackEnemyDistance(CvTacticalPlot::TD_BOTH, iDistance);
+			}
+			if (iDistance < it->getRangedAttackEnemyDistance(CvTacticalPlot::TD_SEA))
+			{
+				if (pSourcePlot->canSeePlot(pTargetPlot, eTeam, iDistance, NO_DIRECTION))
+					it->setRangedAttackEnemyDistance(CvTacticalPlot::TD_SEA, iDistance);
+			}
 		}
 
 		//pt3
 		for (size_t i = 0; i < gCities.size(); i++)
 		{
-			int iDistance = plotDistance(*GC.getMap().plotByIndexUnchecked(gCities[i]), *it->getPlot());
+			pTargetPlot = GC.getMap().plotByIndexUnchecked(gCities[i]);
+			int iDistance = plotDistance(*pSourcePlot, *pTargetPlot);
 			if (iDistance < it->getEnemyDistance(CvTacticalPlot::TD_BOTH))
 				it->setEnemyDistance(CvTacticalPlot::TD_BOTH, iDistance);
 			if (iDistance < it->getEnemyDistance(CvTacticalPlot::TD_LAND))
@@ -9516,6 +9591,21 @@ void CvTacticalPosition::refreshVolatilePlotProperties(bool bInitial)
 				it->setNumAdjacentEnemies(CvTacticalPlot::TD_BOTH, it->getNumAdjacentEnemies(CvTacticalPlot::TD_BOTH) + 1);
 				it->setNumAdjacentEnemies(CvTacticalPlot::TD_LAND, it->getNumAdjacentEnemies(CvTacticalPlot::TD_LAND) + 1);
 				it->setNumAdjacentEnemies(CvTacticalPlot::TD_SEA, it->getNumAdjacentEnemies(CvTacticalPlot::TD_SEA) + 1);
+			}
+			if (iDistance < it->getRangedAttackEnemyDistance(CvTacticalPlot::TD_BOTH))
+			{
+				if (pSourcePlot->canSeePlot(pTargetPlot, eTeam, iDistance, NO_DIRECTION))
+					it->setRangedAttackEnemyDistance(CvTacticalPlot::TD_BOTH, iDistance);
+			}
+			if (iDistance < it->getRangedAttackEnemyDistance(CvTacticalPlot::TD_LAND))
+			{
+				if (pSourcePlot->canSeePlot(pTargetPlot, eTeam, iDistance, NO_DIRECTION))
+					it->setRangedAttackEnemyDistance(CvTacticalPlot::TD_LAND, iDistance);
+			}
+			if (iDistance < it->getRangedAttackEnemyDistance(CvTacticalPlot::TD_SEA))
+			{
+				if (pSourcePlot->canSeePlot(pTargetPlot, eTeam, iDistance, NO_DIRECTION))
+					it->setRangedAttackEnemyDistance(CvTacticalPlot::TD_SEA, iDistance);
 			}
 		}
 	}
@@ -9563,15 +9653,16 @@ void CvTacticalPosition::refreshVolatilePlotProperties(bool bInitial)
 //need a default constructor for stl containers ...
 CvTacticalPosition::CvTacticalPosition()
 {
-	initFromScratch(NO_PLAYER, AL_LOW, NULL, false, false);
+	initFromScratch(NO_PLAYER, AL_LOW, NULL, false, false, false);
 }
 
-void CvTacticalPosition::initFromScratch(PlayerTypes player, eAggressionLevel eAggLvl, CvPlot* pTarget, bool bTargetDistanceRelevant_, bool bReturnToStartPositions_)
+void CvTacticalPosition::initFromScratch(PlayerTypes player, eAggressionLevel eAggLvl, CvPlot* pTarget, bool bTargetDistanceRelevant_, bool bReturnToStartPositions_, int iSaveMovement_)
 {
 	ePlayer = player;
 	pTargetPlot = pTarget;
 	bTargetDistanceRelevant = bTargetDistanceRelevant_;
 	bReturnToStartPositions = bReturnToStartPositions_;
+	nSaveMovement = iSaveMovement_;
 	eAggression = eAggLvl;
 	nOurOriginalUnits = 0;
 	nOriginalEnemies = 0;
@@ -9603,6 +9694,7 @@ void CvTacticalPosition::initFromParent(const CvTacticalPosition& parent)
 	pTargetPlot = parent.pTargetPlot;
 	bTargetDistanceRelevant = parent.bTargetDistanceRelevant;
 	bReturnToStartPositions = parent.bReturnToStartPositions;
+	nSaveMovement = parent.nSaveMovement;
 	eAggression = parent.eAggression;
 	nOurOriginalUnits = parent.nOurOriginalUnits;
 	nOriginalEnemies = parent.nOriginalEnemies;
@@ -10485,10 +10577,10 @@ bool CvTacticalPosition::addAvailableUnit(const CvUnit* pUnit)
 				//the unit AI type is unreliable, so we do this manually
 				else if (pUnit->IsCanAttackRanged() && pUnit->getDomainType() == DOMAIN_SEA && pUnit->maxMoves() > 3 && pUnit->canMoveAfterAttacking())
 					eStrategy = MS_THIRDLINE; //very fast units can stay even further back
-				else if (pUnit->IsCanAttackRanged())
+				else if (pUnit->IsCanAttackRanged() && pUnit->canMoveAfterAttacking() && pUnit->maxMoves() > 2)
 					eStrategy = MS_SECONDLINE; //skirmishers are second line always
 				else
-					eStrategy = MS_FIRSTLINE; //regular melee
+					eStrategy = MS_FIRSTLINE; //regular melee and slingers
 			}
 			break;
 		//carriers should stay back
@@ -10500,7 +10592,7 @@ bool CvTacticalPosition::addAvailableUnit(const CvUnit* pUnit)
 		//they shouldn't fight if the odds are bad
 		case UNITAI_EXPLORE:
 		case UNITAI_EXPLORE_SEA:
-			eStrategy = MS_FIRSTLINE;
+			eStrategy = MS_THIRDLINE;
 			break;
 
 		//combat support, stay out of danger
@@ -10757,7 +10849,7 @@ struct PrSortPairBySecondAsc
 
 //try to find a combination of unit actions (move, attack etc) which does maximal damage to the enemy while exposing us to minimal risk
 vector<STacticalAssignment> TacticalAIHelpers::FindBestUnitAssignments(
-	const vector<CvUnit*>& vUnits, CvPlot* pTarget, eAggressionLevel eAggLvl, CvTactPosStorage& storage, set<int>& unuseableUnits, bool bTargetDistanceRelevant, bool bReturnToStartPositions)
+	const vector<CvUnit*>& vUnits, CvPlot* pTarget, eAggressionLevel eAggLvl, CvTactPosStorage& storage, set<int>& unuseableUnits, bool bTargetDistanceRelevant, bool bReturnToStartPositions, int iSaveMovement)
 {
 	/*
 	abstract:
@@ -10837,7 +10929,7 @@ vector<STacticalAssignment> TacticalAIHelpers::FindBestUnitAssignments(
 	if (!initialPosition)
 		return result;
 
-	initialPosition->initFromScratch(ePlayer, eAggLvl, pTarget, bTargetDistanceRelevant, bReturnToStartPositions);
+	initialPosition->initFromScratch(ePlayer, eAggLvl, pTarget, bTargetDistanceRelevant, bReturnToStartPositions, iSaveMovement);
 
 	//first pass: make sure there are no duplicates and other invalid inputs
 	vector<CvUnit*> ourUnits;

--- a/CvGameCoreDLL_Expansion2/CvTacticalAI.h
+++ b/CvGameCoreDLL_Expansion2/CvTacticalAI.h
@@ -742,6 +742,8 @@ public:
 
 	unsigned char getEnemyDistance(eTactPlotDomain eDomain = TD_BOTH) const;
 	void setEnemyDistance(eTactPlotDomain eDomain, int iDistance);
+	unsigned char getRangedAttackEnemyDistance(eTactPlotDomain eDomain = TD_BOTH) const;
+	void setRangedAttackEnemyDistance(eTactPlotDomain eDomain, int iDistance);
 	bool checkEdgePlotsForSurprises(const CvTacticalPosition& currentPosition, vector<int>& landEnemies, vector<int>& seaEnemies);
 	bool isValid() const { return pPlot != NULL; }
 	bool isEnemyCombatUnit() const { return pEnemyCombatUnit!=NULL; }
@@ -764,6 +766,7 @@ protected:
 
 	unsigned char aiEnemyDistance[3]; //distance to attack targets, not civilians. recomputed every time an enemy is killed or discovered
 	unsigned char aiEnemyCombatUnitsAdjacent[3]; //recomputed every time an enemy is killed or discovered
+	unsigned char aiRangedAttackEnemyDistance[3];
 
 	unsigned char aiFriendlyCombatUnitsAdjacent[3]; //for flanking. set initially and updated every time a unit moves
 	unsigned char aiFriendlyCombatUnitsAdjacentEndTurn[3]; //ranged units need cover. updated every time a unit finishes
@@ -887,6 +890,7 @@ protected:
 	CvPlot* pTargetPlot;
 	bool bTargetDistanceRelevant;
 	bool bReturnToStartPositions;
+	unsigned char nSaveMovement;
 
 	//should be unique
 	size_t iGeneration;
@@ -964,7 +968,7 @@ public:
 
 	CvTacticalPosition();
 
-	void initFromScratch(PlayerTypes player, eAggressionLevel eAggLvl, CvPlot* pTarget, bool bTargetDistanceRelevant, bool bReturnToStartPositions);
+	void initFromScratch(PlayerTypes player, eAggressionLevel eAggLvl, CvPlot* pTarget, bool bTargetDistanceRelevant, bool bReturnToStartPositions, int iSaveMovement);
 	void initFromParent(const CvTacticalPosition& parent);
 	void wipe();
 
@@ -1074,11 +1078,11 @@ namespace TacticalAIHelpers
 	void UpdatePlotDistanceToTarget(PlayerTypes ePlayer, CvPlot* pTargetPlot);
 	int GetPlotDistanceToTarget(int iPlotIndex, DomainTypes eRelevantDomain);
 
-	bool PerformRangedOpportunityAttack(CvUnit* pUnit, bool bAllowMovement = false);
+	bool PerformRangedOpportunityAttack(CvUnit* pUnit, bool bAllowMovement = false, int iSaveMovement = 0);
 	bool PerformOpportunityAttack(CvUnit* pUnit, bool bAllowMovement = false);
 	bool IsAttackNetPositive(CvUnit* pUnit, const CvPlot* pTarget);
-	CvPlot* FindSafestPlotInReach(const CvUnit* pUnit, bool bAllowEmbark, bool bConsiderPush = false);
-	CvPlot* FindClosestSafePlotForHealing(CvUnit* pUnit, bool bConservative = true);
+	pair<CvPlot*, int> FindSafestPlotInReach(const CvUnit* pUnit, bool bAllowEmbark, bool bConsiderPush = false);
+	pair<CvPlot*, int> FindClosestSafePlotForHealing(CvUnit* pUnit, bool bConservative = true);
 	bool IsGoodPlotForStaging(CvPlayer* pPlayer, CvPlot* pCandidate, DomainTypes eDomain);
 	bool IsCloseToContestedBorder(CvPlayer* pPlayer, CvPlot* pPlot);
 
@@ -1098,7 +1102,7 @@ namespace TacticalAIHelpers
 	int SentryScore(const CvPlot* pPlot, PlayerTypes ePlayer);
 
 	bool FindAndExecuteBestUnitAssignments(PlayerTypes ePlayer, vector<CvUnit*>& vUnits, CvPlot* pTarget, eAggressionLevel eAggLvl);
-	vector<STacticalAssignment> FindBestUnitAssignments(const vector<CvUnit*>& vUnits, CvPlot* pTarget, eAggressionLevel eAggLvl, CvTactPosStorage& storage, set<int>& unuseableUnits, bool bTargetDistanceRelevant, bool bReturnToStartPositions = false);
+	vector<STacticalAssignment> FindBestUnitAssignments(const vector<CvUnit*>& vUnits, CvPlot* pTarget, eAggressionLevel eAggLvl, CvTactPosStorage& storage, set<int>& unuseableUnits, bool bTargetDistanceRelevant, bool bReturnToStartPositions = false, int iSaveMovement = 0);
 	bool ExecuteUnitAssignments(PlayerTypes ePlayer, const vector<STacticalAssignment>& vAssignments);
 }
 

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -29264,14 +29264,14 @@ bool CvUnit::shouldHeal(bool bBeforeAttacks) const
 
 		//also depends on what we can do with the unit
 		int iSoftHpLimit = GetMaxHitPoints() / 3;
-		return GetCurrHitPoints() < iSoftHpLimit && ActualHealRate(plot(), false) > 0 && TacticalAIHelpers::GetTargetsInRange(this, true, false).empty();
+		return GetCurrHitPoints() < iSoftHpLimit && ActualHealRate(plot()) > 0 && TacticalAIHelpers::GetTargetsInRange(this, true, false).empty();
 	}
 	else 
 	{
 		if (GetNumEnemyUnitsAdjacent()>0 || IsEnemyCityAdjacent())
 		{
 			//only run away if strictly necessary
-			return isProjectedToDieNextTurn() && (GetDanger() > GetCurrHitPoints());
+			return isProjectedToDieNextTurn() && (GetDanger() > GetCurrHitPoints() + ActualHealRate(plot()));
 		}
 		else
 		{


### PR DESCRIPTION
AI will now be less likely to abandon border cities even if they aren't under active siege.

AI will now position ranged units such that they can actually use them, rather than just putting them at max range regardless of terrain.

Several fixes for AI healing/fleeing logic:

 * Will now prefer to stay put and heal over moving to an equally good healing plot
 * Will more strongly prefer not to embark while fleeing
 * Will now cancel movement upon discovering a unit when fleeing (and reconsider where to flee to)
 * Should be better at pillaging/performing ranged opportunity attacks while fleeing

AI exploring non-explorer units will no longer stray far away from owned cities.

Add rudimentary support for rend (AoEDamageOnMove) in danger calculations.

Workers should now always prioritize cleaning fallout over everything else for a given plot.

AI will now try to use units that give yield on kill to get kills on enemy units.