### PR TITLE
Possible fix for IsBeliefValid crash when city doesn't have any religious presence

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvBeliefClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBeliefClasses.cpp
@@ -2069,7 +2069,7 @@ bool CvReligionBeliefs::IsBeliefValid(BeliefTypes eBelief, ReligionTypes eReligi
 		}
 		if (bHolyCityOnly)
 		{
-			if (pCity != NULL && !pCity->GetCityReligions()->IsHolyCityForReligion(eReligion))
+			if (pCity != NULL && pCity->GetCityReligions()->IsReligionInCity() && !pCity->GetCityReligions()->IsHolyCityForReligion(eReligion))
 			{
 				return false;
 			}
@@ -2079,7 +2079,7 @@ bool CvReligionBeliefs::IsBeliefValid(BeliefTypes eBelief, ReligionTypes eReligi
 	{
 		if (bHolyCityOnly)
 		{
-			if (pCity != NULL && !pCity->GetCityReligions()->IsHolyCityForReligion(eReligion))
+			if (pCity != NULL && pCity->GetCityReligions()->IsReligionInCity() && !pCity->GetCityReligions()->IsHolyCityForReligion(eReligion))
 			{
 				return false;
 			}


### PR DESCRIPTION
Maybe there's another way to fix this that solves the root cause, but this at least removes the crash