### PR TITLE
Fix Squads OOB Read Error

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -15140,13 +15140,20 @@ void CvUnit::DoSquadPlotAssignmentsByDomain(std::vector<CvUnit*> eligibleUnits, 
 	// ring when there are still insufficient plots for the current selection
 	std::vector<CvPlot*> eligiblePlots;
 	int currRingEndIdx = 0;
-	for (int targetPlotIdx = 0; targetPlotIdx < RING_PLOTS[currRingEndIdx]; targetPlotIdx++)
+	for (int targetPlotIdx = 0; 
+		currRingEndIdx < 5 /* Ring array size */ && targetPlotIdx < RING_PLOTS[currRingEndIdx]; 
+		targetPlotIdx++)
 	{
 		CvPlot* pLoopPlot = iterateRingPlots(pDestPlot, targetPlotIdx);
 		if (!pLoopPlot)
 			continue;
 
 		bool isCandidateSameTypeAsDest = isDestWater == pLoopPlot->isWater();
+		// Special case for when the destination is a port city and the unit domain is DOMAIN_SEA
+		if (eligibleUnits.size() > 0 && eligibleUnits.front()->getDomainType() == DOMAIN_SEA && pDestPlot->isCity() && pLoopPlot->isWater())
+		{
+			isCandidateSameTypeAsDest = true;
+		}
 
 		if (isCandidateSameTypeAsDest && eligibleUnits.size() > 0 && eligibleUnits.front()->canMoveInto(*pLoopPlot))
 		{
@@ -30002,7 +30009,7 @@ int CvUnit::ComputePath(const CvPlot* pToPlot, int iFlags, int iMaxTurns, bool b
 			// plot, while also minimizing distance from it's current position
 			std::vector<ScoredPlot> eligiblePlots;
 			int currRingEndIdx = 1;
-			for (int i = 0; i < RING_PLOTS[currRingEndIdx]; i++)
+			for (int i = 0; currRingEndIdx < 5 /* Ring array size */ && i < RING_PLOTS[currRingEndIdx]; i++)
 			{
 				CvPlot* pLoopPlot = iterateRingPlots(pTargetPlot, i);
 				if (!pLoopPlot)


### PR DESCRIPTION
Finally got to the bottom of suspicious hangs occurring in Squads in optimized releaase but not debug builds. Problem was that when the number of units in a squad is too big, or the plot assignment request had no valid solutions, it would try increasingly larger `RING_PLOTS` radiuses to expand the candidate search space. However, this array only has 6 entries, so if it failed to find a solution in the first 5 rings the next read would be to an out of bounds address past the `RING_PLOTS` array. On debug builds this failed silently because the compiler initialized data memory to 0s, so the value at the next out of bound address it read would return a 0, hence the program finished the loop and exited cleanly.

However, on optimized builds where adjacent memory could be holding anything, this loop can go on for a potentially extremely long time. This is almost certainly the same root cause behind
#12721 and #12786 as well, this explains why it didn't just crash but once managed to recover after 10s of hours of wating.

This MR also fixes a related problem where port cities weren't considered water traversable for the purpose of `DOMAIN_SEA` units, resulting in an empty list of destination plots matching the destination type. This fixes Squads movement previews for squads including ships previewing group movement to a coastal city.

Fixes #12840