### PR TITLE
Curious case of Belief_YieldFromSpread

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -26175,10 +26175,7 @@ void CvPlayer::doInstantYield(InstantYieldType iType, bool bCityFaith, GreatPers
 						}
 						if(pCity != NULL)
 						{
-							if (pCity->getOwner() != GetID())
-							{
-								iValue += pReligion->m_Beliefs.GetYieldFromSpread(eYield, GetID(), pLoopCity, true) * max(1, iPassYield+1);
-							}
+							iValue += pReligion->m_Beliefs.GetYieldFromSpread(eYield, GetID(), pLoopCity, true) * max(1, iPassYield+1);
 						}
 					}
 					if (eYield == YIELD_JFD_LOYALTY && eYield == ePassYield)

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -26186,7 +26186,7 @@ void CvPlayer::doInstantYield(InstantYieldType iType, bool bCityFaith, GreatPers
 				{
 					if(ePlayer != NO_PLAYER && ePlayer != GetID())
 					{
-						if(GET_PLAYER(ePlayer).isMinorCiv() && eYield == YIELD_TOURISM)
+						if (!GET_PLAYER(ePlayer).isMajorCiv() && eYield == YIELD_TOURISM)
 						{
 							continue;
 						}


### PR DESCRIPTION
This table is not meant to check if the City is Foreign, we have Belief_YieldFromForeignSpread for that.

I found that the behavior was changed in commit 430e3b0
If I cross reference the commit text, it seems there was some confusion?
Azum talks in #12364 about changing the Tourism, but that part is the Belief_YieldFromForeignSpread
So, looking at the second part of that change, should here
```
CvPlayer &kPlayer = GET_PLAYER(m_eOwner);
if (pCity->getOwner() != m_eOwner)
{
  int iOtherFollowers = pCity->GetCityReligions()->GetFollowersOtherReligions(eReligion, true);
  kPlayer.doInstantYield(INSTANT_YIELD_TYPE_F_SPREAD, false, NO_GREATPERSON, NO_BUILDING, iOtherFollowers, false, pCity->getOwner(), plot());
}
```

instead this pCity->GetOwner() be replaced with NO_PLAYER? It will also need
`if(ePlayer != NO_PLAYER && ePlayer != GetID())` 
guard in the DoInstantYield to be removed (and the ePlayer != GetID() isn't necessary because it is checked in CpUnit.cpp)


