### PR TITLE
Fix strncmp prefix-matching bug in mapscript CustomOption

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvPreGame.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPreGame.cpp
@@ -925,9 +925,8 @@ bool GetGameOption(const char* szOptionName, int& iValue)
 	for(std::vector<CustomOption>::const_iterator it = s_GameOptions.begin();
 	        it != s_GameOptions.end(); ++it)
 	{
-		size_t bytes = 0;
-		const char* szCurrentOptionName = (*it).GetName(bytes);
-		if(strncmp(szCurrentOptionName, szOptionName, bytes) == 0)
+		const char* szCurrentOptionName = (*it).GetName();
+		if(strcmp(szCurrentOptionName, szOptionName) == 0)
 		{
 			iValue = (*it).GetValue();
 			return true;
@@ -1012,9 +1011,8 @@ bool SetGameOption(const char* szOptionName, int iValue)
 	for(size_t i = 0; i < s_GameOptions.size(); i++)
 	{
 		const CustomOption& option = s_GameOptions[i];
-		size_t bytes = 0;
-		const char* szCurrentOptionName = option.GetName(bytes);
-		if(strncmp(szCurrentOptionName, szOptionName, bytes) == 0)
+		const char* szCurrentOptionName = option.GetName();
+		if(strcmp(szCurrentOptionName, szOptionName) == 0)
 		{
 			//I'd like to just set the value here, but that doesn't seem possible
 			//so instead, create a new CustomOption type and assign it to this index.
@@ -1494,9 +1492,8 @@ bool GetMapOption(const char* szOptionName, int& iValue)
 	for(std::vector<CustomOption>::const_iterator it = s_MapOptions.begin();
 	        it != s_MapOptions.end(); ++it)
 	{
-		size_t bytes = 0;
-		const char* szCurrentOptionName = (*it).GetName(bytes);
-		if(strncmp(szCurrentOptionName, szOptionName, bytes) == 0)
+		const char* szCurrentOptionName = (*it).GetName();
+		if(strcmp(szCurrentOptionName, szOptionName) == 0)
 		{
 			iValue = (*it).GetValue();
 			return true;
@@ -1536,9 +1533,8 @@ bool SetMapOption(const char* szOptionName, int iValue)
 	for(size_t i = 0; i < s_MapOptions.size(); i++)
 	{
 		const CustomOption& option = s_MapOptions[i];
-		size_t bytes = 0;
-		const char* szCurrentOptionName = option.GetName(bytes);
-		if(strncmp(szCurrentOptionName, szOptionName, bytes) == 0)
+		const char* szCurrentOptionName = option.GetName();
+		if(strcmp(szCurrentOptionName, szOptionName) == 0)
 		{
 			//I'd like to just set the value here, but that doesn't seem possible
 			//so instead, create a new CustomOption type and assign it to this index.


### PR DESCRIPTION
Issue:
<img width="480" height="310" alt="image" src="https://github.com/user-attachments/assets/2cf7bd86-ceaa-47b0-a8fa-8be4126c99ec" />
<img width="448" height="177" alt="image" src="https://github.com/user-attachments/assets/ab5ce4f9-aff8-4876-ba74-b59ded34c654" />


GetMapOption/SetMapOption and GetGameOption/SetGameOption used strncmp(storedName, searchKey, strlen(storedName)), which made short option names like "1" falsely match longer keys like "10"-"17".

This caused Map.GetCustomOption(17) to return option 1's value (2), affecting default values of these >=10 options if they were intended to have default value that is not 2 (option 1 has default 2 usually so in this case the error doesn't manifest.)

Replaced strncmp with strcmp for exact string matching. 


Tested and it works.