### PR TITLE
Modernize culture from specialists

### DIFF
--- a/(1) Community Patch/Core Files/Overrides/Includes/InfoTooltipInclude.lua
+++ b/(1) Community Patch/Core Files/Overrides/Includes/InfoTooltipInclude.lua
@@ -4190,12 +4190,8 @@ function GetHelpTextForSpecialist(eSpecialist, pCity)
 	local kGreatPersonInfo = GetGreatPersonInfoFromSpecialist(kSpecialistInfo.Type);
 	local strTooltip = L(kSpecialistInfo.Description);
 
-	local iCultureFromSpecialist = pCity:GetCultureFromSpecialist(eSpecialist);
 	for eYield, kYieldInfo in GameInfoCache("Yields") do
 		local iYield = pCity:GetSpecialistYield(eSpecialist, eYield) + pCity:GetSpecialistYieldChange(eSpecialist, eYield);
-		if eYield == YieldTypes.YIELD_CULTURE then
-			iYield = iYield + iCultureFromSpecialist;
-		end
 		if iYield > 0 then
 			strTooltip = string.format("%s +%d%s", strTooltip, iYield, kYieldInfo.IconString);
 		end

--- a/(3a) VP - EUI Compatibility Files/LUA/CityView.lua
+++ b/(3a) VP - EUI Compatibility Files/LUA/CityView.lua
@@ -470,7 +470,6 @@ local function GetSpecialistYields( city, specialist )
 		local cityOwner = Players[ city:GetOwner() ]
 		-- Culture
 		local specialistYield = 0
-		local cultureFromSpecialist = city:GetCultureFromSpecialist( specialistID )
 		local specialistYieldModifier = 0
 		local specialistCultureModifier = city:GetCultureRateModifier() + ( cityOwner and ( cityOwner:GetCultureCityModifier() + ( city:GetNumWorldWonders() > 0 and cityOwner:GetCultureWonderMultiplier() or 0 )) or 0 )
 		-- Yield
@@ -482,16 +481,13 @@ local function GetSpecialistYields( city, specialist )
 			-- COMMUNITY PATCH ENDS
 			specialistYieldModifier = city:GetBaseYieldRateModifier( yieldID )
 			if yieldID == YieldTypes.YIELD_CULTURE then
-				specialistYield = specialistYield + cultureFromSpecialist
 				specialistYieldModifier = specialistYieldModifier + specialistCultureModifier
-				cultureFromSpecialist = 0
 			end
 			-- Vox Populi Comparable Yields
 			specialistYieldModifier = 100
 			yieldTips:insertIf( specialistYield ~= 0 and specialistYield * specialistYieldModifier / 100 .. tostring(YieldIcons[yieldID]) )
 			--yieldTips:insertIf( specialistYield ~= 0 and specialistYield .. tostring(YieldIcons[yieldID]) )
 		end
-		yieldTips:insertIf( cultureFromSpecialist ~= 0 and cultureFromSpecialist .. "[ICON_CULTURE]" )
 		yieldTips:insertIf( civ5_mode and (specialist.GreatPeopleRateChange or 0) ~= 0 and specialist.GreatPeopleRateChange + city:GetEventGPPFromSpecialists() .. GreatPeopleIcon( specialist.Type ) )
 		-- Vox Populi food info
 		local foodPerSpec = city:FoodConsumptionSpecialistTimes100() / 100;

--- a/(3a) VP - EUI Compatibility Files/LUA/EUI_tooltip_library.lua
+++ b/(3a) VP - EUI Compatibility Files/LUA/EUI_tooltip_library.lua
@@ -250,24 +250,15 @@ local function GetSpecialistYields( city, specialist )
 	local specialistID = specialist.ID
 	local tip = ""
 	if city then
-		-- Culture
-		local cultureFromSpecialist = city:GetCultureFromSpecialist( specialistID )
-		cultureFromSpecialist = (cultureFromSpecialist + city:GetSpecialistYield( specialistID, YieldTypes.YIELD_CULTURE ) + city:GetSpecialistYieldChange( specialistID, YieldTypes.YIELD_CULTURE))
-
 		-- Yield
 		for yieldID = 0, YieldTypes.NUM_YIELD_TYPES-1 do
 			-- CBP
