### PR TITLE
Add CPK.UI.Control.Instance.Manager with Queue and Inspect utilities

### DIFF
--- a/(1) Community Patch/Community Patch.civ5proj
+++ b/(1) Community Patch/Community Patch.civ5proj
@@ -3941,6 +3941,10 @@
       <SubType>Lua</SubType>
       <ImportIntoVFS>True</ImportIntoVFS>
     </Content>
+    <Content Include="Kit\UI\Control\CPK.UI.Control.Inspect.lua">
+      <SubType>Lua</SubType>
+      <ImportIntoVFS>True</ImportIntoVFS>
+    </Content>
     <Content Include="Kit\UI\Control\CPK.UI.Control.IsKind.lua">
       <SubType>Lua</SubType>
       <ImportIntoVFS>True</ImportIntoVFS>
@@ -3973,6 +3977,14 @@
       <SubType>Lua</SubType>
       <ImportIntoVFS>True</ImportIntoVFS>
     </Content>
+    <Content Include="Kit\UI\Control\Instance\CPK.UI.Control.Instance.Manager.lua">
+      <SubType>Lua</SubType>
+      <ImportIntoVFS>True</ImportIntoVFS>
+    </Content>
+    <Content Include="Kit\UI\Control\Instance\CPK.UI.Control.Instance.Move.lua">
+      <SubType>Lua</SubType>
+      <ImportIntoVFS>True</ImportIntoVFS>
+    </Content>
     <Content Include="Kit\Util\CPK.Util.Benchmark.lua">
       <SubType>Lua</SubType>
       <ImportIntoVFS>True</ImportIntoVFS>
@@ -3982,6 +3994,10 @@
       <ImportIntoVFS>True</ImportIntoVFS>
     </Content>
     <Content Include="Kit\Util\CPK.Util.FuzzyTrie.lua">
+      <SubType>Lua</SubType>
+      <ImportIntoVFS>True</ImportIntoVFS>
+    </Content>
+    <Content Include="Kit\Util\CPK.Util.Queue.lua">
       <SubType>Lua</SubType>
       <ImportIntoVFS>True</ImportIntoVFS>
     </Content>

--- a/(1) Community Patch/Kit/UI/Control/CPK.UI.Control.Inspect.lua
+++ b/(1) Community Patch/Kit/UI/Control/CPK.UI.Control.Inspect.lua
@@ -1,0 +1,24 @@
+local lua_xpcall = xpcall
+local lua_tostring = tostring
+
+local Void = CPK.FP.Void
+local IsTable = CPK.Type.IsTable
+local IsFunction = CPK.Type.IsFunction
+
+--- Formats a UI control as a string, appending its GetID() where available.
+--- @param control any
+--- @return string
+local function ControlInspect(control)
+	local str = lua_tostring(control)
+
+	if IsTable(control) and IsFunction(control.GetID) then
+		if not str:match(': 00000000$') then
+			local ok, id = lua_xpcall(function() return control:GetID() end, Void)
+			str = str .. ' (' .. lua_tostring(ok and id or nil) .. ')'
+		end
+	end
+
+	return str
+end
+
+CPK.UI.Control.Inspect = ControlInspect

--- a/(1) Community Patch/Kit/UI/Control/Instance/CPK.UI.Control.Instance.Error.lua
+++ b/(1) Community Patch/Kit/UI/Control/Instance/CPK.UI.Control.Instance.Error.lua
@@ -1,36 +1,20 @@
 local lua_error = error
-local lua_xpcall = xpcall
 local lua_tostring = tostring
 local lua_loadstring = loadstring
 local lua_string_format = string.format
 
-local Void = CPK.FP.Void
-local IsTable = CPK.Type.IsTable
-local IsFunction = CPK.Type.IsFunction
+local ControlInspect = CPK.UI.Control.Inspect
 
 local template = [[InstanceError: %s
-	Instance name: %s
-	Instance root: %s
-	Instance parent: %s
-	Instance released: %s
-	Current state: %s
-	Current context: %s
+	Instance:
+		Name:     %s
+		Root:     %s
+		Parent:   %s
+		Released: %s
+	Current:
+		State:   %s
+		Context: %s
 ]]
