### PR TITLE
Include Release PDB in Debug.zip for crash analysis

### DIFF
--- a/NEW RELEASE INSTRUCTIONS.txt
+++ b/NEW RELEASE INSTRUCTIONS.txt
@@ -31,7 +31,14 @@ Make sure you're on the latest master branch.
 
 
 [STEP 2]
-Create a folder somewhere on your computer named "Debug", with two blank folders inside it: "43 Civ" and "Standard".
+Create a folder somewhere on your computer named "Debug" with the following structure:
+  Debug/
+  ├── Standard/
+  │   ├── Release/
+  │   └── Debug/
+  └── 43 Civ/
+      ├── Release/
+      └── Debug/
 
 
 
@@ -92,18 +99,21 @@ This ensures every minidump is traceable to an exact commit, even for official r
 A. Build the CvGameCore_Expansion2.dll file using the Release config (instructions are on the main repository page).
 
 
-B. Place the compiled DLL and PDB files in the "(1) Community Patch" folder, replacing the existing files there.
+B. Place the compiled DLL (not the PDB) in the "(1) Community Patch" folder, replacing the existing file there.
 
 
-C. Open Command Prompt and run the following commands. Leave the window open once you're done.
+C. Copy the Release DLL and PDB from clang-output/Release into the Debug/Standard/Release folder.
+
+
+D. Open Command Prompt and run the following commands. Leave the window open once you're done.
 cd {folder path for Community-Patch-DLL}
 py build_vp_clang.py --config debug
 
 
-D. Go to the clang-output/Debug folder. Cut and paste the compiled DLL and PDB files into the "Standard" folder you created earlier.
+E. Copy the Debug DLL and PDB from clang-output/Debug into the Debug/Standard/Debug folder.
 
 
-E. Delete the clang-output and clang-build folders in the repository.
+F. Delete the clang-output and clang-build folders in the repository.
 
 
 
@@ -111,20 +121,23 @@ E. Delete the clang-output and clang-build folders in the repository.
 A. Build the 43 Civ version of the game core using the Release config: Uncomment "#define MAX_MAJOR_CIVS (43)" in CvGameCoreDLLUtil/include/CustomModsGlobal.h, amend the release commit to include the changed file, then build normally.
 
 
-B. Place the compiled 43 Civ DLL in the "(3b) 43 Civs Community Patch" folder, replacing the existing files there.
+B. Place the compiled 43 Civ DLL (not the PDB) in the "(3b) 43 Civs Community Patch" folder, replacing the existing file there.
 
 
-C. Using your opened Command Prompt window, run the following command. Close the window when you're done.
+C. Copy the 43 Civ Release DLL and PDB from clang-output/Release into the Debug/43 Civ/Release folder.
+
+
+D. Using your opened Command Prompt window, run the following command. Close the window when you're done.
 py build_vp_clang.py --config debug
 
 
-D. Go to the clang-output/Debug folder. Cut and paste the compiled DLL into the "43 Civ" folder you created earlier.
+E. Copy the Debug DLL and PDB from clang-output/Debug into the Debug/43 Civ/Debug folder.
 
 
-E. Compress the Debug folder into a .zip file, then delete the unzipped folder.
+F. Compress the Debug folder into a .zip file, then delete the unzipped folder.
 
 
-F. Delete the clang-output and clang-build folders in the repository.
+G. Delete the clang-output and clang-build folders in the repository.
 
 
 

