### PR TITLE
Rome UA Fixes

### DIFF
--- a/(2) Vox Populi/LUA/CityBannerManager.lua
+++ b/(2) Vox Populi/LUA/CityBannerManager.lua
@@ -322,7 +322,7 @@ function RefreshCityBanner(cityBanner, iActiveTeam, iActivePlayer)
 			controls.PuppetIcon:SetHide(true);
 		end
 
-		-- Rome UA (Annexed City-States)
+		-- Annexed City-States
 		controls.CityStateIcon:SetHide ( not Players[city:GetOriginalOwner()]:IsMinorCiv() or not player:IsAnnexedCityStatesGiveYields())
 		if Players[city:GetOriginalOwner()]:IsMinorCiv() and player:IsAnnexedCityStatesGiveYields() then
 			local cityOriginalOwner = Players[city:GetOriginalOwner()];

--- a/(2) Vox Populi/LUA/CityStateDiploPopup.lua
+++ b/(2) Vox Populi/LUA/CityStateDiploPopup.lua
@@ -1260,7 +1260,7 @@ end
 Controls.UnitTributeButton:RegisterCallback( Mouse.eLClick, OnUnitTributeButtonClicked );
 
 ----------------------------------------------------------------
--- CBP: Forced Annex (Rome UA)
+-- CBP: Forced Annex
 ----------------------------------------------------------------
 function OnBullyAnnexButtonClicked()
 	local pPlayer = Players[g_iMinorCivID];

--- a/(3a) VP - EUI Compatibility Files/LUA/CityBannerManager.lua
+++ b/(3a) VP - EUI Compatibility Files/LUA/CityBannerManager.lua
@@ -1090,7 +1090,7 @@ local function RefreshCityBannersNow()
 			-- Puppet ?
 			instance.CityIsPuppet:SetHide( not isPuppet )
 
-			-- Rome UA (Annexed City-States)
+			-- Annexed City-States
 			if Players[city:GetOriginalOwner()]:IsMinorCiv() then
 				instance.CityIsCityState:SetHide ( not cityOwner:IsAnnexedCityStatesGiveYields())
 			end

--- a/(3a) VP - EUI Compatibility Files/LUA/CityStateDiploPopup.lua
+++ b/(3a) VP - EUI Compatibility Files/LUA/CityStateDiploPopup.lua
@@ -1309,7 +1309,7 @@ end
 Controls.UnitTributeButton:RegisterCallback( Mouse.eLClick, OnUnitTributeButtonClicked )
 
 ----------------------------------------------------------------
--- CBP: Forced Annex (Rome UA)
+-- CBP: Forced Annex
 ----------------------------------------------------------------
 function OnBullyAnnexButtonClicked()
 	local minorPlayer = Players[g_minorCivID]

--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -28877,10 +28877,10 @@ void CvCity::UpdateYieldsFromExistingFriendsAndAllies(bool bRemove)
 	//this method should only be called once per city on its first turn or when the capital moves ...
 
 	int iSign = bRemove ? -1 : +1;
-
+	CvPlayer& kPlayer = GET_PLAYER(getOwner());
+	
 	if (isCapital())
 	{
-		CvPlayer& kPlayer = GET_PLAYER(getOwner());
 		int iNumAllies = kPlayer.GetNumCSAllies();
 		int iNumFriends = kPlayer.GetNumCSFriends();
 		if (iNumAllies > 0 || iNumFriends > 0)
@@ -28895,6 +28895,21 @@ void CvCity::UpdateYieldsFromExistingFriendsAndAllies(bool bRemove)
 		}
 	}
 
+	// Rome UA
+	if (kPlayer.GetPlayerTraits()->IsAnnexedCityStatesGiveYields())
+	{
+		for (int iI = 0; iI < NUM_YIELD_TYPES; iI++)
+		{
+			YieldTypes eYield = (YieldTypes)iI;
+			int iAnnexedYields += isCapital() ? kPlayer.GetYieldInCapitalPerTurnFromAnnexedMinorsTimes100(eYield) : kPlayer.GetYieldInOtherCitiesPerTurnFromAnnexedMinorsTimes100(eYield);
+			if (iAnnexedYields != 0)
+			{
+				ChangeBaseYieldRateFromCSAllianceTimes100(eYield, iBonus);
+				//CUSTOMLOG("adjusted %s in %s by %d/100 for annexation, current value is %d", GC.getYieldInfo(eYield)->getDescription(), getNameKey(), iSign * iAnnexedYields, GetBaseYieldRateFromCSAlliance(eYield));
+			}
+		}
+	}
+	
 	for (int iPlayerLoop = MAX_MAJOR_CIVS; iPlayerLoop < MAX_CIV_PLAYERS; iPlayerLoop++)
 	{
 		PlayerTypes eCityOwner = (PlayerTypes)getOwner();

--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -28895,7 +28895,7 @@ void CvCity::UpdateYieldsFromExistingFriendsAndAllies(bool bRemove)
 		}
 	}
 