-
---- @param control any
---- @return string
-local function fc(control)
-	local str = lua_tostring(control)
-
-	if IsTable(control) and IsFunction(control.GetID) then
-		if not str:match(': 00000000$') then
-			local ok, id = lua_xpcall(function() return control:GetID() end, Void)
-			str = str .. ' (' .. lua_tostring(ok and id or nil) .. ')'
-		end
-	end
-
-	return str
-end
 
 --- @param inst ControlInstance
 --- @param info string
@@ -39,11 +23,11 @@ local function InstanceError(inst, info)
 		template,
 		lua_tostring(info),
 		lua_tostring(inst[1]),
-		fc(inst[3]),
-		fc(inst[4]),
+		ControlInspect(inst[3]),
+		ControlInspect(inst[4]),
 		lua_tostring(inst[2]),
 		lua_tostring(lua_loadstring('return StateName')()),
-		fc(lua_loadstring('return ContextPtr')())
+		ControlInspect(lua_loadstring('return ContextPtr')())
 	)
 
 	lua_error(msg, 3)

--- a/(1) Community Patch/Kit/UI/Control/Instance/CPK.UI.Control.Instance.Make.lua
+++ b/(1) Community Patch/Kit/UI/Control/Instance/CPK.UI.Control.Instance.Make.lua
@@ -3,6 +3,7 @@ local lua_next = next
 local lua_tostring = tostring
 local lua_loadstring = loadstring
 local lua_setmetatable = setmetatable
+local lua_string_format = string.format
 
 local IsString = CPK.Type.IsString
 
@@ -10,6 +11,7 @@ local AssertIsTable = CPK.Assert.IsTable
 local AssertIsString = CPK.Assert.IsString
 
 local InstanceError = CPK.UI.Control.Instance.Error
+local ControlInspect = CPK.UI.Control.Inspect
 
 --- @class ControlInstance
 --- @field [1] string # Instance name
@@ -33,6 +35,15 @@ local ControlInstanceMeta = {
 	end,
 	__newindex = function(self)
 		InstanceError(self, 'Instance modification is prohibited!')
+	end,
+	__tostring = function(self)
+		return lua_string_format(
+			'ControlInstance(name: %s, root: %s, parent: %s, released: %s)',
+			lua_tostring(self[1]),
+			ControlInspect(self[3]),
+			ControlInspect(self[4]),
+			lua_tostring(self[2])
+		)
 	end
 }
 

