### PR TITLE
Border Settle policy column for modmod

### DIFF
--- a/(1) Community Patch/Database Changes/Policies/PolicyTableChanges.sql
+++ b/(1) Community Patch/Database Changes/Policies/PolicyTableChanges.sql
@@ -343,6 +343,9 @@ ALTER TABLE Policies ADD ExtraMissionarySpreads integer DEFAULT 0;
 
 ALTER TABLE Policies ADD GreatDiplomatRateModifier integer DEFAULT 0;
 
+-- Ignore restriction on founding Cities next to borders
+ALTER TABLE Policies ADD BorderSettle boolean DEFAULT 0;
+
 -- Policy Branch - number of unlocked policies (finishers excluded) before branch is unlocked.
 ALTER TABLE PolicyBranchTypes ADD NumPolicyRequirement integer DEFAULT -1;
 

--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -14218,60 +14218,6 @@ void CvCity::processBuilding(BuildingTypes eBuilding, int iChange, bool bFirst, 
 			ChangeUnitClassTrainingAllowed((UnitClassTypes)*it, iChange);
 		}
 
-		// instant tile claim
-		if (iChange > 0)
-		{
-			if (GetPlotsClaimedByBuilding(eBuilding).size() > 0)
-			{
-				const std::vector<CvPlot*>& vTilesClaimed = GetPlotsClaimedByBuilding(eBuilding);
-				for (std::vector<CvPlot*>::const_iterator it = vTilesClaimed.begin(); it != vTilesClaimed.end(); ++it)
-				{
-					int iX = (*it)->getX();
-					int iY = (*it)->getY();
-
-					if (getOwner() == GC.getGame().getActivePlayer())
-					{
-						CvNotifications* pNotifications = GET_PLAYER(getOwner()).GetNotifications();
-						if (pNotifications)
-						{
-							CvPlot* pPlotClaimed = GC.getMap().plot(iX, iY);
-							ResourceTypes eResource = pPlotClaimed->getResourceType(getTeam());
-							CvResourceInfo* pResourceInfo = GC.getResourceInfo(eResource);
-							ASSERT(pResourceInfo);
-							NotificationTypes eNotificationType = NO_NOTIFICATION_TYPE;
-
-							CvString strBuffer;
-							if (pPlotClaimed->getOwner() == NO_PLAYER)
-							{
-								strBuffer = GetLocalizedText("TXT_KEY_NOTIFICATION_BUILDING_CLAIMED_RESOURCE", pBuildingInfo->GetTextKey(), getNameKey(), pResourceInfo->GetTextKey());
-							}
-							else
-							{
-								strBuffer = GetLocalizedText("TXT_KEY_NOTIFICATION_BUILDING_CLAIMED_RESOURCE_FROM_OTHER_PLAYER", pBuildingInfo->GetTextKey(), getNameKey(), pResourceInfo->GetTextKey(), GET_PLAYER(pPlotClaimed->getOwner()).getNameKey());
-							}
-							CvString strSummary = GetLocalizedText("TXT_KEY_NOTIFICATION_BUILDING_CLAIMED_RESOURCE_S");
-
-							switch (pResourceInfo->getResourceUsage())
-							{
-							case RESOURCEUSAGE_LUXURY:
-								eNotificationType = NOTIFICATION_DISCOVERED_LUXURY_RESOURCE;
-								break;
-							case RESOURCEUSAGE_STRATEGIC:
-								eNotificationType = NOTIFICATION_DISCOVERED_STRATEGIC_RESOURCE;
-								break;
-							case RESOURCEUSAGE_BONUS:
-								eNotificationType = NOTIFICATION_DISCOVERED_BONUS_RESOURCE;
-								break;
-							}
-							pNotifications->Add(eNotificationType, strBuffer, strSummary, iX, iY, eResource);
-						}
-					}
-
-					BuyPlot(iX, iY, true);
-				}
-			}
-		}
-
 		// Resource loop
 		ResourceTypes eResource;
 		for (int iResourceLoop = 0; iResourceLoop < GC.getNumResourceInfos(); iResourceLoop++)
