### PR TITLE
Fix malformed CvString declaration ('passing NULL to std:string' assert)

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -613,7 +613,7 @@ void CvUnit::initWithNameOffset(int iID, UnitTypes eUnit, int iNameOffset, UnitA
 		{
 			iNameOffset = GC.getGame().randRangeExclusive(0, iNumNames, CvSeeder(plot()->GetPseudoRandomSeed()));
 		}
-		CvString strName = NULL;
+		CvString strName;
 		//Look for units from previous and current eras.
 		for(iI = 0; iI < iNumNames; iI++)
 		{


### PR DESCRIPTION
The compiler used to generate the release .dlls interpreted `CvString strName = NULL` as `CvString strName = CvString((char*)NULL)` for the 5.1.4 version, for some reason breaking with the previous versions interpretation as `CvString strName = CvString((int)NULL)`. Github's builds and potentially local ones were unaffected.

`CvString strName = NULL` is not properly defined and should just be `CvString strName;`

I used notepads file search function with the regular expression search mask: 
`CvString\s+([a-zA-Z0-9_]*)\s*=\s*NULL`
but it seems CvUnit:616 is the only location where such a construct was used.

Should fix the "passing NULL to std:string" assert popup (but nothing else) reported in these issues:
#12751 
#12773 
#12759 
#12758 
#12755 