### PR TITLE
Refactor Improvement Era Scaling to avoid Landmark overwriting its own age

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -8382,17 +8382,6 @@ void CvPlot::setImprovementType(ImprovementTypes eNewValue, PlayerTypes eBuilder
 					ClearArchaeologicalRecord();
 				}
 			}
-
-			// if the improvement has yield changes by era, it needs the historical record set. 
-			// in the rare case there is also an invisible artifact record on the tile, its age is altered (player has no way to know this)
-			for (int iK = 0; iK < NUM_YIELD_TYPES; ++iK)
-			{
-				if (newImprovementEntry.GetYieldChangePerEra(iK) != 0)
-				{
-					m_kArchaeologyData.m_eEra = GET_PLAYER(eBuilder).GetCurrentEra();
-					break;
-				}
-			}
 			
 			// remove existing resource if this improvement places a new one (needs to be done before setting the improvement to make sure resource counts are updated correctly)
 			ResourceTypes eResourceFromImprovement = (ResourceTypes)newImprovementEntry.GetResourceFromImprovement();
@@ -8569,12 +8558,29 @@ void CvPlot::setImprovementType(ImprovementTypes eNewValue, PlayerTypes eBuilder
 				}
 			}
 
-			if (newImprovementEntry.GetHappinessOnConstruction() != 0 && eBuilder != NO_PLAYER)
+			if (eBuilder != NO_PLAYER)
 			{
-				GET_TEAM(GET_PLAYER(eBuilder).getTeam()).ChangeNumLandmarksBuilt(newImprovementEntry.GetHappinessOnConstruction());
-				if (getOwner() != NO_PLAYER && getOwner() != eBuilder && GET_PLAYER(getOwner()).isMajorCiv())
+				// this column is used to check for landmarks. if it is used for anything else this code will have to change
+				if (newImprovementEntry.GetHappinessOnConstruction() != 0)
 				{
-					GET_TEAM(GET_PLAYER(getOwner()).getTeam()).ChangeNumLandmarksBuilt(newImprovementEntry.GetHappinessOnConstruction());
+					GET_TEAM(GET_PLAYER(eBuilder).getTeam()).ChangeNumLandmarksBuilt(newImprovementEntry.GetHappinessOnConstruction());
+					if (getOwner() != NO_PLAYER && getOwner() != eBuilder && GET_PLAYER(getOwner()).isMajorCiv())
+					{
+						GET_TEAM(GET_PLAYER(getOwner()).getTeam()).ChangeNumLandmarksBuilt(newImprovementEntry.GetHappinessOnConstruction());
+					}
+				}
+				// if the improvement isn't a landmark but has yield changes by era, it needs the historical record set. 
+				else
+				{
+					for (int iK = 0; iK < NUM_YIELD_TYPES; ++iK)
+					{
+						if (newImprovementEntry.GetYieldChangePerEra(iK) != 0)
+						{
+							// in the rare case there is also an (invisible) artifact record on the tile, its age is altered
+							m_kArchaeologyData.m_eEra = GET_PLAYER(eBuilder).GetCurrentEra();
+							break;
+						}
+					}
 				}
 			}
 

--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -8560,9 +8560,9 @@ void CvPlot::setImprovementType(ImprovementTypes eNewValue, PlayerTypes eBuilder
 
 			if (eBuilder != NO_PLAYER)
 			{
-				// this column is used to check for landmarks. if it is used for anything else this code will have to change
 				if (newImprovementEntry.GetHappinessOnConstruction() != 0)
 				{
+					// this actually tracks improvement happiness, not num landmarks built
 					GET_TEAM(GET_PLAYER(eBuilder).getTeam()).ChangeNumLandmarksBuilt(newImprovementEntry.GetHappinessOnConstruction());
 					if (getOwner() != NO_PLAYER && getOwner() != eBuilder && GET_PLAYER(getOwner()).isMajorCiv())
 					{
@@ -8570,7 +8570,8 @@ void CvPlot::setImprovementType(ImprovementTypes eNewValue, PlayerTypes eBuilder
 					}
 				}
 				// if the improvement isn't a landmark but has yield changes by era, it needs the historical record set. 
-				else
+				static const ImprovementTypes eLandmark = (ImprovementTypes)GC.getInfoTypeForString("IMPROVEMENT_LANDMARK");
+				if (eNewValue != eLandmark)
 				{
 					for (int iK = 0; iK < NUM_YIELD_TYPES; ++iK)
 					{


### PR DESCRIPTION
Fix https://github.com/LoneGazebo/Community-Patch-DLL/issues/12946

Bug was obvious -- Landmark qualifies as an Era scaling improvement, so overwrites its own age! Needs to check for Landmark explicitly.

Notice the existing code to check for Landmark is a bit indirect. Works at the moment but the new Torii would count as a Landmark @azum4roll