--- a/(1) Community Patch/Kit/UI/Control/Instance/CPK.UI.Control.Instance.Manager.lua
+++ b/(1) Community Patch/Kit/UI/Control/Instance/CPK.UI.Control.Instance.Manager.lua
@@ -1,0 +1,292 @@
+local lua_next = next
+local lua_error = error
+local lua_tostring = tostring
+local lua_loadstring = loadstring
+local lua_setmetatable = setmetatable
+local lua_string_format = string.format
+
+local Stack = CPK.Util.Stack
+local Queue = CPK.Util.Queue
+
+local AssertIsTable = CPK.Assert.IsTable
+local AssertIsString = CPK.Assert.IsString
+local AssertIsFunction = CPK.Assert.IsFunction
+
+local ControlInspect = CPK.UI.Control.Inspect
+
+local MakeInstance = CPK.UI.Control.Instance.Make
+local MoveInstance = CPK.UI.Control.Instance.Move
+local FreeInstance = CPK.UI.Control.Instance.Free
+
+local errorTemplate = [[InstanceManagerError: %s
+	Manager:
+		Instance: %s
+		Context:  %s
+		Mode:     %s
+		Size:     %d (acquired: %d, recycled: %d)
+	Current:
+		State:    %s
+		Context:  %s
+	Instance: %s
+	Instance state: %s
+]]
+
+--- Configuration options for creating an InstanceManager.
+--- @class InstanceManagerOpts
+--- @field mode? 'LIFO' | 'FIFO'
+--- @field context? Control
+--- @field instance string
+--- @field onCreated nil | (fun(inst: ControlInstance): nil)  # Fires once when a new instance is first created.
+--- @field onAcquire nil | (fun(inst: ControlInstance): nil)  # Fires every time an instance is acquired, new or recycled.
+--- @field onRecycle nil | (fun(inst: ControlInstance): nil)  # Fires when an instance is returned to the pool.
+--- @field onRelease nil | (fun(inst: ControlInstance): nil)  # Fires before an instance is permanently destroyed.
+
+--- Manages the full lifecycle of UI control instances.
+--- Handles creation, reuse, recycling and permanent release of ControlInstances.
+--- Instances move through three states: acquired → recycled → acquired (reuse) or released (destroy).
+--- @class InstanceManager : InstanceManagerOpts
+--- @field instance string
+--- @field mode     'LIFO' | 'FIFO'
+--- @field protected context  Control
+--- @field protected recycled Stack<ControlInstance> | Queue<ControlInstance>
+--- @field protected tracking table<ControlInstance, boolean>  # true = acquired, false = recycled
+local InstanceManagerImpl = {}
+
+--- @protected
+--- @param inst ControlInstance
+--- @param info string
+function InstanceManagerImpl:Error(inst, info)
+	local state = self.tracking[inst]
+	local stateStr = state == nil
+			and 'not tracked'
+			or (state and 'acquired' or 'recycled')
+
+	local msg = lua_string_format(
+		errorTemplate,
+		lua_tostring(info),
+		lua_tostring(self.instance),
+		ControlInspect(self.context),
+		lua_tostring(self.mode),
+		self:Size(), self:CountAcquired(), self:CountRecycled(),
+		lua_tostring(lua_loadstring('return StateName')()),
+		ControlInspect(lua_loadstring('return ContextPtr')()),
+		lua_tostring(inst),
+		stateStr
+	)
+
+	lua_error(msg, 3)
+end
+
+--- Pops a recycled instance from the pool or creates a new one via MakeInstance.
+--- Moves it to `parent`, fires `onCreated` (new instances only),
+--- then `onAcquire`, then shows the root control.
+--- @param parent Control
+--- @return ControlInstance
+function InstanceManagerImpl:Acquire(parent)
+	local inst = self.recycled:Pop()
+
+	if inst then
+		MoveInstance(inst, parent)
+	else
+		inst = MakeInstance(self.instance, parent, self.context)
+		local cb = self.onCreated
+		if cb then cb(inst) end
+	end
+
+	self.tracking[inst] = true
+
+	local cb = self.onAcquire
+	if cb then cb(inst) end
+
+	inst[3]:SetHide(false)
+
+	return inst
+end
+
+--- Returns an acquired instance to the pool.
+--- Hides the root control, fires `onRecycle`,
+--- then pushes the instance onto the recycle stack.
+--- Errors if the instance is already recycled or not known to this manager.
+--- @param inst ControlInstance
+function InstanceManagerImpl:Recycle(inst)
+	if self.tracking[inst] ~= true then
+		local info = self.tracking[inst] == false
+				and 'Recycle called on already recycled instance'
+				or 'Recycle called on instance not known to this manager'
+		self:Error(inst, info)
+	end
+
+	inst[3]:SetHide(true)
+	self.tracking[inst] = false
+
+	local cb = self.onRecycle
+	if cb then cb(inst) end
+
+	self.recycled:Push(inst)
+end
+
+--- Permanently destroys an instance, freeing its underlying control.
+--- Fires `onRelease` before destroying.
+--- Errors if the instance is recycled or not known to this manager.
+--- @param inst ControlInstance
+function InstanceManagerImpl:Release(inst)
+	if self.tracking[inst] ~= true then
+		local info = self.tracking[inst] == false
+				and 'Release called on non-acquired instance'
+				or 'Release called on instance not known to this manager'
+		self:Error(inst, info)
+	end
+
+	self.tracking[inst] = nil
+
+	local cb = self.onRelease
+	if cb then cb(inst) end
+
+	FreeInstance(inst)
+end
+
+--- Returns true if this manager has ever acquired `inst` and it has not been permanently released.
+--- @param inst ControlInstance
+--- @return boolean
+function InstanceManagerImpl:HasInstance(inst)
+	return self.tracking[inst] ~= nil
+end
+
+--- Returns true if `inst` is currently acquired (not yet recycled or released).
+--- @param inst ControlInstance
+--- @return boolean
+function InstanceManagerImpl:HasAcquired(inst)
+	return self.tracking[inst] == true
+end
+
+--- Returns true if `inst` is currently sitting in the recycle pool, waiting to be reused.
+--- @param inst ControlInstance
+--- @return boolean
+function InstanceManagerImpl:HasRecycled(inst)
+	return self.tracking[inst] == false
+end
+
+--- Returns the total number of instances managed (acquired + recycled).
+--- @return integer
+function InstanceManagerImpl:Size()
+	local count = 0
+	for _ in lua_next, self.tracking do
+		count = count + 1
+	end
+	return count
+end
+
+--- Returns the number of currently acquired instances.
+--- @return integer
+function InstanceManagerImpl:CountAcquired()
+	local count = 0
+	for _, v in lua_next, self.tracking do
+		if v then count = count + 1 end
+	end
+	return count
+end
+
+--- Returns the number of instances currently in the recycle pool.
+--- @return integer
+function InstanceManagerImpl:CountRecycled()
+	return self.recycled:Size()
+end
+
+--- Recycles all currently acquired instances, hiding each root and firing `onRecycle`.
+function InstanceManagerImpl:RecycleAcquired()
+	local tracking = self.tracking
+	local recycled = self.recycled
+	local cb = self.onRecycle
+
+	for inst, v in lua_next, tracking do
+		if v then
+			inst[3]:SetHide(true)
+			tracking[inst] = false
+			if cb then cb(inst) end
+			recycled:Push(inst)
+		end
+	end
+end
+
+--- Permanently releases all recycled instances, firing `onRelease` for each before destroying.
+function InstanceManagerImpl:ReleaseRecycled()
+	local tracking = self.tracking
+	local recycled = self.recycled
+	local cb = self.onRelease
+	local inst = recycled:Pop()
+
+	while inst do
+		tracking[inst] = nil
+		if cb then cb(inst) end
+		FreeInstance(inst)
+		inst = recycled:Pop()
+	end
+end
+
+--- @class InstanceManagerMeta
+local InstanceManagerMeta = {}
+
+InstanceManagerMeta.MODE_LIFO = 'LIFO'
+InstanceManagerMeta.MODE_FIFO = 'FIFO'
+
+--- @package
+InstanceManagerMeta.ModeStore = {
+	[InstanceManagerMeta.MODE_FIFO] = Queue,
+	[InstanceManagerMeta.MODE_LIFO] = Stack
+}
+
+--- @package
+InstanceManagerMeta.__index = InstanceManagerImpl
+
+--- @package
+--- @param self InstanceManager
+InstanceManagerMeta.__tostring = function(self)
+	return lua_string_format(
+		'InstanceManager(instance: %s, mode: %s, total: %d, acquired: %d, recycled: %d)',
+		lua_tostring(self.instance),
+		lua_tostring(self.mode),
+		self:Size(),
+		self:CountAcquired(),
+		self:CountRecycled()
+	)
+end
+
+--- Creates a new InstanceManager. Validates all opts fields and errors on invalid input.
+--- Defaults to LIFO ordering if `opts.mode` is not provided.
+--- @param opts InstanceManagerOpts
+--- @return InstanceManager
+function InstanceManagerMeta.New(opts)
+	AssertIsTable(opts) --[[@cast opts table]]
+	AssertIsString(opts.instance)
+
+	local context = opts.context or lua_loadstring('return ContextPtr')()
+
+	AssertIsTable(context)
+
+	local mode = opts.mode or 'LIFO'
+
+	AssertIsString(mode)
+
+	local store = InstanceManagerMeta.ModeStore[mode]
+
+	AssertIsTable(store)
+
+	if opts.onCreated then AssertIsFunction(opts.onCreated) end
+	if opts.onAcquire then AssertIsFunction(opts.onAcquire) end
+	if opts.onRecycle then AssertIsFunction(opts.onRecycle) end
+	if opts.onRelease then AssertIsFunction(opts.onRelease) end
+
+	return lua_setmetatable({
+		mode = mode,
+		context = context,
+		instance = opts.instance,
+		recycled = store.New(),
+		tracking = {},
+		onCreated = opts.onCreated,
+		onAcquire = opts.onAcquire,
+		onRecycle = opts.onRecycle,
+		onRelease = opts.onRelease,
+	}, InstanceManagerMeta)
+end
+
+CPK.UI.Control.Instance.Manager = InstanceManagerMeta