@@ -14389,6 +14335,61 @@ void CvCity::processBuilding(BuildingTypes eBuilding, int iChange, bool bFirst, 
 			ChangeBaseYieldRateFromBuildings(YIELD_CULTURE, pBuildingInfo->GetResourceCultureChange(eResource) * iNumResourceLocal * iChange);
 			ChangeBaseYieldRateFromBuildings(YIELD_FAITH, pBuildingInfo->GetResourceFaithChange(eResource) * iNumResourceLocal * iChange);
 			ChangeBaseHappinessFromBuildings(pBuildingInfo->GetResourceHappiness(eResource) * iNumResourceLocal * iChange);
+		}
+		
+		// instant tile claim.
+		// goes after resource placement so new resources spawned by the building can also get claimed
+		if (iChange > 0)
+		{
+			if (GetPlotsClaimedByBuilding(eBuilding).size() > 0)
+			{
+				const std::vector<CvPlot*>& vTilesClaimed = GetPlotsClaimedByBuilding(eBuilding);
+				for (std::vector<CvPlot*>::const_iterator it = vTilesClaimed.begin(); it != vTilesClaimed.end(); ++it)
+				{
+					int iX = (*it)->getX();
+					int iY = (*it)->getY();
+
+					if (getOwner() == GC.getGame().getActivePlayer())
+					{
+						CvNotifications* pNotifications = GET_PLAYER(getOwner()).GetNotifications();
+						if (pNotifications)
+						{
+							CvPlot* pPlotClaimed = GC.getMap().plot(iX, iY);
+							ResourceTypes eResource = pPlotClaimed->getResourceType(getTeam());
+							CvResourceInfo* pResourceInfo = GC.getResourceInfo(eResource);
+							ASSERT(pResourceInfo);
+							NotificationTypes eNotificationType = NO_NOTIFICATION_TYPE;
+
+							CvString strBuffer;
+							if (pPlotClaimed->getOwner() == NO_PLAYER)
+							{
+								strBuffer = GetLocalizedText("TXT_KEY_NOTIFICATION_BUILDING_CLAIMED_RESOURCE", pBuildingInfo->GetTextKey(), getNameKey(), pResourceInfo->GetTextKey());
+							}
+							else
+							{
+								strBuffer = GetLocalizedText("TXT_KEY_NOTIFICATION_BUILDING_CLAIMED_RESOURCE_FROM_OTHER_PLAYER", pBuildingInfo->GetTextKey(), getNameKey(), pResourceInfo->GetTextKey(), GET_PLAYER(pPlotClaimed->getOwner()).getNameKey());
+							}
+							CvString strSummary = GetLocalizedText("TXT_KEY_NOTIFICATION_BUILDING_CLAIMED_RESOURCE_S");
+
+							switch (pResourceInfo->getResourceUsage())
+							{
+							case RESOURCEUSAGE_LUXURY:
+								eNotificationType = NOTIFICATION_DISCOVERED_LUXURY_RESOURCE;
+								break;
+							case RESOURCEUSAGE_STRATEGIC:
+								eNotificationType = NOTIFICATION_DISCOVERED_STRATEGIC_RESOURCE;
+								break;
+							case RESOURCEUSAGE_BONUS:
+								eNotificationType = NOTIFICATION_DISCOVERED_BONUS_RESOURCE;
+								break;
+							}
+							pNotifications->Add(eNotificationType, strBuffer, strSummary, iX, iY, eResource);
+						}
+					}
+
+					BuyPlot(iX, iY, true);
+				}
+			}
 		}
 
 		if (pBuildingInfo->IsExtraLuxuries())

--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -553,7 +553,7 @@ CvCity::~CvCity()
 
 
 //	--------------------------------------------------------------------------------
