### PR TITLE
Fix captured cities city view exploit

### DIFF
--- a/(1) Community Patch/LUA/CityView.lua
+++ b/(1) Community Patch/LUA/CityView.lua
@@ -739,11 +739,19 @@ local function BuildProductionBox(pCity, ePlayer)
 		Hide(Controls.b1remove);
 	end
 
-	if ePlayer == eActivePlayer then
-		Enable(Controls.PurchaseButton);
+	if ePlayer == eActivePlayer  then
+		Show(Controls.ProductionButton, Controls.PurchaseButton);
+		if pCity:IsIgnoreCityForHappiness() then
+			Disable(Controls.ProductionButton, Controls.PurchaseButton);
+		elseif pCity:IsPuppet() then
+			Disable(Controls.ProductionButton);
+			Enable(Controls.PurchaseButton);
+		else
+			Enable(Controls.ProductionButton, Controls.PurchaseButton);
+		end
 	else
 		Hide(Controls.AutomateProduction);
-		Disable(Controls.ProductionButton, Controls.PurchaseButton);
+		Hide(Controls.ProductionButton, Controls.PurchaseButton);
 	end
 end
 
@@ -1309,7 +1317,7 @@ local function UpdateViewFull()
 	-- Buy tile button
 	Controls.BuyPlotButton:LocalizeAndSetToolTip("TXT_KEY_CITYVIEW_BUY_TILE_TT");
 	Controls.BuyPlotText:LocalizeAndSetText("TXT_KEY_CITYVIEW_BUY_TILE");
-	if GameDefines.BUY_PLOTS_DISABLED ~= 0 then
+	if GameDefines.BUY_PLOTS_DISABLED ~= 0 or pCity:IsIgnoreCityForHappiness() then
 		Disable(Controls.BuyPlotButton);
 	-- Allow cities owned by the active player to always buy plots
 	-- This is to enable tile purchase on Venetian puppets which are always on viewing mode

--- a/(3a) VP - EUI Compatibility Files/LUA/CityView.lua
+++ b/(3a) VP - EUI Compatibility Files/LUA/CityView.lua
@@ -1381,6 +1381,8 @@ end)
 	g_ProdQueueIM.ResetInstances()
 	local queueItems = {}
 
+	local isActivePlayerCity = cityOwnerID == Game.GetActivePlayer()
+	local isCityCaptureViewingMode = city:IsIgnoreCityForHappiness()
 	for queuedItemNumber = 0, math_max( queueLength-1, 0 ) do
 
 		local orderID, itemID, _, isRepeat, isReallyRepeat
@@ -1453,11 +1455,8 @@ end)
 
 		-- Vox Populi gold button
 		if itemInfo then
-			if (bnw_mode and g_activePlayer:MayNotAnnex()) then --Venice puppets needs to buy building on production queue
-				instance.PQGoldButton:SetHide( not goldCostPQ or (isActivePlayerCity or isCityCaptureViewingMode)) 
-			else
-				instance.PQGoldButton:SetHide( not goldCostPQ or g_isViewingMode)
-			end
+			instance.PQGoldButton:SetHide( not goldCostPQ or not isActivePlayerCity or isCityCaptureViewingMode)
+			
 			if goldCostPQ then
 				instance.PQGoldButton:SetDisabled( not canBuyWithGoldPQ )
 				instance.PQGoldButton:SetAlpha( canBuyWithGoldPQ and 1 or 0.5 )
@@ -1500,8 +1499,6 @@ end)
 	-- Update Selection List
 	-------------------------------------------
 
-	local isActivePlayerCity = cityOwnerID == Game.GetActivePlayer()
-	local isCityCaptureViewingMode = UI.IsPopupTypeOpen(ButtonPopupTypes.BUTTONPOPUP_CITY_CAPTURED)
 	local isSelectionList = isActivePlayerCity and not isCityCaptureViewingMode
 
 	Controls.SelectionScrollPanel:SetHide( not isSelectionList )
@@ -1989,7 +1986,7 @@ local function UpdateCityViewNow()
 		local cityOwnerID = city:GetOwner()
 		local cityOwner = Players[cityOwnerID]
 		local isActivePlayerCity = cityOwnerID == Game.GetActivePlayer()
-		local isCityCaptureViewingMode = UI.IsPopupTypeOpen(ButtonPopupTypes.BUTTONPOPUP_CITY_CAPTURED)
+		local isCityCaptureViewingMode = city:IsIgnoreCityForHappiness()
 		g_isDebugMode = Game.IsDebugMode()
 		g_isViewingMode = city:IsPuppet() or not isActivePlayerCity or isCityCaptureViewingMode
 

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaCity.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaCity.cpp
@@ -394,6 +394,7 @@ void CvLuaCity::PushMethods(lua_State* L, int t)
 
 	Method(IsOccupied);
 	Method(SetOccupied);
+	Method(IsIgnoreCityForHappiness);
 
 	Method(IsPuppet);
 	Method(SetPuppet);
@@ -4391,6 +4392,12 @@ int CvLuaCity::lChangeRazingTurns(lua_State* L)
 int CvLuaCity::lIsOccupied(lua_State* L)
 {
 	return BasicLuaMethod(L, &CvCity::IsOccupied);
+}
+//------------------------------------------------------------------------------
+//bool IsIgnoreCityForHappiness();
+int CvLuaCity::lIsIgnoreCityForHappiness(lua_State* L)
+{
+	return BasicLuaMethod(L, &CvCity::IsIgnoreCityForHappiness);
 }
 //------------------------------------------------------------------------------
 //void SetOccupied(bool bValue);

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaCity.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaCity.h
@@ -392,6 +392,7 @@ protected:
 
 	static int lIsOccupied(lua_State* L);
 	static int lSetOccupied(lua_State* L);
+	static int lIsIgnoreCityForHappiness(lua_State* L);
 
 	static int lIsPuppet(lua_State* L);
 	static int lSetPuppet(lua_State* L);


### PR DESCRIPTION
It was possible to choose production and purchase items in captured cities before deciding how to proceed with them