### PR TITLE
Various AI fixes

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvAStar.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAStar.cpp
@@ -31,8 +31,7 @@
 #define PATH_ATTACK_WEIGHT										(200)	//per percent penalty on attack
 #define PATH_DEFENSE_WEIGHT										(20)	//per percent defense bonus on turn end plot
 #define PATH_STEP_WEIGHT										(10)	//relatively small
-#define	PATH_EXPLORE_NON_HILL_WEIGHT							(1000)	//per hill plot we fail to visit
-#define PATH_EXPLORE_NON_REVEAL_WEIGHT							(1000)	//per (neighboring) plot we fail to reveal
+#define	PATH_EXPLORE_NON_EXPLORATION_WEIGHT						(PATH_BASE_COST*45)	//max penalty for missing exploration tiles
 #define PATH_BUILD_ROUTE_REUSE_EXISTING_WEIGHT					(40)	//accept two plots detour to save on maintenance
 #define PATH_END_TURN_FOREIGN_TERRITORY							(PATH_BASE_COST*10)		//per turn end plot outside of our territory
 #define PATH_END_TURN_NO_ROUTE									(PATH_BASE_COST*10)		//when in doubt, prefer to end the turn on a plot with a route
@@ -1457,18 +1456,15 @@ int PathCost(const CvAStarNode* parent, const CvAStarNode* node, const SPathFind
 
 	if (finder->HaveFlag(CvUnit::MOVEFLAG_MAXIMIZE_EXPLORE))
 	{
-		// normalize exploration heuristics by fraction of turn spent
-		int iExploreScale = std::max(1, iMovementCost);
-
 		// discourage plots that immediately end the turn
 		if (iMovesLeft <= 0 && parent->m_iStartMovesForTurn > 1)
 		{
-			iCost += (PATH_EXPLORE_NON_HILL_WEIGHT * iExploreScale) / parent->m_iStartMovesForTurn;
+			iCost += (PATH_EXPLORE_NON_EXPLORATION_WEIGHT * iMovementCost) / (parent->m_iStartMovesForTurn * GD_INT_GET(MOVE_DENOMINATOR));
 		}
 		else
 		{
-			int iExploreValue = GET_PLAYER(pUnit->getOwner()).GetEconomicAI()->GetExploreValue(pToPlot, pUnit->visibilityRange());
-			iCost += ((PATH_EXPLORE_NON_HILL_WEIGHT - iExploreValue) * iExploreScale) / parent->m_iStartMovesForTurn;
+			int iExploreValue = min(GET_PLAYER(pUnit->getOwner()).GetEconomicAI()->GetExploreValue(pToPlot, pUnit->visibilityRange()) * 10, PATH_EXPLORE_NON_EXPLORATION_WEIGHT);
+			iCost += ((PATH_EXPLORE_NON_EXPLORATION_WEIGHT - iExploreValue) * iMovementCost) / (parent->m_iStartMovesForTurn * GD_INT_GET(MOVE_DENOMINATOR));
 		}
 	}
 

--- a/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvHomelandAI.cpp
@@ -231,6 +231,29 @@ bool CvHomelandAI::NeedsUpdate()
 	return m_bNeedsUpdate;
 }
 