-	// Rome UA
+	// Annexed CS
 	if (kPlayer.GetPlayerTraits()->IsAnnexedCityStatesGiveYields())
 	{
 		for (int iI = 0; iI < NUM_YIELD_TYPES; iI++)

--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -28901,10 +28901,10 @@ void CvCity::UpdateYieldsFromExistingFriendsAndAllies(bool bRemove)
 		for (int iI = 0; iI < NUM_YIELD_TYPES; iI++)
 		{
 			YieldTypes eYield = (YieldTypes)iI;
-			int iAnnexedYields += isCapital() ? kPlayer.GetYieldInCapitalPerTurnFromAnnexedMinorsTimes100(eYield) : kPlayer.GetYieldInOtherCitiesPerTurnFromAnnexedMinorsTimes100(eYield);
+			int iAnnexedYields = isCapital() ? kPlayer.GetYieldInCapitalPerTurnFromAnnexedMinorsTimes100(eYield) : kPlayer.GetYieldInOtherCitiesPerTurnFromAnnexedMinorsTimes100(eYield);
 			if (iAnnexedYields != 0)
 			{
-				ChangeBaseYieldRateFromCSAllianceTimes100(eYield, iBonus);
+				ChangeBaseYieldRateFromCSAllianceTimes100(eYield, iAnnexedYields);
 				//CUSTOMLOG("adjusted %s in %s by %d/100 for annexation, current value is %d", GC.getYieldInfo(eYield)->getDescription(), getNameKey(), iSign * iAnnexedYields, GetBaseYieldRateFromCSAlliance(eYield));
 			}
 		}

--- a/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
@@ -14874,7 +14874,7 @@ int CvMinorCivAI::GetSpawnBaseTurns(PlayerTypes ePlayer, bool bCityStateAnnexed)
 		return 0;
 
 	// Not friends
-	// Rome Exception: Annexed Militaristic City-States continue to give units at an allied level
+	// Trait Exception: Annexed Militaristic City-States continue to give units at an allied level
 	if (!bCityStateAnnexed && !IsFriends(ePlayer))
 		return 0;
 
@@ -15255,7 +15255,7 @@ void CvMinorCivAI::DoBuyout(PlayerTypes eMajor)
 	}
 }
 
-/// Transfers all of this City-State's units and cities to eMajor. Called by an Austrian buyout (see above) as well as by the Merchant of Venice's buyout mission and the Rome forced annex.
+/// Transfers all of this City-State's units and cities to eMajor. Called by an Austrian buyout (see above) as well as by the Merchant of Venice's buyout mission and trait ability to force annex.
 int CvMinorCivAI::TransferUnitsAndCitiesToMajor(PlayerTypes eMajor, bool bForced)
 {
 	// Transfer all units

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -23014,12 +23014,13 @@ void CvPlayer::ChangeYieldInCapitalPerTurnFromAnnexedMinorTimes100(PlayerTypes e
 			int iBonus = 0;
 			YieldTypes eYield = (YieldTypes)iI;
 			
+			iBonus += GET_PLAYER(eMinor).GetMinorCivAI()->GetCityYieldFriendFlatBonusTimes100(GetID(), eYield, eEra, true);
 			iBonus += GET_PLAYER(eMinor).GetMinorCivAI()->GetCityYieldAllyFlatBonusTimes100(GetID(), eYield, eEra, true);
 			iBonus *= iSign;
 	
 			//update if necessary
 			//bonus yields are tracked on city level
-			getCapitalCity()->ChangeBaseYieldRateFromCSAllianceTimes100(eYield, iBonus);
+			getCapitalCity()->ChangeBaseYieldRateFromCSAllianceTimes100(eYield, iBonus);  // all recorded under ally
 			m_piYieldInCapitalFromAnnexedMinorsTimes100[eYield] += iBonus;
 		}
 	}
