### PR TITLE
twokay global needs empire size

### DIFF
--- a/(2) Vox Populi/Database Changes/City/Buildings/NewBuildings.xml
+++ b/(2) Vox Populi/Database Changes/City/Buildings/NewBuildings.xml
@@ -2559,7 +2559,7 @@
 			<Help>TXT_KEY_BUILDING_TWOKAY_FOODS_HELP</Help>
 			<Strategy>TXT_KEY_BUILDING_TWOKAY_FOODS_STRATEGY</Strategy>
 			<IsCorporation>true</IsCorporation>
-			<EmpireSizeModifierReduction>-2</EmpireSizeModifierReduction>
+			<EmpireSizeModifierReductionGlobal>-2</EmpireSizeModifierReductionGlobal>
 			<DistressFlatReduction>1</DistressFlatReduction>
 			<PovertyFlatReduction>1</PovertyFlatReduction>
 			<IlliteracyFlatReduction>1</IlliteracyFlatReduction>


### PR DESCRIPTION
As per https://forums.civfanatics.com/threads/9-08-corporations-i-ii.701857/, TwoKay corpo -2% needs from an office should be applied to all cities, not only locally. 

Rn. it's local cause https://github.com/LoneGazebo/Community-Patch-DLL/commit/fa77e6eaf89395c787d1238cbbf324aaa20359d0 removed the Global suffix, making the corpo very weak.