### PR TITLE
Tactical AI fixes and tweaks

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvTacticalAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTacticalAI.cpp
@@ -914,23 +914,30 @@ void CvTacticalAI::ExecuteCaptureCityMoves()
 			{
 				int iRequiredDamage = pCity->GetMaxHitPoints() - pCity->getDamage();
 				int iExpectedDamagePerTurn = ComputeTotalExpectedDamage(*pTarget);
-				//actual siege will typically be longer because not all units actually attack the city each turn
-				int iMaxSiegeTurns = 13; //do we even need a limit here or is this handled through the tactical posture?
 
-				int iCityHealRate = !pCity->IsBlockadedWaterAndLand() ? GD_INT_GET(CITY_HIT_POINTS_HEALED_PER_TURN) : 0;
-
-				//assume the city heals each turn ...
-				if ((iExpectedDamagePerTurn - iCityHealRate) * iMaxSiegeTurns < iRequiredDamage)
+				if (iExpectedDamagePerTurn < iRequiredDamage)
 				{
-					if (GC.getLogging() && GC.getAILogging() && pZone)
-					{
-						CvString strLogString;
-						strLogString.Format("Zone %d, too early for attacking %s, required damage %d, expected max damage per turn %d", 
-							pZone ? pZone->GetZoneID() : -1, pCity->getNameNoSpace().c_str(), iRequiredDamage, iExpectedDamagePerTurn);
-						LogTacticalMessage(strLogString);
-					}
+					//actual siege will typically be longer because not all units actually attack the city each turn
+					int iMaxSiegeTurns = 13; //do we even need a limit here or is this handled through the tactical posture?
 
-					continue;
+					int iCityHealRate = !pCity->IsBlockadedWaterAndLand() ? /*20 in CP, 8 in VP*/ GD_INT_GET(CITY_HIT_POINTS_HEALED_PER_TURN) : 0;
+
+					if (MOD_BALANCE_VP)
+						iCityHealRate += pCity->getPopulation();
+
+					//assume the city heals each turn ...
+					if ((iExpectedDamagePerTurn - iCityHealRate) * iMaxSiegeTurns < iRequiredDamage)
+					{
+						if (GC.getLogging() && GC.getAILogging() && pZone)
+						{
+							CvString strLogString;
+							strLogString.Format("Zone %d, too early for attacking %s, required damage %d, expected max damage per turn %d",
+								pZone ? pZone->GetZoneID() : -1, pCity->getNameNoSpace().c_str(), iRequiredDamage, iExpectedDamagePerTurn);
+							LogTacticalMessage(strLogString);
+						}
+
+						continue;
+					}
 				}
 
 				//see whether we have melee units for capturing
@@ -4621,7 +4628,7 @@ bool CvTacticalAI::FindUnitsWithinStrikingDistance(CvPlot* pTarget)
 			continue;
 
 		// Don't bother with pathfinding if we're very far away
-		if (plotDistance(*pLoopUnit->plot(),*pTarget) > pLoopUnit->baseMoves(false)*4)
+		if (plotDistance(*pLoopUnit->plot(), *pTarget) > pLoopUnit->baseMoves(false) * 4 && !pLoopUnit->getUnitInfo().IsCanChangePort())
 			continue;
 
 		//if it's a fighter plane, don't use it here, we need it for interceptions / sweeps
@@ -6909,6 +6916,11 @@ const SUnitStats* CvBasePosition::GetUnitStats(int iUnitID) const
 		if (it->iUnitID == iUnitID)
 			return &(*it);
 
+	const vector<SUnitStats>& finishedUnits_r = finishedUnits.read();
+	for (vector<SUnitStats>::const_iterator it = finishedUnits_r.begin(); it != finishedUnits_r.end(); ++it)
+		if (it->iUnitID == iUnitID)
+			return &(*it);
+
 	return NULL;
 }
 
@@ -7115,12 +7127,12 @@ size_t CvBasePosition::getFirstInterestingAssignment() const
 
 void CvBasePosition::UpdateScore(const STacticalAssignment& assignment)
 {
-	UpdateScore(assignment.iUnitID, assignment.GetPlotScore(), assignment.GetBonusScore(), assignment.GetDamageDelta());
+	UpdateScore(assignment.iUnitID, assignment.GetPlotScore(), assignment.GetOldPlotScore(), assignment.GetDamageDelta(), assignment.GetBonusScore());
 }
 
