### PR TITLE
Remove rivers and lakes from civilopedia features list

### DIFF
--- a/(2) Vox Populi/Core Files/Overrides/CivilopediaScreen.lua
+++ b/(2) Vox Populi/Core Files/Overrides/CivilopediaScreen.lua
@@ -1434,28 +1434,6 @@ CivilopediaCategory[CategoryTerrain].PopulateList = function()
 		categorizedList[(CategoryTerrain * absurdlyLargeNumTopicsInCategory) + row.ID + 1000] = article; -- add a fudge factor
 	end
 
-	-- now for the fake features (river and lake)
-	for row in GameInfo.FakeFeatures() do
-		local article = {};
-		local name = Locale.ConvertTextKey( row.Description )
-		article.entryName = name;
-		article.entryID = row.ID + 2000;
-		article.entryCategory = CategoryTerrain;
-		article.tooltipTextureOffset, article.tooltipTexture = IconLookup( row.PortraitIndex, buttonSize, row.IconAtlas );
-		if not article.tooltipTextureOffset then
-			article.tooltipTexture = defaultErrorTextureSheet;
-			article.tooltipTextureOffset = nullOffset;
-		end
-
-		sortedList[CategoryTerrain][2][tableid] = article;
-		tableid = tableid + 1;
-
-		-- index by various keys
-		searchableList[Locale.ToLower(name)] = article;
-		searchableTextKeyList[row.Description] = article;
-		categorizedList[(CategoryTerrain * absurdlyLargeNumTopicsInCategory) + row.ID + 2000] = article; -- add a fudge factor
-	end
-
 	-- sort this list alphabetically by localized name
 	table.sort(sortedList[CategoryTerrain][2], Alphabetically);
 


### PR DESCRIPTION
Fixes #12832 

For reference, the only "FakeFeatures" are rivers and lakes.

Before and after pics:
<img width="242" height="548" alt="image" src="https://github.com/user-attachments/assets/7174a397-7d37-4e32-bec8-49f3db6df00c" />
<img width="240" height="515" alt="image" src="https://github.com/user-attachments/assets/ad9fea26-b1b6-45a0-897f-4453167afd4f" />