@@ -23045,6 +23046,7 @@ void CvPlayer::ChangeYieldInOtherCitiesPerTurnFromAnnexedMinorTimes100(PlayerTyp
 			int iBonus = 0;
 			YieldTypes eYield = (YieldTypes)iI;
 			
+			iBonus += GET_PLAYER(eMinor).GetMinorCivAI()->GetCityYieldFriendFlatBonusTimes100(GetID(), eYield, eEra, false);
 			iBonus += GET_PLAYER(eMinor).GetMinorCivAI()->GetCityYieldAllyFlatBonusTimes100(GetID(), eYield, eEra, false);
 			iBonus *= iSign;
 	
@@ -23077,11 +23079,14 @@ void CvPlayer::ChangeYieldPerTurnFromAnnexedMinorTimes100(PlayerTypes eMinor, in
 		const CvMinorCivAI* kMinor = GET_PLAYER(eMinor).GetMinorCivAI();
 		for (int iI = 0; iI < NUM_YIELD_TYPES; iI++)
 		{
+			int iBonus = 0;
 			YieldTypes eYield = (YieldTypes)iI;
 		
-			int iBonus = kMinor->GetYieldAllyFlatBonusTimes100(GetID(), eYield, eEra);
+			iBonus += kMinor->GetYieldFriendFlatBonusTimes100(GetID(), eYield, eEra);
+			iBonus += kMinor->GetYieldAllyFlatBonusTimes100(GetID(), eYield, eEra);
+			iBonus *= iSign;
 		
-			m_piYieldPerTurnFromAnnexedMinorsTimes100[eYield] += iBonus * iSign;
+			m_piYieldPerTurnFromAnnexedMinorsTimes100[eYield] += iBonus;
 		}
 	}
 }

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -4238,7 +4238,7 @@ CvCity* CvPlayer::acquireCity(CvCity* pCity, bool bConquest, bool bGift, bool bO
 	GET_PLAYER(eOldOwner).DoUpdateProximityToPlayers();
 	DoUpdateProximityToPlayers();
 
-	// Rome UA
+	// Annexed CS
 	if (bOriginalMinorCapital)
 	{
 		if (isMajorCiv())
@@ -10056,7 +10056,7 @@ void CvPlayer::doTurn()
 	if(GetTurnsSinceSettledLastCity() >= 0)
 		ChangeTurnsSinceSettledLastCity(1);
 
-	// update timers for unit gifts from annexed city states (Rome UA) and spawn units
+	// update timers for unit gifts from annexed city states and spawn units
 	if (GetPlayerTraits()->IsAnnexedCityStatesGiveYields())
 	{
 		updateTimerAnnexedMilitaryCityStates();
@@ -22916,7 +22916,7 @@ void CvPlayer::ChangeConversionModifier(int iChange)
 	m_iConversionModifier = (m_iConversionModifier + iChange);
 }
 
-// set of functions needed to operate bonus from annexed city states trait (rome UA)
+// set of functions needed to operate bonus from annexed city states trait
 void CvPlayer::addAnnexedCityState(PlayerTypes eMinor)
 {
 	// city states shouldn't be already in the list
@@ -22993,14 +22993,14 @@ void CvPlayer::ChangeNumAnnexedCityStates(int iChange)
 	}
 }
 
-/// Get the yields in the capital from annexed City-States (Rome UA)
+/// Get the yields in the capital from annexed City-States
 int CvPlayer::GetYieldInCapitalPerTurnFromAnnexedMinorsTimes100(YieldTypes eYield) const
 {
 	PRECONDITION(eYield >= 0, "eIndex is expected to be non-negative (invalid Index)");
 	PRECONDITION(eYield < NUM_YIELD_TYPES, "eIndex is expected to be within maximum bounds (invalid Index)");
 	return m_piYieldInCapitalFromAnnexedMinorsTimes100[eYield];
 }
-/// Update the yields in the capital from annexed City-States (Rome UA)
+/// Update the yields in the capital from annexed City-States
 void CvPlayer::ChangeYieldInCapitalPerTurnFromAnnexedMinorTimes100(PlayerTypes eMinor, int iSign, EraTypes eEra)
 {
 	if (GetPlayerTraits()->IsAnnexedCityStatesGiveYields() && getCapitalCity())
@@ -23025,14 +23025,14 @@ void CvPlayer::ChangeYieldInCapitalPerTurnFromAnnexedMinorTimes100(PlayerTypes e
 		}
 	}
 }
