### PR TITLE
Minor builder AI fixes

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
@@ -1989,7 +1989,6 @@ static void UpdateGreatPersonDirectives(vector<OptionWithScore<BuilderDirective>
 			continue;
 
 		int iBestScoreInPlot = 0;
-		int iBestPotentialScoreInPlot = 0;
 
 		for (vector<OptionWithScore<BuilderDirective>>::const_iterator it2 = aDirectives.begin(); it2 != aDirectives.end(); ++it2)
 		{
@@ -2013,13 +2012,11 @@ static void UpdateGreatPersonDirectives(vector<OptionWithScore<BuilderDirective>
 				}
 			}
 
-			int iPotentialScore = it2->option.GetPotentialScore();
-			int iOtherScore = it2->option.m_iScore;
+			int iScore = it2->option.GetPotentialScore();
 
-			if (iPotentialScore > iBestPotentialScoreInPlot)
+			if (iScore > iBestScoreInPlot)
 			{
-				iBestScoreInPlot = iOtherScore;
-				iBestPotentialScoreInPlot = iPotentialScore;
+				iBestScoreInPlot = iScore;
 			}
 		}
 
@@ -4212,7 +4209,7 @@ pair<int,int> CvBuilderTaskingAI::ScorePlotBuild(CvPlot* pPlot, ImprovementTypes
 		}
 	}
 
-	if (bIsWithinWorkRange && pOwningCity)
+	if (bIsBuild && bIsWithinWorkRange && pOwningCity)
 	{
 		int iSimplifiedYieldValue = GetPlotYieldValueSimplified(pPlot, eBuild);
 		int iWorstWorkedValue = INT_MAX;

--- a/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
@@ -3557,7 +3557,6 @@ void CvHomelandAI::ExecuteWorkerMoves()
 				{
 					UnitProcessed(pBuilder->GetID());
 					processedWorkers.insert(pBuilder->GetID());
-					m_workedPlots.insert(GC.getMap().plot(eDirective.m_sX, eDirective.m_sY)->GetPlotIndex());
 					ignoredDirectives.insert(eDirective);
 
 					// Add a sentry point here
@@ -3597,7 +3596,6 @@ void CvHomelandAI::ExecuteWorkerMoves()
 
 				processedWorkers.insert(pBuilder->GetID());
 				ignoredDirectives.insert(eDirective);
-				m_workedPlots.insert(GC.getMap().plot(eDirective.m_sX, eDirective.m_sY)->GetPlotIndex());
 			}
 
 			if (GC.getLogging() && GC.getAILogging())
@@ -3750,6 +3748,8 @@ void CvHomelandAI::ExecuteWorkerMoves()
 					if (!bFinishedBuilding)
 					{
 						int iResourceAmount = eResourceFromImprovement != NO_RESOURCE ? pkImprovementInfo->GetResourceQuantityFromImprovement() : pDirectivePlot->GetNumResourcePostModifiers(m_pPlayer->GetID(), eImprovement);
+						if (bOldConnectedResource)
+							iResourceAmount -= pDirectivePlot->GetNumResourcePostModifiers(m_pPlayer->GetID(), eOldImprovement);
 						sState.mExtraResources[eCreatedResource] += iResourceAmount;
 					}
 					bResourceStateChanged = true;
@@ -3758,7 +3758,9 @@ void CvHomelandAI::ExecuteWorkerMoves()
 				{
 					if (!bFinishedBuilding)
 					{
-						int iResourceAmount = eResourceFromOldImprovement != NO_RESOURCE ? pkOldImprovementInfo->GetResourceQuantityFromImprovement() : pDirectivePlot->getNumResource();
+						int iResourceAmount = eResourceFromOldImprovement != NO_RESOURCE ? pkOldImprovementInfo->GetResourceQuantityFromImprovement() : pDirectivePlot->GetNumResourcePostModifiers(m_pPlayer->GetID(), eOldImprovement);
+						if (bNewConnectsResource)
+							iResourceAmount -= pDirectivePlot->GetNumResourcePostModifiers(m_pPlayer->GetID(), eImprovement);
 						sState.mExtraResources[eRemovedResource] -= iResourceAmount;
 					}
 					bResourceStateChanged = true;
@@ -3866,8 +3868,10 @@ void CvHomelandAI::ExecuteWorkerMoves()
 				// Pruning
 				if (eDirective.m_sX == eOtherDirective.m_sX && eDirective.m_sY == eOtherDirective.m_sY)
 				{
+					bool bCanBuildSimultaneously = (eDirective.m_bIsGreatPerson && eOtherDirective.m_eDirectiveType == BuilderDirective::BUILD_ROUTE)
+						|| (eOtherDirective.m_bIsGreatPerson && eDirective.m_eDirectiveType == BuilderDirective::BUILD_ROUTE);
 					// Prune directives that are in the same plot
-					if (bCanBuild || eDirective == eOtherDirective)
+					if ((bCanBuild && !bCanBuildSimultaneously) || eDirective == eOtherDirective)
 					{
 						continue;
 					}
@@ -3878,10 +3882,10 @@ void CvHomelandAI::ExecuteWorkerMoves()
 							continue;
 
 						// Don't build GP improvements where we want to build better things
-						if (pkOtherImprovementInfo && pkOtherImprovementInfo->IsCreatedByGreatPerson())
+						if (!bCanBuildSimultaneously && pkOtherImprovementInfo && pkOtherImprovementInfo->IsCreatedByGreatPerson())
 							continue;
 
-						if (eOtherImprovement != NO_IMPROVEMENT && eOtherImprovement != eOtherOldImprovement)
+						if (!bCanBuildSimultaneously && eOtherImprovement != NO_IMPROVEMENT && eOtherImprovement != eOtherOldImprovement)
 						{
 							pair<int,int> pScore = pBuilderTaskingAI->ScorePlotBuild(pDirectivePlot, eOtherImprovement, eOtherDirective.m_eBuild, sState);
 

--- a/CvGameCoreDLL_Expansion2/CvTacticalAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTacticalAI.cpp
@@ -5752,11 +5752,12 @@ bool TacticalAIHelpers::PerformOpportunityAttack(CvUnit* pUnit, bool bAllowMovem
 			iScoreThreshold += 1000;
 		}
 		//maybe capture a civilian?
-		else if (pTestPlot->isEnemyUnit(pUnit->getOwner(), false, true) &&
-			pUnit->GetDanger(pTestPlot) == 0 &&
-			pUnit->GetDanger() == 0)
+		else if (pTestPlot->isEnemyUnit(pUnit->getOwner(), false, true))
 		{
-			meleeTargets.push_back(SPlotWithScore(pTestPlot, 10 - plotDistance(*pTestPlot, *pUnit->plot())));
+			bool bIsSafe = pUnit->GetDanger(pTestPlot) == 0 && pUnit->GetDanger() == 0;
+			bool bCanReturn = pUnit->TurnsToReachTarget(pTestPlot, CvUnit::MOVEFLAG_ATTACK, 1) == 0;
+			if (bIsSafe || bCanReturn)
+				meleeTargets.push_back(SPlotWithScore(pTestPlot, 10 - plotDistance(*pTestPlot, *pUnit->plot())));
 		}
 	}
 


### PR DESCRIPTION
Fix small bug in resource evaluation for improvements, causing it to slightly miscount how many resources it has after building/removing improvements in rare cases.

Fix AI thinking existing improvements are a waste to build even though they are already built.