-			if(yieldID ~= YieldTypes.YIELD_CULTURE)then		
-				local specialistYield = city:GetSpecialistYield( specialistID, yieldID )
-				specialistYield = (specialistYield + city:GetSpecialistYieldChange( specialistID, yieldID))
-				if specialistYield ~= 0 then
-					tip = S( "%s %+i%s", tip, specialistYield, YieldIcons[ yieldID ] or "???" )
-				end
+			local specialistYield = city:GetSpecialistYield( specialistID, yieldID )
+			specialistYield = (specialistYield + city:GetSpecialistYieldChange( specialistID, yieldID))
+			if specialistYield ~= 0 then
+				tip = S( "%s %+i%s", tip, specialistYield, YieldIcons[ yieldID ] or "???" )
 			end
 			--END
-		end
-		if cultureFromSpecialist > 0 then
-			tip = S( "%s %+i[ICON_CULTURE]", tip, cultureFromSpecialist )
 		end
 	else
 		for row in GameInfo.SpecialistYields{ SpecialistType = specialist.Type or -1 } do

--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -14939,10 +14939,6 @@ void CvCity::processSpecialist(SpecialistTypes eSpecialist, int iChange, CvCity:
 	updateExtraSpecialistYield();
 	changeSpecialistFreeExperience(pkSpecialist->getExperience() * iChange);
 
-	// Culture
-	int iCulturePerSpecialist = GetCultureFromSpecialist(eSpecialist);
-	ChangeBaseYieldRateFromSpecialists(YIELD_CULTURE, iCulturePerSpecialist * iChange);
-
 	for (int iI = 0; iI < NUM_DOMAIN_TYPES; iI++)
 	{
 		DomainTypes eDomain = (DomainTypes)iI;
@@ -15252,21 +15248,6 @@ void CvCity::ChangeReligiousPressureModifier(ReligionTypes eReligion, int iNewVa
 {
 	SetReligiousPressureModifier(eReligion, (GetReligiousPressureModifier(eReligion) + iNewValue));
 }
-//	--------------------------------------------------------------------------------
-/// Culture from eSpecialist
-int CvCity::GetCultureFromSpecialist(SpecialistTypes eSpecialist) const
-{
-	CvSpecialistInfo* pkSpecialistInfo = GC.getSpecialistInfo(eSpecialist);
-	if (pkSpecialistInfo == NULL)
-	{
-		//This function REQUIRES a valid specialist type.
-		return 0;
-	}
-
-	int iCulture = pkSpecialistInfo->getCulturePerTurn();
-	return iCulture;
-}
-
 //	--------------------------------------------------------------------------------
 const CvHandicapInfo& CvCity::getHandicapInfo() const
 {

--- a/CvGameCoreDLL_Expansion2/CvCity.h
+++ b/CvGameCoreDLL_Expansion2/CvCity.h
@@ -478,8 +478,6 @@ public:
 	void SetReligiousPressureModifier(ReligionTypes eReligion, int iNewValue);
 	void ChangeReligiousPressureModifier(ReligionTypes eReligion, int iNewValue);
 
-	int GetCultureFromSpecialist(SpecialistTypes eSpecialist) const;
-
 	void UpdateOceanStatus();
 
 	const CvHandicapInfo& getHandicapInfo() const;

--- a/CvGameCoreDLL_Expansion2/CvCityCitizens.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCityCitizens.cpp
@@ -807,9 +807,6 @@ YieldAndGPPList CvCityCitizens::GetSpecialistYields(SpecialistTypes eSpecialist)
 		{
 			iYield100 += GET_PLAYER(GetOwner()).getYieldFromNonSpecialistCitizensTimes100(eYield);
 		}
-		//Culture is treated differently, sadly.
-		if (eYield == YIELD_CULTURE)
-			iYield100 += m_pCity->GetCultureFromSpecialist(eSpecialist) * 100;
 
 		//religion bonus
 		ReligionTypes eMajority = m_pCity->GetCityReligions()->GetReligiousMajority();

--- a/CvGameCoreDLL_Expansion2/CvCityStrategyAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCityStrategyAI.cpp
@@ -3723,11 +3723,6 @@ int CityStrategyAIHelpers::GetBuildingYieldValue(CvCity *pCity, BuildingTypes eB
 			{
 				iSpecialistYield = pkSpecialistInfo->getYieldChange(eYield);
 
-				if (eYield == YIELD_CULTURE)
-				{
-					iSpecialistYield += pkSpecialistInfo->getCulturePerTurn();
-				}
-
 				// Laborers don't get any non-specific specialist boosts
 				if (eSpecialist != GD_INT_GET(DEFAULT_SPECIALIST))
 					iSpecialistYield += kPlayer.getSpecialistExtraYield(eYield);

--- a/CvGameCoreDLL_Expansion2/CvInfos.cpp
+++ b/CvGameCoreDLL_Expansion2/CvInfos.cpp
@@ -719,7 +719,6 @@ CvSpecialistInfo::CvSpecialistInfo() :
 	m_iCost(0),
 	m_iGreatPeopleUnitClass(NO_UNITCLASS),
 	m_iGreatPeopleRateChange(0),
-	m_iCulturePerTurn(0),
 	m_iMissionType(NO_MISSION),
 	m_bVisible(false),
 	m_piYieldChange(NULL),
@@ -798,7 +797,6 @@ bool CvSpecialistInfo::CacheResults(Database::Results& kResults, CvDatabaseUtili
 	m_iCost = kResults.GetInt("Cost");
 	m_iExperience = kResults.GetInt("Experience");
 	m_iGreatPeopleRateChange = kResults.GetInt("GreatPeopleRateChange");
-	m_iCulturePerTurn = kResults.GetInt("CulturePerTurn");
 
 	setTexture(kResults.GetText("Texture"));
 
@@ -809,7 +807,7 @@ bool CvSpecialistInfo::CacheResults(Database::Results& kResults, CvDatabaseUtili
 	const char* szType = GetType();
 	kUtility.SetYields(m_piYieldChange, "SpecialistYields", "SpecialistType", szType);
 
-	m_piYieldChange[YIELD_CULTURE] += m_iCulturePerTurn;
+	m_piYieldChange[YIELD_CULTURE] += kResults.GetInt("CulturePerTurn");
 
 	return true;
 }

--- a/CvGameCoreDLL_Expansion2/CvInfos.cpp
+++ b/CvGameCoreDLL_Expansion2/CvInfos.cpp
@@ -747,11 +747,6 @@ int CvSpecialistInfo::getGreatPeopleRateChange() const
 	return m_iGreatPeopleRateChange;
 }
 //------------------------------------------------------------------------------
-int CvSpecialistInfo::getCulturePerTurn() const
-{
-	return m_iCulturePerTurn;
-}
-
 int CvSpecialistInfo::getMissionType() const
 {
 	return m_iMissionType;
@@ -813,6 +808,8 @@ bool CvSpecialistInfo::CacheResults(Database::Results& kResults, CvDatabaseUtili
 	//Arrays
 	const char* szType = GetType();
 	kUtility.SetYields(m_piYieldChange, "SpecialistYields", "SpecialistType", szType);
+
+	m_piYieldChange[YIELD_CULTURE] += m_iCulturePerTurn;
 
 	return true;
 }

--- a/CvGameCoreDLL_Expansion2/CvInfos.h
+++ b/CvGameCoreDLL_Expansion2/CvInfos.h
@@ -261,7 +261,6 @@ public:
 
 	int getGreatPeopleUnitClass() const;
 	int getGreatPeopleRateChange() const;
-	int getCulturePerTurn() const;
 	int getMissionType() const;
 	void setMissionType(int iNewType);
 	int getExperience() const;
@@ -282,7 +281,6 @@ protected:
 
 	int m_iGreatPeopleUnitClass;
 	int m_iGreatPeopleRateChange;
-	int m_iCulturePerTurn;
 	int m_iMissionType;
 	int m_iExperience;
 

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaCity.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaCity.cpp
@@ -598,7 +598,6 @@ void CvLuaCity::PushMethods(lua_State* L, int t)
 	Method(CanPlaceUnitHere);
 
 	Method(GetSpecialistYield);
-	Method(GetCultureFromSpecialist);
 
 	Method(GetNumForcedWorkingPlots);
 
@@ -6223,11 +6222,6 @@ int CvLuaCity::lGetSpecialistYield(lua_State* L)
 	lua_pushinteger(L, iValue);
 
 	return 1;
-}
-//------------------------------------------------------------------------------
-int CvLuaCity::lGetCultureFromSpecialist(lua_State* L)
-{
-	return BasicLuaMethod(L, &CvCity::GetCultureFromSpecialist);
 }
 //------------------------------------------------------------------------------
 int CvLuaCity::lGetReligionCityRangeStrikeModifier(lua_State* L)

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaCity.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaCity.h
@@ -606,7 +606,6 @@ protected:
 	static int lCanPlaceUnitHere(lua_State* L);
 
 	static int lGetSpecialistYield(lua_State* L);
-	static int lGetCultureFromSpecialist(lua_State* L);
 
 	static int lGetReligionCityRangeStrikeModifier(lua_State* L);
 


### PR DESCRIPTION
Azum's suggestion (https://github.com/LoneGazebo/Community-Patch-DLL/pull/12975#issuecomment-4446722421) to move the column CulturePerTurn on Specialists into the SpecialistYields table, as was done in some other places like Buildings

Actually this wasn't the issue in the end, but this does seem to work and I guess it's nicer/cleaner to have?