--- a/(1) Community Patch/Kit/UI/Control/Instance/CPK.UI.Control.Instance.Move.lua
+++ b/(1) Community Patch/Kit/UI/Control/Instance/CPK.UI.Control.Instance.Move.lua
@@ -1,0 +1,28 @@
+local AssertIsTable = CPK.Assert.IsTable
+
+local InstanceError = CPK.UI.Control.Instance.Error
+
+--- Moves control instance to another parent.
+--- @param inst ControlInstance
+--- @param dest Control
+local function MoveControlInstance(inst, dest)
+	AssertIsTable(inst)
+	AssertIsTable(dest)
+
+	if inst[2] then
+		InstanceError(inst, 'Failed to move instance. Instance already released!')
+	end
+
+	local root = inst[3]
+
+	AssertIsTable(root)
+
+	--[[@cast root Control]]
+
+	root:ChangeParent(dest)
+	inst[4] = dest
+
+	return inst
+end
+
+CPK.UI.Control.Instance.Move = MoveControlInstance

--- a/(1) Community Patch/Kit/Util/CPK.Util.Queue.lua
+++ b/(1) Community Patch/Kit/Util/CPK.Util.Queue.lua
@@ -1,0 +1,109 @@
+local lua_setmetatable = setmetatable
+
+--- FIFO queue backed by two internal stacks.
+--- Items are pushed onto one stack and popped from the other.
+--- When the pop-side runs empty it is refilled by reversing the push-side,
+--- keeping both Push and Pop amortized O(1).
+--- @generic T
+--- @class Queue<T>
+--- @field protected pushed_items T[]
+--- @field protected pushed_count integer
+--- @field protected popped_items T[]
+--- @field protected popped_count integer
+--- @field public Pop  fun(self: Queue<T>): T | nil
+--- @field public Peek fun(self: Queue<T>): T | nil
+--- @field public Push fun(self: Queue<T>, item: T): Queue<T>
+--- @field public Size fun(self: Queue<T>): integer
+--- @field public Empty fun(self: Queue<T>): boolean
+local QueueImpl = {}
+
+--- @package
+function QueueImpl:Drain()
+	local pushed = self.pushed_items
+	local popped = self.popped_items
+	local count  = self.pushed_count
+
+	local j      = 1
+
+	for i = count, 1, -1 do
+		popped[j] = pushed[i]
+		pushed[i] = nil
+		j = j + 1
+	end
+
+	self.popped_count = count
+	self.pushed_count = 0
+end
+
+--- Removes and returns the value from the front of the queue.
+function QueueImpl:Pop()
+	if self.popped_count <= 0 then
+		if self.pushed_count <= 0 then
+			return nil
+		end
+
+		self:Drain()
+	end
+
+	local count = self.popped_count
+	local item = self.popped_items[count]
+
+	self.popped_items[count] = nil
+	self.popped_count = count - 1
+
+	return item
+end
+
+--- Returns the value at the front of the queue without removing it.
+function QueueImpl:Peek()
+	if self.popped_count <= 0 then
+		if self.pushed_count <= 0 then
+			return nil
+		end
+
+		self:Drain()
+	end
+
+	return self.popped_items[self.popped_count]
+end
+
+--- Adds one value to the back of the queue.
+--- If value is nil then does nothing.
+function QueueImpl:Push(item)
+	if item ~= nil then
+		local count = self.pushed_count + 1
+		self.pushed_items[count] = item
+		self.pushed_count = count
+	end
+
+	return self
+end
+
+--- Returns the number of items currently in the queue.
+function QueueImpl:Size()
+	return self.pushed_count + self.popped_count
+end
+
+--- Checks if the queue is empty (has 0 items).
+function QueueImpl:Empty()
+	return self.pushed_count <= 0 and self.popped_count <= 0
+end
+
+--- @class QueueMeta
+local QueueMeta = {}
+
+--- @package
+QueueMeta.__index = QueueImpl
+
+--- Creates a new, empty FIFO queue.
+--- @return Queue<unknown>
+function QueueMeta.New()
+	return lua_setmetatable({
+		pushed_items = {},
+		pushed_count = 0,
+		popped_items = {},
+		popped_count = 0,
+	}, QueueMeta)
+end
+
+CPK.Util.Queue = QueueMeta

