### PR TITLE
vanilla missile text except can be intercepted

### DIFF
--- a/(1) Community Patch/Database Changes/Text/en_US/Concepts/CoreConceptTextChanges.sql
+++ b/(1) Community Patch/Database Changes/Text/en_US/Concepts/CoreConceptTextChanges.sql
@@ -33,6 +33,10 @@ UPDATE Language_en_US
 SET Text = 'At the end of melee combat, one or both units may have sustained damage and lost "hit points." If a unit''s hit points are reduced to 0, that unit is destroyed. If after melee combat the defending unit has been destroyed and the attacker survives, the attacking unit moves into the defender''s hex [COLOR_YELLOW]unless defending a Citadel, Fort, or City, at which point the melee unit remains in place[ENDCOLOR]. If it moves, the winner will capture any non-military units in that hex. If the defending unit survives, it retains possession of its hex and any other units in the hex.[NEWLINE][NEWLINE]Most units use up all of their movement when attacking. Some however have the ability to move after combat - if they survive the battle and have movement points left to expend.[NEWLINE][NEWLINE]Any surviving units involved in the combat will receive "experience points" (XPs), which may be expended to give the unit promotions.'
 WHERE Tag = 'TXT_KEY_COMBAT_MELEERESULTS_HEADING3_BODY';
 
+UPDATE Language_en_US
+SET Text = 'Missiles are one-shot weapons. They perform a single air strike mission against a target, and then, win or lose, they are destroyed. They can be intercepted.' 
+WHERE Tag= 'TXT_KEY_AIRPOWER_MISSILES_HEADING2_BODY';
+
 -- Map
 UPDATE Language_en_US
 SET Text = 'The ruin provides a map of the nearest unrevealed City (lifting the fog of war from a number of tiles).'


### PR DESCRIPTION
the original is

```
		<Row Tag="TXT_KEY_AIRPOWER_MISSILES_HEADING2_BODY">
			<Text>Missiles are one-shot weapons. They perform a single air strike mission against a target, and then, win or lose, they are destroyed. Unlike normal aircraft, missiles cannot be intercepted. </Text>
		</Row>
```