### PR TITLE
Zealotry fix

### DIFF
--- a/(2) Vox Populi/Database Changes/Units/UnitSweeps.sql
+++ b/(2) Vox Populi/Database Changes/Units/UnitSweeps.sql
@@ -105,14 +105,14 @@ SET HurryCostModifier = 25
 WHERE SpaceshipProject IS NOT NULL;
 
 -----------------------------------------------------------------
--- RequiresFaithPurchaseEnabled: only applicable to land/air units
+-- RequiresFaithPurchaseEnabled
 -- This blocks the unit from being always faith purchasable as long as it has a faith cost
 -----------------------------------------------------------------
 
 -- All non-naval military units except mercenary units
 UPDATE Units
 SET RequiresFaithPurchaseEnabled = 1
-WHERE CombatClass IN (SELECT Type FROM UnitCombatInfos WHERE IsMilitary = 1 AND IsNaval = 0)
+WHERE CombatClass IN (SELECT Type FROM UnitCombatInfos WHERE IsMilitary = 1)
 AND PurchaseOnly = 0;
 
 -- Siege Tower and Archaeologist also require beliefs to be faith purchased

--- a/(2) Vox Populi/Database Changes/Units/UnitSweeps.sql
+++ b/(2) Vox Populi/Database Changes/Units/UnitSweeps.sql
@@ -109,7 +109,7 @@ WHERE SpaceshipProject IS NOT NULL;
 -- This blocks the unit from being always faith purchasable as long as it has a faith cost
 -----------------------------------------------------------------
 
--- All non-naval military units except mercenary units
+-- All military units except mercenary units
 UPDATE Units
 SET RequiresFaithPurchaseEnabled = 1
 WHERE CombatClass IN (SELECT Type FROM UnitCombatInfos WHERE IsMilitary = 1)

--- a/CvGameCoreDLL_Expansion2/CvBeliefClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBeliefClasses.cpp
@@ -1266,7 +1266,7 @@ int CvBeliefEntry::GetMaxYieldModifierPerFollowerPercent(int i) const
 	return m_piMaxYieldModifierPerFollowerPercent ? m_piMaxYieldModifierPerFollowerPercent[i] : -1;
 }
 
-/// Can we buy units of this era with faith?
+/// Can we buy land units of this era with faith?
 bool CvBeliefEntry::IsFaithUnitPurchaseEra(int i) const
 {
 	PRECONDITION(i > -1, "Index out of bounds");
@@ -1280,7 +1280,7 @@ bool CvBeliefEntry::IsFaithUnitPurchaseSpecific(int i) const
 	PRECONDITION(i < GC.getNumUnitInfos(), "Index out of bounds");
 	return m_pbFaithPurchaseUnitSpecificEnabled ? m_pbFaithPurchaseUnitSpecificEnabled[i] : false;
 }
