### PR TITLE
Remove unused bArchaeologyChoicePending code

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -8183,8 +8183,6 @@ void CvPlot::setImprovementType(ImprovementTypes eNewValue, PlayerTypes eBuilder
 		}
 	}
 
-	bool bArchaeologyChoicePending = false;
-
 	if (eOldImprovement != eNewValue)
 	{
 		PlayerTypes eOldBuilder = GetPlayerThatBuiltImprovement();
@@ -9023,14 +9021,6 @@ void CvPlot::setImprovementType(ImprovementTypes eNewValue, PlayerTypes eBuilder
 				setImprovementType(NO_IMPROVEMENT);
 			}
 		}
-	}
-
-	// Do the AI's dig site choice at the very end since it could replace the tile with a Landmark, so it's better to do that after all the other code updating things has run
-	if (bArchaeologyChoicePending)
-	{
-		CvPlayer& kBuilder = GET_PLAYER(eBuilder);
-		ArchaeologyChoiceType eChoice = kBuilder.GetCulture()->GetArchaeologyChoice(this);
-		kBuilder.GetCulture()->DoArchaeologyChoice(eChoice);
 	}
 }
 


### PR DESCRIPTION
Archaeology choice logic is handled in changeBuildProgress so this ChoicePending code is no longer needed.

`bArchaeologyChoicePending` is not referenced or changed anywhere else in the codebase.

Fixes #12948