### PR TITLE
cppcheck fixes

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvAIOperation.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAIOperation.cpp
@@ -210,7 +210,7 @@ void CvAIOperation::SetMusterPlot(CvPlot* pMuster)
 	if (pMuster==NULL)
 	{
 		m_iMusterX = INVALID_PLOT_COORD;
-		m_iMusterX = INVALID_PLOT_COORD;
+		m_iMusterY = INVALID_PLOT_COORD;
 	}
 	else
 	{

--- a/CvGameCoreDLL_Expansion2/CvAdvisorCounsel.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAdvisorCounsel.cpp
@@ -1400,6 +1400,7 @@ void CvAdvisorCounsel::BuildCounselList(PlayerTypes ePlayer)
 		{
 			// warn the player they are about to not be an ally with a minor civ
 			iMessageRating = 80;
+			// cppcheck-suppress knownConditionTrueFalse
 			if(eEnemyPlayer != NO_PLAYER)
 			{
 				strLoc = Localization::Lookup("TXT_KEY_DIPLOSTRATEGY_ALMOST_LOST_CITY_STATE_ALLY_WAR_WITH_MAJOR");
@@ -1468,6 +1469,7 @@ void CvAdvisorCounsel::BuildCounselList(PlayerTypes ePlayer)
 		{
 			// warn the player they are about to not be an friend with a minor civ
 			iMessageRating = 60;
+			// cppcheck-suppress knownConditionTrueFalse
 			if(eEnemyPlayer != NO_PLAYER)
 			{
 				strLoc = Localization::Lookup("TXT_KEY_DIPLOSTRATEGY_ALMOST_LOST_CITY_STATE_FRIENDSHIP_WAR_WITH_MAJOR");
@@ -1534,7 +1536,7 @@ void CvAdvisorCounsel::BuildCounselList(PlayerTypes ePlayer)
 		}
 		else
 		{
-			iMessageRating = 20;
+			// cppcheck-suppress knownConditionTrueFalse
 			if(eEnemyPlayer != NO_PLAYER)
 			{
 				strLoc = Localization::Lookup("TXT_KEY_DIPLOSTRATEGY_BEFRIEND_CITY_STATE_WAR_WITH_MAJOR");

--- a/CvGameCoreDLL_Expansion2/CvArmyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvArmyAI.cpp
@@ -478,7 +478,7 @@ int CvArmyAI::GetTotalPower()
 CvFormationSlotEntry CvArmyAI::GetSlotInfo(size_t iSlotID) const
 {
 	CvMultiUnitFormationInfo* thisFormation = GetFormation();
-	if (thisFormation && iSlotID >= 0 && iSlotID < thisFormation->getNumFormationSlotEntries())
+	if (thisFormation && iSlotID < thisFormation->getNumFormationSlotEntries())
 		return thisFormation->getFormationSlotEntry(iSlotID);
 
 	return CvFormationSlotEntry();

--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
@@ -2529,7 +2529,6 @@ void CvBuilderTaskingAI::AddImprovingPlotsDirective(vector<OptionWithScore<Build
 				if (pkChopBuild && pkChopBuild->getImprovement() == NO_IMPROVEMENT && pkChopBuild->isFeatureRemoveOnly(eFeature) && m_pPlayer->canBuild(pPlot, eLoopBuild))
 				{
 					eChopBuild = eLoopBuild;
-					pkChopBuild = pkChopBuild;
 					break;
 				}
 			}
@@ -3485,9 +3484,6 @@ PlotBuildScore CvBuilderTaskingAI::ScorePlotBuild(CvPlot* pPlot, ImprovementType
 			{
 				BuildTypes eOtherBuild = (BuildTypes)iBuild;
 
-				if (eOtherBuild == NO_BUILD)
-					continue;
-
 				CvBuildInfo* pkOtherBuildInfo = GC.getBuildInfo(eOtherBuild);
 				if (!pkOtherBuildInfo)
 					continue;
@@ -3829,7 +3825,7 @@ PlotBuildScore CvBuilderTaskingAI::ScorePlotBuild(CvPlot* pPlot, ImprovementType
 
 				if (iNewAdjacentWorkedYield != 0 || iNewAdjacentUnworkedYield != 0)
 				{
-					int iAdjacentCityYieldModifier = pAdjacentOwningCity ? GetYieldCityModifierTimes100(pAdjacentOwningCity, eYield) : 100;
+					int iAdjacentCityYieldModifier = GetYieldCityModifierTimes100(pAdjacentOwningCity, eYield);
 					iSecondaryScore += (iNewAdjacentWorkedYield * iYieldModifier * iAdjacentCityYieldModifier) / 100;
 					iPotentialScore += (iNewAdjacentUnworkedYield * iYieldModifier * iAdjacentCityYieldModifier) / 100;
 				}
@@ -3951,7 +3947,7 @@ PlotBuildScore CvBuilderTaskingAI::ScorePlotBuild(CvPlot* pPlot, ImprovementType
 				CvImprovementEntry* pkOldImprovementInfo = GC.getImprovementInfo(eOldImprovement);
 				if (pkOldImprovementInfo && (pkOldImprovementInfo->IsConnectsResource(eResource) || pkOldImprovementInfo->GetResourceFromImprovement() == eResource))
 				{
-					ResourceTypes eResourceFromOldImprovement = pkOldImprovementInfo ? (ResourceTypes)pkOldImprovementInfo->GetResourceFromImprovement() : NO_RESOURCE;
+					ResourceTypes eResourceFromOldImprovement = (ResourceTypes)pkOldImprovementInfo->GetResourceFromImprovement();
 					int iOldResourceQuantityFromImprovement = pkOldImprovementInfo->GetResourceQuantityFromImprovement();
 					if (iOldResourceQuantityFromImprovement <= 0)
 						iOldResourceQuantityFromImprovement = 1;

--- a/CvGameCoreDLL_Expansion2/CvBuildingClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuildingClasses.cpp
@@ -849,7 +849,6 @@ bool CvBuildingEntry::CacheResults(Database::Results& kResults, CvDatabaseUtilit
 	szTextVal = kResults.GetText("FreeBuildingThisCity");
 	m_iFreeBuildingThisCity = GC.getInfoTypeForString(szTextVal, true);
 
-	szTextVal = kResults.GetText("FreeBuildingTradeTargetCity");
 	m_bTradeRouteInvulnerable = kResults.GetBool("TradeRouteInvulnerable");
 	m_iTRSpeedBoost = kResults.GetInt("TRSpeedBoost");
 	m_iTRVisionBoost = kResults.GetInt("TRVisionBoost");

--- a/CvGameCoreDLL_Expansion2/CvBuildingProductionAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuildingProductionAI.cpp
@@ -306,27 +306,21 @@ int CvBuildingProductionAI::CheckBuildingBuildSanity(BuildingTypes eBuilding, in
 			for (int iMinorLoop = MAX_MAJOR_CIVS; iMinorLoop < MAX_CIV_PLAYERS; iMinorLoop++)
 			{
 				PlayerTypes eMinor = (PlayerTypes)iMinorLoop;
-				if (eMinor != NO_PLAYER)
+				CvPlayer* pMinor = &GET_PLAYER(eMinor);
+				CvMinorCivAI* pMinorCivAI = pMinor->GetMinorCivAI();
+				if (pMinorCivAI && pMinorCivAI->IsActiveQuestForPlayer(m_pCity->getOwner(), MINOR_CIV_QUEST_BUILD_X_BUILDINGS))
 				{
-					CvPlayer* pMinor = &GET_PLAYER(eMinor);
-					if (pMinor)
+					if ((BuildingTypes)pMinorCivAI->GetQuestData1(m_pCity->getOwner(), MINOR_CIV_QUEST_BUILD_X_BUILDINGS) == eBuilding)
 					{
-						CvMinorCivAI* pMinorCivAI = pMinor->GetMinorCivAI();
-						if (pMinorCivAI && pMinorCivAI->IsActiveQuestForPlayer(m_pCity->getOwner(), MINOR_CIV_QUEST_BUILD_X_BUILDINGS))
-						{
-							if ((BuildingTypes)pMinorCivAI->GetQuestData1(m_pCity->getOwner(), MINOR_CIV_QUEST_BUILD_X_BUILDINGS) == eBuilding)
-							{
-								iBonus += 10;
-							}
-							if ((BuildingTypes)pMinorCivAI->GetQuestData1(m_pCity->getOwner(), MINOR_CIV_QUEST_CONSTRUCT_NATIONAL_WONDER) == eBuilding)
-							{
-								iBonus += 10;
-							}
-							if ((BuildingTypes)pMinorCivAI->GetQuestData1(m_pCity->getOwner(), MINOR_CIV_QUEST_CONSTRUCT_WONDER) == eBuilding)
-							{
-								iBonus += 10;
-							}
-						}
+						iBonus += 10;
+					}
+					if ((BuildingTypes)pMinorCivAI->GetQuestData1(m_pCity->getOwner(), MINOR_CIV_QUEST_CONSTRUCT_NATIONAL_WONDER) == eBuilding)
+					{
+						iBonus += 10;
+					}
+					if ((BuildingTypes)pMinorCivAI->GetQuestData1(m_pCity->getOwner(), MINOR_CIV_QUEST_CONSTRUCT_WONDER) == eBuilding)
+					{
+						iBonus += 10;
 					}
 				}
 			}
@@ -1165,9 +1159,6 @@ int CvBuildingProductionAI::CheckBuildingBuildSanity(BuildingTypes eBuilding, in
 	for(int iI = 0; iI < NUM_YIELD_TYPES; iI++)
 	{
 		const YieldTypes eYield = static_cast<YieldTypes>(iI);
-		if(eYield == NO_YIELD)
-			continue;
-
 		if(!MOD_BALANCE_CORE_JFD && eYield > YIELD_CULTURE_LOCAL)
 			continue;
 
@@ -1348,7 +1339,7 @@ int CvBuildingProductionAI::CheckBuildingBuildSanity(BuildingTypes eBuilding, in
 			{
 				PlayerTypes eLoopPlayer = (PlayerTypes)iPlayerLoop;
 
-				if (eLoopPlayer != NO_PLAYER && eLoopPlayer != kPlayer.GetID() && GET_PLAYER(eLoopPlayer).GetDiplomacyAI()->IsPlayerValid(eLoopPlayer) && GET_TEAM(kPlayer.getTeam()).isAtWar(GET_PLAYER(eLoopPlayer).getTeam()))
+				if (eLoopPlayer != kPlayer.GetID() && GET_PLAYER(eLoopPlayer).GetDiplomacyAI()->IsPlayerValid(eLoopPlayer) && GET_TEAM(kPlayer.getTeam()).isAtWar(GET_PLAYER(eLoopPlayer).getTeam()))
 				{
 					if (kPlayer.GetDiplomacyAI()->GetWarState(eLoopPlayer) < WAR_STATE_STALEMATE)
 					{

--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -1055,9 +1055,6 @@ void CvCity::init(int iID, PlayerTypes eOwner, int iX, int iY, bool bBumpUnits, 
 	for (int iI = 0; iI < NUM_YIELD_TYPES; iI++)
 	{
 		YieldTypes eYield = (YieldTypes)iI;
-		if (eYield == NO_YIELD)
-			continue;
-
 		UpdateSpecialReligionYields(eYield);
 		UpdateCityYields(eYield);
 
@@ -2675,9 +2672,6 @@ void CvCity::doTurn()
 		for (int iI = 0; iI < NUM_YIELD_TYPES; iI++)
 		{
 			YieldTypes eYield = (YieldTypes)iI;
-			if (eYield == NO_YIELD)
-				continue;
-
 			UpdateSpecialReligionYields(eYield);
 			UpdateCityYields(eYield);
 		}
@@ -2725,9 +2719,6 @@ void CvCity::UpdateAllNonPlotYields(bool bIncludePlayerHappiness)
 	for (int iI = 0; iI < NUM_YIELD_TYPES; iI++)
 	{
 		YieldTypes eYield = (YieldTypes)iI;
-		if (eYield == NO_YIELD)
-			continue;
-
 		//Simplification - errata yields not worth considering.
 		if ((YieldTypes)iI > YIELD_CULTURE_LOCAL && !MOD_BALANCE_CORE_JFD)
 			break;
@@ -3226,39 +3217,36 @@ void CvCity::DoEvents(bool bEspionageOnly)
 	for (int iLoop = 0; iLoop < GC.getNumCityEventChoiceInfos(); iLoop++)
 	{
 		CityEventChoiceTypes eEventChoice = (CityEventChoiceTypes)iLoop;
-		if (eEventChoice != NO_EVENT_CHOICE_CITY)
+		if (GetEventChoiceDuration(eEventChoice) > 0)
 		{
-			if (GetEventChoiceDuration(eEventChoice) > 0)
+			ChangeEventChoiceDuration(eEventChoice, -1);
+			CvModEventCityChoiceInfo* pkEventInfo = GC.getCityEventChoiceInfo(eEventChoice);
+			if (pkEventInfo != NULL)
 			{
-				ChangeEventChoiceDuration(eEventChoice, -1);
-				CvModEventCityChoiceInfo* pkEventInfo = GC.getCityEventChoiceInfo(eEventChoice);
-				if (pkEventInfo != NULL)
-				{
-					//we expire these in a special way.
-					if (pkEventInfo->isCounterspyMission())
-						continue;
+				//we expire these in a special way.
+				if (pkEventInfo->isCounterspyMission())
+					continue;
 
-					if (GC.getLogging())
-					{
-
-						CvString playerName;
-						FILogFile* pLog = NULL;
-						CvString strBaseString;
-						CvString strOutBuf;
-						CvString strFileName = "EventCityLogging.csv";
-						playerName = getName();
-						pLog = LOGFILEMGR.GetLog(strFileName, FILogFile::kDontTimeStamp);
-						strBaseString.Format("%03d, ", GC.getGame().getElapsedGameTurns());
-						strBaseString += playerName + ", ";
-						strOutBuf.Format("Event choice: %s. Cooldown Active. Changing Value by -1. Cooldown Remaining: %d", pkEventInfo->GetDescription(), GetEventChoiceDuration(eEventChoice));
-						strBaseString += strOutBuf;
-						pLog->Msg(strBaseString);
-					}
-				}
-				if (GetEventChoiceDuration(eEventChoice) == 0)
+				if (GC.getLogging())
 				{
-					DoCancelEventChoice(eEventChoice);
+
+					CvString playerName;
+					FILogFile* pLog = NULL;
+					CvString strBaseString;
+					CvString strOutBuf;
+					CvString strFileName = "EventCityLogging.csv";
+					playerName = getName();
+					pLog = LOGFILEMGR.GetLog(strFileName, FILogFile::kDontTimeStamp);
+					strBaseString.Format("%03d, ", GC.getGame().getElapsedGameTurns());
+					strBaseString += playerName + ", ";
+					strOutBuf.Format("Event choice: %s. Cooldown Active. Changing Value by -1. Cooldown Remaining: %d", pkEventInfo->GetDescription(), GetEventChoiceDuration(eEventChoice));
+					strBaseString += strOutBuf;
+					pLog->Msg(strBaseString);
 				}
+			}
+			if (GetEventChoiceDuration(eEventChoice) == 0)
+			{
+				DoCancelEventChoice(eEventChoice);
 			}
 		}
 	}
@@ -3296,9 +3284,6 @@ void CvCity::DoEvents(bool bEspionageOnly)
 	for (int iLoop = 0; iLoop < GC.getNumCityEventInfos(); iLoop++)
 	{
 		CityEventTypes eEvent = (CityEventTypes)iLoop;
-		if (eEvent == NO_EVENT_CITY)
-			continue;
-
 		CvModCityEventInfo* pkEventInfo = GC.getCityEventInfo(eEvent);
 		if (pkEventInfo == NULL)
 			continue;
@@ -3522,24 +3507,21 @@ void CvCity::DoStartEvent(CityEventTypes eChosenEvent, bool bSendMsg)
 			for (int iLoop = 0; iLoop < GC.getNumCityEventChoiceInfos(); iLoop++)
 			{
 				eEventChoice = (CityEventChoiceTypes)iLoop;
-				if (eEventChoice != NO_EVENT_CHOICE_CITY)
+				CvModEventCityChoiceInfo* pkEventChoiceInfo = GC.getCityEventChoiceInfo(eEventChoice);
+				if (pkEventChoiceInfo != NULL)
 				{
-					CvModEventCityChoiceInfo* pkEventChoiceInfo = GC.getCityEventChoiceInfo(eEventChoice);
-					if (pkEventChoiceInfo != NULL)
+					if (IsCityEventChoiceValid(eEventChoice, eChosenEvent))
 					{
-						if (IsCityEventChoiceValid(eEventChoice, eChosenEvent))
+						iNumEvent++;
+						if (pkEventInfo->getNumChoices() == 1)
 						{
-							iNumEvent++;
-							if (pkEventInfo->getNumChoices() == 1)
+							DoEventChoice(eEventChoice, eChosenEvent, bSendMsg);
+							if (isHuman(ISHUMAN_AI_EVENT_CHOICE))
 							{
-								DoEventChoice(eEventChoice, eChosenEvent, bSendMsg);
-								if (isHuman(ISHUMAN_AI_EVENT_CHOICE))
-								{
-									CvPopupInfo kPopupInfo(BUTTONPOPUP_MODDER_7, eEventChoice, GetID(), getOwner());
-									GC.GetEngineUserInterface()->AddPopup(kPopupInfo);
-								}
-								return;
+								CvPopupInfo kPopupInfo(BUTTONPOPUP_MODDER_7, eEventChoice, GetID(), getOwner());
+								GC.GetEngineUserInterface()->AddPopup(kPopupInfo);
 							}
+							return;
 						}
 					}
 				}
@@ -3630,9 +3612,6 @@ bool CvCity::IsCityEventValid(CityEventTypes eEvent)
 			for (int iPlayerLoop = 0; iPlayerLoop < MAX_MAJOR_CIVS; iPlayerLoop++)
 			{
 				ePlayer = (PlayerTypes)iPlayerLoop;
-				if (ePlayer == NO_PLAYER)
-					continue;
-
 				CvPlayer& kPlayer2 = GET_PLAYER(ePlayer);
 
 				if (!pLinkerInfo->CheckOtherPlayers() && ePlayer != getOwner())
@@ -3851,65 +3830,44 @@ bool CvCity::IsCityEventValid(CityEventTypes eEvent)
 	if (pkEventInfo->getBuildingRequired() != -1)
 	{
 		BuildingClassTypes eBuilding = (BuildingClassTypes)pkEventInfo->getBuildingRequired();
-		if (eBuilding != NO_BUILDINGCLASS)
-		{
-			if (GetCityBuildings()->GetNumBuildingClass(eBuilding) <= 0)
-				return false;
-		}
+		if (GetCityBuildings()->GetNumBuildingClass(eBuilding) <= 0)
+			return false;
 	}
 	if (pkEventInfo->getBuildingLimiter() != -1)
 	{
 		BuildingClassTypes eBuilding = (BuildingClassTypes)pkEventInfo->getBuildingLimiter();
-		if (eBuilding != NO_BUILDINGCLASS)
-		{
-			if (GetCityBuildings()->GetNumBuildingClass(eBuilding) > 0)
-				return false;
-		}
+		if (GetCityBuildings()->GetNumBuildingClass(eBuilding) > 0)
+			return false;
 	}
 	if (pkEventInfo->getRequiredImprovement() != -1)
 	{
 		ImprovementTypes eImprovement = (ImprovementTypes)pkEventInfo->getRequiredImprovement();
-		if (eImprovement != NO_IMPROVEMENT)
-		{
-			if (!HasImprovement(eImprovement))
-				return false;
-		}
+		if (!HasImprovement(eImprovement))
+			return false;
 	}
 	if (pkEventInfo->getLocalResourceRequired() != -1)
 	{
 		ResourceTypes eResource = (ResourceTypes)pkEventInfo->getLocalResourceRequired();
-		if (eResource != NO_RESOURCE)
-		{
-			if (!HasResource(eResource))
-				return false;
-		}
+		if (!HasResource(eResource))
+			return false;
 	}
 	if (pkEventInfo->hasNearbyFeature() != -1)
 	{
 		FeatureTypes eFeature = (FeatureTypes)pkEventInfo->hasNearbyFeature();
-		if (eFeature != NO_FEATURE)
-		{
-			if (!IsHasFeatureLocal(eFeature))
-				return false;
-		}
+		if (!IsHasFeatureLocal(eFeature))
+			return false;
 	}
 	if (pkEventInfo->hasNearbyTerrain() != -1)
 	{
 		TerrainTypes eTerrain = (TerrainTypes)pkEventInfo->hasNearbyTerrain();
-		if (eTerrain != NO_TERRAIN)
-		{
-			if (!HasTerrain(eTerrain))
-				return false;
-		}
+		if (!HasTerrain(eTerrain))
+			return false;
 	}
 	//Check our minimum yields - this looks at stored values, not yields per turn.
 	bool bHas = true;
 	for (int iI = 0; iI < NUM_YIELD_TYPES; iI++)
 	{
 		YieldTypes eYield = (YieldTypes)iI;
-		if (eYield == NO_YIELD)
-			return false;
-
 		int iNeededYield = pkEventInfo->getYieldMinimum(eYield);
 		iNeededYield *= GC.getGame().getGameSpeedInfo().getInstantYieldPercent();
 		iNeededYield /= 100;
@@ -4125,9 +4083,6 @@ bool CvCity::IsCityEventChoiceValid(CityEventChoiceTypes eChosenEventChoice, Cit
 			for (int iPlayerLoop = 0; iPlayerLoop < MAX_MAJOR_CIVS; iPlayerLoop++)
 			{
 				ePlayer = (PlayerTypes)iPlayerLoop;
-				if (ePlayer == NO_PLAYER)
-					continue;
-
 				CvPlayer& kPlayer2 = GET_PLAYER(ePlayer);
 
 				if (!pLinkerInfo->CheckOtherPlayers() && ePlayer != getOwner())
@@ -4421,65 +4376,45 @@ bool CvCity::IsCityEventChoiceValid(CityEventChoiceTypes eChosenEventChoice, Cit
 	if (pkEventInfo->hasNearbyFeature() != -1)
 	{
 		FeatureTypes eFeature = (FeatureTypes)pkEventInfo->hasNearbyFeature();
-		if (eFeature != NO_FEATURE)
-		{
-			if (!IsHasFeatureLocal(eFeature))
-				return false;
-		}
+		if (!IsHasFeatureLocal(eFeature))
+			return false;
 	}
 	if (pkEventInfo->hasNearbyTerrain() != -1)
 	{
 		TerrainTypes eTerrain = (TerrainTypes)pkEventInfo->hasNearbyTerrain();
-		if (eTerrain != NO_TERRAIN)
-		{
-			if (!HasTerrain(eTerrain))
-				return false;
-		}
+		if (!HasTerrain(eTerrain))
+			return false;
 	}
 
 	if (pkEventInfo->getBuildingRequired() != -1)
 	{
 		BuildingClassTypes eBuilding = (BuildingClassTypes)pkEventInfo->getBuildingRequired();
-		if (eBuilding != NO_BUILDINGCLASS)
-		{
-			if (GetCityBuildings()->GetNumBuildingClass(eBuilding) <= 0)
-				return false;
-		}
+		if (GetCityBuildings()->GetNumBuildingClass(eBuilding) <= 0)
+			return false;
 	}
 	if (pkEventInfo->getBuildingLimiter() != -1)
 	{
 		BuildingClassTypes eBuilding = (BuildingClassTypes)pkEventInfo->getBuildingLimiter();
-		if (eBuilding != NO_BUILDINGCLASS)
-		{
-			if (GetCityBuildings()->GetNumBuildingClass(eBuilding) > 0)
-				return false;
-		}
+		if (GetCityBuildings()->GetNumBuildingClass(eBuilding) > 0)
+			return false;
 	}
 	if (pkEventInfo->getRequiredImprovement() != -1)
 	{
 		ImprovementTypes eImprovement = (ImprovementTypes)pkEventInfo->getRequiredImprovement();
-		if (eImprovement != NO_IMPROVEMENT)
-		{
-			if (!HasImprovement(eImprovement))
-				return false;
-		}
+		if (!HasImprovement(eImprovement))
+			return false;
 	}
 	if (pkEventInfo->getLocalResourceRequired() != -1)
 	{
 		ResourceTypes eResource = (ResourceTypes)pkEventInfo->getLocalResourceRequired();
-		if (eResource != NO_RESOURCE)
-		{
-			if (!HasResource(eResource))
-				return false;
-		}
+		if (!HasResource(eResource))
+			return false;
 	}
 	//Check our minimum yields - this looks at stored values, not yields per turn.
 	bool bHas = true;
 	for (int iI = 0; iI < NUM_YIELD_TYPES; iI++)
 	{
 		YieldTypes eYield = (YieldTypes)iI;
-		if (eYield == NO_YIELD)
-			continue;
 
 		int iNeededYield = pkEventInfo->getYieldMinimum(eYield);
 		if (pkEventInfo->getPreCheckEventYield(eYield) != 0)
@@ -4615,13 +4550,10 @@ bool CvCity::IsCityEventChoiceValidEspionage(CityEventChoiceTypes eEventChoice, 
 		for (int iLoop = 0; iLoop < GC.getNumCityEventInfos(); iLoop++)
 		{
 			CityEventTypes eParentEvent = (CityEventTypes)iLoop;
-			if (eParentEvent != NO_EVENT_CITY)
+			if (pkEventInfo->isParentEvent(eParentEvent))
 			{
-				if (pkEventInfo->isParentEvent(eParentEvent))
-				{
-					eEvent = eParentEvent;
-					break;
-				}
+				eEvent = eParentEvent;
+				break;
 			}
 		}
 	}
@@ -4656,8 +4588,6 @@ bool CvCity::IsCityEventChoiceValidEspionage(CityEventChoiceTypes eEventChoice, 
 	for (int iI = 0; iI < NUM_YIELD_TYPES; iI++)
 	{
 		YieldTypes eYield = (YieldTypes)iI;
-		if (eYield == NO_YIELD)
-			continue;
 
 		int iSiphonYield = pkEventInfo->getYieldSiphon(eYield);
 		if (iSiphonYield <= 0)
@@ -4843,10 +4773,7 @@ void CvCity::DoCancelEventChoice(CityEventChoiceTypes eChosenEventChoice)
 			if (pkEventChoiceInfo->getEventPromotion() != -1)
 			{
 				PromotionTypes ePromotion = (PromotionTypes)pkEventChoiceInfo->getEventPromotion();
-				if (ePromotion != -1)
-				{
-					changeFreePromotionCount(ePromotion, -1);
-				}
+				changeFreePromotionCount(ePromotion, -1);
 			}
 
 			if (pkEventChoiceInfo->getSpecialistsGreatPersonPointsPerTurn() != 0)
@@ -4857,21 +4784,16 @@ void CvCity::DoCancelEventChoice(CityEventChoiceTypes eChosenEventChoice)
 			for (int iI = 0; iI < GC.getNumResourceInfos(); iI++)
 			{
 				ResourceTypes eResource = (ResourceTypes)iI;
-				if (eResource != NO_RESOURCE)
+				int iBonus = pkEventChoiceInfo->getEventResourceChange(eResource);
+				iBonus *= -1;
+				if (iBonus != 0)
 				{
-					int iBonus = pkEventChoiceInfo->getEventResourceChange(eResource);
-					iBonus *= -1;
-					if (iBonus != 0)
-					{
-						GET_PLAYER(getOwner()).changeNumResourceTotal(eResource, iBonus * -1, false, true, true);
-					}
+					GET_PLAYER(getOwner()).changeNumResourceTotal(eResource, iBonus * -1, false, true, true);
 				}
 			}
 			for (int iI = 0; iI < NUM_YIELD_TYPES; iI++)
 			{
 				YieldTypes eYield = (YieldTypes)iI;
-				if (eYield == NO_YIELD)
-					continue;
 
 				int iYieldChange = pkEventChoiceInfo->getCityYield(eYield);
 				if (iYieldChange != 0)
@@ -4904,7 +4826,7 @@ void CvCity::DoCancelEventChoice(CityEventChoiceTypes eChosenEventChoice)
 				for (int iJ = 0; iJ < GC.getNumImprovementInfos(); iJ++)
 				{
 					ImprovementTypes eImprovement = (ImprovementTypes)iJ;
-					if (eImprovement != NO_IMPROVEMENT && pkEventChoiceInfo->getImprovementYield(eImprovement, eYield) != 0)
+					if (pkEventChoiceInfo->getImprovementYield(eImprovement, eYield) != 0)
 					{
 						ChangeEventImprovementYield(eImprovement, eYield, pkEventChoiceInfo->getImprovementYield(eImprovement, eYield) * -1);
 						bChanged = true;
@@ -4913,7 +4835,7 @@ void CvCity::DoCancelEventChoice(CityEventChoiceTypes eChosenEventChoice)
 				for (int iJ = 0; iJ < GC.getNumFeatureInfos(); iJ++)
 				{
 					FeatureTypes eFeature = (FeatureTypes)iJ;
-					if (eFeature != NO_FEATURE && pkEventChoiceInfo->getFeatureYield(eFeature, eYield) != 0)
+					if (pkEventChoiceInfo->getFeatureYield(eFeature, eYield) != 0)
 					{
 						ChangeEventFeatureYield(eFeature, eYield, pkEventChoiceInfo->getFeatureYield(eFeature, eYield) * -1);
 						bChanged = true;
@@ -4922,7 +4844,7 @@ void CvCity::DoCancelEventChoice(CityEventChoiceTypes eChosenEventChoice)
 				for (int iJ = 0; iJ < GC.getNumTerrainInfos(); iJ++)
 				{
 					TerrainTypes eTerrain = (TerrainTypes)iJ;
-					if (eTerrain != NO_TERRAIN && pkEventChoiceInfo->getTerrainYield(eTerrain, eYield) != 0)
+					if (pkEventChoiceInfo->getTerrainYield(eTerrain, eYield) != 0)
 					{
 						ChangeEventTerrainYield(eTerrain, eYield, pkEventChoiceInfo->getTerrainYield(eTerrain, eYield) * -1);
 						bChanged = true;
@@ -4931,7 +4853,7 @@ void CvCity::DoCancelEventChoice(CityEventChoiceTypes eChosenEventChoice)
 				for (int iJ = 0; iJ < GC.getNumResourceInfos(); iJ++)
 				{
 					ResourceTypes eResource = (ResourceTypes)iJ;
-					if (eResource != NO_RESOURCE && pkEventChoiceInfo->getResourceYield(eResource, eYield) != 0)
+					if (pkEventChoiceInfo->getResourceYield(eResource, eYield) != 0)
 					{
 						ChangeEventResourceYield(eResource, eYield, pkEventChoiceInfo->getResourceYield(eResource, eYield) * -1);
 						bChanged = true;
@@ -5046,8 +4968,6 @@ void CvCity::DoCancelEventChoice(CityEventChoiceTypes eChosenEventChoice)
 				for (int iI = 0; iI < NUM_YIELD_TYPES; iI++)
 				{
 					YieldTypes eYield = (YieldTypes)iI;
-					if (eYield == NO_YIELD)
-						continue;
 
 					UpdateSpecialReligionYields(eYield);
 					UpdateCityYields(eYield);
@@ -5529,8 +5449,6 @@ CvString CvCity::GetDisabledTooltip(CityEventChoiceTypes eChosenEventChoice, int
 			for (int iI = 0; iI < NUM_YIELD_TYPES; iI++)
 			{
 				YieldTypes eYield = (YieldTypes)iI;
-				if (eYield == NO_YIELD)
-					continue;
 
 				int iSiphonYield = pkEventInfo->getYieldSiphon(eYield);
 				if (iSiphonYield <= 0)
@@ -5584,9 +5502,6 @@ CvString CvCity::GetDisabledTooltip(CityEventChoiceTypes eChosenEventChoice, int
 			for (int iPlayerLoop = 0; iPlayerLoop < MAX_MAJOR_CIVS; iPlayerLoop++)
 			{
 				ePlayer = (PlayerTypes)iPlayerLoop;
-				if (ePlayer == NO_PLAYER)
-					continue;
-
 				CvPlayer& kPlayer2 = GET_PLAYER(ePlayer);
 
 				if (!pLinkerInfo->CheckOtherPlayers() && ePlayer != getOwner())
@@ -6322,8 +6237,6 @@ CvString CvCity::GetDisabledTooltip(CityEventChoiceTypes eChosenEventChoice, int
 	for (int iI = 0; iI < NUM_YIELD_TYPES; iI++)
 	{
 		YieldTypes eYield = (YieldTypes)iI;
-		if (eYield == NO_YIELD)
-			continue;
 
 		int iNeededYield = pkEventInfo->getYieldMinimum(eYield);
 		if (pkEventInfo->getPreCheckEventYield(eYield) != 0)
@@ -6454,12 +6367,9 @@ void CvCity::DoEventChoice(CityEventChoiceTypes eEventChoice, CityEventTypes eCi
 				for (int iLoop = 0; iLoop < GC.getNumCityEventInfos(); iLoop++)
 				{
 					CityEventTypes eEvent = (CityEventTypes)iLoop;
-					if (eEvent != NO_EVENT_CITY)
+					if (pkEventChoiceInfo->isParentEvent(eEvent))
 					{
-						if (pkEventChoiceInfo->isParentEvent(eEvent))
-						{
-							SetEventActive(eEvent, false);
-						}
+						SetEventActive(eEvent, false);
 					}
 				}
 			}
@@ -6571,8 +6481,6 @@ void CvCity::DoEventChoice(CityEventChoiceTypes eEventChoice, CityEventTypes eCi
 			for (int iI = 0; iI < NUM_YIELD_TYPES; iI++)
 			{
 				YieldTypes eYield = (YieldTypes)iI;
-				if (eYield == NO_YIELD)
-					continue;
 
 				int iPassYield = pkEventChoiceInfo->getPreCheckEventYield(eYield);
 				iPassYield *= -1;
@@ -6596,27 +6504,24 @@ void CvCity::DoEventChoice(CityEventChoiceTypes eEventChoice, CityEventTypes eCi
 						for (int iLoop = 0; iLoop < GC.getNumCityEventInfos(); iLoop++)
 						{
 							CityEventTypes eEvent = (CityEventTypes)iLoop;
-							if (eEvent != NO_EVENT_CITY)
+							if (pkEventChoiceInfo->isParentEvent(eEvent))
 							{
-								if (pkEventChoiceInfo->isParentEvent(eEvent))
+								CvModCityEventInfo* pkEventInfo = GC.getCityEventInfo(eEvent);
+								if (pkEventInfo != NULL)
 								{
-									CvModCityEventInfo* pkEventInfo = GC.getCityEventInfo(eEvent);
-									if (pkEventInfo != NULL)
-									{
-										Localization::String strMessage;
-										Localization::String strSummary;
-										strMessage = Localization::Lookup("TXT_KEY_NOTIFICATION_EVENT_FAILED_CITY");
-										strMessage << pkEventChoiceInfo->GetDescription();
-										strMessage << GetScaledHelpText(eEventChoice, false, -1, NO_PLAYER);
-										strMessage << pkEventInfo->GetDescription();
-										strMessage << getNameKey();
-										strSummary = Localization::Lookup("TXT_KEY_NOTIFICATION_EVENT_FAILED_CITY_T");
-										strSummary << pkEventInfo->GetDescription();
-										strSummary << getNameKey();
+									Localization::String strMessage;
+									Localization::String strSummary;
+									strMessage = Localization::Lookup("TXT_KEY_NOTIFICATION_EVENT_FAILED_CITY");
+									strMessage << pkEventChoiceInfo->GetDescription();
+									strMessage << GetScaledHelpText(eEventChoice, false, -1, NO_PLAYER);
+									strMessage << pkEventInfo->GetDescription();
+									strMessage << getNameKey();
+									strSummary = Localization::Lookup("TXT_KEY_NOTIFICATION_EVENT_FAILED_CITY_T");
+									strSummary << pkEventInfo->GetDescription();
+									strSummary << getNameKey();
 
-										pNotifications->Add(NOTIFICATION_GENERIC, strMessage.toUTF8(), strSummary.toUTF8(), getX(), getY(), GetID(), getOwner());
-										break;
-									}
+									pNotifications->Add(NOTIFICATION_GENERIC, strMessage.toUTF8(), strSummary.toUTF8(), getX(), getY(), GetID(), getOwner());
+									break;
 								}
 							}
 						}
@@ -6747,8 +6652,6 @@ void CvCity::DoEventChoice(CityEventChoiceTypes eEventChoice, CityEventTypes eCi
 			for (int iI = 0; iI < GC.getNumBuildingClassInfos(); iI++)
 			{
 				BuildingClassTypes eBuildingClass = static_cast<BuildingClassTypes>(iI);
-				if (eBuildingClass == NO_BUILDINGCLASS)
-					continue;
 
 				if (GetCityBuildings()->GetNumBuildingClass(eBuildingClass) <= 0)
 					continue;
@@ -6797,8 +6700,6 @@ void CvCity::DoEventChoice(CityEventChoiceTypes eEventChoice, CityEventTypes eCi
 			for (int iI = 0; iI < NUM_YIELD_TYPES; iI++)
 			{
 				YieldTypes eYield = (YieldTypes)iI;
-				if (eYield == NO_YIELD)
-					continue;
 
 				int iYieldChange = pkEventChoiceInfo->getCityYield(eYield);
 				if (iYieldChange != 0)
@@ -7265,8 +7166,6 @@ void CvCity::DoEventChoice(CityEventChoiceTypes eEventChoice, CityEventTypes eCi
 			for (int iI = 0; iI < GC.getNumReligionInfos(); iI++)
 			{
 				ReligionTypes eReligion = (ReligionTypes)iI;
-				if (eReligion == NO_RELIGION)
-					continue;
 
 				int iPercent = (ReligionTypes)pkEventChoiceInfo->getEventConvertReligionPercent(iI);
 				if (iPercent > 0)
@@ -7334,7 +7233,7 @@ void CvCity::DoEventChoice(CityEventChoiceTypes eEventChoice, CityEventTypes eCi
 						for (int iPlayerLoop = 0; iPlayerLoop < MAX_CIV_PLAYERS; iPlayerLoop++)
 						{
 							PlayerTypes ePlayer = (PlayerTypes)iPlayerLoop;
-							if (ePlayer != NO_PLAYER && GET_PLAYER(ePlayer).isMajorCiv())
+							if (GET_PLAYER(ePlayer).isMajorCiv())
 							{
 								//Not global? Skip all but me.
 								if (!bGlobal && ePlayer != getOwner())
@@ -7369,8 +7268,6 @@ void CvCity::DoEventChoice(CityEventChoiceTypes eEventChoice, CityEventTypes eCi
 			for (int iI = 0; iI < NUM_YIELD_TYPES; iI++)
 			{
 				YieldTypes eYield = (YieldTypes)iI;
-				if (eYield == NO_YIELD)
-					continue;
 
 				UpdateSpecialReligionYields(eYield);
 				UpdateCityYields(eYield);
@@ -7880,8 +7777,6 @@ void CvCity::updateEconomicValue()
 			continue;
 
 		ResourceTypes eResource = pLoopPlot->getResourceType(getTeam());
-		if (eResource == NO_RESOURCE)
-			continue;
 
 		//for plots owned by this city or reasonably likely to be claimed
 		bool bGood = false;
@@ -7905,7 +7800,7 @@ void CvCity::updateEconomicValue()
 		PlayerTypes ePossibleOwner = (PlayerTypes)iPlayerLoop;
 		m_aiEconomicValue[iPlayerLoop] = 0; //everybody gets a new value
 
-		if (ePossibleOwner != NO_PLAYER && GET_PLAYER(ePossibleOwner).isAlive())
+		if (GET_PLAYER(ePossibleOwner).isAlive())
 		{
 			int iResourceValue = 0;
 			if (validResources.size() > 0)
@@ -7914,8 +7809,6 @@ void CvCity::updateEconomicValue()
 				{
 					//todo: add something for currently unworked plots (future potential)
 					ResourceTypes eResource = (ResourceTypes)validResources.GetElement(iResourceLoop);
-					if (eResource == NO_RESOURCE)
-						continue;
 
 					if (GET_TEAM(GET_PLAYER(ePossibleOwner).getTeam()).IsResourceObsolete(eResource))
 						continue;
@@ -15051,8 +14944,6 @@ void CvCity::processSpecialist(SpecialistTypes eSpecialist, int iChange, CvCity:
 	for (int iI = 0; iI < NUM_DOMAIN_TYPES; iI++)
 	{
 		DomainTypes eDomain = (DomainTypes)iI;
-		if (eDomain == NO_DOMAIN)
-			continue;
 
 		int iModifierPerSpecialist = GET_PLAYER(getOwner()).GetPlayerTraits()->GetDomainProductionModifiersPerSpecialist(eDomain);
 
@@ -15291,8 +15182,6 @@ void CvCity::UpdateReligion(ReligionTypes eNewMajority, bool bRecalcPlotYields)
 	for (int iI = 0; iI < NUM_YIELD_TYPES; iI++)
 	{
 		YieldTypes eYield = (YieldTypes)iI;
-		if (eYield == NO_YIELD)
-			continue;
 
 		UpdateSpecialReligionYields(eYield);
 		UpdateCityYields(eYield);
@@ -15933,7 +15822,7 @@ void CvCity::CheckForOperationUnits()
 	{
 		PlayerTypes eLoopPlayer = (PlayerTypes) iPlayerLoop;
 
-		if (eLoopPlayer != NO_PLAYER && GET_PLAYER(eLoopPlayer).isAlive() && eLoopPlayer != getOwner())
+		if (GET_PLAYER(eLoopPlayer).isAlive() && eLoopPlayer != getOwner())
 		{
 			if (kPlayer.GetDiplomacyAI()->IsWantsSneakAttack(eLoopPlayer))
 			{
@@ -16764,8 +16653,6 @@ void CvCity::setPopulation(int iNewValue, bool bReassignPop /* = true */, bool b
 					for (int iGreatPersonTypes = 0; iGreatPersonTypes < GC.getNumGreatPersonInfos(); iGreatPersonTypes++)
 					{
 						GreatPersonTypes eGreatPerson = (GreatPersonTypes)iGreatPersonTypes;
-						if (eGreatPerson == NO_GREATPERSON)
-							continue;
 
 						SpecialistTypes eSpecialist = (SpecialistTypes)GC.getGreatPersonInfo(eGreatPerson)->GetSpecialistType();
 						if (eSpecialist == NO_SPECIALIST)
@@ -27392,7 +27279,7 @@ void CvCity::updateStrengthValue()
 			for (int iPlayerLoop = 0; iPlayerLoop < MAX_MAJOR_CIVS; iPlayerLoop++)
 			{
 				PlayerTypes eLoopPlayer = (PlayerTypes)iPlayerLoop;
-				if (eLoopPlayer != NO_PLAYER && GET_PLAYER(getOwner()).GetMinorCivAI()->IsProtectedByMajor(eLoopPlayer))
+				if (GET_PLAYER(getOwner()).GetMinorCivAI()->IsProtectedByMajor(eLoopPlayer))
 				{
 					iProtections++;
 				}

--- a/CvGameCoreDLL_Expansion2/CvCityAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCityAI.cpp
@@ -235,21 +235,18 @@ void CvCityAI::AI_DoEventChoice(CityEventTypes eChosenEvent)
 			for(int iLoop = 0; iLoop < GC.getNumCityEventChoiceInfos(); iLoop++)
 			{
 				CityEventChoiceTypes eEventChoice = (CityEventChoiceTypes)iLoop;
-				if(eEventChoice != NO_EVENT_CHOICE_CITY)
+				CvModEventCityChoiceInfo* pkEventChoiceInfo = GC.getCityEventChoiceInfo(eEventChoice);
+				if(pkEventChoiceInfo != NULL)
 				{
-					CvModEventCityChoiceInfo* pkEventChoiceInfo = GC.getCityEventChoiceInfo(eEventChoice);
-					if(pkEventChoiceInfo != NULL)
+					if(IsCityEventChoiceValid(eEventChoice, eChosenEvent))
 					{
-						if(IsCityEventChoiceValid(eEventChoice, eChosenEvent))
+						for(int iFlavor = 0; iFlavor < GC.getNumFlavorTypes(); iFlavor++)
 						{
-							for(int iFlavor = 0; iFlavor < GC.getNumFlavorTypes(); iFlavor++)
+							if(pkEventChoiceInfo->getFlavorValue(iFlavor) > 0)
 							{
-								if(pkEventChoiceInfo->getFlavorValue(iFlavor) > 0)
-								{
-									int iOurFlavor = GET_PLAYER(getOwner()).GetGrandStrategyAI()->GetPersonalityAndGrandStrategy((FlavorTypes)iFlavor);
-									iOurFlavor += pkEventChoiceInfo->getFlavorValue(iFlavor);
-									flavorChoices.push_back(eEventChoice, iOurFlavor);
-								}
+								int iOurFlavor = GET_PLAYER(getOwner()).GetGrandStrategyAI()->GetPersonalityAndGrandStrategy((FlavorTypes)iFlavor);
+								iOurFlavor += pkEventChoiceInfo->getFlavorValue(iFlavor);
+								flavorChoices.push_back(eEventChoice, iOurFlavor);
 							}
 						}
 					}
@@ -295,20 +292,17 @@ void CvCityAI::AI_DoEventChoice(CityEventTypes eChosenEvent)
 			for(int iLoop = 0; iLoop < GC.getNumCityEventChoiceInfos(); iLoop++)
 			{
 				CityEventChoiceTypes eEventChoice = (CityEventChoiceTypes)iLoop;
-				if(eEventChoice != NO_EVENT_CHOICE_CITY)
+				CvModEventCityChoiceInfo* pkEventChoiceInfo = GC.getCityEventChoiceInfo(eEventChoice);
+				if(pkEventChoiceInfo != NULL)
 				{
-					CvModEventCityChoiceInfo* pkEventChoiceInfo = GC.getCityEventChoiceInfo(eEventChoice);
-					if(pkEventChoiceInfo != NULL)
+					if(IsCityEventChoiceValid(eEventChoice, eChosenEvent))
 					{
-						if(IsCityEventChoiceValid(eEventChoice, eChosenEvent))
+						int iRandom = GC.getGame().getJonRandNum(pkEventInfo->getNumChoices(), "Random Event Choice");
+						if(iRandom <= 0)
 						{
-							int iRandom = GC.getGame().getJonRandNum(pkEventInfo->getNumChoices(), "Random Event Choice");
-							if(iRandom <= 0)
-							{
-								iRandom = 1;
-							}
-							randomChoices.push_back(eEventChoice, iRandom);
+							iRandom = 1;
 						}
+						randomChoices.push_back(eEventChoice, iRandom);
 					}
 				}
 			}

--- a/CvGameCoreDLL_Expansion2/CvCityCitizens.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCityCitizens.cpp
@@ -420,7 +420,7 @@ int CvCityCitizens::GetBonusPlotValue(CvPlot* pPlot, YieldTypes eYield, SPrecomp
 
 			iBonus += iEffect;
 		}
-		iBonus = m_pCity->GetYieldPerXFeatureFromBuildingsTimes100(eFeature, eYield);
+		iBonus += m_pCity->GetYieldPerXFeatureFromBuildingsTimes100(eFeature, eYield);
 	}
 	if (eTerrain != NO_TERRAIN)
 	{
@@ -3766,9 +3766,9 @@ void SPrecomputedExpensiveNumbers::update(CvCity* pCity, bool bInsideLoop)
 
 		// the smallest possible decrease in yield rate that would increase unhappiness from the respective need by 1
 		iBasicNeedsRateChangeForIncreasedDistress = -INT_MAX;
-		iBasicNeedsRateChangeForIncreasedDistress = -INT_MAX;
-		iBasicNeedsRateChangeForIncreasedDistress = -INT_MAX;
-		iBasicNeedsRateChangeForIncreasedDistress = -INT_MAX;
+		iGoldRateChangeForIncreasedPoverty = -INT_MAX;
+		iScienceRateChangeForIncreasedIlliteracy = -INT_MAX;
+		iCultureRateChangeForIncreasedBoredom = -INT_MAX;
 		int iLimit = MOD_BALANCE_UNCAPPED_UNHAPPINESS ? INT_MAX : pCity->getPopulation();
 		if (iDistress < iLimit)
 		{

--- a/CvGameCoreDLL_Expansion2/CvCultureClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCultureClasses.cpp
@@ -141,7 +141,7 @@ GreatWorkClass CvGameCulture::GetGreatWorkClass(int iIndex) const
 CvString CvGameCulture::GetGreatWorkTooltip(int iIndex, PlayerTypes eOwner) const
 {
 	PRECONDITION(iIndex < GetNumGreatWorks(), "Bad Great Work index");
-	CvString szTooltip = "";
+	CvString szTooltip;
 
 	const CvGreatWork *pWork = &m_CurrentGreatWorks[iIndex];
 	PRECONDITION(pWork->m_eClassType != NO_GREAT_WORK_CLASS, "Invalid Great Work Class");
@@ -328,7 +328,7 @@ CvString CvGameCulture::GetGreatWorkName(int iIndex) const
 CvString CvGameCulture::GetGreatWorkArtist(int iIndex) const
 {
 	PRECONDITION(iIndex < GetNumGreatWorks(), "Bad Great Work index");
-	CvString szArtist = "";
+	CvString szArtist;
 
 	const CvGreatWork *pWork = &m_CurrentGreatWorks[iIndex];
 	szArtist = pWork->m_szGreatPersonName;
@@ -363,7 +363,7 @@ CvString CvGameCulture::GetGreatWorkEra(int iIndex) const
 CvString CvGameCulture::GetGreatWorkEraAbbreviation(int iIndex) const
 {
 	PRECONDITION(iIndex < GetNumGreatWorks(), "Bad Great Work index");
-	CvString szEra = "";
+	CvString szEra;
 
 	const CvGreatWork *pWork = &m_CurrentGreatWorks[iIndex];
 	szEra = GC.getEraInfo(pWork->m_eEra)->getAbbreviation();
@@ -374,7 +374,7 @@ CvString CvGameCulture::GetGreatWorkEraAbbreviation(int iIndex) const
 CvString CvGameCulture::GetGreatWorkEraShort(int iIndex) const
 {
 	PRECONDITION(iIndex < GetNumGreatWorks(), "Bad Great Work index");
-	CvString szEra = "";
+	CvString szEra;
 
 	const CvGreatWork *pWork = &m_CurrentGreatWorks[iIndex];
 	szEra = GC.getEraInfo(pWork->m_eEra)->getShortDesc();
@@ -5909,7 +5909,7 @@ CvString CvCityCulture::GetTourismTooltip()
 /// What is the tooltip describing the tourism output?
 CvString CvCityCulture::GetFilledSlotsTooltip()
 {
-	CvString szRtnValue = "";
+	CvString szRtnValue;
 	const int iGWWriting = m_pCity->GetCityBuildings()->GetNumGreatWorks(CvTypes::getGREAT_WORK_SLOT_LITERATURE());
 	const int iGWArt = m_pCity->GetCityBuildings()->GetNumGreatWorks(CvTypes::getGREAT_WORK_SLOT_ART_ARTIFACT());
 	const int iGWMusic = m_pCity->GetCityBuildings()->GetNumGreatWorks(CvTypes::getGREAT_WORK_SLOT_MUSIC());
@@ -5921,7 +5921,7 @@ CvString CvCityCulture::GetFilledSlotsTooltip()
 /// What is the tooltip describing the tourism output?
 CvString CvCityCulture::GetTotalSlotsTooltip()
 {
-	CvString szRtnValue = "";
+	CvString szRtnValue;
 	CvString szTemp1;
 	CvString szTemp2;
 	CvString szTemp3;

--- a/CvGameCoreDLL_Expansion2/CvDealClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDealClasses.cpp
@@ -6661,7 +6661,7 @@ CvDeal* CvGameDeals::GetDeal(uint index)
 //------------------------------------------------------------------------------
 void CvGameDeals::DestroyDeal(uint index)
 {
-	std::vector<std::pair<uint, CvDeal*> >::iterator it = m_Deals.end();
+	std::vector<std::pair<uint, CvDeal*> >::iterator it;
 	for(it = m_Deals.begin();
 	        it != m_Deals.end(); ++it)
 	{

--- a/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDiplomacyAI.cpp
@@ -22764,7 +22764,6 @@ void CvDiplomacyAI::DoUpdatePrimeLeagueAlly()
 			{
 				ePrimeLeagueAlly = ePlayer;
 				iPrimeVotes = iVotes;
-				ePrimeAlignment = eAlignment;
 			}
 			// In the event of yet another tie, sort by opinion score
 			else if (iVotes == iPrimeVotes)
@@ -22772,8 +22771,6 @@ void CvDiplomacyAI::DoUpdatePrimeLeagueAlly()
 				if (GetCachedOpinionWeight(ePlayer) < GetCachedOpinionWeight(ePrimeLeagueAlly))
 				{
 					ePrimeLeagueAlly = ePlayer;
-					iPrimeVotes = iVotes;
-					ePrimeAlignment = eAlignment;
 				}
 			}
 		}
@@ -25820,7 +25817,6 @@ void CvDiplomacyAI::DoUpdatePeaceTreatyWillingness(bool bMyTurn)
 					if (GET_PLAYER(vEnemyTeamMembers[i]).isAlive())
 						RefusePeaceTreaty(vEnemyTeamMembers[i], strLogMessage);
 				}
-				continue;
 			}
 		}
 
@@ -42949,7 +42945,7 @@ bool CvDiplomacyAI::IsEndDoFAcceptable(PlayerTypes ePlayer, bool bIgnoreCurrentD
 	bool bCultural = iFlavorCulture > 6;
 	bCultural |= IsCultural() || IsSecondaryCultural();
 	bCultural |= IsCompetingForVictory() && IsGoingForCultureVictory();
-	bCultural = GetPlayer()->GetPlayerTraits()->IsTourism();
+	bCultural |= GetPlayer()->GetPlayerTraits()->IsTourism();
 
 	ePromiseState = GetNoDiggingPromiseState(ePlayer);
 	if (ePromiseState == PROMISE_STATE_BROKEN)
@@ -43712,7 +43708,7 @@ void CvDiplomacyAI::DoDenouncePlayer(PlayerTypes ePlayer)
 	GET_PLAYER(ePlayer).GetDiplomacyAI()->DoReevaluatePlayer(GetID());
 	DoReevaluatePlayer(ePlayer);
 
-	Localization::String someoneDenounceInfo = Localization::Lookup("TXT_KEY_NOTIFICATION_DENOUNCE");
+	Localization::String someoneDenounceInfo;
 	int iMessage = GetDenounceMessage(ePlayer);
 	if (iMessage > 0 && iMessage <= 7)
 	{
@@ -47351,7 +47347,7 @@ int CvDiplomacyAI::GetIdeologyScore(PlayerTypes ePlayer)
 				iOpinionWeight /= 100;
 			}
 		}
-		else if (eMyBranch != eTheirBranch)
+		else
 		{
 			iOpinionWeight += iEraMod * /*10*/ GD_INT_GET(OPINION_WEIGHT_DIFFERENT_LATE_POLICIES);
 
@@ -54559,7 +54555,6 @@ void CvDiplomacyAI::DoVassalTaxesRaisedStatement(PlayerTypes ePlayer, DiploState
 						// Modify player view to all AI teammates
 						if (GET_PLAYER(eLoopPlayer).getTeam() == GetTeam())
 						{
-							eLoopPlayer = (PlayerTypes) iPlayerLoop;
 							GET_PLAYER(ePlayer).GetDiplomacyAI()->SetVassalTaxRaised(eLoopPlayer, false);
 						}
 					}
@@ -54607,7 +54602,6 @@ void CvDiplomacyAI::DoVassalTaxesLoweredStatement(PlayerTypes ePlayer, DiploStat
 						// Modify player view to all AI teammates
 						if (GET_PLAYER(eLoopPlayer).getTeam() == GetTeam())
 						{
-							eLoopPlayer = (PlayerTypes) iPlayerLoop;
 							GET_PLAYER(ePlayer).GetDiplomacyAI()->SetVassalTaxLowered(eLoopPlayer, false);
 						}
 					}

--- a/CvGameCoreDLL_Expansion2/CvDllContext.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDllContext.cpp
@@ -1041,7 +1041,7 @@ ICvRandom1* CvDllGameContext::GetRandomNumberGenerator(unsigned int index)
 //------------------------------------------------------------------------------
 void CvDllGameContext::DestroyRandomNumberGenerator(unsigned int index)
 {
-	std::vector<std::pair<uint, CvRandom*> >::iterator it = m_RandomNumberGenerators.end();
+	std::vector<std::pair<uint, CvRandom*> >::iterator it;
 	for(it = m_RandomNumberGenerators.begin();
 	        it != m_RandomNumberGenerators.end(); ++it)
 	{
@@ -1082,7 +1082,7 @@ ICvNetInitInfo1* CvDllGameContext::GetNetInitInfo(unsigned int index)
 //------------------------------------------------------------------------------
 void CvDllGameContext::DestroyNetInitInfo(unsigned int index)
 {
-	std::vector<std::pair<uint, CvDllNetInitInfo*> >::iterator it = m_NetInitInfos.end();
+	std::vector<std::pair<uint, CvDllNetInitInfo*> >::iterator it;
 	for(it = m_NetInitInfos.begin();
 	        it != m_NetInitInfos.end(); ++it)
 	{
@@ -1123,7 +1123,7 @@ ICvNetLoadGameInfo1* CvDllGameContext::GetNetLoadGameInfo(unsigned int index)
 //------------------------------------------------------------------------------
 void CvDllGameContext::DestroyNetLoadGameInfo(unsigned int index)
 {
-	std::vector<std::pair<uint, CvDllNetLoadGameInfo*> >::iterator it = m_NetLoadGameInfos.end();
+	std::vector<std::pair<uint, CvDllNetLoadGameInfo*> >::iterator it;
 	for(it = m_NetLoadGameInfos.begin();
 	        it != m_NetLoadGameInfos.end(); ++it)
 	{

--- a/CvGameCoreDLL_Expansion2/CvEconomicAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvEconomicAI.cpp
@@ -1213,7 +1213,7 @@ bool CvEconomicAI::CanWithdrawMoneyForPurchase(PurchaseType ePurchase, int iAmou
 		}
 
 		// Is this the one, if so, check balance remaining
-		else if(request.m_eType == ePurchase)
+		else
 		{
 			return (iBalance >=iAmount);
 		}
@@ -1249,7 +1249,7 @@ int CvEconomicAI::AmountAvailableForPurchase(PurchaseType ePurchase)
 		}
 
 		// Is this the one, if so, check balance remaining
-		else if(request.m_eType == ePurchase)
+		else
 		{
 			return (iBalance);
 		}
@@ -5009,7 +5009,7 @@ int EconomicAIHelpers::IsTestStrategy_ScoreDiplomats(CvPlayer* pPlayer)
 				iScore += (iVictoryAllyDispute - iCSDistaste);
 			}
 		}
-		else if (iCSDistaste < 0)
+		else
 		{
 			if(iMinorAllyDispute > 0)
 			{

--- a/CvGameCoreDLL_Expansion2/CvEspionageClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvEspionageClasses.cpp
@@ -3032,12 +3032,10 @@ int CvPlayerEspionage::CalcPerTurn(int iSpyState, CvCity* pCity, int iSpyIndex, 
 		}
 		return iBase;
 	}
-	break;
 	case SPY_STATE_SURVEILLANCE:
 	{
 		return 1;
 	}
-	break;
 	case SPY_STATE_GATHERING_INTEL:
 	{
 		if(pCity)
@@ -3097,12 +3095,10 @@ int CvPlayerEspionage::CalcPerTurn(int iSpyState, CvCity* pCity, int iSpyIndex, 
 	{
 		return 0;
 	}
-	break;
 	case SPY_STATE_MAKING_INTRODUCTIONS:
 	{
 		return 1;
 	}
-	break;
 	case SPY_STATE_SCHMOOZE:
 	{
 		if (MOD_BALANCE_VP)
@@ -3180,7 +3176,6 @@ int CvPlayerEspionage::CalcRequired(int iSpyState, CvCity* pCity, int iSpyIndex,
 		}
 		return iTime;
 	}
-	break;
 	case SPY_STATE_GATHERING_INTEL:
 	{
 		if(pCity)
@@ -3241,12 +3236,10 @@ int CvPlayerEspionage::CalcRequired(int iSpyState, CvCity* pCity, int iSpyIndex,
 	{
 		return GC.getGame().GetTurnsUntilMinorCivElection();
 	}
-	break;
 	case SPY_STATE_MAKING_INTRODUCTIONS:
 	{
 		return (iSpyTurnsToMakeIntroductions * GC.getGame().getGameSpeedInfo().getLeaguePercent()) / 100;
 	}
-	break;
 	}
 
 	ASSERT(false, "CalcRequired cannot handle that iSpyState");

--- a/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
@@ -1099,7 +1099,7 @@ void CvMinorCivQuest::EnableInfluence(PlayerTypes ePlayer)
 CvString CvMinorCivQuest::GetRewardString(PlayerTypes ePlayer, bool bFinish) const
 {
 	CvString szTooltip = "";
-	CvString szTooltipHeader = "";
+	CvString szTooltipHeader;
 	if (ePlayer == NO_PLAYER || !GET_PLAYER(ePlayer).isMajorCiv())
 		return szTooltip;
 
@@ -9828,7 +9828,7 @@ PlayerTypes CvMinorCivAI::SpawnRebels()
 	{
 		iRebelBoilPoint += iRebelBoilPoint * 125 / 100;
 	}
-	else if (eProximity < PLAYER_PROXIMITY_CLOSE)
+	else
 	{
 		iRebelBoilPoint += iRebelBoilPoint * 100 / 125;
 	}

--- a/CvGameCoreDLL_Expansion2/CvNotifications.cpp
+++ b/CvGameCoreDLL_Expansion2/CvNotifications.cpp
@@ -1151,7 +1151,6 @@ bool CvNotifications::IsNotificationRedundant(Notification& notification)
 
 		return false;
 	}
-	break;
 
 	case NOTIFICATION_FREE_TECH:
 	{
@@ -1177,7 +1176,6 @@ bool CvNotifications::IsNotificationRedundant(Notification& notification)
 
 		return false;
 	}
-	break;
 
 	case NOTIFICATION_POLICY:
 	{
@@ -1203,7 +1201,6 @@ bool CvNotifications::IsNotificationRedundant(Notification& notification)
 
 		return false;
 	}
-	break;
 
 	case NOTIFICATION_FREE_POLICY:
 	{
@@ -1229,7 +1226,6 @@ bool CvNotifications::IsNotificationRedundant(Notification& notification)
 
 		return false;
 	}
-	break;
 
 	case NOTIFICATION_PRODUCTION:
 	{
@@ -1256,7 +1252,6 @@ bool CvNotifications::IsNotificationRedundant(Notification& notification)
 
 		return false;
 	}
-	break;
 
 	case NOTIFICATION_CITY_TILE:
 	{
@@ -1285,7 +1280,6 @@ bool CvNotifications::IsNotificationRedundant(Notification& notification)
 
 		return false;
 	}
-	break;
 
 	case NOTIFICATION_ENEMY_IN_TERRITORY:
 	{
@@ -1310,7 +1304,6 @@ bool CvNotifications::IsNotificationRedundant(Notification& notification)
 
 		return false;
 	}
-	break;
 
 	case NOTIFICATION_UNIT_PROMOTION:
 	{
@@ -1338,7 +1331,6 @@ bool CvNotifications::IsNotificationRedundant(Notification& notification)
 
 		return false;
 	}
-	break;
 
 	case NOTIFICATION_DIPLOMACY_DECLARATION:
 	{
@@ -1375,7 +1367,6 @@ bool CvNotifications::IsNotificationRedundant(Notification& notification)
 
 		return false;
 	}
-	break;
 
 	case NOTIFICATION_FOUND_PANTHEON:
 	case NOTIFICATION_FOUND_RELIGION:
@@ -1406,7 +1397,6 @@ bool CvNotifications::IsNotificationRedundant(Notification& notification)
 
 		return false;
 	}
-	break;
 
 	case NOTIFICATION_LEAGUE_CALL_FOR_PROPOSALS:
 	case NOTIFICATION_LEAGUE_CALL_FOR_VOTES:
@@ -1433,7 +1423,6 @@ bool CvNotifications::IsNotificationRedundant(Notification& notification)
 		}
 		return false;
 	}
-	break;
 
 	case NOTIFICATION_LEAGUE_PROJECT_COMPLETE:
 	case NOTIFICATION_LEAGUE_PROJECT_PROGRESS:
@@ -1508,7 +1497,6 @@ bool CvNotifications::IsNotificationExpired(int iIndex)
 		else if(!pCity->CanRangeStrikeNow())
 			return true;
 	}
-	break;
 
 	case NOTIFICATION_GOODY:
 	{
@@ -1550,7 +1538,6 @@ bool CvNotifications::IsNotificationExpired(int iIndex)
 		//Expire this notification if there are no more techs that can be researched at this time.
 		return pkPlayerTechs->GetNumTechsCanBeResearched() == 0;
 	}
-	break;
 	case NOTIFICATION_FREE_TECH:
 	{
 		CvPlayerAI& kPlayer = GET_PLAYER(m_ePlayer);
@@ -1775,7 +1762,6 @@ bool CvNotifications::IsNotificationExpired(int iIndex)
 		CvGameReligions* pkReligions(kGame.GetGameReligions());
 		return pkReligions->CanCreatePantheon(m_ePlayer, true) != CvGameReligions::FOUNDING_OK;
 	}
-	break;
 
 	case NOTIFICATION_ADD_REFORMATION_BELIEF:
 	{
@@ -1794,7 +1780,6 @@ bool CvNotifications::IsNotificationExpired(int iIndex)
 
 		return pkReligions->HasCreatedReligion(m_ePlayer);
 	}
-	break;
 
 	case NOTIFICATION_ENHANCE_RELIGION:
 	{
@@ -1810,14 +1795,12 @@ bool CvNotifications::IsNotificationExpired(int iIndex)
 		const CvReligion* pReligion = pkReligions->GetReligion(eReligion, m_ePlayer);
 		return (NULL != pReligion && pReligion->m_bEnhanced);
 	}
-	break;
 
 	case NOTIFICATION_SPY_STOLE_TECH:
 	{
 		CvPlayerEspionage* pEspionage = GET_PLAYER(m_ePlayer).GetEspionage();
 		return pEspionage->m_aiNumTechsToStealList[m_aNotifications[iIndex].m_iGameDataIndex] <= 0;
 	}
-	break;
 
 	case NOTIFICATION_LEAGUE_CALL_FOR_PROPOSALS:
 	{
@@ -1825,7 +1808,6 @@ bool CvNotifications::IsNotificationExpired(int iIndex)
 		CvLeague* pLeague = GC.getGame().GetGameLeagues()->GetLeague(eLeague);
 		return !pLeague->CanPropose(m_ePlayer);
 	}
-	break;
 
 	case NOTIFICATION_CHOOSE_ARCHAEOLOGY:
 	{
@@ -1851,7 +1833,6 @@ bool CvNotifications::IsNotificationExpired(int iIndex)
 		CvLeague* pLeague = GC.getGame().GetGameLeagues()->GetLeague(eLeague);
 		return !pLeague->CanVote(m_ePlayer);
 	}
-	break;
 
 	case NOTIFICATION_PLAYER_CONNECTING:
 	{
@@ -1911,7 +1892,6 @@ bool CvNotifications::IsNotificationExpired(int iIndex)
 		}
 		return true;
 	}
-	break;
 	case -1608954742:
 	{
 		CityEventTypes eCityEvent = (CityEventTypes)m_aNotifications[iIndex].m_iGameDataIndex;
@@ -1926,7 +1906,6 @@ bool CvNotifications::IsNotificationExpired(int iIndex)
 		}
 		return true;
 	}
-	break;
 	case 419811917: // Player Event Notification
 	{
 		EventTypes eEvent = (EventTypes)m_aNotifications[iIndex].m_iGameDataIndex;
@@ -1970,7 +1949,6 @@ bool CvNotifications::IsNotificationExpired(int iIndex)
 		}
 		return true;
 	}
-	break;
 	case -364200720:
 	{
 		CvCity* pCity = GC.getMap().plot(m_aNotifications[iIndex].m_iX, m_aNotifications[iIndex].m_iY)->getPlotCity();
@@ -1980,13 +1958,11 @@ bool CvNotifications::IsNotificationExpired(int iIndex)
 		if (!pCity->isPendingCapture())
 			return true;
 	}
-	break;
 
 	default:	// don't expire
 	{
 		return false;
 	}
-	break;
 	}
 
 	return false;

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -4613,7 +4613,6 @@ CvString CvPlayer::getNewCityName() const
 		strName = pNode->m_data;
 		if(isCityNameValid(strName, true))
 		{
-			strName = pNode->m_data;
 			break;
 		}
 	}
@@ -21984,7 +21983,6 @@ int CvPlayer::GetUnhappinessFromCityBuildings(CvCity* pAssumeCityAnnexed, CvCity
 	int iLoop = 0;
 	for (const CvCity* pLoopCity = firstCity(&iLoop); pLoopCity != NULL; pLoopCity = nextCity(&iLoop))
 	{
-		bCityValid = false;
 
 		// Assume pLoopCity is Annexed, and does NOT count
 		if (pLoopCity == pAssumeCityAnnexed)
@@ -23481,7 +23479,7 @@ void CvPlayer::ProcessLeagueResolutions()
 			}
 		}
 	}
-	else if(!IsLeagueArt())
+	else
 	{
 		int iLoop = 0;
 		for(CvCity* pLoopCity = GET_PLAYER(GetID()).firstCity(&iLoop); pLoopCity != NULL; pLoopCity = GET_PLAYER(GetID()).nextCity(&iLoop))
@@ -49477,7 +49475,7 @@ UnitTypes CvPlayer::GetCompetitiveSpawnUnitType(const bool bIncludeRanged, const
 				continue;
 
 			// Cross check in case mods forget to change unit classes after repurposing default units
-			if (!pUnitInfo || pUnitInfo->GetUnitClassType() != eUnitClass)
+			if (pUnitInfo->GetUnitClassType() != eUnitClass)
 				continue;
 
 			eUnit = eReplaceUnit;

--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -3280,12 +3280,8 @@ bool CvPlot::canBuild(BuildTypes eBuild, PlayerTypes ePlayer, bool bTestVisible,
 	{
 		if(GC.getBuildInfo(eBuild)->isFeatureRemove(getFeatureType()))
 		{
-			if(getFeatureType() == FEATURE_FALLOUT && GC.getBuildInfo(eBuild)->isFeatureRemove(FEATURE_FALLOUT))
-			{
-				bValid = true;
-			}
-			else
-			if(bTestPlotOwner)
+			if((getFeatureType() != FEATURE_FALLOUT || !GC.getBuildInfo(eBuild)->isFeatureRemove(FEATURE_FALLOUT)) &&
+				bTestPlotOwner)
 			{
 				if(isOwned() && (eTeam != getTeam()) && !atWar(eTeam, getTeam()))
 				{

--- a/CvGameCoreDLL_Expansion2/CvReligionClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvReligionClasses.cpp
@@ -394,7 +394,7 @@ bool CvGameReligions::IsValidTarget(ReligionTypes eReligion, CvCity* pFromCity, 
 			}
 		}
 	}
-	else if (pFromCity->getOwner() == pToCity->getOwner())
+	else
 	{
 		if (GET_PLAYER(pFromCity->getOwner()).GetPlayerTraits()->IsNoNaturalReligionSpread())
 		{
@@ -8077,6 +8077,7 @@ int CvReligionAI::ScoreYieldForReligionTimes100(YieldTypes eYield) const
 	{
 	case YIELD_FOOD:
 		iPersonFlavor = pFlavorManager->GetPersonalityIndividualFlavor((FlavorTypes)GC.getInfoTypeForString("FLAVOR_GROWTH")) * 50;
+		break;
 	case YIELD_PRODUCTION:
 		iPersonFlavor = pFlavorManager->GetPersonalityIndividualFlavor((FlavorTypes)GC.getInfoTypeForString("FLAVOR_PRODUCTION")) * 50;
 		break;

--- a/CvGameCoreDLL_Expansion2/CvTacticalAnalysisMap.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTacticalAnalysisMap.cpp
@@ -78,7 +78,7 @@ void CvTacticalDominanceZone::SetZoneCity(CvCity* pCity)
 
 eTacticalDominanceFlags CvTacticalDominanceZone::GetRangedDominanceFlag(int iDominancePercentage) const
 {
-	if ( GetEnemyRangedStrength() <= 0 && GetFriendlyRangedStrength() > 0)
+	if ( GetEnemyRangedStrength() == 0 && GetFriendlyRangedStrength() > 0)
 	{
 		return TACTICAL_DOMINANCE_FRIENDLY;
 	}
@@ -123,7 +123,7 @@ eTacticalDominanceFlags CvTacticalDominanceZone::GetUnitCountDominanceFlag(int i
 
 eTacticalDominanceFlags CvTacticalDominanceZone::GetNavalRangedDominanceFlag(int iDominancePercentage) const
 {
-	if (GetEnemyNavalRangedStrength() <= 0 && GetFriendlyNavalRangedStrength() > 0)
+	if (GetEnemyNavalRangedStrength() == 0 && GetFriendlyNavalRangedStrength() > 0)
 	{
 		return TACTICAL_DOMINANCE_FRIENDLY;
 	}
@@ -347,14 +347,14 @@ bool CvTacticalDominanceZone::HasNeighborZone(PlayerTypes eOwner) const
 eTacticalDominanceFlags CvTacticalDominanceZone::SetOverallDominance(int iDominancePercentage)
 {
 	// Look at ratio of friendly to enemy strength
-	if(GetOverallEnemyStrength()+GetOverallFriendlyStrength()<=0)
+	if(GetOverallEnemyStrength() == 0 && GetOverallFriendlyStrength() == 0)
 	{
 		m_eOverallDominanceFlag = TACTICAL_DOMINANCE_NO_UNITS_VISIBLE; //also covers cities ...
 	}
 	else
 	{
 		// Otherwise compute it by strength
-		if (GetOverallEnemyStrength() <= 0 && GetTotalFriendlyUnitCount() > 0) //make sure the denominator is valid later on
+		if (GetOverallEnemyStrength() == 0 && GetTotalFriendlyUnitCount() > 0) //make sure the denominator is valid later on
 		{
 			m_eOverallDominanceFlag = TACTICAL_DOMINANCE_FRIENDLY;
 		}

--- a/CvGameCoreDLL_Expansion2/CvTacticalAnalysisMap.h
+++ b/CvGameCoreDLL_Expansion2/CvTacticalAnalysisMap.h
@@ -122,6 +122,7 @@ public:
 	}
 	inline void AddFriendlyMeleeStrength(int iStrength)
 	{
+		ASSERT(iStrength >= 0);
 		m_iFriendlyMeleeStrength += iStrength;
 	}
 	inline unsigned int GetEnemyMeleeStrength() const
@@ -130,6 +131,7 @@ public:
 	}
 	inline void AddEnemyMeleeStrength(int iStrength)
 	{
+		ASSERT(iStrength >= 0);
 		m_iEnemyMeleeStrength += iStrength;
 	}
 	inline unsigned int GetFriendlyRangedStrength() const
@@ -138,6 +140,7 @@ public:
 	}
 	inline void AddFriendlyRangedStrength(int iRangedStrength)
 	{
+		ASSERT(iRangedStrength >= 0);
 		m_iFriendlyRangedStrength += iRangedStrength;
 	}
 	inline unsigned int GetEnemyRangedStrength() const
@@ -146,6 +149,7 @@ public:
 	}
 	inline void AddEnemyRangedStrength(int iRangedStrength)
 	{
+		ASSERT(iRangedStrength >= 0);
 		m_iEnemyRangedStrength += iRangedStrength;
 	}
 	inline unsigned int GetFriendlyNavalStrength() const
@@ -154,6 +158,7 @@ public:
 	}
 	inline void AddFriendlyNavalStrength(int iStrength)
 	{
+		ASSERT(iStrength >= 0);
 		m_iFriendlyNavalStrength += iStrength;
 	}
 	inline unsigned int GetEnemyNavalStrength() const
@@ -162,6 +167,7 @@ public:
 	}
 	inline void AddEnemyNavalStrength(int iStrength)
 	{
+		ASSERT(iStrength >= 0);
 		m_iEnemyNavalStrength += iStrength;
 	}
 	inline unsigned int GetFriendlyNavalRangedStrength() const
@@ -170,6 +176,7 @@ public:
 	}
 	inline void AddFriendlyNavalRangedStrength(int iRangedStrength)
 	{
+		ASSERT(iRangedStrength >= 0);
 		m_iFriendlyNavalRangedStrength += iRangedStrength;
 	}
 	inline unsigned int GetEnemyNavalRangedStrength() const
@@ -178,6 +185,7 @@ public:
 	}
 	inline void AddEnemyNavalRangedStrength(int iRangedStrength)
 	{
+		ASSERT(iRangedStrength >= 0);
 		m_iEnemyNavalRangedStrength += iRangedStrength;
 	}
 	inline int GetTotalFriendlyUnitCount() const
@@ -202,6 +210,7 @@ public:
 	}
 	inline void AddNeutralStrength(int iUnitStrength)
 	{
+		ASSERT(iUnitStrength >= 0);
 		m_iNeutralUnitStrength += iUnitStrength;
 	}
 	inline int GetNeutralUnitCount() const

--- a/CvGameCoreDLL_Expansion2/CvTeam.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTeam.cpp
@@ -6546,7 +6546,7 @@ void CvTeam::setHasTech(TechTypes eIndex, bool bNewValue, PlayerTypes ePlayer, b
 			}
 
 			ResourceTypes eHiddenArtifactResource = (ResourceTypes)GC.getInfoTypeForString("RESOURCE_HIDDEN_ARTIFACTS", true);
-			CvResourceInfo* pHiddenArtifactResource = pHiddenArtifactResource = GC.getResourceInfo(eHiddenArtifactResource);
+			CvResourceInfo* pHiddenArtifactResource = GC.getResourceInfo(eHiddenArtifactResource);
 			if(eHiddenArtifactResource != NO_RESOURCE && pHiddenArtifactResource)
 			{
 				TechTypes eDefaultTech = (TechTypes)pHiddenArtifactResource->getTechReveal();

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -1567,6 +1567,7 @@ void CvUnit::reset(int iID, UnitTypes eUnit, PlayerTypes eOwner, bool bConstruct
 	m_bCapturedAsConscript = false;
 	m_eUnitType = eUnit;
 	m_pUnitInfo = (NO_UNIT != m_eUnitType) ? GC.getUnitInfo(m_eUnitType) : NULL;
+	ASSERT(NO_UNIT == m_eUnitType || m_pUnitInfo != NULL, "getUnitInfo returned NULL for a valid unit type");
 	m_iBaseCombat = (NO_UNIT != m_eUnitType) ? m_pUnitInfo->GetCombat() : 0;
 	m_iBaseRangedCombat = (NO_UNIT != m_eUnitType) ? m_pUnitInfo->GetRangedCombat() : 0;
 	m_eCombatType = (NO_UNIT != m_eUnitType) ? (UnitCombatTypes)m_pUnitInfo->GetUnitCombatType() : NO_UNITCOMBAT;
@@ -4362,7 +4363,7 @@ bool CvUnit::isBetterDefenderThan(const CvUnit* pDefender, const CvUnit* pAttack
 		return false;
 	}
 
-	if(IsCanDefend() && !(pDefender->IsCanDefend()))
+	if(!(pDefender->IsCanDefend()))
 	{
 		return true;
 	}
@@ -10372,7 +10373,7 @@ bool CvUnit::pillage()
 					iTileValue /= 100;
 
 					// Did the plot owner's master fail to protect their territory?
-					if (!isBarbarian() && GET_PLAYER(pPlot->getOwner()).isMajorCiv() && GET_PLAYER(pPlot->getOwner()).IsVassalOfSomeone())
+					if (GET_PLAYER(pPlot->getOwner()).isMajorCiv() && GET_PLAYER(pPlot->getOwner()).IsVassalOfSomeone())
 					{
 						for (int iPlayerLoop = 0; iPlayerLoop < MAX_MAJOR_CIVS; iPlayerLoop++)
 						{
@@ -11558,8 +11559,6 @@ int CvUnit::GetScaleAmount(int iAmountToScale) const
 	{
 		iExtra = 0;
 		ImprovementTypes eImprovement = (ImprovementTypes)i;
-		if (eImprovement == NO_IMPROVEMENT)
-			continue;
 
 		int iScaleAmount = getUnitInfo().GetScalingFromOwnedImprovements(eImprovement);
 		if (iScaleAmount <= 0)
@@ -12533,9 +12532,6 @@ void CvUnit::PerformCultureBomb(int iRadius)
 				YieldTypes eYield = (YieldTypes)iI;
 
 				int iPassYield = 0;
-
-				if (eYield == NO_YIELD)
-					continue;
 
 				TerrainTypes eTerrain = pLoopPlot->getTerrainType();
 
@@ -17587,15 +17583,12 @@ int CvUnit::GetRangeCombatDamage(const CvUnit* pDefender, const CvCity* pCity, i
 	else if (pDefender)
 	{
 		//extra damage with special promotion
-		if (GetMoraleBreakChance() != 0 && pDefender && pDefender->GetNumFallBackPlotsAvailable(*this) == 0)
+		if (GetMoraleBreakChance() != 0 && pDefender->GetNumFallBackPlotsAvailable(*this) == 0)
 			iDamage = (iDamage * 150) / 100;
 
-		if (pDefender)
-		{
-			iDamage *= 100 + pDefender->GetDamageTakenMod();
-			iDamage /= 100;
-			iDamage = max(0, iDamage + pDefender->getChangeDamageValue());
-		}
+		iDamage *= 100 + pDefender->GetDamageTakenMod();
+		iDamage /= 100;
+		iDamage = max(0, iDamage + pDefender->getChangeDamageValue());
 	}
 
 	return iDamage;
@@ -20902,20 +20895,17 @@ void CvUnit::setXY(int iX, int iY, bool bGroup, bool bUpdate, bool bShow, bool b
 
 						CvCity* pLoopCity = NULL;
 						int iLoop = 0;
-						if (pNewPlot)
+						for (pLoopCity = kPlayer.firstCity(&iLoop); pLoopCity != NULL; pLoopCity = kPlayer.nextCity(&iLoop))
 						{
-							for (pLoopCity = kPlayer.firstCity(&iLoop); pLoopCity != NULL; pLoopCity = kPlayer.nextCity(&iLoop))
+							CvPlot* pCityPlot = pLoopCity->plot();
+							if (pCityPlot)
 							{
-								CvPlot* pCityPlot = pLoopCity->plot();
-								if (pCityPlot)
-								{
-									iDistance = plotDistance(pNewPlot->getX(), pNewPlot->getY(), pCityPlot->getX(), pCityPlot->getY());
+								iDistance = plotDistance(pNewPlot->getX(), pNewPlot->getY(), pCityPlot->getX(), pCityPlot->getY());
 
-									if (iBestCityDistance == -1 || iDistance < iBestCityDistance)
-									{
-										iBestCityID = pLoopCity->GetID();
-										iBestCityDistance = iDistance;
-									}
+								if (iBestCityDistance == -1 || iDistance < iBestCityDistance)
+								{
+									iBestCityID = pLoopCity->GetID();
+									iBestCityDistance = iDistance;
 								}
 							}
 						}
@@ -28392,11 +28382,11 @@ CvUnit* CvUnit::GetPotentialUnitToSwapWith(const CvPlot & swapPlot) const
 								continue;
 
 							// Make sure units belong to the same player
-							if (pLoopUnit && pLoopUnit->getOwner() == getOwner())
+							if (pLoopUnit->getOwner() == getOwner())
 							{
 								if (pLoopUnit->IsCombatUnit() && pLoopUnit->ReadyToSwap())
 								{
-									if (pLoopUnit->canEnterTerrain(*plot(), CvUnit::MOVEFLAG_DESTINATION) && pLoopUnit->canEnterTerritory(plot()->getTeam(),true) && pLoopUnit->ReadyToSwap())
+									if (pLoopUnit->canEnterTerrain(*plot(), CvUnit::MOVEFLAG_DESTINATION) && pLoopUnit->canEnterTerritory(plot()->getTeam(),true))
 									{
 										// Can the unit I am swapping with get to me this turn?
 										SPathFinderUserData data(pLoopUnit, CvUnit::MOVEFLAG_IGNORE_DANGER | CvUnit::MOVEFLAG_IGNORE_STACKING_SELF, 1);
@@ -29151,7 +29141,6 @@ bool CvUnit::canRangeStrikeAt(int iX, int iY, bool bNeedWar, bool bNoncombatAllo
 						continue;
 				}
 
-				if(!pLoopUnit) continue;
 
 				TeamTypes loopTeam = pLoopUnit->getTeam();
 
@@ -34052,7 +34041,7 @@ void CvUnit::RemoveCargoPromotions(CvUnit& cargounit)
 			allembark = true;
 		}
 	}
-	else if(!isCargo())
+	else
 	{
 		PromotionTypes ePromotionArmyOnShip = (PromotionTypes) GC.getInfoTypeForString("PROMOTION_ARMY_ON_SHIP", true);
 		PromotionTypes ePromotionRangePenalty = (PromotionTypes) GC.getInfoTypeForString("PROMOTION_ARMY_RANGE_PENALTY", true);

--- a/CvGameCoreDLL_Expansion2/CvUnitCombat.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnitCombat.cpp
@@ -694,14 +694,14 @@ void CvUnitCombat::GenerateRangedCombatInfo(CvUnit& kAttacker, CvUnit* pkDefende
 	pkCombatInfo->setMaxExperienceAllowed(BATTLE_UNIT_ATTACKER, iMaxXP);
 	pkCombatInfo->setInBorders(BATTLE_UNIT_ATTACKER, plot.getOwner() == kAttacker.getOwner());
 
-	bool bGeneralsXP = !kAttacker.isBarbarian();
+	bool bGeneralsXP;
 	if (!plot.isCity())
 	{
-		bGeneralsXP = !pkDefender->isBarbarian();
+		bGeneralsXP = !kAttacker.isBarbarian() && !pkDefender->isBarbarian();
 	} 
 	else
 	{
-		bGeneralsXP = !plot.getPlotCity()->isBarbarian();
+		bGeneralsXP = !kAttacker.isBarbarian() && !plot.getPlotCity()->isBarbarian();
 	}
 
 	if (GC.getGame().isOption(GAMEOPTION_BARB_GG_GA_POINTS))
@@ -1542,14 +1542,14 @@ void CvUnitCombat::GenerateAirCombatInfo(CvUnit& kAttacker, CvUnit* pkDefender, 
 	pkCombatInfo->setMaxExperienceAllowed(BATTLE_UNIT_ATTACKER, iMaxXP);
 	pkCombatInfo->setInBorders(BATTLE_UNIT_ATTACKER, plot.getOwner() == eDefenderOwner);
 
-	bool bGeneralsXP = !kAttacker.isBarbarian();
+	bool bGeneralsXP;
 	if (!plot.isCity())
 	{
-		bGeneralsXP = !pkDefender->isBarbarian();
+		bGeneralsXP = !kAttacker.isBarbarian() && !pkDefender->isBarbarian();
 	}
 	else
 	{
-		bGeneralsXP = !plot.getPlotCity()->isBarbarian();
+		bGeneralsXP = !kAttacker.isBarbarian() && !plot.getPlotCity()->isBarbarian();
 	}
 
 	if (GC.getGame().isOption(GAMEOPTION_BARB_GG_GA_POINTS))
@@ -2640,79 +2640,82 @@ uint CvUnitCombat::ApplyNuclearExplosionDamage(const CvCombatMemberEntry* pkDama
 		}
 	}
 
-	// Send out notifications to the world
-	for (std::vector<PlayerTypes>::iterator iter = vAffectedPlayers.begin(); iter != vAffectedPlayers.end(); ++iter)
+	// Send out notifications to the world (attacker identity required; skipped for meltdowns where pkAttacker is null)
+	if (pkAttacker != NULL)
 	{
-		if (*iter == pkAttacker->getOwner())
-			continue;
-
-		if (GET_PLAYER(pkAttacker->getOwner()).isMajorCiv() && GET_PLAYER(pkAttacker->getOwner()).getTeam() != GET_PLAYER(*iter).getTeam())
+		for (std::vector<PlayerTypes>::iterator iter = vAffectedPlayers.begin(); iter != vAffectedPlayers.end(); ++iter)
 		{
-			GET_PLAYER(*iter).GetDiplomacyAI()->ChangeNumTimesNuked(pkAttacker->getOwner(), 1);
-		}
+			if (*iter == pkAttacker->getOwner())
+				continue;
 
-		if (GET_PLAYER(*iter).isHuman(ISHUMAN_NOTIFICATIONS) && GET_PLAYER(*iter).isAlive())
-		{
-			CvNotifications* pNotifications = GET_PLAYER(*iter).GetNotifications();
-			if (pNotifications)
+			if (GET_PLAYER(pkAttacker->getOwner()).isMajorCiv() && GET_PLAYER(pkAttacker->getOwner()).getTeam() != GET_PLAYER(*iter).getTeam())
 			{
-				Localization::String strSummary = Localization::Lookup("TXT_KEY_NUKE_STRIKE_AFFECTED_S");
-				Localization::String strBuffer = Localization::Lookup("TXT_KEY_NUKE_STRIKE_AFFECTED");
-				strBuffer << GET_PLAYER(pkAttacker->getOwner()).getCivilizationAdjectiveKey();
-				pNotifications->Add(NOTIFICATION_UNIT_DIED, strBuffer.toUTF8(), strSummary.toUTF8(), pkTargetPlot->getX(), pkTargetPlot->getY(), (int)pkAttacker->getUnitType(), pkAttacker->getOwner());
-			}
-		}
-	}
-	for (int iPlayerLoop = 0; iPlayerLoop < MAX_PLAYERS; iPlayerLoop++)
-	{
-		PlayerTypes eLoopPlayer = (PlayerTypes) iPlayerLoop;
-
-		if (GET_PLAYER(eLoopPlayer).isObserver() || (GET_PLAYER(eLoopPlayer).isHuman(ISHUMAN_NOTIFICATIONS) && GET_PLAYER(eLoopPlayer).isAlive()))
-		{
-			if (!GET_PLAYER(eLoopPlayer).isObserver())
-			{
-				if (eLoopPlayer == pkAttacker->getOwner())
-					continue;
-
-				if (pkTargetPlot->isOwned() && !pkTargetPlot->isRevealed(GET_PLAYER(eLoopPlayer).getTeam()) && !GET_TEAM(GET_PLAYER(eLoopPlayer).getTeam()).isHasMet(GET_PLAYER(pkTargetPlot->getOwner()).getTeam()))
-					continue;
-
-				if (std::find(vAffectedPlayers.begin(), vAffectedPlayers.end(), eLoopPlayer) != vAffectedPlayers.end())
-					continue;
+				GET_PLAYER(*iter).GetDiplomacyAI()->ChangeNumTimesNuked(pkAttacker->getOwner(), 1);
 			}
 
-			CvNotifications* pNotifications = GET_PLAYER(eLoopPlayer).GetNotifications();
-			if (pNotifications)
+			if (GET_PLAYER(*iter).isHuman(ISHUMAN_NOTIFICATIONS) && GET_PLAYER(*iter).isAlive())
 			{
-				Localization::String strSummary = Localization::Lookup("TXT_KEY_NUKE_STRIKE_S");
-
-				if (pkTargetPlot->isOwned())
+				CvNotifications* pNotifications = GET_PLAYER(*iter).GetNotifications();
+				if (pNotifications)
 				{
-					Localization::String strBuffer = Localization::Lookup("TXT_KEY_NUKE_STRIKE_OWNED_TERRITORY");
-					strBuffer << GET_PLAYER(pkAttacker->getOwner()).getCivilizationShortDescription();
-					strBuffer << GET_PLAYER(pkTargetPlot->getOwner()).getCivilizationShortDescription();
-
-					if (pkTargetPlot->isRevealed(GET_PLAYER(eLoopPlayer).getTeam()))
-					{
-						pNotifications->Add(NOTIFICATION_UNIT_DIED, strBuffer.toUTF8(), strSummary.toUTF8(), pkTargetPlot->getX(), pkTargetPlot->getY(), (int)pkAttacker->getUnitType(), pkAttacker->getOwner());
-					}
-					else
-					{
-						pNotifications->Add(NOTIFICATION_UNIT_DIED, strBuffer.toUTF8(), strSummary.toUTF8(), -1, -1, (int)pkAttacker->getUnitType(), pkAttacker->getOwner());
-					}
+					Localization::String strSummary = Localization::Lookup("TXT_KEY_NUKE_STRIKE_AFFECTED_S");
+					Localization::String strBuffer = Localization::Lookup("TXT_KEY_NUKE_STRIKE_AFFECTED");
+					strBuffer << GET_PLAYER(pkAttacker->getOwner()).getCivilizationAdjectiveKey();
+					pNotifications->Add(NOTIFICATION_UNIT_DIED, strBuffer.toUTF8(), strSummary.toUTF8(), pkTargetPlot->getX(), pkTargetPlot->getY(), (int)pkAttacker->getUnitType(), pkAttacker->getOwner());
 				}
-				else
-				{
-					Localization::String strBuffer = Localization::Lookup("TXT_KEY_NUKE_STRIKE_UNOWNED_TERRITORY");
-					strBuffer << GET_PLAYER(pkAttacker->getOwner()).getCivilizationShortDescription();
+			}
+		}
+		for (int iPlayerLoop = 0; iPlayerLoop < MAX_PLAYERS; iPlayerLoop++)
+		{
+			PlayerTypes eLoopPlayer = (PlayerTypes) iPlayerLoop;
 
-					if (pkTargetPlot->isRevealed(GET_PLAYER(eLoopPlayer).getTeam()))
+			if (GET_PLAYER(eLoopPlayer).isObserver() || (GET_PLAYER(eLoopPlayer).isHuman(ISHUMAN_NOTIFICATIONS) && GET_PLAYER(eLoopPlayer).isAlive()))
+			{
+				if (!GET_PLAYER(eLoopPlayer).isObserver())
+				{
+					if (eLoopPlayer == pkAttacker->getOwner())
+						continue;
+
+					if (pkTargetPlot->isOwned() && !pkTargetPlot->isRevealed(GET_PLAYER(eLoopPlayer).getTeam()) && !GET_TEAM(GET_PLAYER(eLoopPlayer).getTeam()).isHasMet(GET_PLAYER(pkTargetPlot->getOwner()).getTeam()))
+						continue;
+
+					if (std::find(vAffectedPlayers.begin(), vAffectedPlayers.end(), eLoopPlayer) != vAffectedPlayers.end())
+						continue;
+				}
+
+				CvNotifications* pNotifications = GET_PLAYER(eLoopPlayer).GetNotifications();
+				if (pNotifications)
+				{
+					Localization::String strSummary = Localization::Lookup("TXT_KEY_NUKE_STRIKE_S");
+
+					if (pkTargetPlot->isOwned())
 					{
-						pNotifications->Add(NOTIFICATION_UNIT_DIED, strBuffer.toUTF8(), strSummary.toUTF8(), pkTargetPlot->getX(), pkTargetPlot->getY(), (int)pkAttacker->getUnitType(), pkAttacker->getOwner());
+						Localization::String strBuffer = Localization::Lookup("TXT_KEY_NUKE_STRIKE_OWNED_TERRITORY");
+						strBuffer << GET_PLAYER(pkAttacker->getOwner()).getCivilizationShortDescription();
+						strBuffer << GET_PLAYER(pkTargetPlot->getOwner()).getCivilizationShortDescription();
+
+						if (pkTargetPlot->isRevealed(GET_PLAYER(eLoopPlayer).getTeam()))
+						{
+							pNotifications->Add(NOTIFICATION_UNIT_DIED, strBuffer.toUTF8(), strSummary.toUTF8(), pkTargetPlot->getX(), pkTargetPlot->getY(), (int)pkAttacker->getUnitType(), pkAttacker->getOwner());
+						}
+						else
+						{
+							pNotifications->Add(NOTIFICATION_UNIT_DIED, strBuffer.toUTF8(), strSummary.toUTF8(), -1, -1, (int)pkAttacker->getUnitType(), pkAttacker->getOwner());
+						}
 					}
 					else
 					{
-						pNotifications->Add(NOTIFICATION_UNIT_DIED, strBuffer.toUTF8(), strSummary.toUTF8(), -1, -1, (int)pkAttacker->getUnitType(), pkAttacker->getOwner());
+						Localization::String strBuffer = Localization::Lookup("TXT_KEY_NUKE_STRIKE_UNOWNED_TERRITORY");
+						strBuffer << GET_PLAYER(pkAttacker->getOwner()).getCivilizationShortDescription();
+
+						if (pkTargetPlot->isRevealed(GET_PLAYER(eLoopPlayer).getTeam()))
+						{
+							pNotifications->Add(NOTIFICATION_UNIT_DIED, strBuffer.toUTF8(), strSummary.toUTF8(), pkTargetPlot->getX(), pkTargetPlot->getY(), (int)pkAttacker->getUnitType(), pkAttacker->getOwner());
+						}
+						else
+						{
+							pNotifications->Add(NOTIFICATION_UNIT_DIED, strBuffer.toUTF8(), strSummary.toUTF8(), -1, -1, (int)pkAttacker->getUnitType(), pkAttacker->getOwner());
+						}
 					}
 				}
 			}
@@ -4227,7 +4230,7 @@ void CvUnitCombat::ApplyPostKillTraitEffects(CvUnit* pkWinner, CvUnit* pkLoser)
 		}
 	}
 	// If the modder wants the healing to be negative (ie additional damage), then let it be
-	else if(pkWinner->getHPHealedIfDefeatEnemy() < 0 && (pkLoser->getOwner() != BARBARIAN_PLAYER || !(pkWinner->IsHealIfDefeatExcludeBarbarians()) || !(pkWinner->isExtraAttackHealthOnKill())))
+	else if(pkWinner->getHPHealedIfDefeatEnemy() < 0 && (pkLoser->getOwner() != BARBARIAN_PLAYER || !(pkWinner->IsHealIfDefeatExcludeBarbarians())))
 	{
 		if(pkWinner->getHPHealedIfDefeatEnemy() <= (pkWinner->getDamage() - pkWinner->GetMaxHitPoints()))
 		{

--- a/CvGameCoreDLL_Expansion2/CvUnitProductionAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnitProductionAI.cpp
@@ -125,7 +125,7 @@ UnitTypes CvUnitProductionAI::RecommendUnit(UnitAITypes eUnitAIType, bool bAllow
 		if(pkUnitInfo)
 		{
 			// Make sure it matches the requested unit AI type
-			if (eUnitAIType != NO_UNITAI && !pkUnitInfo->GetUnitAIType(eUnitAIType))
+			if (!pkUnitInfo->GetUnitAIType(eUnitAIType))
 				continue;
 
 			if (!bAllowStrategicResource && pkUnitInfo->GetResourceType() != NO_RESOURCE)
@@ -760,7 +760,7 @@ int CvUnitProductionAI::CheckUnitBuildSanity(UnitTypes eUnit, bool bForOperation
 			{
 				PlayerTypes eLoopPlayer = (PlayerTypes)iPlayerLoop;
 
-				if (eLoopPlayer != NO_PLAYER && eLoopPlayer != kPlayer.GetID() && kPlayer.GetDiplomacyAI()->IsPlayerValid(eLoopPlayer) && 
+				if (eLoopPlayer != kPlayer.GetID() && kPlayer.GetDiplomacyAI()->IsPlayerValid(eLoopPlayer) && 
 					(kPlayer.GetProximityToPlayer(eLoopPlayer) == PLAYER_PROXIMITY_NEIGHBORS || GET_TEAM(kPlayer.getTeam()).isAtWar(GET_PLAYER(eLoopPlayer).getTeam())))
 				{
 					int iTheirAir = GET_PLAYER(eLoopPlayer).GetNumUnitsWithUnitAI(UNITAI_DEFENSE_AIR, false) + GET_PLAYER(eLoopPlayer).GetNumUnitsWithUnitAI(UNITAI_ATTACK_AIR, false);
@@ -942,12 +942,9 @@ int CvUnitProductionAI::CheckUnitBuildSanity(UnitTypes eUnit, bool bForOperation
 							for (int iI = 0; iI < NUM_YIELD_TYPES; iI++)
 							{
 								const YieldTypes eYield = static_cast<YieldTypes>(iI);
-								if (eYield != NO_YIELD)
+								if (pEntry->GetYieldFromKills(eYield) > 0)
 								{
-									if (pEntry->GetYieldFromKills(eYield) > 0)
-									{
-										iReligiousBonus += (pEntry->GetYieldFromKills(eYield) / 5);
-									}
+									iReligiousBonus += (pEntry->GetYieldFromKills(eYield) / 5);
 								}
 							}
 						}
@@ -1145,10 +1142,6 @@ int CvUnitProductionAI::CheckUnitBuildSanity(UnitTypes eUnit, bool bForOperation
 		//Archaeologists? Only if we have digs nearby.
 		if(pkUnitEntry->GetDefaultUnitAIType() == UNITAI_ARCHAEOLOGIST)
 		{
-			if(kPlayer.isMinorCiv())
-			{
-				return SR_IMPOSSIBLE;
-			}
 			static EconomicAIStrategyTypes eWantArch = (EconomicAIStrategyTypes) GC.getInfoTypeForString("ECONOMICAISTRATEGY_NEED_ARCHAEOLOGISTS");
 			if(!kPlayer.GetEconomicAI()->IsUsingStrategy(eWantArch))
 			{
@@ -1178,12 +1171,10 @@ int CvUnitProductionAI::CheckUnitBuildSanity(UnitTypes eUnit, bool bForOperation
 						break;
 
 					const YieldTypes eYield = static_cast<YieldTypes>(iI);
-					if(eYield != NO_YIELD)
+
+					if(kPlayer.GetPlayerTraits()->GetArtifactYieldChanges(eYield) > 0)
 					{
-						if(kPlayer.GetPlayerTraits()->GetArtifactYieldChanges(eYield) > 0)
-						{
-							iBonus += 500;
-						}
+						iBonus += 500;
 					}
 				}
 			}
@@ -1535,13 +1526,10 @@ int CvUnitProductionAI::CheckUnitBuildSanity(UnitTypes eUnit, bool bForOperation
 	for (int iI = 0; iI < NUM_YIELD_TYPES; iI++)
 	{
 		const YieldTypes eYield = static_cast<YieldTypes>(iI);
-		if (eYield != NO_YIELD)
+		int iYieldAmountOnComplete = GC.getUnitInfo(eUnit)->GetYieldOnCompletion(eYield);
+		if (iYieldAmountOnComplete > 0)
 		{
-			int iYieldAmountOnComplete = GC.getUnitInfo(eUnit)->GetYieldOnCompletion(eYield);
-			if (iYieldAmountOnComplete > 0)
-			{
-				iInstantYieldBonus += (iYieldAmountOnComplete * iInstantYieldImportanceScale);
-			}
+			iInstantYieldBonus += (iYieldAmountOnComplete * iInstantYieldImportanceScale);
 		}
 	}
 

--- a/CvGameCoreDLL_Expansion2/CvVotingClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvVotingClasses.cpp
@@ -1400,10 +1400,6 @@ void CvActiveResolution::DoEffects(PlayerTypes ePlayer)
 			for (int iMinor = MAX_MAJOR_CIVS; iMinor < MAX_CIV_PLAYERS; iMinor++)
 			{
 				PlayerTypes eMinor = (PlayerTypes) iMinor;
-				if(eMinor == NO_PLAYER)
-				{
-					continue;
-				}
 				if (GET_PLAYER(eMinor).isAlive() && GET_PLAYER(eMinor).GetMinorCivAI()->GetBaseFriendshipWithMajor(ePlayer) < iNeutral)
 				{
 					if (pLeague->IsMember(eMinor))
@@ -3244,25 +3240,22 @@ bool CvLeague::IsResolutionEffectsValid(ResolutionTypes eResolution, int iPropos
 				return false;
 			}
 		}
-		if (eDiploVictory != NO_VICTORY)
+		for (int i = 0; i < GC.getNumLeagueSpecialSessionInfos(); i++)
 		{
-			for (int i = 0; i < GC.getNumLeagueSpecialSessionInfos(); i++)
+			LeagueSpecialSessionTypes e = (LeagueSpecialSessionTypes)i;
+			CvLeagueSpecialSessionEntry* pSessionInfo = GC.getLeagueSpecialSessionInfo(e);
+			if(pSessionInfo->IsUnitedNations())
 			{
-				LeagueSpecialSessionTypes e = (LeagueSpecialSessionTypes)i;
-				CvLeagueSpecialSessionEntry* pSessionInfo = GC.getLeagueSpecialSessionInfo(e);
-				if(pSessionInfo->IsUnitedNations())
+				ResolutionTypes eResolution = LeagueHelpers::IsResolutionForTriggerActive(pSessionInfo->GetResolutionTrigger());
+				if(eResolution == NO_RESOLUTION)
 				{
-					ResolutionTypes eResolution = LeagueHelpers::IsResolutionForTriggerActive(pSessionInfo->GetResolutionTrigger());
-					if(eResolution == NO_RESOLUTION)
+					if (sTooltipSink != NULL)
 					{
-						if (sTooltipSink != NULL)
-						{
-							(*sTooltipSink) += "[NEWLINE][NEWLINE][COLOR_WARNING_TEXT]";
-							(*sTooltipSink) += Localization::Lookup("TXT_KEY_LEAGUE_OVERVIEW_INVALID_RESOLUTION_PREREQ").toUTF8();
-							(*sTooltipSink) += "[ENDCOLOR]";
-						}
-						return false;
+						(*sTooltipSink) += "[NEWLINE][NEWLINE][COLOR_WARNING_TEXT]";
+						(*sTooltipSink) += Localization::Lookup("TXT_KEY_LEAGUE_OVERVIEW_INVALID_RESOLUTION_PREREQ").toUTF8();
+						(*sTooltipSink) += "[ENDCOLOR]";
 					}
+					return false;
 				}
 			}
 		}
@@ -3418,7 +3411,7 @@ bool CvLeague::IsResolutionEffectsValid(ResolutionTypes eResolution, int iPropos
 		for (int iPlayerLoop = 0; iPlayerLoop < MAX_CIV_PLAYERS; iPlayerLoop++)
 		{
 			PlayerTypes eLoopPlayer = (PlayerTypes) iPlayerLoop;
-			if ((eLoopPlayer != NO_PLAYER) && GET_PLAYER(eLoopPlayer).isAlive() && !GET_PLAYER(eLoopPlayer).isMinorCiv())
+			if (GET_PLAYER(eLoopPlayer).isAlive() && !GET_PLAYER(eLoopPlayer).isMinorCiv())
 			{
 				if (GET_TEAM(GET_PLAYER(eLoopPlayer).getTeam()).GetNumVassals() > 0)
 				{
@@ -3949,7 +3942,7 @@ int CvLeague::GetPotentialVotesForMember(PlayerTypes ePlayer, PlayerTypes eFromP
 						for (int iPlayerLoop = 0; iPlayerLoop < MAX_CIV_PLAYERS; iPlayerLoop++)
 						{
 							eLoopPlayer = (PlayerTypes) iPlayerLoop;
-							if((eLoopPlayer != NO_PLAYER) && GET_PLAYER(eLoopPlayer).isAlive() && !GET_PLAYER(eLoopPlayer).isMinorCiv() && (eLoopPlayer != eFromPlayer))
+							if(GET_PLAYER(eLoopPlayer).isAlive() && !GET_PLAYER(eLoopPlayer).isMinorCiv() && (eLoopPlayer != eFromPlayer))
 							{
 								iNumVotes += GET_PLAYER(eFromPlayer).GetLeagueAI()->GetVoteCommitment(eLoopPlayer, it->GetID(), vChoices[i], /*bEnact*/ true);
 								iNumVotes += GET_PLAYER(eFromPlayer).GetLeagueAI()->GetVoteCommitment(eLoopPlayer, it->GetID(), vChoices[i], /*bEnact*/ false);
@@ -5325,7 +5318,7 @@ int CvLeague::GetExtraVotesForFollowingReligion(PlayerTypes ePlayer)
 						for (int iPlayerLoop = 0; iPlayerLoop < MAX_MAJOR_CIVS; iPlayerLoop++)
 						{
 							eLoopPlayer = (PlayerTypes) iPlayerLoop;
-							if((eLoopPlayer != NO_PLAYER) && GET_PLAYER(eLoopPlayer).isAlive() && !GET_PLAYER(eLoopPlayer).isMinorCiv() && (eLoopPlayer != ePlayer))
+							if(GET_PLAYER(eLoopPlayer).isAlive() && !GET_PLAYER(eLoopPlayer).isMinorCiv() && (eLoopPlayer != ePlayer))
 							{
 								if (GET_PLAYER(eLoopPlayer).GetReligions()->HasReligionInMostCities(eReligion))
 								{
@@ -5716,7 +5709,7 @@ CvString CvLeague::GetResolutionName(ResolutionTypes eResolution, int iResolutio
 				}
 			}
 		}
-		else if (!bDone)
+		if (!bDone)
 		{
 			for (RepealProposalList::iterator it = m_vRepealProposals.begin(); it != m_vRepealProposals.end(); ++it)
 			{
@@ -7282,7 +7275,7 @@ void CvLeague::StartSession()
 	for (int iPlayerLoop = 0; iPlayerLoop < MAX_MAJOR_CIVS; iPlayerLoop++)
 	{
 		PlayerTypes ePlayer = PlayerTypes(iPlayerLoop);
-		if (ePlayer != NO_PLAYER && GET_PLAYER(ePlayer).isAlive())
+		if (GET_PLAYER(ePlayer).isAlive())
 		{
 			int iDelegates = CalculateStartingVotesForMember(ePlayer);
 			if (iDelegates > 0)
@@ -8843,7 +8836,7 @@ void CvLeague::CheckProjectsProgress()
 				for (int iPlayerLoop = 0; iPlayerLoop < MAX_MAJOR_CIVS; iPlayerLoop++)
 				{
 					PlayerTypes eLoopPlayer = (PlayerTypes)iPlayerLoop;
-					if (eLoopPlayer == NO_PLAYER || !GET_PLAYER(eLoopPlayer).isAlive())
+					if (!GET_PLAYER(eLoopPlayer).isAlive())
 						continue;
 
 					CvPlayer &kPlayer = GET_PLAYER(eLoopPlayer);
@@ -11216,7 +11209,7 @@ CvLeagueAI::KnowledgeLevels CvLeagueAI::GetKnowledgeGivenToOtherPlayer(PlayerTyp
 	// Shared Ideology
 	PolicyBranchTypes eMyIdeology = GetPlayer()->GetPlayerPolicies()->GetLateGamePolicyTree();
 	PolicyBranchTypes eTheirIdeology = GET_PLAYER(eToPlayer).GetPlayerPolicies()->GetLateGamePolicyTree();
-	bool bShareIdeology = ((eMyIdeology == eTheirIdeology) && (eMyIdeology != NO_POLICY_BRANCH_TYPE) && (eTheirIdeology != NO_POLICY_BRANCH_TYPE));
+	bool bShareIdeology = ((eMyIdeology == eTheirIdeology) && (eMyIdeology != NO_POLICY_BRANCH_TYPE));
 
 	// Espionage
 	bool bSpyVisitingUs = GetPlayer()->GetEspionage()->IsOtherDiplomatVisitingMe(eToPlayer);
@@ -11699,7 +11692,7 @@ void CvLeagueAI::AllocateVotes(CvLeague* pLeague)
 	for (int i = 0; i < MAX_MAJOR_CIVS; i++)
 	{
 		PlayerTypes ePlayer = (PlayerTypes)i;
-		if (ePlayer == NO_PLAYER || !pLeague->IsMember(ePlayer))
+		if (!pLeague->IsMember(ePlayer))
 			continue;
 
 		if (GetPlayer()->GetID() == ePlayer)

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaCity.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaCity.cpp
@@ -4720,10 +4720,6 @@ int CvLuaCity::lGetYieldFromCityYieldTimes100(lua_State* L)
 	for(int iI = 0; iI < NUM_YIELD_TYPES; iI++)
 	{
 		YieldTypes eIndex2 = (YieldTypes)iI;
-		if(eIndex2 == NO_YIELD)
-		{
-			continue;
-		}
 		if (eIndex2 == eIndex1)
 		{
 			continue;
@@ -6491,22 +6487,15 @@ int CvLuaCity::lIsCityEventChoiceActive(lua_State* L)
 						for(int iLoop = 0; iLoop < GC.getNumCityEventInfos(); iLoop++)
 						{
 							CityEventTypes eEvent = (CityEventTypes)iLoop;
-							if(eEvent != NO_EVENT_CITY)
+							CvModCityEventInfo* pkEventInfo = GC.getCityEventInfo(eEvent);
+							if(pkEventInfo != NULL)
 							{
-								CvModCityEventInfo* pkEventInfo = GC.getCityEventInfo(eEvent);
-								if(pkEventInfo != NULL)
+								if(pkEventChoiceInfo->isParentEvent(eEvent))
 								{
-									if(pkEventChoiceInfo->isParentEvent(eEvent))
+									if(pkEventInfo->getNumChoices() == 1)
 									{
-										CvModCityEventInfo* pkEventInfo = GC.getCityEventInfo(eEvent);
-										if(pkEventInfo != NULL)
-										{
-											if(pkEventInfo->getNumChoices() == 1)
-											{
-												bResult = true;
-												break;
-											}
-										}
+										bResult = true;
+										break;
 									}
 								}
 							}

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaGame.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaGame.cpp
@@ -4086,10 +4086,6 @@ int CvLuaGame::lGetInactiveContractUnitList(lua_State* L)
 			for(int j = 0; j < GC.getNumUnitInfos(); j++)
 			{
 				UnitTypes eUnit = (UnitTypes)j;
-			
-				if(eUnit == NO_UNIT)
-					continue;
-
 				CvUnitEntry* pkUnitInfo = GC.getUnitInfo(eUnit);
 				if(!pkUnitInfo)
 					continue;
@@ -4134,10 +4130,6 @@ int CvLuaGame::lGetActiveContractUnitList(lua_State* L)
 			for(int j = 0; j < GC.getNumUnitInfos(); j++)
 			{
 				UnitTypes eUnit = (UnitTypes)j;
-			
-				if(eUnit == NO_UNIT)
-					continue;
-
 				CvUnitEntry* pkUnitInfo = GC.getUnitInfo(eUnit);
 				if(!pkUnitInfo)
 					continue;

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
@@ -3909,7 +3909,7 @@ int CvLuaPlayer::lGetInfluenceSpyRankTooltip(lua_State* L)
 	CvString szRank = lua_tostring(L, 3);
 	PlayerTypes eOtherPlayer = (PlayerTypes)lua_tointeger(L, 4);
 
-	CvString szResult = "";
+	CvString szResult;
 	szResult = pkPlayer->GetCulture()->GetInfluenceSpyRankTooltip(szSpyName, szRank, eOtherPlayer);
 	lua_pushstring(L, szResult);
 	return 1;
@@ -5826,7 +5826,7 @@ int CvLuaPlayer::lGetInternationalTradeRouteTotal(lua_State* L)
 	{
 		kTradeConnection.m_eConnectionType = TRADE_CONNECTION_INTERNATIONAL;
 	}
-	else if (MOD_TRADE_INTERNAL_GOLD_ROUTES && pOriginCity->getTeam() == pDestCity->getTeam())
+	else if (MOD_TRADE_INTERNAL_GOLD_ROUTES)
 	{
 		kTradeConnection.m_eConnectionType = TRADE_CONNECTION_GOLD_INTERNAL;
 	}
@@ -5855,7 +5855,7 @@ int CvLuaPlayer::lGetInternationalTradeRouteScience(lua_State* L)
 	{
 		kTradeConnection.m_eConnectionType = TRADE_CONNECTION_INTERNATIONAL;
 	}
-	else if (MOD_TRADE_INTERNAL_GOLD_ROUTES && pOriginCity->getTeam() == pDestCity->getTeam())
+	else if (MOD_TRADE_INTERNAL_GOLD_ROUTES)
 	{
 		kTradeConnection.m_eConnectionType = TRADE_CONNECTION_GOLD_INTERNAL;
 	}
@@ -5883,7 +5883,7 @@ int CvLuaPlayer::lGetInternationalTradeRouteCulture(lua_State* L)
 	{
 		kTradeConnection.m_eConnectionType = TRADE_CONNECTION_INTERNATIONAL;
 	}
-	else if (MOD_TRADE_INTERNAL_GOLD_ROUTES && pOriginCity->getTeam() == pDestCity->getTeam())
+	else if (MOD_TRADE_INTERNAL_GOLD_ROUTES)
 	{
 		kTradeConnection.m_eConnectionType = TRADE_CONNECTION_GOLD_INTERNAL;
 	}
@@ -11995,7 +11995,7 @@ int CvLuaPlayer::lIsHasDefensivePact(lua_State* L)
 	for (int iPlayerLoop = 0; iPlayerLoop < MAX_PLAYERS; iPlayerLoop++)
 	{
 		PlayerTypes ePlayerLoop = (PlayerTypes) iPlayerLoop;
-		if(ePlayerLoop != eOtherPlayer && ePlayerLoop != NO_PLAYER && ePlayerLoop != pkPlayer->GetID())
+		if(ePlayerLoop != eOtherPlayer && ePlayerLoop != pkPlayer->GetID())
 		{
 			if(GET_TEAM(pkPlayer->getTeam()).IsHasDefensivePact(GET_PLAYER(ePlayerLoop).getTeam()))
 			{
@@ -18374,18 +18374,15 @@ int CvLuaPlayer::lIsEventChoiceActive(lua_State* L)
 						for(int iLoop = 0; iLoop < GC.getNumEventInfos(); iLoop++)
 						{
 							EventTypes eEvent = (EventTypes)iLoop;
-							if(eEvent != NO_EVENT)
+							if(pkEventChoiceInfo->isParentEvent(eEvent))
 							{
-								if(pkEventChoiceInfo->isParentEvent(eEvent))
+								CvModEventInfo* pkEventInfo = GC.getEventInfo(eEvent);
+								if(pkEventInfo != NULL)
 								{
-									CvModEventInfo* pkEventInfo = GC.getEventInfo(eEvent);
-									if(pkEventInfo != NULL)
+									if(pkEventInfo->getNumChoices() == 1)
 									{
-										if(pkEventInfo->getNumChoices() == 1)
-										{
-											bResult = true;
-											break;
-										}
+										bResult = true;
+										break;
 									}
 								}
 							}
@@ -18509,8 +18506,6 @@ int CvLuaPlayer::lGetActivePlayerEventChoices(lua_State* L)
 	for (int iI = 0; iI < GC.getNumEventChoiceInfos(); iI++)
 	{
 		EventChoiceTypes eEventChoice = (EventChoiceTypes)iI;
-		if (eEventChoice == NO_EVENT_CHOICE)
-			continue;
 
 		CvModEventChoiceInfo* pkEventChoiceInfo = GC.getEventChoiceInfo(eEventChoice);
 		if (pkEventChoiceInfo != NULL)
@@ -18522,20 +18517,17 @@ int CvLuaPlayer::lGetActivePlayerEventChoices(lua_State* L)
 				for (int iLoop = 0; iLoop < GC.getNumEventInfos(); iLoop++)
 				{
 					EventTypes eEvent = (EventTypes)iLoop;
-					if (eEvent != NO_EVENT)
+					if (pkEventChoiceInfo->isParentEvent(eEvent))
 					{
-						if (pkEventChoiceInfo->isParentEvent(eEvent))
+						eParentEvent = eEvent;
+						CvModEventInfo* pkEventInfo = GC.getEventInfo(eEvent);
+						if (pkEventInfo != NULL)
 						{
-							eParentEvent = eEvent;
-							CvModEventInfo* pkEventInfo = GC.getEventInfo(eEvent);
-							if (pkEventInfo != NULL)
+							if (pkEventInfo->getNumChoices() == 1)
 							{
-								if (pkEventInfo->getNumChoices() == 1)
-								{
-									bNotChoice = true;
-								}
-								break;
+								bNotChoice = true;
 							}
+							break;
 						}
 					}
 				}
@@ -18575,8 +18567,6 @@ int CvLuaPlayer::lGetActiveCityEventChoices(lua_State* L)
 	for (int iI = 0; iI < GC.getNumCityEventChoiceInfos(); iI++)
 	{
 		CityEventChoiceTypes eEventChoice = (CityEventChoiceTypes)iI;
-		if (eEventChoice == NO_EVENT_CHOICE_CITY)
-			continue;
 
 		CvModEventCityChoiceInfo* pkEventChoiceInfo = GC.getCityEventChoiceInfo(eEventChoice);
 		if (pkEventChoiceInfo != NULL)
@@ -18593,20 +18583,17 @@ int CvLuaPlayer::lGetActiveCityEventChoices(lua_State* L)
 					for (int iLoop = 0; iLoop < GC.getNumCityEventInfos(); iLoop++)
 					{
 						CityEventTypes eEvent = (CityEventTypes)iLoop;
-						if (eEvent != NO_EVENT_CITY)
+						if (pkEventChoiceInfo->isParentEvent(eEvent))
 						{
-							if (pkEventChoiceInfo->isParentEvent(eEvent))
+							eParentEvent = eEvent;
+							CvModCityEventInfo* pkCityEventInfo = GC.getCityEventInfo(eEvent);
+							if (pkCityEventInfo != NULL)
 							{
-								eParentEvent = eEvent;
-								CvModCityEventInfo* pkCityEventInfo = GC.getCityEventInfo(eEvent);
-								if (pkCityEventInfo != NULL)
+								if (pkCityEventInfo->getNumChoices() == 1)
 								{
-									if (pkCityEventInfo->getNumChoices() == 1)
-									{
-										bNotChoice = true;
-									}
-									break;
+									bNotChoice = true;
 								}
+								break;
 							}
 						}
 					}
@@ -18653,8 +18640,6 @@ int CvLuaPlayer::lGetRecentPlayerEventChoices(lua_State* L)
 	for (int iI = 0; iI < GC.getNumEventChoiceInfos(); iI++)
 	{
 		EventChoiceTypes eEventChoice = (EventChoiceTypes)iI;
-		if (eEventChoice == NO_EVENT_CHOICE)
-			continue;
 
 		CvModEventChoiceInfo* pkEventChoiceInfo = GC.getEventChoiceInfo(eEventChoice);
 		if (pkEventChoiceInfo != NULL)
@@ -18666,23 +18651,20 @@ int CvLuaPlayer::lGetRecentPlayerEventChoices(lua_State* L)
 				for (int iLoop = 0; iLoop < GC.getNumEventInfos(); iLoop++)
 				{
 					EventTypes eEvent = (EventTypes)iLoop;
-					if (eEvent != NO_EVENT)
+					if (pkEventChoiceInfo->isParentEvent(eEvent))
 					{
-						if (pkEventChoiceInfo->isParentEvent(eEvent))
-						{							
-							CvModEventInfo* pkEventInfo = GC.getEventInfo(eEvent);
-							if (pkEventInfo != NULL)
+						CvModEventInfo* pkEventInfo = GC.getEventInfo(eEvent);
+						if (pkEventInfo != NULL)
+						{
+							if (pkEventInfo->getNumChoices() == 1)
 							{
-								if (pkEventInfo->getNumChoices() == 1)
-								{
-									bInstant = true;
-								}
-								if (pkEventInfo->getNumChoices() > 1)
-								{
-									eParentEvent = eEvent;
-								}
-								break;
+								bInstant = true;
 							}
+							if (pkEventInfo->getNumChoices() > 1)
+							{
+								eParentEvent = eEvent;
+							}
+							break;
 						}
 					}
 				}
@@ -18721,8 +18703,6 @@ int CvLuaPlayer::lGetRecentCityEventChoices(lua_State* L)
 	for (int iI = 0; iI < GC.getNumCityEventChoiceInfos(); iI++)
 	{
 		CityEventChoiceTypes eEventChoice = (CityEventChoiceTypes)iI;
-		if (eEventChoice == NO_EVENT_CHOICE_CITY)
-			continue;
 
 		CvModEventCityChoiceInfo* pkEventChoiceInfo = GC.getCityEventChoiceInfo(eEventChoice);
 		if (pkEventChoiceInfo != NULL)
@@ -18739,23 +18719,20 @@ int CvLuaPlayer::lGetRecentCityEventChoices(lua_State* L)
 					for (int iLoop = 0; iLoop < GC.getNumCityEventInfos(); iLoop++)
 					{
 						CityEventTypes eEvent = (CityEventTypes)iLoop;
-						if (eEvent != NO_EVENT_CITY)
+						if (pkEventChoiceInfo->isParentEvent(eEvent))
 						{
-							if (pkEventChoiceInfo->isParentEvent(eEvent))
+							CvModCityEventInfo* pkCityEventInfo = GC.getCityEventInfo(eEvent);
+							if (pkCityEventInfo != NULL)
 							{
-								CvModCityEventInfo* pkCityEventInfo = GC.getCityEventInfo(eEvent);
-								if (pkCityEventInfo != NULL)
+								if (pkCityEventInfo->getNumChoices() == 1)
 								{
-									if (pkCityEventInfo->getNumChoices() == 1)
-									{
-										bInstant = true;
-									}
-									else if (pkCityEventInfo->getNumChoices() > 1)
-									{
-										eParentEvent = eEvent;
-									}
-									break;
+									bInstant = true;
 								}
+								else if (pkCityEventInfo->getNumChoices() > 1)
+								{
+									eParentEvent = eEvent;
+								}
+								break;
 							}
 						}
 					}

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlot.cpp
@@ -2119,10 +2119,13 @@ int CvLuaPlot::lGetActiveFogOfWarMode(lua_State* L)
 	{
 	case FOGOFWARMODE_OFF:
 		fow = 2;
+		break;
 	case FOGOFWARMODE_UNEXPLORED:
 		fow = 0;
+		break;
 	case FOGOFWARMODE_NOVIS:
 		fow = 1;
+		break;
 	}
 
 	lua_pushinteger(L, fow);

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaTeam.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaTeam.cpp
@@ -1162,7 +1162,7 @@ int CvLuaTeam::lIsWarBlockedByPeaceTreaty(lua_State* L)
 	{
 		TeamTypes eLoopTeam = (TeamTypes) iTeamLoop;
 
-		if (eLoopTeam != NO_TEAM && eLoopTeam != pkTeam->GetID() && eLoopTeam != eOtherTeam)
+		if (eLoopTeam != pkTeam->GetID() && eLoopTeam != eOtherTeam)
 		{
 			if (GET_TEAM(eLoopTeam).IsHasDefensivePact(eOtherTeam) || GET_TEAM(eOtherTeam).IsVassal(eLoopTeam))
 			{

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaUnit.cpp
@@ -6569,28 +6569,21 @@ int CvLuaUnit::lGetMonopolyAttackBonus(lua_State* L)
 	for (int iResourceLoop = 0; iResourceLoop < GC.getNumResourceInfos(); iResourceLoop++)
 	{
 		ResourceTypes eResourceLoop = (ResourceTypes) iResourceLoop;
-		if(eResourceLoop != NO_RESOURCE)
+		CvResourceInfo* pInfo = GC.getResourceInfo(eResourceLoop);
+		if (pInfo && pInfo->isMonopoly())
 		{
-			CvResourceInfo* pInfo = GC.getResourceInfo(eResourceLoop);
-			if (pInfo && pInfo->isMonopoly())
+			// Strategic monopolies
+			if (GET_PLAYER(pkUnit->getOwner()).HasStrategicMonopoly(eResourceLoop) && (pInfo->getMonopolyAttackBonus() > 0 || pInfo->getMonopolyAttackBonus(MONOPOLY_STRATEGIC) > 0))
 			{
-				// Strategic monopolies
-				if (GET_PLAYER(pkUnit->getOwner()).HasStrategicMonopoly(eResourceLoop) && (pInfo->getMonopolyAttackBonus() > 0 || pInfo->getMonopolyAttackBonus(MONOPOLY_STRATEGIC) > 0))
-				{
-					iAttackBonus +=  pInfo->getMonopolyAttackBonus();
-					iAttackBonus += pInfo->getMonopolyAttackBonus(MONOPOLY_STRATEGIC);
-				}
-				// Global monopolies
-				if (GET_PLAYER(pkUnit->getOwner()).HasGlobalMonopoly(eResourceLoop) && pInfo->getMonopolyAttackBonus(MONOPOLY_GLOBAL) > 0)
-				{
-					int iTempBonus = pInfo->getMonopolyAttackBonus(MONOPOLY_GLOBAL);
-					if (iTempBonus != 0)
-					{
-						iTempBonus += GET_PLAYER(pkUnit->getOwner()).GetMonopolyModPercent(); // Global monopolies get the mod percent boost from policies.
-					}
-
-					iAttackBonus += iTempBonus;
-				}
+				iAttackBonus +=  pInfo->getMonopolyAttackBonus();
+				iAttackBonus += pInfo->getMonopolyAttackBonus(MONOPOLY_STRATEGIC);
+			}
+			// Global monopolies
+			if (GET_PLAYER(pkUnit->getOwner()).HasGlobalMonopoly(eResourceLoop) && pInfo->getMonopolyAttackBonus(MONOPOLY_GLOBAL) > 0)
+			{
+				int iTempBonus = pInfo->getMonopolyAttackBonus(MONOPOLY_GLOBAL);
+				iTempBonus += GET_PLAYER(pkUnit->getOwner()).GetMonopolyModPercent(); // Global monopolies get the mod percent boost from policies.
+				iAttackBonus += iTempBonus;
 			}
 		}
 	}
@@ -6606,28 +6599,21 @@ int CvLuaUnit::lGetMonopolyDefenseBonus(lua_State* L)
 	for (int iResourceLoop = 0; iResourceLoop < GC.getNumResourceInfos(); iResourceLoop++)
 	{
 		ResourceTypes eResourceLoop = (ResourceTypes) iResourceLoop;
-		if(eResourceLoop != NO_RESOURCE)
+		CvResourceInfo* pInfo = GC.getResourceInfo(eResourceLoop);
+		if (pInfo && pInfo->isMonopoly())
 		{
-			CvResourceInfo* pInfo = GC.getResourceInfo(eResourceLoop);
-			if (pInfo && pInfo->isMonopoly())
+			// Strategic monopolies
+			if (GET_PLAYER(pkUnit->getOwner()).HasStrategicMonopoly(eResourceLoop) && (pInfo->getMonopolyDefenseBonus() > 0 || pInfo->getMonopolyDefenseBonus(MONOPOLY_STRATEGIC) > 0))
 			{
-				// Strategic monopolies
-				if (GET_PLAYER(pkUnit->getOwner()).HasStrategicMonopoly(eResourceLoop) && (pInfo->getMonopolyDefenseBonus() > 0 || pInfo->getMonopolyDefenseBonus(MONOPOLY_STRATEGIC) > 0))
-				{
-					iDefenseBonus +=  pInfo->getMonopolyDefenseBonus();
-					iDefenseBonus += pInfo->getMonopolyAttackBonus(MONOPOLY_STRATEGIC);
-				}
-				// Global monopolies
-				if (GET_PLAYER(pkUnit->getOwner()).HasGlobalMonopoly(eResourceLoop) && pInfo->getMonopolyDefenseBonus(MONOPOLY_GLOBAL) > 0)
-				{
-					int iTempBonus = pInfo->getMonopolyDefenseBonus(MONOPOLY_GLOBAL);
-					if (iTempBonus != 0)
-					{
-						iTempBonus += GET_PLAYER(pkUnit->getOwner()).GetMonopolyModPercent(); // Global monopolies get the mod percent boost from policies.
-					}
-
-					iDefenseBonus += iTempBonus;
-				}
+				iDefenseBonus +=  pInfo->getMonopolyDefenseBonus();
+				iDefenseBonus += pInfo->getMonopolyAttackBonus(MONOPOLY_STRATEGIC);
+			}
+			// Global monopolies
+			if (GET_PLAYER(pkUnit->getOwner()).HasGlobalMonopoly(eResourceLoop) && pInfo->getMonopolyDefenseBonus(MONOPOLY_GLOBAL) > 0)
+			{
+				int iTempBonus = pInfo->getMonopolyDefenseBonus(MONOPOLY_GLOBAL);
+				iTempBonus += GET_PLAYER(pkUnit->getOwner()).GetMonopolyModPercent(); // Global monopolies get the mod percent boost from policies.
+				iDefenseBonus += iTempBonus;
 			}
 		}
 	}

--- a/CvWorldBuilderMap/include/CvWorldBuilderMapElementAllocator.h
+++ b/CvWorldBuilderMap/include/CvWorldBuilderMapElementAllocator.h
@@ -234,9 +234,11 @@ private:
 
 		// Allocate the new memory block
 		Entry *aNew = (Entry*)FMALLOC(sizeof(Entry) * uiSize, c_eMPoolTypeGame, 0);
-		FAssertMsg(aNew != NULL, "Failed to allocate!");
 		if( aNew == NULL )
+		{
+			FAssertMsg(false, "Failed to allocate!");
 			return false;
+		}
 
 		// If there was a previous memory block then copy it over and free it
 		if( m_uiSize > 0 )


### PR DESCRIPTION
cppcheck: remove 31 dead break statements after return

Each switch/case block ended with an explicit return statement followed by a break; on the line after the closing brace. The break is unreachable because the return already exits the function. This is a common copy-paste heritage pattern from earlier Civ5 code that added break after every case as boilerplate, even when the case body terminated with return.

CvEspionageClasses.cpp: 7 sites (GetSpyTurns function)
CvNotifications.cpp:    24 sites (IsNotificationExpired and related)

cppcheck: remove dead redundantAssignment and redundantContinue

CvDiplomacyAI.cpp – GetPrimeLeagueAlly / DoUpdateLeagueInfo:
- In the 'else if (eAlignment == ePrimeAlignment)' branch, eAlignment and ePrimeAlignment are guaranteed equal by the condition, so:
  * ePrimeAlignment = eAlignment in the iVotes > iPrimeVotes block is a no-op.
  * iPrimeVotes = iVotes and ePrimeAlignment = eAlignment in the nested 'else if (iVotes == iPrimeVotes)' block are both no-ops (tautological under that condition). Only ePrimeLeagueAlly = ePlayer is meaningful. Remove the three dead assignments.
- In two loop bodies (one for VassalTaxRaised, one for VassalTaxLowered): eLoopPlayer is assigned (PlayerTypes)iPlayerLoop at declaration, then immediately re-assigned the identical value inside the first if-block. Remove the redundant inner assignments.
- RefusePeaceTreaty loop: 'continue' was the last statement in the outer loop body and had no effect. Remove it.

CvPlayer.cpp – GenerateCityName:
- Inside the city-name-candidate loop: strName = pNode->m_data was set unconditionally before the validity check, then set again to the same value inside the if(isCityNameValid) block before break. Remove the inner redundant assignment.

CvBuildingClasses.cpp – CvBuildingEntry::CacheResults:
- szTextVal = kResults.GetText("FreeBuildingTradeTargetCity") was fetched but never passed to getInfoTypeForString. No member variable stores this value; the fetch is dead. Remove the orphaned line.

CvAdvisorCounsel.cpp – AppendtoAdvisorInfoReligionMinorCiv:
- iMessageRating = 20 was set at the start of an else block whose only live path (eEnemyPlayer != NO_PLAYER) is suppressed as always-false. The unconditional iMessageRating = 0 later in the block always overwrote it before use. Remove the dead assignment.

CvPlot.cpp – canBuild feature-remove section:
- In the FEATURE_FALLOUT branch bValid = true was set, but the unconditional bValid = true immediately after the entire if/else-if block always covers this case. Remove the redundant in-branch assignment; leave the empty block body to preserve the if/else guard preventing bTestPlotOwner logic from running for fallout plots.

cppcheck: remove redundant initializations (14 sites, 7 files)

Each site declares a variable with an initial value that is always overwritten before it is first read — the initializer is dead code. Removing it silences cppcheck, eliminates the wasted construction cost, and makes the intent (variable will be set before use) explicit.

CvCultureClasses.cpp (6 sites):
- GetGreatWorkTooltip: CvString szTooltip = "" — overwritten by toUTF8() call
- GetGreatWorkArtist: CvString szArtist = "" — immediately overwritten from pWork
- GetGreatWorkEraAbbreviation: CvString szEra = "" — immediately overwritten
- GetGreatWorkEraShort: CvString szEra = "" — immediately overwritten
- GetFilledSlotsTooltip: CvString szRtnValue = "" — overwritten by GetLocalizedText
- GetTotalSlotsTooltip: CvString szRtnValue = "" — overwritten by GetLocalizedText

CvDllContext.cpp (3 sites):
- DestroyRandomNumberGenerator, DestroyNetInitInfo, DestroyNetLoadGameInfo: each declares 'iterator it = container.end()' then immediately assigns it = container.begin() in the for-loop header. Remove the initializer.

CvDealClasses.cpp (1 site):
- DestroyDeal: same iterator = container.end() pattern as CvDllContext.

CvDiplomacyAI.cpp (1 site):
- DoDenouncePlayer: Localization::String someoneDenounceInfo initialised with TXT_KEY_NOTIFICATION_DENOUNCE but the exhaustive if/else-if/.../else chain that follows always assigns the variable (the final else also assigns the same key). The initialisation runs a redundant Lookup.

CvMinorCivAI.cpp (1 site):
- GetQuestBonusString: CvString szTooltipHeader = "" is always overwritten by the ternary (bFinish ? ... : ...) before it is ever read.

CvLuaPlayer.cpp (1 site):
- lGetInfluenceSpyRankTooltip: CvString szResult = "" immediately overwritten.

CvPlayer.cpp (1 site):
- GetUnhappinessFromCityForHappiness loop body: bCityValid = false at the top of each iteration is always overwritten by the exhaustive if/else-if/else chain that follows. Remove the dead assignment.

cppcheck: fix 7 logic bugs mis-reported as dead code

Each of these was flagged as redundantAssignment or redundantAssignInSwitch but is actually a behavioural defect.

CvLuaPlot.cpp lGetActiveFogOfWarMode:
- All 3 switch cases for FOGOFWARMODE_* were missing break statements. Every fog mode fell through to FOGOFWARMODE_NOVIS, always returning 1 (NOVIS). FOGOFWARMODE_OFF (2) and FOGOFWARMODE_UNEXPLORED (0) never reached Lua. Add break after each case assignment.

CvReligionClasses.cpp ScoreYieldForReligionTimes100:
- YIELD_FOOD case was missing break and fell through to YIELD_PRODUCTION. Food yield was scored using FLAVOR_PRODUCTION * 50 instead of FLAVOR_GROWTH * 50. Add break after the FLAVOR_GROWTH assignment.

CvDiplomacyAI.cpp (GetCivOpinion area, bCultural block):
- bCultural accumulated three |= conditions (flavor, IsCultural/Secondary, culture victory) then was entirely overwritten by plain assignment: bCultural = GetPlayer()->GetPlayerTraits()->IsTourism() Discarding all prior flags. Fix: change = to |= to match the bReligious and bScientific patterns immediately above.

CvAIOperation.cpp SetMusterPlot:
- In the NULL-muster path: m_iMusterX = INVALID_PLOT_COORD was written twice (copy-paste). m_iMusterY was never cleared, leaving it at whatever stale coordinate the previous operation had stored. Fix second line to m_iMusterY = INVALID_PLOT_COORD.

CvCityCitizens.cpp GetBonusPlotValue:
- iBonus accumulated religion-based feature yield (iBonus += iEffect) then building-based feature yield overwrote it entirely (iBonus = GetYield...). Religion yield was silently discarded. Fix: change = to += so both sources contribute to the total.

CvCityCitizens.cpp SPrecomputedExpensiveNumbers update block:
- Copy-paste error: all four initialisation lines read iBasicNeedsRateChangeForIncreasedDistress = -INT_MAX leaving iGoldRateChangeForIncreasedPoverty, iScienceRateChangeForIncreasedIlliteracy and iCultureRateChangeForIncreasedBoredom at 0 instead of -INT_MAX. This caused the citizen-placement threshold comparisons (lines ~1111-1119) to trigger prematurely for gold/science/culture, biasing specialist assignment toward happiness-yield tiles. Fix the three wrong variable names.

CvUnitCombat.cpp GenerateRangedCombatInfo / GenerateAirCombatInfo:
  - bool bGeneralsXP = !kAttacker.isBarbarian() was declared before an if/else block that always overwrote it:
      if branch:   bGeneralsXP = !pkDefender->isBarbarian()
      else branch: bGeneralsXP = !plot.getPlotCity()->isBarbarian()
    Fix: Include !kAttacker.isBarbarian() in both branches

cppcheck: fix unsignedLessThanZero and unsignedPositive comparisons

CvTacticalAnalysisMap.cpp - GetEnemyRangedStrength(), GetEnemyNavalRangedStrength(), and GetOverallEnemyStrength() all return unsigned int. Comparing an unsigned int with <= 0 is logically equivalent to == 0 but misleadingly implies a negative arm that can never be reached. Change to == 0 throughout.

Line 350: GetOverallEnemyStrength()+GetOverallFriendlyStrength()<=0 Two unsigned values sum to zero only when both are zero. Rewrite as GetOverallEnemyStrength()==0 && GetOverallFriendlyStrength()==0 to make the intent explicit and match the existing pattern on line 1155.

CvArmyAI.cpp:481 - iSlotID is size_t (unsigned). iSlotID >= 0 is always true and the negative arm is unreachable dead code. Remove the guard.

cppcheck: fix multiCondition (else-if always true) in 6 files, 8 sites

Each site has if (A) {...} else if (!A) {...} where !A is the exact logical negation of A. In the else branch A is already false, so the additional else-if guard is a tautology. Replace with plain else.

Sites fixed:
- CvDiplomacyAI.cpp:47354  else if (eMyBranch != eTheirBranch)
- CvEconomicAI.cpp:1216    else if(request.m_eType == ePurchase)
- CvEconomicAI.cpp:1252    else if(request.m_eType == ePurchase)
- CvEconomicAI.cpp:5012    else if (iCSDistaste < 0)
- CvMinorCivAI.cpp:9831    else if (eProximity < PLAYER_PROXIMITY_CLOSE)
- CvPlayer.cpp:23484       else if(!IsLeagueArt())
- CvReligionClasses.cpp:397 else if (pFromCity->getOwner() == pToCity->getOwner())
- CvUnit.cpp:34044         else if(!isCargo())

cppcheck: add ASSERT for nullPointer in CvUnit.cpp SetInitialValues

GC.getUnitInfo() is annotated _Ret_maybenull_. When m_eUnitType is not NO_UNIT the result is stored in m_pUnitInfo and then immediately dereferenced in three ternaries (GetCombat, GetRangedCombat, GetUnitCombatType) without a null guard.

getUnitInfo() returning NULL for a valid unit type is a data or engine bug that cannot be recovered from. Add ASSERT to document the invariant and catch the violation in debug builds before the crash.

cppcheck: identicalConditionAfterEarlyExit in CvPlayer.cpp and CvUnit.cpp

CvPlayer.cpp:49480 - after if (!pUnitInfo) continue at line 49476, the sub-condition !pUnitInfo in if (!pUnitInfo || ...) is always false. Remove the dead sub-condition; keep only the meaningful type check.

CvUnit.cpp:29143 - pLoopUnit is already null-checked at line 29128 and then unconditionally dereferenced inside the MOD_GLOBAL_SUBS_UNDER_ICE_IMMUNITY block. The second if(!pLoopUnit) continue at line 29143 is unreachable dead code. Remove it.

cppcheck: fix selfAssignment in CvTeam.cpp and CvBuilderTaskingAI.cpp

CvTeam.cpp:6549 - CvResourceInfo* p = p = GC.getResourceInfo(...) is a chained self-assignment at declaration; reading p before it is initialized is undefined behaviour in C++03. Remove the redundant self-assignment.

CvBuilderTaskingAI.cpp:2532 - pkChopBuild = pkChopBuild is a pure dead no-op; the variable was just assigned by GC.getBuildInfo() on the same iteration. Remove the dead line.

cppcheck: fix nullPointer in CvUnitCombat.cpp ApplyNuclearExplosionDamage

ApplyNuclearExplosionDamage(CvPlot*, int iDamageLevel, CvUnit* pkAttacker=NULL) is called from CvCity.cpp and CvPlot.cpp with no attacker unit (meltdown scenario), which passes NULL into the 5-argument overload.  Both notification loops after the damage phase (vAffectedPlayers loop and MAX_PLAYERS loop) then unconditionally dereference pkAttacker->getOwner() / getUnitType(), causing a null pointer crash whenever a reactor meltdown triggers a nuke.

Fix: wrap both loops with if (pkAttacker != NULL).  Notifications that describe the attacker's identity make no sense for a meltdown anyway. The GenerateNuclearExplosionDamage comment at line 2729 already documents 'The attacker is optional - this is also called for a meltdown'.

cppcheck: knownConditionTrueFalse type B in CvUnitCombat.cpp DoResolveCombat

In the else-if branch of if(pkWinner->isExtraAttackHealthOnKill()), the sub-condition !(pkWinner->isExtraAttackHealthOnKill()) is always true (the outer if already checked it), making the whole OR always true and rendering the barbarian-exclusion terms (pkLoser->getOwner() != BARBARIAN_PLAYER || !IsHealIfDefeatExcludeBarbarians()) dead code.

Fix: remove the always-true sub-condition from the OR.  This also restores the intended barbarian-exclusion logic: negative getHPHealedIfDefeatEnemy values now correctly bypass barbarians when IsHealIfDefeatExcludeBarbarians() is set, which was previously short-circuited by the always-true term.

cppcheck: CvCity.cpp remaining knownConditionTrueFalse fixes (type C + type B)

Type C — loop-variable sentinel checks (0-based loop can never equal -1):
- Remove eYield==NO_YIELD continue from 10 NUM_YIELD_TYPES loops
- Remove eResource==NO_RESOURCE continue from 3 getNumResourceInfos loops
- Remove eReligion==NO_RELIGION continue from getNumReligionInfos loop
- Remove eDomain==NO_DOMAIN continue from getNumDomainInfos loop
- Remove eGreatPerson==NO_GREATPERSON continue from getNumGreatPersonInfos loop
- Remove eImprovement==NO_IMPROVEMENT continue from 4 getNumImprovementInfos loops
- Remove eBuildingClass==NO_BUILDINGCLASS continue from getNumBuildingClassInfos loop
- Remove eLoopPlayer!=NO_PLAYER && from 2 compound conditions in MAX loops
- Remove ePlayer!=NO_PLAYER && and ePossibleOwner!=NO_PLAYER && from compounds

Type B — redundant inner guards inside outer != -1 checked blocks (second occurrence of the event-info pattern fixed in Commit 2):
- Remove if(eFeature!=NO_FEATURE) wrapper in IsCityEventChoiceValid
- Remove if(eTerrain!=NO_TERRAIN) wrapper in IsCityEventChoiceValid
- Remove if(eBuilding!=NO_BUILDINGCLASS) wrapper (getBuildingRequired branch)
- Remove if(eBuilding!=NO_BUILDINGCLASS) wrapper (getBuildingLimiter branch)
- Remove if(eImprovement!=NO_IMPROVEMENT) wrapper (getRequiredImprovement branch)
- Remove if(eResource!=NO_RESOURCE) wrapper (getLocalResourceRequired branch)
- Remove if(ePromotion!=-1) inner guard inside outer getEventPromotion()!=-1 block
- Remove if(eResource!=NO_RESOURCE) wrapper in undo-resource loop
- Remove eImprovement/eFeature/eTerrain/eResource !=NO_XXX && from compound conditions inside corresponding getNumXxxInfos inner loops
- Unwrap if(eParentEvent!=NO_EVENT_CITY) in IsCityEventChoiceValidEspionage loop
- Unwrap two if(eEvent!=NO_EVENT_CITY) in DoApplyEventChoice loops
- Fix indentation of notification block after outer-wrapper removal

cppcheck: fix duplicateCondition in CvWorldBuilderMapElementAllocator.h; suppress eEnemyPlayer warnings in CvAdvisorCounsel.cpp

CvWorldBuilderMap/include/CvWorldBuilderMapElementAllocator.h:
- Move FAssertMsg inside null check to remove assertion-then-opposite-condition pattern (duplicateCondition): FAssertMsg(aNew!=NULL) followed by if(aNew==NULL) is logically redundant.  New form: if(aNew==NULL) { FAssertMsg(false,...); return false; } preserves both the debug assert and the release-mode graceful failure.

CvGameCoreDLL_Expansion2/CvAdvisorCounsel.cpp:
- The three if(eEnemyPlayer != NO_PLAYER) blocks are intentional placeholder code for an unfinished rival-civ-influence advisor feature (documented by the TODO comment at the declaration site).  Removing them silences cppcheck at the cost of erasing developer intent and making the feature harder to complete. Correct fix (Type D pattern): add '// cppcheck-suppress knownConditionTrueFalse' above each of the three guarded blocks so cppcheck is satisfied while the scaffolding and its TODO remain visible to future implementers.

cppcheck: remove remaining always-false/always-true loop-enum and nested checks

Additional knownConditionTrueFalse fixes not covered in previous commits.

CvVotingClasses.cpp:
- eMinor==NO_PLAYER removed from MAX_MAJOR_CIVS..MAX_CIV_PLAYERS loop
- eLoopPlayer!=NO_PLAYER removed from two MAX_CIV_PLAYERS loops (compound &&)
- eDiploVictory!=NO_VICTORY unwrapped (guaranteed by prior return-false guard)

CvUnit.cpp:
- eImprovement==NO_IMPROVEMENT removed from 0..getNumImprovementInfos loop
- eYield==NO_YIELD removed from 0..NUM_YIELD_TYPES loop (culture bomb yields)
- IsCanDefend() removed from else-branch condition (return false above guarantees it)
- !isBarbarian() removed from inner condition inside outer !isBarbarian() guard
- pDefender && removed from inner MoraleBreak condition inside else-if(pDefender)
- if(pDefender) wrapper removed for DamageTakenMod block (same outer guarantee)
- pLoopUnit && removed from swap loop (continue-if-null is two lines above)
- pLoopUnit->ReadyToSwap() removed from inner condition (outer if already checks it)
- if(pNewPlot) wrapper removed (pNewPlot->isGoody() called unconditionally above)

CvUnitProductionAI.cpp:
- eUnitAIType!=NO_UNITAI removed (guarded by if(eUnitAIType<=NO_UNITAI) return at top)
- eLoopPlayer!=NO_PLAYER removed from 0..MAX_MAJOR_CIVS loop
- eYield!=NO_YIELD wrappers removed from three 0..NUM_YIELD_TYPES loops
- dead if(kPlayer.isMinorCiv()) block removed inside !isMinorCiv() outer guard

cppcheck: fix redundant conditions inside guarding blocks (knownConditionTrueFalse type B)

Conditions re-checked inside blocks that already tested or guaranteed them.

- CvBuilderTaskingAI.cpp: eOtherBuild==NO_BUILD in 0-based build loop (type C missed in prev commit); pAdjacentOwningCity null ternary (already null-checked two lines above with continue); pkOldImprovementInfo null ternary (already guarded by outer if)
- CvBuildingProductionAI.cpp: pMinor null check (GET_PLAYER returns a reference, address-of-reference is never null)
- CvCity.cpp: six inner NO_BUILDINGCLASS/NO_IMPROVEMENT/NO_RESOURCE/NO_FEATURE/ NO_TERRAIN checks inside outer '!= -1' guards (NO_XXX == -1, so outer check already guarantees the enum is valid)
- CvVotingClasses.cpp: 'else if (!bDone)' made repeal-proposal search unreachable (else branch implies bDone==true); changed to 'if (!bDone)' to restore intended sequential active->enact->repeal search; eTheirIdeology!=NO_POLICY_BRANCH_TYPE redundant when eMyIdeology==eTheirIdeology and eMyIdeology!=NO_POLICY_BRANCH_TYPE
- Lua/CvLuaPlayer.cpp: pOriginCity->getTeam()==pDestCity->getTeam() redundant in three else-if branches (the if condition already tested !=, so the else implies ==)

cppcheck: remove always-false loop-variable enum checks (knownConditionTrueFalse type C)

Loop variables cast from 0-based integer counters can never equal NO_XXX (-1). Remove the impossible enum guards from nine files.

- CvBuildingProductionAI.cpp: eMinor!=NO_PLAYER (minor loop), eYield==NO_YIELD, eLoopPlayer!=NO_PLAYER (compound condition)
- CvCityAI.cpp: two eEventChoice!=NO_EVENT_CHOICE_CITY wrappers
- CvCity.cpp: eYield==NO_YIELD (3x), eEventChoice!=NO_EVENT_CHOICE_CITY (2x), eEvent==NO_EVENT_CITY, ePlayer==NO_PLAYER (3x), eYield==NO_YIELD return false
- CvVotingClasses.cpp: eLoopPlayer!=NO_PLAYER, ePlayer!=NO_PLAYER, eLoopPlayer==NO_PLAYER, ePlayer==NO_PLAYER
- Lua/CvLuaCity.cpp: eIndex2==NO_YIELD, eEvent!=NO_EVENT_CITY wrapper
- Lua/CvLuaGame.cpp: two eUnit==NO_UNIT checks
- Lua/CvLuaPlayer.cpp: ePlayerLoop!=NO_PLAYER, four eEventChoice continue checks, five eEvent!=NO_EVENT/NO_EVENT_CITY wrappers
- Lua/CvLuaTeam.cpp: eLoopTeam!=NO_TEAM from compound condition
- Lua/CvLuaUnit.cpp: two eResourceLoop!=NO_RESOURCE wrappers (also removes the iTempBonus!=0 redundancy guarded by >0 outer check)