### PR TITLE
Parameterize SQL queries and add post-mod ANALYZE

### DIFF
--- a/(2) Vox Populi/Core Files/Overrides/CivilopediaScreen.lua
+++ b/(2) Vox Populi/Core Files/Overrides/CivilopediaScreen.lua
@@ -2774,7 +2774,7 @@ CivilopediaCategory[CategoryTech].SelectArticle = function( techID, shouldAddToL
 			thisPlayer = Players[Game.GetActivePlayer()];
 			if thisPlayer ~= nil then
 				leaderID = thisPlayer:GetLeaderType();
-				for leaderTraits in DB.Query( "SELECT TraitType FROM Leader_Traits INNER JOIN Leaders on Leaders.Type = LeaderType WHERE Leaders.ID = " .. leaderID ) do
+				for leaderTraits in DB.Query( "SELECT TraitType FROM Leader_Traits INNER JOIN Leaders on Leaders.Type = LeaderType WHERE Leaders.ID = ?", leaderID ) do
 					traitType = leaderTraits.TraitType;
 					break;
 				end
@@ -6521,7 +6521,7 @@ CivilopediaCategory[CategoryResources].SelectArticle = function( resourceID, sho
 		thisPlayer = Players[Game.GetActivePlayer()];
 		if thisPlayer ~= nil then
 			leaderID = thisPlayer:GetLeaderType();
-			for leaderTraits in DB.Query( "SELECT TraitType FROM Leader_Traits INNER JOIN Leaders on Leaders.Type = LeaderType WHERE Leaders.ID = " .. leaderID ) do
+			for leaderTraits in DB.Query( "SELECT TraitType FROM Leader_Traits INNER JOIN Leaders on Leaders.Type = LeaderType WHERE Leaders.ID = ?", leaderID ) do
 				traitType = leaderTraits.TraitType;
 				break;
 			end

--- a/(3a) VP - EUI Compatibility Files/ImprovedTopPanel/TopPanel.lua
+++ b/(3a) VP - EUI Compatibility Files/ImprovedTopPanel/TopPanel.lua
@@ -467,7 +467,7 @@ local function UpdateTopPanelNow()
 	local traitType = "";
 	if g_activePlayer ~= nil then
 		leaderID = g_activePlayer:GetLeaderType();
-		for leaderTraits in DB.Query( "SELECT TraitType FROM Leader_Traits INNER JOIN Leaders on Leaders.Type = LeaderType WHERE Leaders.ID = " .. leaderID ) do
+		for leaderTraits in DB.Query( "SELECT TraitType FROM Leader_Traits INNER JOIN Leaders on Leaders.Type = LeaderType WHERE Leaders.ID = ?", leaderID ) do
 			traitType = leaderTraits.TraitType;
 			break;
 		end

--- a/CvGameCoreDLL_Expansion2/CustomMods.cpp
+++ b/CvGameCoreDLL_Expansion2/CustomMods.cpp
@@ -178,9 +178,11 @@ void CustomMods::prefetchCache() {
 	while (kPostDefines.Step()) {
 		Database::Results kLookup;
 		char szSQL[512];
-		sprintf_s(szSQL, "select ROWID from %s where Type = '%s' LIMIT 1", kPostDefines.GetText("Table"), kPostDefines.GetText("Type"));
+		// Table name must be concatenated (SQLite doesn't support parameterized identifiers)
+		sprintf_s(szSQL, "select ROWID from %s where Type = ? LIMIT 1", kPostDefines.GetText("Table"));
 
 		if (db->Execute(kLookup, szSQL)) {
+			kLookup.Bind(1, kPostDefines.GetText("Type"));
 			if (kLookup.Step()) {
 				kInsert.Bind(1, kPostDefines.GetText("Name"));
 				kInsert.Bind(2, kLookup.GetInt(0));

--- a/CvGameCoreDLL_Expansion2/CvDllDatabaseUtility.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDllDatabaseUtility.cpp
@@ -175,6 +175,11 @@ bool CvDllDatabaseUtility::CacheGameDatabaseData()
 	//Clear out database cache and tune for runtime use.
 	DB.ClearCountCache();
 
+	// Refresh query planner statistics for indexes added by the mod.
+	// The engine runs ANALYZE before mods are loaded, so post-mod
+	// indexes (60+ from AddTableIndexes.sql) lack statistics.
+	DB.Analyze();
+
 	//Log Database Memory statistics
 	LogMsg(DB.CalculateMemoryStats());
 
@@ -224,17 +229,15 @@ bool CvDllDatabaseUtility::PerformDatabasePostProcessing()
 		const char* szTableName = kPostDefines.GetText("Table");
 		char szSQL[512];
 
-		sprintf_s(szSQL, "select ROWID from %s where Type = '%s' LIMIT 1", szTableName, szKeyName);
+		// Table name must be concatenated (SQLite doesn't support parameterized identifiers)
+		sprintf_s(szSQL, "select ROWID from %s where Type = ? LIMIT 1", szTableName);
 
 		Database::Results kLookup;
-
-		//Compile the command.
 		if(db->Execute(kLookup, szSQL))
 		{
-			//Run the command.
+			kLookup.Bind(1, szKeyName);
 			if(kLookup.Step())
 			{
-				//Perform insertion
 				kInsert.Bind(1, szName);
 				kInsert.Bind(2, kLookup.GetInt(0));
 				kInsert.Step();
@@ -486,19 +489,27 @@ void CvDllDatabaseUtility::DatabaseRemapper()
 								}
 								vTableIDs.push_back(kQuery.GetInt(0));
 							}
+							// Prepare UPDATE once per table, bind+execute for each row
+							char szUpdate[512];
+							sprintf_s(szUpdate, "UPDATE %s SET ID = ? WHERE ID = ?", szTableName);
+							Database::Results kUpdate;
 							bool bFirst = true;
-							for (uint ui = 0; ui < vTableIDs.size(); ui++)
+							if (DB.Execute(kUpdate, szUpdate))
 							{
-								if (vTableIDs[ui] != static_cast<int>(ui))
+								for (uint ui = 0; ui < vTableIDs.size(); ui++)
 								{
-									if (bFirst)
+									if (vTableIDs[ui] != static_cast<int>(ui))
 									{
-										LogMsg("Table %s: Remapping %u incorrect IDs, starting with %d -> %u. ", szTableName, vTableIDs.size() - ui, vTableIDs[ui], ui);
-										bFirst = false;
+										if (bFirst)
+										{
+											LogMsg("Table %s: Remapping %u incorrect IDs, starting with %d -> %u. ", szTableName, vTableIDs.size() - ui, vTableIDs[ui], ui);
+											bFirst = false;
+										}
+										kUpdate.Bind(1, (int)ui);
+										kUpdate.Bind(2, vTableIDs[ui]);
+										kUpdate.Execute();
+										kUpdate.Reset();
 									}
-									char szUpdate[512];
-									sprintf_s(szUpdate, "UPDATE %s SET ID = %d WHERE ID = %d;", szTableName, (int)ui, vTableIDs[ui]);
-									DB.Execute(szUpdate);
 								}
 							}
 						}

--- a/CvGameCoreDLL_Expansion2/CvInfos.cpp
+++ b/CvGameCoreDLL_Expansion2/CvInfos.cpp
@@ -4530,11 +4530,9 @@ bool CvHandicapInfo::CacheResults(Database::Results& kResults, CvDatabaseUtility
 		kUtility.InitializeArray(m_piGoodies, m_iNumGoodies, 0);
 
 		Database::Results kArrayResults;
-		char szSQL[512];
-		sprintf_s(szSQL, "select GoodyHuts.ID from HandicapInfo_Goodies inner join GoodyHuts on GoodyType = GoodyHuts.Type where HandicapType = '%s';", szHandicapType);
-
-		if (DB.Execute(kArrayResults, szSQL))
+		if (DB.Execute(kArrayResults, "select GoodyHuts.ID from HandicapInfo_Goodies inner join GoodyHuts on GoodyType = GoodyHuts.Type where HandicapType = ?"))
 		{
+			kArrayResults.Bind(1, szHandicapType);
 			int i = 0;
 			while (kArrayResults.Step())
 			{
@@ -4930,21 +4928,22 @@ bool CvGameSpeedInfo::CacheResults(Database::Results& kResults, CvDatabaseUtilit
 		const char* szGameSpeedInfoType = GetType();
 
 		//Calculate number of turn increments
-		char szCountSQL[256];
-		sprintf_s(szCountSQL, "select count(*) from GameSpeed_Turns where GameSpeedType = '%s'", szGameSpeedInfoType);
-		Database::SingleResult kCount;
-		if(DB.Execute(kCount, szCountSQL))
+		Database::Results kCount;
+		if(DB.Execute(kCount, "select count(*) from GameSpeed_Turns where GameSpeedType = ?"))
 		{
-			m_iNumTurnIncrements = kCount.GetInt(0);
+			kCount.Bind(1, szGameSpeedInfoType);
+			if(kCount.Step())
+			{
+				m_iNumTurnIncrements = kCount.GetInt(0);
+			}
 		}
 
 		//Update turn increments
 		allocateGameTurnInfos(getNumTurnIncrements());
-		char szSQL[256];
-		sprintf_s(szSQL, "select * from GameSpeed_Turns where GameSpeedType = '%s'", szGameSpeedInfoType);
 		Database::Results kArrayResults;
-		if(DB.Execute(kArrayResults, szSQL))
+		if(DB.Execute(kArrayResults, "select * from GameSpeed_Turns where GameSpeedType = ?"))
 		{
+			kArrayResults.Bind(1, szGameSpeedInfoType);
 			int i = 0;
 			while(kArrayResults.Step())
 			{
@@ -5372,13 +5371,10 @@ bool CvBuildInfo::CacheResults(Database::Results& kResults, CvDatabaseUtility& k
 		kUtility.InitializeArray(m_paiFeatureObsoleteTech, "Features");
 		kUtility.InitializeArray(m_pabFeatureRemoveOnly, "Features");
 
-		char szQuery[512];
-		const char* szFeatureQuery = "select * from BuildFeatures where BuildType = '%s'";
-		sprintf_s(szQuery, 512, szFeatureQuery, GetType());
-
 		Database::Results kArrayResults;
-		if(DB.Execute(kArrayResults, szQuery))
+		if(DB.Execute(kArrayResults, "select * from BuildFeatures where BuildType = ?"))
 		{
+			kArrayResults.Bind(1, GetType());
 			while(kArrayResults.Step())
 			{
 				const char* szFeatureType			= kArrayResults.GetText("FeatureType");
@@ -6572,11 +6568,9 @@ bool CvResourceInfo::CacheResults(Database::Results& kResults, CvDatabaseUtility
 		m_piResourceQuantityTypes[0] = 1;
 
 		Database::Results kArrayResults;
-		char szQuery[512];
-		sprintf_s(szQuery, "select Quantity from Resource_QuantityTypes where ResourceType = '%s';", szResourceType);
-
-		if(DB.Execute(kArrayResults, szQuery))
+		if(DB.Execute(kArrayResults, "select Quantity from Resource_QuantityTypes where ResourceType = ?"))
 		{
+			kArrayResults.Bind(1, szResourceType);
 			int i = 0;
 			while(kArrayResults.Step())
 			{

--- a/CvGameCoreDLL_Expansion2/CvProjectClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvProjectClasses.cpp
@@ -137,10 +137,9 @@ bool CvProjectEntry::CacheResults(Database::Results& kResults, CvDatabaseUtility
 		kUtility.InitializeArray(m_piVictoryMinThreshold, iNumVictories);
 
 		Database::Results kDBResults;
-		char szQuery[512] = {0};
-		sprintf_s(szQuery, "select VictoryType, Threshold, MinThreshold from Project_VictoryThresholds where ProjectType = '%s';", szProjectType);
-		if(DB.Execute(kDBResults, szQuery))
+		if(DB.Execute(kDBResults, "select VictoryType, Threshold, MinThreshold from Project_VictoryThresholds where ProjectType = ?"))
 		{
+			kDBResults.Bind(1, szProjectType);
 			while(kDBResults.Step())
 			{
 				const char* szVictoryType = kDBResults.GetText("VictoryType");

--- a/CvGameCoreDLL_Expansion2/CvPromotionClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPromotionClasses.cpp
@@ -3583,10 +3583,10 @@ bool CvPromotionEntry::IsUnitNaming(int i) const
 void CvPromotionEntry::GetUnitName(UnitTypes eUnit, CvString& sUnitName) const
 {
 	Database::Results kDBResults;
-	char szQuery[512] = {0};
-	sprintf_s(szQuery, "select Name from UnitPromotions_UnitName n, UnitPromotions p, Units u where n.PromotionType = p.Type and n.UnitType = u.Type and p.ID = %i and u.ID = %i;", GetID(), eUnit);
-	if(DB.Execute(kDBResults, szQuery))
+	if(DB.Execute(kDBResults, "select Name from UnitPromotions_UnitName n, UnitPromotions p, Units u where n.PromotionType = p.Type and n.UnitType = u.Type and p.ID = ? and u.ID = ?"))
 	{
+		kDBResults.Bind(1, GetID());
+		kDBResults.Bind(2, (int)eUnit);
 		while(kDBResults.Step())
 		{
 			sUnitName = kDBResults.GetText("Name");


### PR DESCRIPTION
Replace sprintf_s string interpolation with parameter binding (?/Bind) for all SQL value parameters in C++ and Lua code.

C++ (6 files, 11 queries):
- CvInfos.cpp: HandicapInfo_Goodies, GameSpeed_Turns (count+select), Resource_QuantityTypes, BuildFeatures
- CvProjectClasses.cpp: Project_VictoryThresholds
- CvPromotionClasses.cpp: UnitPromotions_UnitName
- CvDllDatabaseUtility.cpp: PostDefines ROWID lookup, DatabaseRemapper UPDATE (converted to prepare-once with Bind/Execute/Reset per row)
- CustomMods.cpp: CustomModPostDefines ROWID lookup

GameSpeed_Turns count query changed from SingleResult to Results because SingleResult auto-steps in SetCommand() before Bind() can be called.

Lua (2 files, 3 queries):
- CivilopediaScreen.lua (x2): Leader_Traits JOIN query
- VP - EUI Compatibility Files/ImprovedTopPanel/TopPanel.lua: Leader_Traits JOIN query

Add DB.Analyze() call in CvDllDatabaseUtility::CacheGameDatabaseData() after ClearCountCache() to refresh query planner statistics for the 60+ indexes added by mod SQL files.