### PR TITLE
Restrict Squads code execution in common functions

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -30015,7 +30015,7 @@ int CvUnit::ComputePath(const CvPlot* pToPlot, int iFlags, int iMaxTurns, bool b
 	}
 
 	// If no path exists but continue to closest plot flag is set try to move to an adjacent plot
-	if (MOD_SQUADS)
+	if (MOD_SQUADS && GetSquadNumber() > -1)
 	{
 		newPath = GC.GetPathFinder().GetPath(getX(), getY(), x, y, data);
 
@@ -30412,7 +30412,7 @@ int CvUnit::UnitPathTo(int iX, int iY, int iFlags)
 			PublishQueuedVisualizationMoves();
 			// If the path is non-empty but all plots on it aren't valid moves this turn,
 			// wait and recalculate and try again next turn
-			if (MOD_SQUADS && (iFlags & CvUnit::MOVEFLAG_CONTINUE_TO_CLOSEST_PLOT) && CanStackUnitAtPlot(plot()))
+			if ((MOD_SQUADS && GetSquadNumber() > -1) && (iFlags & CvUnit::MOVEFLAG_CONTINUE_TO_CLOSEST_PLOT) && CanStackUnitAtPlot(plot()))
 			{
 				finishMoves();
 				return MOVE_RESULT_NEXT_TURN;

--- a/CvGameCoreDLL_Expansion2/CvUnitMission.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnitMission.cpp
@@ -496,7 +496,7 @@ void CvUnitMission::ContinueMission(CvUnit* hUnit, int iSteps)
 
 					int iResult = CvUnit::MOVE_RESULT_CANCEL;
 
-					if (MOD_SQUADS && (kMissionData.iFlags & CvUnit::MOVEFLAG_CONTINUE_TO_CLOSEST_PLOT) && !hUnit->m_kLastPath.empty()) {
+					if (MOD_SQUADS && hUnit->GetSquadNumber() > -1 && (kMissionData.iFlags & CvUnit::MOVEFLAG_CONTINUE_TO_CLOSEST_PLOT) && !hUnit->m_kLastPath.empty()) {
 						// If moving as a squad, continue previous re-routed path instead of original destination again
 						iResult = hUnit->UnitAttackWithMove(hUnit->m_kLastPath.back().m_iX, hUnit->m_kLastPath.back().m_iY, kMissionData.iFlags);
 					}
@@ -508,7 +508,7 @@ void CvUnitMission::ContinueMission(CvUnit* hUnit, int iSteps)
 
 					if (iResult == CvUnit::MOVE_RESULT_CANCEL)
 					{
-						if (MOD_SQUADS && (kMissionData.iFlags & CvUnit::MOVEFLAG_CONTINUE_TO_CLOSEST_PLOT))
+						if (MOD_SQUADS && hUnit->GetSquadNumber() > -1 && (kMissionData.iFlags & CvUnit::MOVEFLAG_CONTINUE_TO_CLOSEST_PLOT))
 						{
 							if (hUnit->m_kLastPath.empty())
 							{
@@ -527,7 +527,7 @@ void CvUnitMission::ContinueMission(CvUnit* hUnit, int iSteps)
 					{
 						//nothing to attack, continue movement
 						int iResult = 0;
-						if (MOD_SQUADS && (kMissionData.iFlags & CvUnit::MOVEFLAG_CONTINUE_TO_CLOSEST_PLOT)) {
+						if (MOD_SQUADS && hUnit->GetSquadNumber() > -1 && (kMissionData.iFlags & CvUnit::MOVEFLAG_CONTINUE_TO_CLOSEST_PLOT)) {
 							// If moving as a squad, continue previous re-routed path instead of original destination again
 							iResult = hUnit->UnitPathTo(hUnit->m_kLastPath.back().m_iX, hUnit->m_kLastPath.back().m_iY, kMissionData.iFlags);
 						}
@@ -551,7 +551,7 @@ void CvUnitMission::ContinueMission(CvUnit* hUnit, int iSteps)
 								hUnit->SetIsGrouped(false);
 							}
 
-							if (MOD_SQUADS && (kMissionData.iFlags & CvUnit::MOVEFLAG_CONTINUE_TO_CLOSEST_PLOT))
+							if (MOD_SQUADS && hUnit->GetSquadNumber() > -1 && (kMissionData.iFlags & CvUnit::MOVEFLAG_CONTINUE_TO_CLOSEST_PLOT))
 							{
 								// Wait for rest of squad once arrived
 								hUnit->TryEndSquadMovement();
@@ -720,7 +720,7 @@ void CvUnitMission::ContinueMission(CvUnit* hUnit, int iSteps)
 				if(hUnit->m_kLastPath.empty())
 				{
 					bDone = true;
-					if (MOD_SQUADS && (kMissionData.iFlags & CvUnit::MOVEFLAG_CONTINUE_TO_CLOSEST_PLOT))
+					if (MOD_SQUADS && hUnit->GetSquadNumber() > -1 && (kMissionData.iFlags & CvUnit::MOVEFLAG_CONTINUE_TO_CLOSEST_PLOT))
 					{
 						// Wait for rest of squad once arrived
 						hUnit->TryEndSquadMovement();


### PR DESCRIPTION
Blocks off running expensive squads code behind a check that the unit is in a squad. Should lead to some level of performance improvement. Removes the potential for interactions with AI-controlled units that set `CvUnit::MOVEFLAG_CONTINUE_TO_CLOSEST_PLOT` in their movement missions for players that have the mod enabled, which may have been causing odd behavior.

Potentially fixes [12679](https://github.com/LoneGazebo/Community-Patch-DLL/issues/12679) though it's hard to test