### PR TITLE
Change religion territory bonus handling in CvUnit.cpp

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -16287,20 +16287,18 @@ int CvUnit::GetGenericMeleeStrengthModifier(const CvUnit* pOtherUnit, const CvPl
 		{
 			if (!pOtherUnit->isBarbarian() && !GET_PLAYER(pOtherUnit->getOwner()).isMinorCiv() && pOtherUnit->getOwner() != NO_PLAYER)
 			{
-				ReligionTypes eOwnedReligion = kPlayer.GetReligions()->GetOwnedReligion();
+				ReligionTypes eStateReligion = kPlayer.GetReligions()->GetStateReligion();
 				ReligionTypes eTheirReligion = GET_PLAYER(pOtherUnit->getOwner()).GetReligions()->GetStateReligion();
 
-				if (eOwnedReligion != NO_RELIGION)
+				if (eStateReligion != NO_RELIGION)
 				{
-					const CvReligion* pReligion = pReligions->GetReligion(eOwnedReligion, getOwner());
+					const CvReligion* pReligion = pReligions->GetReligion(eStateReligion, getOwner());
 					if (pReligion)
 					{
-						CvCity* pHolyCity = pReligion->GetHolyCity();
-
 						//Full bonus against different religion
-						int iScaler = (eTheirReligion != eOwnedReligion) ? 1 : 2;
-						int iOtherOwn = pReligion->m_Beliefs.GetCombatVersusOtherReligionOwnLands(getOwner(), pHolyCity);
-						int iOtherTheir = pReligion->m_Beliefs.GetCombatVersusOtherReligionTheirLands(getOwner(), pHolyCity);
+						int iScaler = (eTheirReligion != eStateReligion) ? 1 : 2;
+						int iOtherOwn = pReligion->m_Beliefs.GetCombatVersusOtherReligionOwnLands(getOwner());
+						int iOtherTheir = pReligion->m_Beliefs.GetCombatVersusOtherReligionTheirLands(getOwner());
 
 						// Bonus in own land
 						if (iOtherOwn > 0 && pBattlePlot->IsFriendlyTerritory(getOwner()))
@@ -17144,20 +17142,18 @@ int CvUnit::GetMaxRangedCombatStrength(const CvUnit* pOtherUnit, const CvCity* p
 		{
 			if (!pOtherUnit->isBarbarian() && !GET_PLAYER(pOtherUnit->getOwner()).isMinorCiv() && pOtherUnit->getOwner() != NO_PLAYER)
 			{
-				ReligionTypes eOwnedReligion = kPlayer.GetReligions()->GetOwnedReligion();
+				ReligionTypes eStateReligion = kPlayer.GetReligions()->GetStateReligion();
 				ReligionTypes eTheirReligion = GET_PLAYER(pOtherUnit->getOwner()).GetReligions()->GetStateReligion();
 
-				if (eOwnedReligion != NO_RELIGION)
+				if (eStateReligion != NO_RELIGION)
 				{
-					const CvReligion* pReligion = pReligions->GetReligion(eOwnedReligion, getOwner());
+					const CvReligion* pReligion = pReligions->GetReligion(eStateReligion, getOwner());
 					if (pReligion)
 					{
-						CvCity* pHolyCity = pReligion->GetHolyCity();
-
 						//Full bonus against different religion
-						int iScaler = (eTheirReligion != eOwnedReligion) ? 1 : 2;
-						int iOtherOwn = pReligion->m_Beliefs.GetCombatVersusOtherReligionOwnLands(getOwner(), pHolyCity);
-						int iOtherTheir = pReligion->m_Beliefs.GetCombatVersusOtherReligionTheirLands(getOwner(), pHolyCity);
+						int iScaler = (eTheirReligion != eStateReligion) ? 1 : 2;
+						int iOtherOwn = pReligion->m_Beliefs.GetCombatVersusOtherReligionOwnLands(getOwner());
+						int iOtherTheir = pReligion->m_Beliefs.GetCombatVersusOtherReligionTheirLands(getOwner());
 
 						// Bonus in own land
 						if (iOtherOwn > 0 && pTargetPlot->IsFriendlyTerritory(getOwner()))


### PR DESCRIPTION
Fix #12953

1) Check state religion not owned religion, since its a reformation bonus other players should get it 
2) remove holy city argument -- this just results in checking if the holy city follows its own religion, but I don't see why this bonus should stop working in that case (Founders can't even check for that)