--- a/(1) Community Patch/Kit/Util/CPK.Util.Stack.lua
+++ b/(1) Community Patch/Kit/Util/CPK.Util.Stack.lua
@@ -1,18 +1,20 @@
 local lua_setmetatable = setmetatable
-local lua_table_remove = table.remove
 
+--- LIFO stack. Items are pushed and popped from the same end (top).
 --- @generic T
 --- @class Stack<T>
---- @field protected items any[]
+--- @field protected items T[]
 --- @field protected count integer
+--- @field public Pop fun(self: Stack<T>): T | nil
+--- @field public Peek fun(self: Stack<T>): T | nil
+--- @field public Push fun(self: Stack<T>, item: T): Stack<T>
+--- @field public Size fun(self: Stack<T>): integer
+--- @field public Empty fun(self: Stack<T>): boolean
 local StackImpl = {}
 
 --- Removes and returns the value from the top of the stack.
---- @return any
 function StackImpl:Pop()
-	if self.count <= 0 then
-		return nil
-	end
+	if self.count <= 0 then return nil end
 
 	local item = lua_table_remove(self.items)
 	self.count = self.count - 1
@@ -21,14 +23,12 @@ function StackImpl:Pop()
 end
 
 --- Returns the value at the top of the stack without removing it.
---- @return T
 function StackImpl:Peek()
 	return self.items[self.count]
 end
 
 --- Adds one value to the top of the stack.
 --- If value is nil then does nothing.