--- a/docs/minidumps.md
+++ b/docs/minidumps.md
@@ -8,6 +8,7 @@ A minidump (crash dump) is a diagnostic file that captures the state of the game
 - [Locating Minidump Files](#locating-minidump-files)
 - [Filename Format](#filename-format)
 - [Version String Format](#version-string-format)
+- [Obtaining Symbol Files (PDB)](#obtaining-symbol-files-pdb)
 - [Analyzing Minidumps](#analyzing-minidumps)
   - [Using Visual Studio](#using-visual-studio)
   - [Using WinDbg](#using-windbg)
@@ -121,11 +122,25 @@ This allows developers to immediately know:
 3. **Game log** - Printed at startup: `"Gamecore was built from git version Release-5.1-3-gabc123d Clean"`
 4. **WinDbg output** - Visible when analyzing the dump with `!analyze -v`
 
+## Obtaining Symbol Files (PDB)
+
+Symbol files (`.pdb`) are essential for meaningful minidump analysis. Without matching PDB files, you'll only see raw memory addresses instead of function names, source files, and line numbers.
+
+**Where to find PDB files:**
+
+| Source | Contains | How to Get |
+|--------|----------|------------|
+| **Debug.zip** (GitHub Release) | Release and Debug DLL+PDB for Standard and 43 Civ variants | Download from the [Releases page](https://github.com/LoneGazebo/Community-Patch-DLL/releases). The `Release/` subfolder has the PDB matching the installer DLL. |
+| **CI Artifacts** | Release and Debug DLL+PDB for Clang and MSVC builds | Download from the GitHub Actions build for the specific commit (e.g. `VP_Clang_Release_*`). Note: CI artifacts are built from the final tagged commit and may not match the DLL shipped in the installer (see below). |
+| **Local Build** | PDB for your build | `BuildOutput\Release\` (MSVC) or `clang-output\Release\` (Clang) after building |
+
+**Important:** The PDB must match the exact DLL binary. For analyzing user crash dumps, always use the PDB from **Debug.zip** — it was built alongside the installer DLL and has a matching PDB signature. CI artifacts are built from the tagged commit after the installer is packaged, so their PDB signatures will not match the shipped DLL.
+
 ## Analyzing Minidumps
 
 ### Using Visual Studio
 
-Visual Studio can open and analyze minidump files, but may have limitations with Release builds or when debug symbols (PDB files) are not available.
+Visual Studio can open and analyze minidump files.
 
 **Steps:**
 1. Open Visual Studio (2008, 2013, 2019, or 2022)
@@ -135,10 +150,9 @@ Visual Studio can open and analyze minidump files, but may have limitations with
 5. Examine the **Call Stack** window to see where the crash occurred
 6. Use the **Autos** or **Locals** windows to inspect variable values
 
-**Limitations:**
-- May require matching PDB files (symbol files) from the exact build
-- Some Release builds may have limited information due to optimizations
-- Visual Studio may refuse to load some dumps
+**If symbols aren't loading automatically**, set the symbol path:
+- Debug → Options → Debugging → Symbols
+- Add the folder containing the matching `CvGameCore_Expansion2.pdb` from Debug.zip (see [Obtaining Symbol Files](#obtaining-symbol-files-pdb) above)
 
 ### Using WinDbg
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -156,7 +156,14 @@ def check_git_status():
 # =============================================================================
 
 def create_debug_folder(debug_folder: Path) -> Tuple[Path, Path]:
-    """Create Debug folder with Standard and 43 Civ subfolders."""
+    """Create Debug folder with Standard and 43 Civ subfolders.
+
+    Each variant gets Release/ and Debug/ subfolders so the layout is:
+        Debug/Standard/Release/{dll,pdb}
+        Debug/Standard/Debug/{dll,pdb}
+        Debug/43 Civ/Release/{dll,pdb}
+        Debug/43 Civ/Debug/{dll,pdb}
+    """
     print(f"Creating debug folder structure at: {debug_folder}")
     standard_folder = debug_folder / "Standard"
     civ43_folder = debug_folder / "43 Civ"
@@ -455,6 +462,8 @@ def copy_dll_and_pdb(config: str, destination: Path):
 
     dll_path = output_dir / "CvGameCore_Expansion2.dll"
     pdb_path = output_dir / "CvGameCore_Expansion2.pdb"
+
+    destination.mkdir(parents=True, exist_ok=True)
 
     if dll_path.exists():
         shutil.copy2(dll_path, destination / "CvGameCore_Expansion2.dll")
@@ -847,11 +856,12 @@ def main():
         if not build_dll('release'):
             raise RuntimeError("Release build failed")
         copy_release_dll_to_mod(is_43_civ=False)
+        copy_dll_and_pdb('release', standard_folder / "Release")
 
         print("\n  Building Debug configuration...")
         if not build_dll('debug'):
             raise RuntimeError("Debug build failed")
-        copy_dll_and_pdb('debug', standard_folder)
+        copy_dll_and_pdb('debug', standard_folder / "Debug")
 
         print("\n  Cleaning up build folders...")
         cleanup_build_folders()
@@ -866,11 +876,12 @@ def main():
         if not build_dll('release'):
             raise RuntimeError("43 Civ Release build failed")
         copy_release_dll_to_mod(is_43_civ=True)
+        copy_dll_and_pdb('release', civ43_folder / "Release")
 
         print("\n  Building Debug configuration (43 Civ)...")
         if not build_dll('debug'):
             raise RuntimeError("43 Civ Debug build failed")
-        copy_dll_and_pdb('debug', civ43_folder)
+        copy_dll_and_pdb('debug', civ43_folder / "Debug")
 
         disable_43_civ_build()
 


### PR DESCRIPTION
- Add Release DLL+PDB to Debug.zip alongside existing Debug builds
- Organize Debug.zip with symmetric Release/ and Debug/ subfolders
- Add mkdir safety in copy_dll_and_pdb for new subdirectory paths
- Document PDB sources and CI vs installer commit mismatch in minidumps.md
- Update manual release instructions for new Debug.zip structure
- Clarify DLL-only (no PDB) goes to mod folder for installer