-void CvCity::init(int iID, PlayerTypes eOwner, int iX, int iY, bool bBumpUnits, bool bInitialFounding, ReligionTypes eInitialReligion, const char* szName, CvUnitEntry* pkSettlerUnitEntry)
+void CvCity::init(int iID, PlayerTypes eOwner, int iX, int iY, bool bBumpUnits, bool bInitialFounding, ReligionTypes eInitialReligion, const char* szName, CvUnit* pkSettler)
 {
 	VALIDATE_OBJECT();
 	//CvPlot* pAdjacentPlot;
@@ -604,8 +604,15 @@ void CvCity::init(int iID, PlayerTypes eOwner, int iX, int iY, bool bBumpUnits, 
 	//only after the owner is set!
 	pPlot->setIsCity(true, m_iID, getWorkPlotDistance());
 
-	//clear the first ring
+	//clear the first ring(s)
 	int iRange = min(1, /*1*/ GD_INT_GET(CITY_STARTING_RINGS));
+
+	// if this is also a culture bomb (passed check in SiteEvaluator->CanFoundCity), first use the culture bomb code
+	if (pkSettler && pPlot->IsAdjacentOwnedByTeamOtherThan(kOwner.getTeam()))
+	{
+		pkSettler->PerformCultureBomb(iRange);
+	}
+	
 	for (int iDX = -iRange; iDX <= iRange; iDX++)
 	{
 		for (int iDY = -iRange; iDY <= iRange; iDY++)
@@ -993,24 +1000,25 @@ void CvCity::init(int iID, PlayerTypes eOwner, int iX, int iY, bool bBumpUnits, 
 	}
 
 	// Stuff for Pioneers and Colonists
-	if (bInitialFounding && pkSettlerUnitEntry)
+	if (bInitialFounding && pkSettler)
 	{
-		if (pkSettlerUnitEntry->GetNumColonyFound() > 0)
+		CvUnitEntry& pkSettlerUnitEntry = pkSettler->getUnitInfo();
+		if (pkSettlerUnitEntry.GetNumColonyFound() > 0)
 		{
 			InitBoost(/*3*/ GD_INT_GET(PIONEER_EXTRA_PLOTS), /*3*/ GD_INT_GET(PIONEER_POPULATION_CHANGE), 1);
 			DoCreatePuppet();
 		}
-		if (pkSettlerUnitEntry->IsFoundMid())
+		if (pkSettlerUnitEntry.IsFoundMid())
 		{
 			InitBoost(/*3*/ GD_INT_GET(PIONEER_EXTRA_PLOTS), /*3*/ GD_INT_GET(PIONEER_POPULATION_CHANGE), /*25*/ GD_INT_GET(PIONEER_FOOD_PERCENT));
 		}
-		if (pkSettlerUnitEntry->IsFoundLate())
+		if (pkSettlerUnitEntry.IsFoundLate())
 		{
 			InitBoost(/*5*/ GD_INT_GET(COLONIST_EXTRA_PLOTS), /*5*/ GD_INT_GET(COLONIST_POPULATION_CHANGE), /*50*/ GD_INT_GET(COLONIST_FOOD_PERCENT));
 		}
 
 		const CvCivilizationInfo& kCivInfo = getCivilizationInfo();
-		for (set<int>::const_iterator it = pkSettlerUnitEntry->GetBuildOnFound().begin(); it != pkSettlerUnitEntry->GetBuildOnFound().end(); ++it)
+		for (set<int>::const_iterator it = pkSettlerUnitEntry.GetBuildOnFound().begin(); it != pkSettlerUnitEntry.GetBuildOnFound().end(); ++it)
 		{
 			const BuildingClassTypes eBuildingClass = static_cast<BuildingClassTypes>(*it);
 			const BuildingTypes eFreeBuilding = static_cast<BuildingTypes>(kCivInfo.getCivilizationBuildings(eBuildingClass));

--- a/CvGameCoreDLL_Expansion2/CvCity.h
+++ b/CvGameCoreDLL_Expansion2/CvCity.h
@@ -82,7 +82,7 @@ public:
 		YIELD_UPDATE_GLOBAL //update yields and player happiness
 	};
 
-	void init(int iID, PlayerTypes eOwner, int iX, int iY, bool bBumpUnits = true, bool bInitialFounding = true, ReligionTypes eInitialReligion = NO_RELIGION, const char* szName = NULL, CvUnitEntry* pkSettlerUnitEntry = NULL);
+	void init(int iID, PlayerTypes eOwner, int iX, int iY, bool bBumpUnits = true, bool bInitialFounding = true, ReligionTypes eInitialReligion = NO_RELIGION, const char* szName = NULL, CvUnit* pkSettler = NULL);
 	void uninit();
 	void reset(int iID = 0, PlayerTypes eOwner = NO_PLAYER, int iX = 0, int iY = 0, bool bConstructorCall = false);
 	void setupGraphical();

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -2903,14 +2903,14 @@ CvPlot* CvPlayer::addFreeUnit(UnitTypes eUnit, bool bGameStart, UnitAITypes eUni
 	return pNewUnit->plot();
 }
 
-CvCity* CvPlayer::initCity(int iX, int iY, bool bBumpUnits, bool bInitialFounding, ReligionTypes eInitialReligion, const char* szName, CvUnitEntry* pkSettlerUnitEntry)
+CvCity* CvPlayer::initCity(int iX, int iY, bool bBumpUnits, bool bInitialFounding, ReligionTypes eInitialReligion, const char* szName, CvUnit* pkSettler)
 {
 	CvCity* pNewCity = addCity();
 	ASSERT(pNewCity != NULL, "City is not assigned a valid value");
 	if(pNewCity != NULL)
 	{
 		ASSERT(!(GC.getMap().plot(iX, iY)->isCity()), "No city is expected at this plot when initializing new city");
-		pNewCity->init(pNewCity->GetID(), GetID(), iX, iY, bBumpUnits, bInitialFounding, eInitialReligion, szName, pkSettlerUnitEntry);
+		pNewCity->init(pNewCity->GetID(), GetID(), iX, iY, bBumpUnits, bInitialFounding, eInitialReligion, szName, pkSettler);
 		pNewCity->GetCityStrategyAI()->UpdateFlavorsForNewCity();
 		pNewCity->DoUpdateCheapestPlotInfluenceDistance();
 
@@ -13730,7 +13730,7 @@ bool CvPlayer::canFoundCityExt(int iX, int iY, bool bIgnoreDistanceToExistingCit
 	return bCanFound;
 }
 
-void CvPlayer::foundCity(int iX, int iY, ReligionTypes eReligion, bool bForce, CvUnitEntry* pkSettlerUnitEntry)
+void CvPlayer::foundCity(int iX, int iY, ReligionTypes eReligion, bool bForce, CvUnit* pkSettler)
 {
 	if(!bForce && !canFoundCity(iX, iY))
 		return;
@@ -13742,7 +13742,7 @@ void CvPlayer::foundCity(int iX, int iY, ReligionTypes eReligion, bool bForce, C
 	if (GetNumCitiesFounded() == 0 && isMajorCiv())
 		GC.getGame().NewCapitalFounded(getPlotFoundValue(iX, iY));
 
-	CvCity* pCity = initCity(iX, iY, true, true, eReligion, NULL, pkSettlerUnitEntry);
+	CvCity* pCity = initCity(iX, iY, true, true, eReligion, NULL, pkSettler);
 
 	ASSERT(pCity != NULL, "City is not assigned a valid value");
 	if(pCity == NULL)

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -277,6 +277,7 @@ CvPlayer::CvPlayer() :
 	, m_iMinorScienceAlliesCount()
 	, m_iMinorResourceBonusCount()
 	, m_iAbleToAnnexCityStatesCount()
+	, m_iBorderSettle()
 	, m_iOnlyTradeSameIdeology()
 	, m_iFreeSpecialist()
 	, m_iCultureBombTimer()
@@ -1425,6 +1426,7 @@ void CvPlayer::uninit()
 	m_iMinorScienceAlliesCount = 0;
 	m_iMinorResourceBonusCount = 0;
 	m_iAbleToAnnexCityStatesCount = 0;
+	m_iBorderSettle = 0;
 	m_iOnlyTradeSameIdeology = 0;
 	m_iSupplyFreeUnits = 0;
 	m_strJFDCurrencyName = "";
@@ -29838,7 +29840,21 @@ bool CvPlayer::IsAbleToAnnexCityStates() const
 
 	return false;
 }
-	//JFD
+
+bool CvPlayer::IsBorderSettle() const
+{
+	if (m_iBorderSettle > 0)
+		return true;
+
+	return false;
+}
+
+void CvPlayer::SetBorderSettle(int iValue)
+{
+	m_iBorderSettle += iValue;
+}
+
+// JFD
 void CvPlayer::SetPiety(int iValue)
 {
 	GAMEEVENTINVOKE_HOOK(GAMEEVENT_PietyChanged, GetID(), GetPiety(), iValue);
@@ -42411,6 +42427,7 @@ void CvPlayer::processPolicies(PolicyTypes ePolicy, int iChange)
 	ChangeFreeFoodBox(pkPolicyInfo->GetFreeFoodBox() * iChange);
 	ChangeStrategicResourceMod(pkPolicyInfo->GetStrategicResourceMod() * iChange);
 	ChangeAbleToAnnexCityStatesCount(pkPolicyInfo->IsAbleToAnnexCityStates() * iChange);
+	SetBorderSettle(pkPolicyInfo->IsBorderSettle() * iChange);
 	ChangeOnlyTradeSameIdeology(pkPolicyInfo->IsOnlyTradeSameIdeology() * iChange);
 	ChangeDistressFlatReductionGlobal(pkPolicyInfo->GetDistressFlatReduction() * iChange);
 	ChangePovertyFlatReductionGlobal(pkPolicyInfo->GetPovertyFlatReduction() * iChange);
@@ -43893,6 +43910,7 @@ void CvPlayer::Serialize(Player& player, Visitor& visitor)
 	visitor(player.m_iMinorScienceAlliesCount);
 	visitor(player.m_iMinorResourceBonusCount);
 	visitor(player.m_iAbleToAnnexCityStatesCount);
+	visitor(player.m_iBorderSettle);
 	visitor(player.m_iOnlyTradeSameIdeology);
 	visitor(player.m_iSupplyFreeUnits);
 	visitor(player.m_abActiveContract);

--- a/CvGameCoreDLL_Expansion2/CvPlayer.h
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.h
@@ -101,7 +101,7 @@ public:
 	void addFreeUnitAI(UnitAITypes eUnitAI, bool bGameStart, int iCount, bool bCompleteKills = false);
 	CvPlot* addFreeUnit(UnitTypes eUnit, bool bGameStart, UnitAITypes eUnitAI = NO_UNITAI, bool bCompleteKills = false);
 
-	CvCity* initCity(int iX, int iY, bool bBumpUnits = true, bool bInitialFounding = true, ReligionTypes eInitialReligion = NO_RELIGION, const char* szName = NULL, CvUnitEntry* pkSettlerUnitEntry = NULL);
+	CvCity* initCity(int iX, int iY, bool bBumpUnits = true, bool bInitialFounding = true, ReligionTypes eInitialReligion = NO_RELIGION, const char* szName = NULL, CvUnit* pkSettler = NULL);
 
 	CvCity* acquireCity(CvCity* pCity, bool bConquest, bool bGift, bool bOriginally);
 	bool IsValidBuildingForPlayer(CvCity* pCity, BuildingTypes eBuilding, bool bConquest);
@@ -318,7 +318,7 @@ public:
 	bool canFoundCityExt(int iX, int iY, bool bIgnoreDistanceToExistingCities, bool bIgnoreHappiness, CvString* toolTipSink = NULL) const;
 	bool canFoundCity(int iX, int iY) const;
 
-	void foundCity(int iX, int iY, ReligionTypes eReligion = NO_RELIGION, bool bForce = false, CvUnitEntry* pkSettlerUnitEntry = NULL);
+	void foundCity(int iX, int iY, ReligionTypes eReligion = NO_RELIGION, bool bForce = false, CvUnit* pkSettler = NULL);
 
 	bool canTrainUnit(UnitTypes eUnit, bool bContinue = false, bool bTestVisible = false, bool bIgnoreCost = false, bool bIgnoreUniqueUnitStatus = false, bool bIgnoreTechRequirements = false, CvString* toolTipSink = NULL) const;
 	bool canConstruct(BuildingTypes eBuilding, bool bContinue = false, bool bTestVisible = false, bool bIgnoreCost = false, CvString* toolTipSink = NULL) const;

--- a/CvGameCoreDLL_Expansion2/CvPlayer.h
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.h
@@ -1312,6 +1312,9 @@ public:
 	int GetAbleToAnnexCityStatesCount() const;
 	void ChangeAbleToAnnexCityStatesCount(int iChange);
 
+	bool IsBorderSettle() const;
+	void SetBorderSettle(int iValue);
+
 	bool IsOnlyTradeSameIdeology() const;
 	void ChangeOnlyTradeSameIdeology(int iChange);
 	
@@ -3237,6 +3240,7 @@ protected:
 	int m_iMinorScienceAlliesCount;
 	int m_iMinorResourceBonusCount;
 	int m_iAbleToAnnexCityStatesCount;
+	int m_iBorderSettle;
 	int m_iOnlyTradeSameIdeology;
 	int m_iSupplyFreeUnits; //military units which don't count against the supply limit
 	std::vector<CvString> m_aistrInstantYield; // not serialized
@@ -4040,6 +4044,7 @@ SYNC_ARCHIVE_VAR(int, m_iMinorFriendshipDecayMod)
 SYNC_ARCHIVE_VAR(int, m_iMinorScienceAlliesCount)
 SYNC_ARCHIVE_VAR(int, m_iMinorResourceBonusCount)
 SYNC_ARCHIVE_VAR(int, m_iAbleToAnnexCityStatesCount)
+SYNC_ARCHIVE_VAR(int, m_iBorderSettle)
 SYNC_ARCHIVE_VAR(int, m_iOnlyTradeSameIdeology)
 SYNC_ARCHIVE_VAR(int, m_iSupplyFreeUnits)
 SYNC_ARCHIVE_VAR(std::vector<bool>, m_abActiveContract)

--- a/CvGameCoreDLL_Expansion2/CvPolicyClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPolicyClasses.cpp
@@ -224,6 +224,7 @@ CvPolicyEntry::CvPolicyEntry(void):
 	m_bRevealAllCapitals(false),
 	m_bGarrisonFreeMaintenance(false),
 	m_bAbleToAnnexCityStates(false),
+	m_bBorderSettle(false),
 	m_bOneShot(false),
 	m_bIsOnlyTradeSameIdeology(false),
 	m_bIncludesOneShotFreeUnits(false),
@@ -686,6 +687,7 @@ bool CvPolicyEntry::CacheResults(Database::Results& kResults, CvDatabaseUtility&
 	m_bEnablesSSPartHurry = kResults.GetBool("EnablesSSPartHurry");
 	m_bEnablesSSPartPurchase = kResults.GetBool("EnablesSSPartPurchase");
 	m_bAbleToAnnexCityStates = kResults.GetBool("AbleToAnnexCityStates");
+	m_bBorderSettle = kResults.GetBool("BorderSettle");
 	m_bOneShot = kResults.GetBool("OneShot");
 	m_bIsOnlyTradeSameIdeology = kResults.GetBool("IsOnlyTradeSameIdeology");
 	m_bIncludesOneShotFreeUnits = kResults.GetBool("IncludesOneShotFreeUnits");
@@ -2453,6 +2455,12 @@ bool CvPolicyEntry::IsEnablesSSPartPurchase() const
 bool CvPolicyEntry::IsAbleToAnnexCityStates() const
 {
 	return m_bAbleToAnnexCityStates;
+}
+
+/// Do we ignore border adjancency restriction when founding cities?
+bool CvPolicyEntry::IsBorderSettle() const
+{
+	return m_bBorderSettle;
 }
 
 /// Only trade with same ideologies

--- a/CvGameCoreDLL_Expansion2/CvPolicyClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvPolicyClasses.h
@@ -233,6 +233,7 @@ public:
 	bool IsEnablesSSPartHurry() const;
 	bool IsEnablesSSPartPurchase() const;
 	bool IsAbleToAnnexCityStates() const;
+	bool IsBorderSettle() const;
 	std::string pyGetWeLoveTheKing()
 	{
 		return GetWeLoveTheKing();
@@ -652,6 +653,7 @@ private:
 	bool m_bEnablesSSPartHurry;
 	bool m_bEnablesSSPartPurchase;
 	bool m_bAbleToAnnexCityStates;
+	bool m_bBorderSettle;
 
 	bool m_bIsOnlyTradeSameIdeology;
 	bool m_bOneShot;

--- a/CvGameCoreDLL_Expansion2/CvSiteEvaluationClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvSiteEvaluationClasses.cpp
@@ -104,9 +104,52 @@ bool CvCitySiteEvaluator::CanFoundCity(const CvPlot* pPlot, const CvPlayer* pPla
 			return false;
 		}
 
-		if(pPlot->IsAdjacentOwnedByTeamOtherThan(pPlayer->getTeam()) && !pPlayer->IsBorderSettle())
+		if(pPlot->IsAdjacentOwnedByTeamOtherThan(pPlayer->getTeam()))
 		{
-			return false;
+			// not allowed unless player has special permission (will cause culture bomb)
+			if (!pPlayer->IsBorderSettle())
+				return false;
+			// do not allow AI to culture bomb people they want to be friends with
+			else if (!pPlayer->isHuman(ISHUMAN_AI_DIPLOMACY) && pPlayer->isMajorCiv())
+			{
+				// assume only a 1 tile culture bomb
+				for (int iK = 0; iK < RING_PLOTS[1]; iK++)
+				{
+					CvPlot* pAdjacentPlot = iterateRingPlots(pPlot, iK);
+					if (!pAdjacentPlot)
+						continue;
+	
+					// We can't steal city plots
+					if (pAdjacentPlot->isCity())
+						continue;
+		
+					if (pAdjacentPlot->IsStealBlockedByImprovement())
+						continue;
+					
+					PlayerTypes eOwner = pAdjacentPlot->getOwner();
+	
+					// We already own this plot
+					if (eOwner == pPlayer->GetID())
+						continue;
+	
+					if (eOwner != NO_PLAYER)
+					{
+						// Check if we shouldn't steal from them
+						if (pPlayer->isMajorCiv() && pPlayer->GetDiplomacyAI()->IsBadTheftTarget(eOwner, THEFT_TYPE_CULTURE_BOMB))
+						{
+							return false;
+						}
+						else if (pPlayer->isMinorCiv())
+						{
+							PlayerTypes eAlly = pPlayer->GetMinorCivAI()->GetAlly();
+							if (eAlly != NO_PLAYER && GET_PLAYER(eAlly).getTeam() == GET_PLAYER(eOwner).getTeam())
+							{
+								return false;
+							}
+						}
+					}
+				}
+			}
 		}
 
 		// Has the AI agreed to not settle here?

--- a/CvGameCoreDLL_Expansion2/CvSiteEvaluationClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvSiteEvaluationClasses.cpp
@@ -104,7 +104,7 @@ bool CvCitySiteEvaluator::CanFoundCity(const CvPlot* pPlot, const CvPlayer* pPla
 			return false;
 		}
 
-		if(pPlot->IsAdjacentOwnedByTeamOtherThan(pPlayer->getTeam()))
+		if(pPlot->IsAdjacentOwnedByTeamOtherThan(pPlayer->getTeam()) && !pPlayer->IsBorderSettle())
 		{
 			return false;
 		}

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -10595,7 +10595,7 @@ bool CvUnit::foundCity()
 	CvPlayerAI& kActivePlayer = GET_PLAYER(eActivePlayer);
 
 	ReligionTypes eReligion = (MOD_GLOBAL_RELIGIOUS_SETTLERS && GetReligionData()->GetReligion() > RELIGION_PANTHEON) ? GetReligionData()->GetReligion() : NO_RELIGION;
-	kPlayer.foundCity(getX(), getY(), eReligion, false, m_pUnitInfo);
+	kPlayer.foundCity(getX(), getY(), eReligion, false, this);
 
 	if (IsCanAttack() && plot()->getPlotCity() != NULL) 
 	{


### PR DESCRIPTION
Allows you to bypass the border check and culture bomb with Settlers.
Before, bypassing the check would steal the tiles but not cause any diplomatic incident, by using culture bomb code we trigger all the related consequences. 
Rudimentary AI diplo consideration to stop them using the effect on people they wouldn't culture bomb.

Since I was looking at tile acquisition, this also includes a swap around of ProcessBuilding logic to support Legen's proposal