-void CvBasePosition::UpdateScore(int iUnitId, int iPlotScore, int iDamageDelta_, int iBonusScore_)
+void CvBasePosition::UpdateScore(int iUnitId, int iPlotScore, int iOldPlotScore, int iDamageDelta_, int iBonusScore_)
 {
-	iScoreOverParent += iBonusScore_ + iPlotScore + iDamageDelta_;
+	iScoreOverParent += iBonusScore_ + iPlotScore - iOldPlotScore + iDamageDelta_;
 	iDamageDelta += iDamageDelta_;
 	iBonusScore += iBonusScore_;
 
@@ -7754,11 +7766,17 @@ static int DamageAdjacentUnits(SUnitIDValueContainer& unitDamage, int& iDamageDe
 	return iDamage;
 }
 
+static int GetPrevPlotScore(int iUnitID, const CvBasePosition& position)
+{
+	const STacticalAssignment* prevAssignment = position.getLatestAssignment(iUnitID);
+	return prevAssignment ? prevAssignment->GetPlotScore() : 0;
+}
+
 static STacticalAssignment* ScorePlotForPillageMove(const SUnitStats& unit, const CvTacticalPlot* testPlot, int iAssumedMovesLeft, const CvTacticalPosition& assumedPosition)
 {
 	//default action is do nothing and invalid score (not -INT_MAX, to prevent overflows!)
 	STacticalAssignment* result = gAssignmentStorage.peekNext();
-	result->init(unit.iPlotIndex,testPlot->getPlotIndex(), unit.iUnitID, iAssumedMovesLeft, unit.eMoveStrategy, A_PILLAGE);
+	result->init(unit.iPlotIndex,testPlot->getPlotIndex(), unit.iUnitID, iAssumedMovesLeft, unit.eMoveStrategy, A_PILLAGE, GetPrevPlotScore(unit.iUnitID, assumedPosition));
 
 	//the plot we're checking right now
 	const CvPlot* pTestPlot = testPlot->getPlot();
@@ -7967,7 +7985,7 @@ static STacticalAssignment* ScorePlotForCombatUnitMove(const SUnitStats& unit, c
 {
 	//default action is do nothing and invalid score (not -INT_MAX, to prevent overflows!)
 	STacticalAssignment* result = gAssignmentStorage.peekNext();
-	result->init(unit.iPlotIndex,testPlot->getPlotIndex(), unit.iUnitID, unit.iMovesLeft, unit.eMoveStrategy, A_MOVE);
+	result->init(unit.iPlotIndex,testPlot->getPlotIndex(), unit.iUnitID, unit.iMovesLeft, unit.eMoveStrategy, A_MOVE, GetPrevPlotScore(unit.iUnitID, assumedPosition));
 
 	//the plot we're checking right now
 	const CvPlot* pTestPlot = testPlot->getPlot();
@@ -8006,7 +8024,7 @@ static STacticalAssignment* ScorePlotForCombatUnitMove(const SUnitStats& unit, c
 	};
 	static const int iPlotScoreForEnemyDistanceSeaAttack[5][5] = {
 		{ -1,-1,-1,-1,-1 }, //none (should not occur)
-		{ 12, 8, 7, 7, -1 }, //firstline (note that it's ok to evaluate the score in an enemy plot for a firstline unit -> meleekill) 
+		{ 12, 8, 6, 1, -1 }, //firstline (note that it's ok to evaluate the score in an enemy plot for a firstline unit -> meleekill) 
 		{ -1, 8, 8, 6, -1 }, //secondline
 		{  1, 6, 8, 8, -1 }, //thirdline (ranged and damaged melee units)
 		{ -1, 1, 8,  8, -1 }, //support (can also happen for damaged melee units)
@@ -8033,12 +8051,25 @@ static STacticalAssignment* ScorePlotForCombatUnitMove(const SUnitStats& unit, c
 
 		if (pTestPlot->isFriendlyCity(*pUnit))
 			iPlotScore = 12;
-		// wounded units can go wherever as long as they don't die (danger checked later)
-		else if (iCurrentHealth < gMinHpForTactsim)
+		// wounded units and scouts can go wherever as long as they don't die (danger checked later)
+		else if (iCurrentHealth < gMinHpForTactsim || pUnit->getUnitInfo().GetDefaultUnitAIType() == UNITAI_EXPLORE)
 			iPlotScore = 12;
 
+		// move skirmishers in to fire
 		if (bSkirmisher && iEnemyDistance == 1)
 			iPlotScore += 3;
+
+		// if we are not in a good spot, try moving
+		if (iPlotScore <= 6 && pTestPlot == pUnit->plot())
+			iPlotScore -= 2;
+
+		// Move melee units in to capture cities
+		if (!pUnit->IsCanAttackRanged() && testPlot->getEnemyDistance() == 1)
+		{
+			CvCity* pAdjacentCity = pTestPlot->GetAdjacentCity();
+			if (pAdjacentCity && pAdjacentCity->GetMaxHitPoints() - pAdjacentCity->getDamage() <= 5 && GET_PLAYER(pAdjacentCity->getOwner()).IsAtWarWith(pUnit->getOwner()))
+				iPlotScore += 5;
+		}
 
 		//if we made a kill, assume we are in a good plot
 		//this is very important because enemy distance changes and we might end up with -1
@@ -8083,51 +8114,56 @@ static STacticalAssignment* ScorePlotForCombatUnitMove(const SUnitStats& unit, c
 	}
 
 	//give a bonus for potential fortifying/healing
-	if (result->eAssignmentType == A_FINISH_TEMP && unit.iMovesLeft == unit.iMaxMoves)
+	if (result->eAssignmentType == A_FINISH_TEMP)
 	{
-		if (!pUnit->isAlwaysHeal() && pUnit->getDamage() + unit.iSelfDamage > 0 && !pUnit->IsCannotHeal(/*bConsiderResourceShortage*/ true) && !pUnit->isEmbarked())
+		if (unit.iMovesLeft == unit.iMaxMoves)
 		{
-			int iHealRate = pUnit->ActualHealRate(pTestPlot, false);
-
-			if (iHealRate > 0)
+			if (pUnit->getDamage() + unit.iSelfDamage > 0 && !pUnit->IsCannotHeal(/*bConsiderResourceShortage*/ true) && !pUnit->isEmbarked())
 			{
-				if (iHealRate > pUnit->getDamage() + unit.iSelfDamage)
-					iHealRate = pUnit->getDamage() + unit.iSelfDamage;
+				int iHealRate = pUnit->ActualHealRate(pTestPlot, false);
 
-				iDamageDelta += iHealRate;
-				iSelfDamage -= iHealRate;
+				if (iHealRate > 0)
+				{
+					if (iHealRate > pUnit->getDamage() + unit.iSelfDamage)
+						iHealRate = pUnit->getDamage() + unit.iSelfDamage;
 
-				result->eAssignmentType = A_HEAL;
+					iDamageDelta += iHealRate;
+					iSelfDamage -= iHealRate;
+
+					result->eAssignmentType = A_HEAL;
+				}
+			}
+			if (pUnit->IsEverFortifyable() && !pUnit->isEmbarked())
+			{
+				// This happens at the beginning of our next turn, so we can't assume enemy units will stick around, and we won't deal any damage this turn
+				if (pUnit->GetDamageAoEFortified() > 0)
+					iBonusScore += testPlot->getNumAdjacentEnemies(CvTacticalPlot::TD_BOTH) * pUnit->GetDamageAoEFortified() / 3;
+
+				if (unit.eMoveStrategy == MS_FIRSTLINE)
+					iPlotScore += 1;
 			}
 		}
-		if (pUnit->IsEverFortifyable() && !pUnit->isEmbarked())
+		else
 		{
-			// This happens at the beginning of our next turn, so we can't assume enemy units will stick around, and we won't deal any damage this turn
-			if (pUnit->GetDamageAoEFortified() > 0)
-				iBonusScore += testPlot->getNumAdjacentEnemies(CvTacticalPlot::TD_BOTH) * pUnit->GetDamageAoEFortified() / 3;
+			if (pUnit->getDamage() + unit.iSelfDamage > 0 && !pUnit->IsCannotHeal(/*bConsiderResourceShortage*/ true) && !pUnit->isEmbarked())
+			{
+				if (pUnit->isAlwaysHeal())
+				{
+					int iHealRate = pUnit->ActualHealRate(pTestPlot, false);
+					if (iHealRate > pUnit->getDamage() + unit.iSelfDamage)
+						iHealRate = pUnit->getDamage() + unit.iSelfDamage;
 
-			if (unit.eMoveStrategy == MS_FIRSTLINE)
-				iPlotScore += 1;
-		}
-	}
-	else if (evalMode == EM_FINAL)
-	{
-		
-		if (unit.iMovesLeft != unit.iMaxMoves && pUnit->isAlwaysHeal())
-		{
-			int iHealRate = pUnit->ActualHealRate(pTestPlot, false);
-			if (iHealRate > pUnit->getDamage() + unit.iSelfDamage)
-				iHealRate = pUnit->getDamage() + unit.iSelfDamage;
+					iSelfDamage -= iHealRate;
+				}
+				else if (pUnit->GetFlatHealRate() > 0)
+				{
+					int iHealRate = pUnit->GetFlatHealRate();
+					if (iHealRate > pUnit->getDamage() + unit.iSelfDamage)
+						iHealRate = pUnit->getDamage() + unit.iSelfDamage;
 
-			iSelfDamage -= iHealRate;
-		}
-		else if (unit.iMovesLeft != unit.iMaxMoves && pUnit->GetFlatHealRate() > 0 && !pUnit->IsCannotHeal(true) && pUnit->getDomainType() == pTestPlot->getDomain())
-		{
-			int iHealRate = pUnit->GetFlatHealRate();
-			if (iHealRate > pUnit->getDamage() + unit.iSelfDamage)
-				iHealRate = pUnit->getDamage() + unit.iSelfDamage;
-
-			iSelfDamage -= iHealRate;
+					iSelfDamage -= iHealRate;
+				}
+			}
 		}
 
 		int iCitadelDamage = testPlot->GetAdjacentImprovementDamage();
@@ -8138,6 +8174,10 @@ static STacticalAssignment* ScorePlotForCombatUnitMove(const SUnitStats& unit, c
 			iDamageDelta -= iDamageTaken;
 			iSelfDamage += iDamageTaken;
 		}
+
+		// unit giving extra strength to an adjacent city?
+		if (pUnit->GetAdjacentCityDefenseMod() > 0 && pTestPlot->IsAdjacentCity(pUnit->getTeam()))
+			iPlotScore++;
 	}
 
 	// aoe damage on move
@@ -8165,10 +8205,6 @@ static STacticalAssignment* ScorePlotForCombatUnitMove(const SUnitStats& unit, c
 			//clamp the sentinel to worst-possible arithmetic-safe value
 			iDangerScore = SHRT_MIN;
 		}
-
-		// unit giving extra strength to an adjacent city?
-		if (pUnit->GetAdjacentCityDefenseMod() > 0 && pTestPlot->IsAdjacentCity(pUnit->getTeam()))
-			iPlotScore++;
 	}
 	else
 	{
@@ -8233,7 +8269,7 @@ static STacticalAssignment* ScorePlotForNonFightingUnitMove(const SUnitStats& un
 {
 	//default action is do nothing and invalid score (not -INT_MAX, to prevent overflows!)
 	STacticalAssignment* result = gAssignmentStorage.peekNext();
-	result->init(unit.iPlotIndex,testPlot->getPlotIndex(), unit.iUnitID, unit.iMovesLeft, unit.eMoveStrategy, A_MOVE);
+	result->init(unit.iPlotIndex,testPlot->getPlotIndex(), unit.iUnitID, unit.iMovesLeft, unit.eMoveStrategy, A_MOVE, GetPrevPlotScore(unit.iUnitID, assumedPosition));
 	int iScore = 0;
 		
 	//the plot we're checking right now
@@ -8302,7 +8338,7 @@ static STacticalAssignment* ScorePlotForNonFightingUnitMove(const SUnitStats& un
 static STacticalAssignment* ScorePlotForRangedAttack(const SUnitStats& unit, const CvTacticalPlot* assumedUnitPlot, const CvTacticalPlot* enemyPlot, const CvTacticalPosition& assumedPosition)
 {
 	STacticalAssignment* result = gAssignmentStorage.peekNext();
-	result->init(unit.iPlotIndex, enemyPlot->getPlotIndex(), unit.iUnitID, unit.iMovesLeft, unit.eMoveStrategy, A_RANGEATTACK);
+	result->init(unit.iPlotIndex, enemyPlot->getPlotIndex(), unit.iUnitID, unit.iMovesLeft, unit.eMoveStrategy, A_RANGEATTACK, GetPrevPlotScore(unit.iUnitID, assumedPosition));
 
 	int iBonusScore = 0;
 
@@ -8338,7 +8374,7 @@ static STacticalAssignment* ScorePlotForMeleeAttack(const SUnitStats& unit, cons
 {
 	//default action is invalid
 	STacticalAssignment* result = gAssignmentStorage.peekNext();
-	result->init(unit.iPlotIndex, enemyPlot->getPlotIndex(), unit.iUnitID, 0, unit.eMoveStrategy, A_MELEEATTACK);
+	result->init(unit.iPlotIndex, enemyPlot->getPlotIndex(), unit.iUnitID, 0, unit.eMoveStrategy, A_MELEEATTACK, GetPrevPlotScore(unit.iUnitID, assumedPosition));
 
 	int iBonusScore = 0;
 
@@ -8420,7 +8456,7 @@ static STacticalAssignment* ScorePlotForMeleeAttack(const SUnitStats& unit, cons
 static STacticalAssignment* ScorePlotForAdmiralHeal(const SUnitStats& unit, const CvTacticalPlot* assumedUnitPlot, int iAssumedMovesLeft, const CvTacticalPosition& assumedPosition)
 {
 	STacticalAssignment* result = gAssignmentStorage.peekNext();
-	result->init(unit.iPlotIndex, assumedUnitPlot->getPlotIndex(), unit.iUnitID, 0, unit.eMoveStrategy, A_USE_POWER);
+	result->init(unit.iPlotIndex, assumedUnitPlot->getPlotIndex(), unit.iUnitID, 0, unit.eMoveStrategy, A_USE_POWER, GetPrevPlotScore(unit.iUnitID, assumedPosition));
 
 	if (iAssumedMovesLeft == 0)
 		return result;
@@ -9187,7 +9223,7 @@ void CvTacticalPosition::getPreferredAssignmentsForUnit(const SUnitStats& unit, 
 	//also cannot check for the existamce of good moves here because we don't know yet if we can actually execute the good-looking moves
 	//could also sort the moves by a secondary criterion, but best solution seems to be the "bad unit' mechanism to restart the sim
 	STacticalAssignment* blocked = gAssignmentStorage.peekNext();
-	blocked->init(unit.iPlotIndex, unit.iPlotIndex, unit.iUnitID, unit.iMovesLeft, unit.eMoveStrategy, A_BLOCKED);
+	blocked->init(unit.iPlotIndex, unit.iPlotIndex, unit.iUnitID, unit.iMovesLeft, unit.eMoveStrategy, A_BLOCKED, GetPrevPlotScore(unit.iUnitID, *this));
 	blocked->SetScore(-10, 0, 0);
 	gPossibleMoves.push_back(OptionWithScore<STacticalAssignment*>(blocked, blocked->Score()));
 	gAssignmentStorage.consumeOne();
@@ -9235,7 +9271,7 @@ void CvTacticalPosition::dropSuperfluousUnits(int iMaxUnitsToKeep)
 			vector<SUnitStats>::iterator toDrop = find_if(availableUnits_w.begin(), availableUnits_w.end(), PrMatchingUnit(itUnit->iUnitID));
 			availableUnits_w.erase(toDrop);
 			STacticalAssignment blocked;
-			blocked.init(itUnit->iPlotIndex, itUnit->iPlotIndex, itUnit->iUnitID, itUnit->iMovesLeft, itUnit->eMoveStrategy, A_BLOCKED);
+			blocked.init(itUnit->iPlotIndex, itUnit->iPlotIndex, itUnit->iUnitID, itUnit->iMovesLeft, itUnit->eMoveStrategy, A_BLOCKED, GetPrevPlotScore(itUnit->iUnitID, *this));
 			blocked.SetScore(0, 0, 0);
 			assignedMoves_w.push_back(blocked);
 		}
@@ -9437,7 +9473,7 @@ bool CvTacticalPosition::makeNextAssignments(int iMaxBranches, int iMaxChoicesPe
 		if (a == RESULT_ADDED_W_VIS_CHANGE || b == RESULT_ADDED_W_VIS_CHANGE)
 		{
 			STacticalAssignment restart;
-			restart.init(-1, -1, aRef.iUnitID, 0, aRef.eMoveType, A_RESTART);
+			restart.init(-1, -1, aRef.iUnitID, 0, aRef.eMoveType, A_RESTART, GetPrevPlotScore(aRef.iUnitID, *this));
 			restart.SetScore(0, 0, 0);
 			pNewChild->assignedMoves.write().push_back(restart);
 		}
@@ -9667,6 +9703,8 @@ bool CvTacticalPosition::addFinishMovesIfAcceptable(bool bEarlyFinish, int& iBad
 	//order is important here, need to add finish moves first!
 	if (bEarlyFinish || isKillOrImprovedPosition())
 	{
+		vector<SUnitStats>& finishedUnits_w = finishedUnits.write();
+		finishedUnits_w.insert(finishedUnits_w.end(), notQuiteFinishedUnits_r.begin(), notQuiteFinishedUnits_r.end());
 		notQuiteFinishedUnits.write().clear();
 		iBadUnitID = -1;
 		return true;
@@ -10078,6 +10116,7 @@ void CvTacticalPosition::initFromScratch(PlayerTypes player, eAggressionLevel eA
 	tactPlots.clear();
 	availableUnits.clear();
 	notQuiteFinishedUnits.clear();
+	finishedUnits.clear();
 	assignedMoves.clear();
 	enemyPlots.clear();
 	freedPlots.clear();
@@ -10125,6 +10164,7 @@ void CvTacticalPosition::initFromParent(const CvTacticalPosition& parent)
 	assignedMoves.inheritFrom(parent.assignedMoves.read());
 	availableUnits.inheritFrom(parent.availableUnits.read());
 	notQuiteFinishedUnits.inheritFrom(parent.notQuiteFinishedUnits.read());
+	finishedUnits.inheritFrom(parent.finishedUnits.read());
 	freedPlots.inheritFrom(parent.freedPlots.read());
 	enemyPlots.inheritFrom(parent.enemyPlots.read());
 	unitDamageDealt.inheritFrom(parent.unitDamageDealt.read());
@@ -10789,10 +10829,8 @@ bool CvTacticalPosition::addAvailableUnit(const CvUnit* pUnit)
 				eStrategy = MS_SECONDLINE;
 			else
 			{
-				if (pUnit->getUnitInfo().GetDefaultUnitAIType() == UNITAI_EXPLORE)
-					eStrategy = MS_THIRDLINE; // Scouts should stay in the backline
 				//the unit AI type is unreliable, so we do this manually
-				else if (pUnit->IsCanAttackRanged() && pUnit->getDomainType() == DOMAIN_SEA && pUnit->maxMoves() > 3 && pUnit->canMoveAfterAttacking())
+				if (pUnit->IsCanAttackRanged() && pUnit->getDomainType() == DOMAIN_SEA && pUnit->maxMoves() > 3 && pUnit->canMoveAfterAttacking())
 					eStrategy = MS_THIRDLINE; //very fast units can stay even further back
 				else if (pUnit->IsCanAttackRanged() && pUnit->canMoveAfterAttacking() && pUnit->maxMoves() > 2)
 					eStrategy = MS_SECONDLINE; //skirmishers are second line always
@@ -10888,7 +10926,7 @@ static bool IsAttackMove(eUnitAssignmentType eAssignmentType)
 static STacticalAssignment* ScorePlotForSupportMove(const SUnitStats& unit, const CvPlot* pPlot, int iAssumedMovesLeft, const CvSupportPosition& assumedPosition, eUnitMoveEvalMode evalMode, bool bLastPosition)
 {
 	STacticalAssignment* result = gAssignmentStorage.peekNext();
-	result->init(unit.iPlotIndex, pPlot->GetPlotIndex(), unit.iUnitID, iAssumedMovesLeft, unit.eMoveStrategy, A_MOVE);
+	result->init(unit.iPlotIndex, pPlot->GetPlotIndex(), unit.iUnitID, iAssumedMovesLeft, unit.eMoveStrategy, A_MOVE, GetPrevPlotScore(unit.iUnitID, assumedPosition));
 
 	int iPlotScore = 0;
 	int iBonusScore = 0;
@@ -11055,22 +11093,16 @@ static STacticalAssignment* ScorePlotForSupportMove(const SUnitStats& unit, cons
 
 			if (!pPlot->isCity())
 			{
-				if (!finalTactPlot || !finalTactPlot->isCombatEndTurn())
+				if (!pDefender)
 				{
-					iDangerScore -= min(iDanger, pUnit->GetMaxHitPoints());
-
-					if (iDanger == 0)
-						iDangerScore -= pUnit->GetMaxHitPoints() / 3;
+					iDangerScore -= min(max(iDanger, pUnit->GetMaxHitPoints() / 3), pUnit->GetMaxHitPoints());
 				}
 				else
 				{
-					if (pDefender)
-					{
-						int iDefenderDamageTotal = iDanger + iDefenderDamage + pDefender->getDamage();
-						iDangerScore -= iDefenderDamageTotal * pUnit->GetMaxHitPoints() / (pDefender->GetMaxHitPoints() * 3);
-					}
-					else
-						iDangerScore -= pUnit->GetMaxHitPoints() / 3;
+					int iDefenderDamageTotal = iDanger + iDefenderDamage + pDefender->getDamage();
+					if (iDanger == 0)
+						iDefenderDamageTotal /= 3;
+					iDangerScore -= iDefenderDamageTotal * pUnit->GetMaxHitPoints() / (pDefender->GetMaxHitPoints() * 3);
 				}
 			}
 
@@ -11238,6 +11270,8 @@ int CvSupportPosition::GetUnitDanger(const SUnitStats& unit, const CvPlot* pPlot
 	if (!pDefender)
 	{
 		pDefender = pPlot->getBestDefender(ePlayer);
+		if (pDefender && !pDefender->TurnProcessed() && pDefender->getMoves() > 0)
+			pDefender = NULL;
 	}
 
 	if (pDefender)
@@ -11272,9 +11306,6 @@ void CvSupportPosition::getPreferredAssignmentsForUnit(const SUnitStats& unit, i
 		{
 			// Try to move towards the target
 			int iNewPlotDistanceToTarget = TacticalAIHelpers::GetPlotDistanceToTarget(it->iPlotIndex, pUnit->getDomainType());
-			if (iNewPlotDistanceToTarget > iOldPlotDistanceToTarget)
-				continue;
-
 			iMoveTowardsTargetScore = iOldPlotDistanceToTarget - iNewPlotDistanceToTarget;
 		}
 
@@ -11371,7 +11402,7 @@ bool CvSupportPosition::makeNextAssignments(int iMaxBranches, int iMaxChoicesPer
 		if (assignmentResult == RESULT_ADDED_W_VIS_CHANGE)
 		{
 			STacticalAssignment restart;
-			restart.init(-1, -1, gOverAllChoices[i].option->iUnitID, 0, gOverAllChoices[i].option->eMoveType, A_RESTART);
+			restart.init(-1, -1, gOverAllChoices[i].option->iUnitID, 0, gOverAllChoices[i].option->eMoveType, A_RESTART, GetPrevPlotScore(gOverAllChoices[i].option->iUnitID, *this));
 			restart.SetScore(0, 0, 0);
 			pNewChild->assignedMoves.write().push_back(restart);
 		}
@@ -11474,6 +11505,10 @@ bool CvSupportPosition::addFinishMovesIfAcceptable()
 		}
 	}
 
+	vector<SUnitStats>& finishedUnits_w = finishedUnits.write();
+	finishedUnits_w.insert(finishedUnits_w.end(), notQuiteFinishedUnits_r.begin(), notQuiteFinishedUnits_r.end());
+	notQuiteFinishedUnits.write().clear();
+
 	return true;
 }
 
@@ -11497,11 +11532,12 @@ CvSupportPosition::CvSupportPosition()
 	iLastToAttackPlotIndex = -1;
 
 	childPositions.clear();
-	notQuiteFinishedUnits.clear();
 	assignedMoves.clear();
 	availableUnits.clear();
 	freedPlots.clear();
 	availableUnits.clear();
+	notQuiteFinishedUnits.clear();
+	finishedUnits.clear();
 	finalCombatPositionUnits.clear();
 	plotScores.clear();
 
@@ -11594,9 +11630,10 @@ void CvSupportPosition::initFromTacticalPosition(const CvTacticalPosition& tactP
 	iLastToAttackPlotIndex = tactPos.getAssignments().back().iToPlotIndex;
 
 	childPositions.clear();
-	notQuiteFinishedUnits.clear();
 	assignedMoves.clear();
 	availableUnits.clear();
+	notQuiteFinishedUnits.clear();
+	finishedUnits.clear();
 	finalCombatPositionUnits.clear();
 	plotScores.clear();
 
@@ -11661,6 +11698,7 @@ void CvSupportPosition::initFromParent(const CvSupportPosition& parent)
 	assignedMoves.inheritFrom(parent.assignedMoves.read());
 	availableUnits.inheritFrom(parent.availableUnits.read());
 	notQuiteFinishedUnits.inheritFrom(parent.notQuiteFinishedUnits.read());
+	finishedUnits.inheritFrom(parent.finishedUnits.read());
 	freedPlots.inheritFrom(parent.freedPlots.read());
 	finalCombatPositionUnits.inheritFrom(parent.finalCombatPositionUnits.read());
 	plotScores.inheritFrom(parent.plotScores.read());
@@ -12175,7 +12213,11 @@ vector<STacticalAssignment> TacticalAIHelpers::FindBestUnitAssignments(
 
 	//first pass: make sure there are no duplicates and other invalid inputs
 	vector<const CvUnit*> ourUnits;
-	vector<int> unitXP(vUnits.size());
+	vector<int> unitXP;
+
+	ourUnits.reserve(vUnits.size());
+	unitXP.reserve(vUnits.size());
+
 	for (size_t i = 0; i < vUnits.size(); i++)
 	{
 		CvUnit* pUnit = vUnits[i];

--- a/CvGameCoreDLL_Expansion2/CvTacticalAI.h
+++ b/CvGameCoreDLL_Expansion2/CvTacticalAI.h
@@ -548,9 +548,9 @@ public:
 
 	STacticalAssignment() : eAssignmentType(A_BLOCKED), iUnitID(-1), iTotalScore(0), iFromPlotIndex(0), iToPlotIndex(0),
 		iRemainingMoves(0), eMoveType(MS_NONE), unitDamage(SUnitIDValueContainer()), unitHealing(SUnitIDValueContainer()),
-		iCityDamage(0), iSelfDamage(0), iDamagedCityId(0), iPlotScore(0), iBonusScore(0), iDamageDelta(0) {}
+		iCityDamage(0), iSelfDamage(0), iDamagedCityId(0), iPlotScore(0), iBonusScore(0), iDamageDelta(0), iOldPlotScore(0) {}
 
-	STacticalAssignment(int iFromPlot, int iToPlot, int iUnitID_, int iRemainingMoves_, eUnitMovementStrategy eMoveType_, eUnitAssignmentType eType_)
+	STacticalAssignment(int iFromPlot, int iToPlot, int iUnitID_, int iRemainingMoves_, eUnitMovementStrategy eMoveType_, eUnitAssignmentType eType_, int iOldPlotScore_)
 	{
 		eAssignmentType = eType_;
 		iUnitID = iUnitID_;
@@ -558,6 +558,7 @@ public:
 		iToPlotIndex = iToPlot;
 		iRemainingMoves = iRemainingMoves_;
 		eMoveType = eMoveType_;
+		iOldPlotScore = iOldPlotScore_;
 
 		iCityDamage = 0;
 		iSelfDamage = 0;
@@ -569,7 +570,7 @@ public:
 		SetImpossible();
 	}
 
-	void init(int iFromPlot, int iToPlot, int iUnitID_, int iRemainingMoves_, eUnitMovementStrategy eMoveType_, eUnitAssignmentType eType_)
+	void init(int iFromPlot, int iToPlot, int iUnitID_, int iRemainingMoves_, eUnitMovementStrategy eMoveType_, eUnitAssignmentType eType_, int iOldPlotScore_)
 	{
 		VALIDATE_OBJECT();
 		eAssignmentType = eType_;
@@ -578,6 +579,7 @@ public:
 		iToPlotIndex = iToPlot;
 		iRemainingMoves = iRemainingMoves_;
 		eMoveType = eMoveType_;
+		iOldPlotScore = iOldPlotScore_;
 
 		iCityDamage = 0;
 		iSelfDamage = 0;
@@ -596,14 +598,14 @@ public:
 		iPlotScore = iPlotScore_;
 		iBonusScore = iBonusScore_;
 		iDamageDelta = iDamageDelta_;
-		iTotalScore = iPlotScore + (iBonusScore + iDamageDelta) * 10;
+		iTotalScore = iPlotScore - iOldPlotScore + (iBonusScore + iDamageDelta) * 10;
 	}
 	void SetScore(const STacticalAssignment* other)
 	{
 		iPlotScore = other->iPlotScore;
 		iBonusScore = other->iBonusScore;
 		iDamageDelta = other->iDamageDelta;
-		iTotalScore = iPlotScore + (iBonusScore + iDamageDelta) * 10;
+		iTotalScore = iPlotScore - iOldPlotScore + (iBonusScore + iDamageDelta) * 10;
 	}
 	void AddScore(int iPlotScoreChange, int iBonusScoreChange, int iDamageDeltaChange)
 	{
@@ -611,7 +613,7 @@ public:
 		iPlotScore += iPlotScoreChange;
 		iBonusScore += iBonusScoreChange;
 		iDamageDelta += iDamageDeltaChange;
-		iTotalScore = iPlotScore + (iBonusScore + iDamageDelta) * 10;
+		iTotalScore = iPlotScore - iOldPlotScore + (iBonusScore + iDamageDelta) * 10;
 	}
 	void AddScore(const STacticalAssignment* other)
 	{
@@ -619,7 +621,7 @@ public:
 		iPlotScore += other->iPlotScore;
 		iBonusScore += other->iBonusScore;
 		iDamageDelta += other->iDamageDelta;
-		iTotalScore = iPlotScore + (iBonusScore + iDamageDelta) * 10;
+		iTotalScore = iPlotScore - iOldPlotScore + (iBonusScore + iDamageDelta) * 10;
 	}
 	void SetImpossible()
 	{
@@ -628,6 +630,7 @@ public:
 	int GetPlotScore() const { return iPlotScore; }
 	int GetBonusScore() const { return iBonusScore; }
 	int GetDamageDelta() const { return iDamageDelta; }
+	int GetOldPlotScore() const { return iOldPlotScore; }
 	void wipe()
 	{
 		SUnitIDValueContainer().swap(unitDamage);
@@ -640,6 +643,7 @@ protected:
 	short iPlotScore;
 	short iBonusScore;
 	short iDamageDelta;
+	short iOldPlotScore;
 };
 
 struct SComboMove
@@ -701,14 +705,13 @@ struct SComboMove
 	bool operator==(const SComboMove& rhs) const { return getA() == rhs.getA() && hasB() == rhs.hasB() && (!hasB() || getB() == rhs.getB()); }
 	bool addMove(const STacticalAssignment& move);
 
-	// When comparing combination moves, we should evaluate double moves as the average value of the two moves
 	struct PrEvalOrder
 	{
 		bool operator() (const SComboMove& lhs, const SComboMove& rhs)
 		{
-			int lhsScore = !lhs.hasB() ? lhs.getA().Score() : (lhs.getA().Score() + lhs.getB().Score()) / 2;
-			int rhsScore = !rhs.hasB() ? rhs.getA().Score() : (rhs.getA().Score() + rhs.getB().Score()) / 2;
-			return lhs.getA().Score() > rhs.getA().Score();
+			int lhsScore = !lhs.hasB() ? lhs.getA().Score() : lhs.getA().Score() + lhs.getB().Score();
+			int rhsScore = !rhs.hasB() ? rhs.getA().Score() : rhs.getA().Score() + rhs.getB().Score();
+			return lhsScore > rhsScore;
 		}
 	};
 };
@@ -1136,6 +1139,7 @@ protected:
 
 	SCoWField<vector<SUnitStats>> availableUnits; //units which still need an assignment
 	SCoWField<vector<SUnitStats>> notQuiteFinishedUnits; //unit which have no moves left and we need to do a deferred check if it's ok to stay in the plot
+	SCoWField<vector<SUnitStats>> finishedUnits; //unit that is fully finished
 
 	//set in constructor, constant afterwards
 	PlayerTypes ePlayer;
@@ -1223,6 +1227,7 @@ public:
 		assignedMoves.wipe();
 		availableUnits.wipe();
 		notQuiteFinishedUnits.wipe();
+		finishedUnits.wipe();
 		freedPlots.wipe();
 
 		// hook for derived classes
@@ -1260,7 +1265,7 @@ public:
 	size_t GetNumAssignments() const { return assignedMoves.read().size(); }
 
 	void UpdateScore(const STacticalAssignment& assignment);
-	void UpdateScore(int iUnitId, int iPlotScore, int iDamageDelta, int iBonusScore);
+	void UpdateScore(int iUnitId, int iPlotScore, int iOldPlotScore, int iDamageDelta, int iBonusScore);
 
 	//sort descending cumulative score. only makes sense for "completed" positions
 	bool operator<(const CvBasePosition& rhs) { return getScoreTotal() > rhs.getScoreTotal(); }


### PR DESCRIPTION
Fix wrong median unit XP calculation, leading to tactical AI treating all its units as very important.

Make AI more willing to send melee ships in to attack.

Fix AI not wanting to swap units in and out.

Fix GGs and GAs suiciding because they don't know where friendly units are.

Fix units standing still in bad positions.