+bool IsUnfriendlyTerritory(TeamTypes eTeam, const CvPlot* pPlot, const CvUnit* pUnit)
+{
+	TeamTypes ePlotTeam = pPlot->getTeam();
+	if (ePlotTeam != NO_TEAM && ePlotTeam != eTeam)
+	{
+		CvTeam& kMyTeam = GET_TEAM(eTeam);
+		CvTeam& kTheirTeam = GET_TEAM(ePlotTeam);
+		if (kTheirTeam.isMinorCiv() && kMyTeam.isMajorCiv())
+		{
+			if (kMyTeam.isHasMet(ePlotTeam) && !pUnit->IsAngerFreeUnit())
+			{
+				// If we are friends etc we may go there
+				CvMinorCivAI* pMinorAI = GET_PLAYER(kTheirTeam.getLeaderID()).GetMinorCivAI();
+				if (!pMinorAI->IsPlayerHasOpenBorders(pUnit->getOwner()))
+				{
+					return true;
+				}
+			}
+		}
+	}
+	return false;
+}
+
 CvPlot* CvHomelandAI::GetBestExploreTarget(const CvUnit* pUnit, int iMaxTurns) const
 {
 	if (!pUnit)
@@ -306,19 +329,19 @@ CvPlot* CvHomelandAI::GetBestExploreTarget(const CvUnit* pUnit, int iMaxTurns) c
 
 		if (pEvalPlot == pUnit->plot())
 		{
+			if (IsUnfriendlyTerritory(m_pPlayer->getTeam(), pEvalPlot, pUnit))
+				continue;
+
 			// Check if we should stay and heal
-			if (!pUnit->hasMoved() && iMaxTurns == 1 && !pUnit->isHuman(ISHUMAN_AI_UNITS))
+			if (!pUnit->hasMoved() && iMaxTurns <= 3 && !pUnit->isHuman(ISHUMAN_AI_UNITS))
 			{
 				int iDamage = pUnit->getDamage();
-				int iHealRate = pUnit->ActualHealRate(pEvalPlot, false);
-				if (iDamage >= iHealRate)
+				int iHealRate = min(pUnit->ActualHealRate(pEvalPlot, false), iDamage);
+				iHealRate -= pUnit->GetDanger(pEvalPlot);
+				if (iHealRate >= 7 || (iHealRate > 0 && iDamage > 30))
 				{
-					iHealRate -= pUnit->GetDanger(pEvalPlot);
-					if (iHealRate > 0)
-					{
-						int iScore = (iDamage + iHealRate) * 10;
-						vReachablePlotByScore.push_back(SPlotWithScore(pEvalPlot, -iScore));
-					}
+					int iScore = iHealRate * 20;
+					vReachablePlotByScore.push_back(SPlotWithScore(pEvalPlot, -iScore));
 				}
 			}
 			continue;
@@ -400,18 +423,34 @@ CvPlot* CvHomelandAI::GetBestExploreTarget(const CvUnit* pUnit, int iMaxTurns) c
 
 		iPlotScore += EconomicAIHelpers::GetExtraExploreValue(pEvalPlot, iPlotVisibilityRange, m_pPlayer->getTeam());
 
-		int iPathLengthPenalty = reachablePlot->iPathLength * GD_INT_GET(MOVE_DENOMINATOR) * pUnit->maxMoves() * 2;
+		int iPathLengthPenalty = reachablePlot->iPathLength * pUnit->maxMoves() * 2;
 		int iMovesLeftBonus = reachablePlot->iMovesLeft * 2;
 
 		int iTotalScore = iPlotScore - iNearbyPenalty + iMovesLeftBonus - iPathLengthPenalty;
 
 		//careful with plots that are too dangerous
-		int iAcceptableDanger = pUnit->GetCurrHitPoints() / 2;
-		int iDanger = pUnit->GetDanger(pEvalPlot);
-		if (iDanger > iAcceptableDanger)
-			continue;
-		if (iDanger > iAcceptableDanger / 2)
-			iTotalScore /= 2;
+		if (reachablePlot->iMovesLeft <= GD_INT_GET(MOVE_DENOMINATOR))
+		{
+			int iAcceptableDanger = pUnit->GetCurrHitPoints() / 2;
+			int iDanger = pUnit->GetDanger(pEvalPlot);
+			if (iDanger > iAcceptableDanger)
+				continue;
+
+			if (iDanger > 0)
+				iTotalScore -= iDanger * 10;
+		}
+
+		// Avoid angering city states
+		if (reachablePlot->iMovesLeft < 2 * GD_INT_GET(MOVE_DENOMINATOR))
+		{
+			if (IsUnfriendlyTerritory(m_pPlayer->getTeam(), pEvalPlot, pUnit))
+			{
+				if (reachablePlot->iMovesLeft == 0)
+					continue;
+				else
+					iTotalScore /= 2;
+			}
+		}
 
 		vReachablePlotByScore.push_back(SPlotWithScore(pEvalPlot, -iTotalScore));
 	}
@@ -2952,17 +2991,11 @@ bool CvHomelandAI::ExecuteExplorerMoves(CvUnit* pUnit)
 
 	CvPlot* pBestPlot = NULL;
 
-	//step 5: if we didn't find a worthwhile plot among our adjacent plots, check the global targets and pick a new one
+	//step 5: look for good targets, starting nearby and extending outwards
 	if (pUnit->movesLeft() > 0)
 	{
-		int iDist = 1;
-		pBestPlot = GetBestExploreTarget(pUnit, iDist);
-
-		if (!pBestPlot)
-		{
-			iDist = 3;
-			pBestPlot = pBestPlotDist3;
-		}
+		int iDist = 3;
+		pBestPlot = pBestPlotDist3;
 
 		if (!pBestPlot)
 		{

--- a/CvGameCoreDLL_Expansion2/CvTacticalAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTacticalAI.cpp
@@ -8753,7 +8753,10 @@ void CvTacticalPosition::getPreferredAssignmentsForUnit(const SUnitStats& unit, 
 
 					//score functions are biased so that only scores > 0 are interesting moves
 					//still allow mildly negative moves here, maybe we want to do combo moves later!
-					moveToPlot.iPlotScore += iDamageScore * 10;
+					if (moveToPlot.iRemainingMoves > 0)
+						moveToPlot.iPlotScore += iDamageScore * 10;
+					else
+						moveToPlot.iPlotScore += iDamageScore * 5;
 				}
 				//undo the hypothetical kill
 				moveToPlot.iKillOrNearKillId = -1;


### PR DESCRIPTION
Exploring units will not heal and will try not to end their turn in non-friendly city state territory.

Improve AI danger calculations for exploring units.

Performance improvement for explorers, skip an unnecessary pathfinding call.

Fix incorrect distance calculation when evaluating exploration plots.