-/// Get the yields in other cities from annexed City-States (Rome UA)
+/// Get the yields in other cities from annexed City-States
 int CvPlayer::GetYieldInOtherCitiesPerTurnFromAnnexedMinorsTimes100(YieldTypes eYield) const
 {
 	PRECONDITION(eYield >= 0, "eIndex is expected to be non-negative (invalid Index)");
 	PRECONDITION(eYield < NUM_YIELD_TYPES, "eIndex is expected to be within maximum bounds (invalid Index)");
 	return m_piYieldInOtherCitiesFromAnnexedMinorsTimes100[eYield];
 }
-/// Update the yields in other cities from annexed City-States (Rome UA)
+/// Update the yields in other cities from annexed City-States
 void CvPlayer::ChangeYieldInOtherCitiesPerTurnFromAnnexedMinorTimes100(PlayerTypes eMinor, int iSign, EraTypes eEra)
 {
 	if (GetPlayerTraits()->IsAnnexedCityStatesGiveYields())
@@ -23060,14 +23060,14 @@ void CvPlayer::ChangeYieldInOtherCitiesPerTurnFromAnnexedMinorTimes100(PlayerTyp
 		}
 	}
 }
-/// Get the yields per turn from annexed City-States (Rome UA)
+/// Get the yields per turn from annexed City-States
 int CvPlayer::GetYieldPerTurnFromAnnexedMinorsTimes100(YieldTypes eYield) const
 {
 	PRECONDITION(eYield >= 0, "eIndex is expected to be non-negative (invalid Index)");
 	PRECONDITION(eYield < NUM_YIELD_TYPES, "eIndex is expected to be within maximum bounds (invalid Index)");
 	return m_piYieldPerTurnFromAnnexedMinorsTimes100[eYield];
 }
-/// Update the yields per turn from annexed City-States (Rome UA)
+/// Update the yields per turn from annexed City-States
 void CvPlayer::ChangeYieldPerTurnFromAnnexedMinorTimes100(PlayerTypes eMinor, int iSign, EraTypes eEra)
 {
 	if (GetPlayerTraits()->IsAnnexedCityStatesGiveYields())
@@ -23090,12 +23090,12 @@ void CvPlayer::ChangeYieldPerTurnFromAnnexedMinorTimes100(PlayerTypes eMinor, in
 		}
 	}
 }
-/// Get the happiness per turn from annexed City-States (Rome UA)
+/// Get the happiness per turn from annexed City-States
 int CvPlayer::GetHappinessFromAnnexedMinors() const
 {
 	return m_iHappinessFromAnnexedMinors;
 }
-/// Update the happiness per turn from annexed City-States (Rome UA)
+/// Update the happiness per turn from annexed City-States
 void CvPlayer::ChangeHappinessFromAnnexedMinor(PlayerTypes eMinor, int iSign, EraTypes eEra)
 {
 	if (GetPlayerTraits()->IsAnnexedCityStatesGiveYields() && (GET_PLAYER(eMinor).GetMinorCivAI()->GetTrait() == MINOR_CIV_TRAIT_MERCANTILE))
@@ -33074,7 +33074,7 @@ void CvPlayer::setTurnActive(bool bNewValue, bool bDoTurn) // R: bDoTurn default
 							iExpectedAlliance += GetPlayerTraits()->GetYieldFromCSAlly(eYield) * iNumAllies * iEra * 100;
 							iExpectedFriendship += GetPlayerTraits()->GetYieldFromCSFriend(eYield) * iNumFriends * iEra * 100;
 						}
-						// Rome UA
+						// Annexed CS
 						if (GetPlayerTraits()->IsAnnexedCityStatesGiveYields())
 						{
 							iExpectedAlliance += pCity->isCapital() ? GetYieldInCapitalPerTurnFromAnnexedMinorsTimes100(eYield) : GetYieldInOtherCitiesPerTurnFromAnnexedMinorsTimes100(eYield);

--- a/CvGameCoreDLL_Expansion2/CvTreasury.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTreasury.cpp
@@ -415,7 +415,7 @@ int CvTreasury::CalculateGrossGoldTimes100()
 		iNetGold += m_pPlayer->GetYieldPerTurnFromMinors(YIELD_GOLD) * 100;
 	}
 
-	// Annexed City-States (Rome UA)
+	// Annexed City-States
 	iNetGold += m_pPlayer->GetYieldPerTurnFromAnnexedMinorsTimes100(YIELD_GOLD);
 
 	//Espionage Events


### PR DESCRIPTION
1. Update yields on newly acquired cities, fixes #12791 #13021

2. Include friend yields as well as ally, so yields indeed behave as if the annexed CS "were allies"