---- @param item any
 function StackImpl:Push(item)
 	if item ~= nil then
 		self.count = self.count + 1
@@ -39,13 +39,11 @@ function StackImpl:Push(item)
 end
 
 --- Returns the number of items currently in the stack.
---- @return integer # The number of items.
 function StackImpl:Size()
 	return self.count
 end
 
 --- Checks if the stack is empty (has 0 items).
---- @return boolean
 function StackImpl:Empty()
 	return self.items[1] == nil
 end
@@ -57,10 +55,8 @@ local StackMeta = {}
 StackMeta.__index = StackImpl
 
 --- Creates a new, empty stack.
---- @generic T
---- @param _ nil | `T`
---- @return Stack<T>
-function StackMeta.New(_)
+--- @return Stack<unknown>
+function StackMeta.New()
 	local this = {
 		count = 0,
 		items = {}


### PR DESCRIPTION
## CPK Instance Manager

Adds a managed lifecycle replacement for the base game `InstanceManager`, alongside two supporting utilities.

### Motivation

The base game `InstanceManager` has no lifecycle hooks, no state tracking, no good error reporting, and locks the parent control at construction time. Every UI screen that uses it ends up with the same boilerplate: manual show/hide, no visibility into what is active or pooled, and silent failures when instances are misused. This PR introduces a CPK replacement that addresses all of that while keeping the migration path straightforward.

### New files

**`CPK.UI.Control.Instance.Manager`** — the main addition. Manages UI control instances through three states: *acquired* (in use), *recycled* (returned to the free list, hidden), and *released* (permanently destroyed).
- `Acquire(parent)` / `Recycle(inst)` / `Release(inst)` — core lifecycle
- `onCreated` fires once on first allocation — good for registering callbacks and static setup
- `onAcquire` / `onRecycle` / `onRelease` hooks for per-use configuration and cleanup
- `mode = 'LIFO'` (default) or `'FIFO'` ordering of the recycled free list — FIFO gives stable sequential ordering without needing `SortChildren`
- `RecycleAcquired()` / `ReleaseRecycled()` for bulk operations
- `HasInstance` / `HasAcquired` / `HasRecycled` / `Size` / `CountAcquired` / `CountRecycled` for inspection
- Error messages with pool state, instance details, current game state and context

**`CPK.Util.Queue`** — two-stack amortised O(1) FIFO queue with the same `Push` / `Pop` / `Peek` / `Size` / `Empty` interface as `Stack`, usable as a drop-in alternative inside the manager for ordered recycling.