### PR TITLE
Let modded Inca still settle on Mountains

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvSiteEvaluationClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvSiteEvaluationClasses.cpp
@@ -80,7 +80,7 @@ bool CvCitySiteEvaluator::CanFoundCity(const CvPlot* pPlot, const CvPlayer* pPla
 
 	if(!pPlot->isValidMovePlot(pPlayer ? pPlayer->GetID() : NO_PLAYER ))
 	{
-		if (!pPlot->IsMountain() || !pPlayer->WorkersMountainPass())
+		if (!pPlot->isMountain() || !pPlayer->WorkersMountainPass())
 			return false;
 	}
 


### PR DESCRIPTION
I was missing this update of the new civilian-only mountain passing in the SiteEvaluation method that gets called to decide if Founding is an allowed action (this is the one that gets overridden if there is a road on the tile)