-/// Can we buy units of this era with faith?
+/// Can we access this building class?
 bool CvBeliefEntry::IsBuildingClassEnabled(int i) const
 {
 	PRECONDITION(i > -1, "Index out of bounds");
@@ -1434,7 +1434,7 @@ bool CvBeliefEntry::CacheResults(Database::Results& kResults, CvDatabaseUtility&
 	kUtility.PopulateArrayByValue(m_piYieldPerOtherReligionFollower, "Yields", "Belief_YieldPerOtherReligionFollower", "YieldType", "BeliefType", szBeliefType, "Yield");
 	kUtility.PopulateArrayByValue(m_paiLakePlotYieldChange, "Yields", "Belief_LakePlotYield", "YieldType", "BeliefType", szBeliefType, "Yield");	
 	kUtility.PopulateArrayByExistence(m_pbFaithPurchaseUnitSpecificEnabled, "Units", "Belief_SpecificFaithUnitPurchase", "UnitType", "BeliefType", szBeliefType);
-	kUtility.PopulateArrayByExistence(m_pbFaithPurchaseUnitEraEnabled, "Eras", "Belief_EraFaithUnitPurchase", "EraType", "BeliefType", szBeliefType);
+	kUtility.PopulateArrayByExistence(m_pbFaithPurchaseUnitEraEnabled, "Eras", "Belief_EraFaithLandUnitPurchase", "EraType", "BeliefType", szBeliefType);
 	kUtility.PopulateArrayByExistence(m_pbBuildingClassEnabled, "BuildingClasses", "Belief_BuildingClassFaithPurchase", "BuildingClassType", "BeliefType", szBeliefType);
 
 	//YieldPerBorderGrowth
@@ -3906,7 +3906,7 @@ bool CvReligionBeliefs::IsBuildingClassEnabled(BuildingClassTypes eType, PlayerT
 	return false;
 }
 
-/// Is there a belief that allows faith buying of units
+/// Is there a belief that allows faith buying of land units
 bool CvReligionBeliefs::IsFaithBuyingEnabled(EraTypes eEra, PlayerTypes ePlayer, const CvCity* pCity, bool bHolyCityOnly) const
 {
 	CvBeliefXMLEntries* pBeliefs = GC.GetGameBeliefs();

--- a/CvGameCoreDLL_Expansion2/CvBeliefClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBeliefClasses.cpp
@@ -1434,7 +1434,7 @@ bool CvBeliefEntry::CacheResults(Database::Results& kResults, CvDatabaseUtility&
 	kUtility.PopulateArrayByValue(m_piYieldPerOtherReligionFollower, "Yields", "Belief_YieldPerOtherReligionFollower", "YieldType", "BeliefType", szBeliefType, "Yield");
 	kUtility.PopulateArrayByValue(m_paiLakePlotYieldChange, "Yields", "Belief_LakePlotYield", "YieldType", "BeliefType", szBeliefType, "Yield");	
 	kUtility.PopulateArrayByExistence(m_pbFaithPurchaseUnitSpecificEnabled, "Units", "Belief_SpecificFaithUnitPurchase", "UnitType", "BeliefType", szBeliefType);
-	kUtility.PopulateArrayByExistence(m_pbFaithPurchaseUnitEraEnabled, "Eras", "Belief_EraFaithLandUnitPurchase", "EraType", "BeliefType", szBeliefType);
+	kUtility.PopulateArrayByExistence(m_pbFaithPurchaseUnitEraEnabled, "Eras", "Belief_EraFaithUnitPurchase", "EraType", "BeliefType", szBeliefType);
 	kUtility.PopulateArrayByExistence(m_pbBuildingClassEnabled, "BuildingClasses", "Belief_BuildingClassFaithPurchase", "BuildingClassType", "BeliefType", szBeliefType);
 
 	//YieldPerBorderGrowth

--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -30485,10 +30485,6 @@ bool CvCity::IsCanPurchase(const std::vector<int>& vPreExistingBuildings, bool b
 				return false;
 
 			CvUnitEntry* pkUnitInfo = GC.getUnitInfo(eUnitType);
-			//naval units are only for the UA!
-			if (pkUnitInfo->GetDomainType() == DOMAIN_SEA && pkUnitInfo->GetSpecialUnitType() == NO_SPECIALUNIT && !GET_PLAYER(getOwner()).GetPlayerTraits()->IsCanPurchaseNavalUnitsFaith())
-				return false;
-
 			ReligionTypes eReligion;
 			if (pkUnitInfo->IsFoundReligion())
 			{
@@ -30499,6 +30495,7 @@ bool CvCity::IsCanPurchase(const std::vector<int>& vPreExistingBuildings, bool b
 				eReligion = GetCityReligions()->GetReligiousMajority();
 			}
 			const CvReligion* pReligion = GC.getGame().GetGameReligions()->GetReligion(eReligion, getOwner());
+			// if there is a belief that unlocks a specific unit, that is the *only* way to purchase that unit
 			bool bSpecificBeliefBlocked = false;
 			if (pReligion)
 			{
@@ -30537,32 +30534,50 @@ bool CvCity::IsCanPurchase(const std::vector<int>& vPreExistingBuildings, bool b
 			if (eBeliefUnlock != NO_BELIEF && !HasBelief(eBeliefUnlock))
 				return false;
 
+			// Can this be purchased due to Belief_EraFaithUnitPurchase table? (Zealotry/Holy Warriors/Religious Fervor)
+			// Table only works on Land Units. Naval Units can only pass this check with a Trait column.
 			if (pkUnitInfo->IsRequiresFaithPurchaseEnabled())
 			{
-				if (!pReligion)
+				// air units are not allowed
+				if (pkUnitInfo->GetDomainType() == DOMAIN_AIR)
 					return false;
 
-				if (!canTrain(eUnitType, false, !bTestTrainable, false /*bIgnoreCost*/, true /*bWillPurchase*/))
-					return false;
-
-				TechTypes ePrereqTech = static_cast<TechTypes>(pkUnitInfo->GetPrereqAndTech());
-				if (ePrereqTech == NO_TECH)
+				// UA lets naval units skip the rest of this block, else they are not allowed
+				else if (pkUnitInfo->GetDomainType() == DOMAIN_SEA)
 				{
-					if (!pReligion->m_Beliefs.IsFaithBuyingEnabled((EraTypes)0, getOwner(), this)) // Ed?
+					if (pkUnitInfo->GetSpecialUnitType() != NO_SPECIALUNIT || !GET_PLAYER(getOwner()).GetPlayerTraits()->IsCanPurchaseNavalUnitsFaith())
 						return false;
 				}
+
+				// only land units should remain
 				else
 				{
-					CvTechEntry* pkTechInfo = GC.GetGameTechs()->GetEntry(ePrereqTech);
-					if (!pReligion->m_Beliefs.IsFaithBuyingEnabled((EraTypes)pkTechInfo->GetEra(), getOwner(), this))
+					if (!pReligion)
 						return false;
-
-					if (pkUnitInfo->GetDefaultUnitAIType() == UNITAI_ARCHAEOLOGIST)
+	
+					if (!canTrain(eUnitType, false, !bTestTrainable, false /*bIgnoreCost*/, true /*bWillPurchase*/))
 						return false;
+					
+					TechTypes ePrereqTech = static_cast<TechTypes>(pkUnitInfo->GetPrereqAndTech());
+					if (ePrereqTech == NO_TECH)
+					{
+						if (!pReligion->m_Beliefs.IsFaithBuyingEnabled((EraTypes)0, getOwner(), this)) // Ed?
+							return false;
+					}
+					else
+					{
+						CvTechEntry* pkTechInfo = GC.GetGameTechs()->GetEntry(ePrereqTech);
+						if (!pReligion->m_Beliefs.IsFaithBuyingEnabled((EraTypes)pkTechInfo->GetEra(), getOwner(), this))
+							return false;
+	
+						if (pkUnitInfo->GetDefaultUnitAIType() == UNITAI_ARCHAEOLOGIST)
+							return false;
+					}
 				}
 			}
 			else
 			{
+				// removed from the list of options by the specific unit table (e.g. Archaeologist)
 				if (bSpecificBeliefBlocked)
 					return false;
 

--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -30538,6 +30538,9 @@ bool CvCity::IsCanPurchase(const std::vector<int>& vPreExistingBuildings, bool b
 			// Table only works on Land Units. Naval Units can only pass this check with a Trait column.
 			if (pkUnitInfo->IsRequiresFaithPurchaseEnabled())
 			{
+				if (!canTrain(eUnitType, false, !bTestTrainable, false /*bIgnoreCost*/, true /*bWillPurchase*/))
+					return false;
+				
 				// air units are not allowed
 				if (pkUnitInfo->GetDomainType() == DOMAIN_AIR)
 					return false;
@@ -30553,9 +30556,6 @@ bool CvCity::IsCanPurchase(const std::vector<int>& vPreExistingBuildings, bool b
 				else
 				{
 					if (!pReligion)
-						return false;
-	
-					if (!canTrain(eUnitType, false, !bTestTrainable, false /*bIgnoreCost*/, true /*bWillPurchase*/))
 						return false;
 					
 					TechTypes ePrereqTech = static_cast<TechTypes>(pkUnitInfo->GetPrereqAndTech());


### PR DESCRIPTION
Fundamental fix for #12838

Will allow modmods to have faith purchasable unique naval units with RequiresFaithPurchaseEnabled=0

Part of the logic looks a bit redundant--the archaeologist check--but that (the first check) is for CP-only.
(This way you could do like a belief that lets you buy Cargo Ships and it wouldn't get unlocked by Zealotry)