### PR TITLE
Fix Royal Guardhouse supply effect

### DIFF
--- a/(2) Vox Populi/Database Changes/City/Buildings/NewBuildings.xml
+++ b/(2) Vox Populi/Database Changes/City/Buildings/NewBuildings.xml
@@ -2110,7 +2110,7 @@
 			<Description>TXT_KEY_BUILDING_ROYAL_GUARDHOUSE</Description>
 			<Civilopedia>TXT_KEY_BUILDING_ROYAL_GUARDHOUSE_TEXT</Civilopedia>
 			<Help>TXT_KEY_BUILDING_ROYAL_GUARDHOUSE_HELP</Help>
-			<CitySupplyModifier>20</CitySupplyModifier>
+			<CitySupplyModifierGlobal>10</CitySupplyModifierGlobal>
 			<CapitalOnly>true</CapitalOnly>
 			<SpecialistType>SPECIALIST_ENGINEER</SpecialistType>
 			<SpecialistCount>1</SpecialistCount>


### PR DESCRIPTION
https://forums.civfanatics.com/threads/7-vt-supply-cap-rework.689244/ Policy text was updated but xml fell behind.

Note: I don't think this will actually accomplish what the OP says in that thread. 20% in capital is weaker than 10% in all cities, except very early. So this will be a buff to Tradition supply in late game (?)