### PR TITLE
(10-004c) colonialism rebalance (no new generalized bonus)

### DIFF
--- a/(2) Vox Populi/Database Changes/Policies/Imperialism.sql
+++ b/(2) Vox Populi/Database Changes/Policies/Imperialism.sql
@@ -90,8 +90,8 @@ VALUES
 -- Naval Tradition (now Colonialism)
 UPDATE Policies
 SET
-	MonopolyModPercent = 10,
-	MonopolyModFlat = 3
+	MonopolyModPercent = 5,
+	MonopolyModFlat = 5
 WHERE Type = 'POLICY_NAVAL_TRADITION';
 
 DELETE FROM Policy_BuildingClassHappiness

--- a/(2) Vox Populi/Database Changes/Text/en_US/Civilizations/CivilizationTextChanges.sql
+++ b/(2) Vox Populi/Database Changes/Text/en_US/Civilizations/CivilizationTextChanges.sql
@@ -450,7 +450,7 @@ SET Text = 'Sumpah Palapa'
 WHERE Tag = 'TXT_KEY_TRAIT_SPICE_SHORT';
 
 UPDATE Language_en_US
-SET Text = 'When you gain a City, one of 3 unique Luxuries ([ICON_RES_CLOVES]/[ICON_RES_PEPPER]/[ICON_RES_NUTMEG]) will appear nearby. +5% to unique Yield and [ICON_GOLDEN_AGE] Golden Age duration modifiers from [ICON_MONOPOLY] Global Monopolies; +2 to Yields and [ICON_HAPPINESS_1] Happiness from [ICON_MONOPOLY] Global Monopolies.'
+SET Text = 'When you gain a City, one of 3 unique Luxuries ([ICON_RES_CLOVES]/[ICON_RES_PEPPER]/[ICON_RES_NUTMEG]) will appear nearby. Each [ICON_MONOPOLY] Global Monopoly Bonus is increased by an additional 5% if it''s percentage-based, or by +2 otherwise.'
 WHERE Tag = 'TXT_KEY_TRAIT_SPICE';
 
 UPDATE Language_en_US

--- a/(2) Vox Populi/Database Changes/Text/en_US/Policies/PolicyTextChanges.sql
+++ b/(2) Vox Populi/Database Changes/Text/en_US/Policies/PolicyTextChanges.sql
@@ -350,7 +350,7 @@ SET Text = 'Exchange Markets'
 WHERE Tag = 'TXT_KEY_POLICY_CULTURAL_DIPLOMACY';
 
 UPDATE Language_en_US
-SET Text = '[COLOR_POSITIVE_TEXT]Exchange Markets[ENDCOLOR][NEWLINE][ICON_BULLET]+1 [ICON_INTERNATIONAL_TRADE] Trade Route.[NEWLINE][ICON_BULLET]+15% [ICON_TOURISM] Tourism modifier for [COLOR_POSITIVE_TEXT]Trade Routes[ENDCOLOR].[NEWLINE][ICON_BULLET]+1 of every Strategic Resource for every three City-State Alliances you maintain.[NEWLINE][ICON_BULLET]Resources from City-States count towards Global Monopolies.'
+SET Text = '[COLOR_POSITIVE_TEXT]Exchange Markets[ENDCOLOR][NEWLINE][ICON_BULLET]+1 [ICON_INTERNATIONAL_TRADE] Trade Route.[NEWLINE][ICON_BULLET]+15% [ICON_TOURISM] Tourism modifier for [COLOR_POSITIVE_TEXT]Trade Routes[ENDCOLOR].[NEWLINE][ICON_BULLET]+1 of every Strategic Resource for every three [ICON_CITY_STATE] City-State Alliances you maintain.[NEWLINE][ICON_BULLET]Resources from [ICON_CITY_STATE] City-States count towards [ICON_MONOPOLY] Global Monopolies.'
 WHERE Tag = 'TXT_KEY_POLICY_CULTURAL_DIPLOMACY_HELP';
 
 UPDATE Language_en_US
@@ -362,7 +362,7 @@ SET Text = 'Trade Confederacy'
 WHERE Tag = 'TXT_KEY_POLICY_MERCHANT_CONFEDERACY';
 
 UPDATE Language_en_US
-SET Text = '[COLOR_POSITIVE_TEXT]Trade Confederacy[ENDCOLOR][NEWLINE][ICON_BULLET]+1 [ICON_HAPPINESS_1] Happiness for every active [ICON_INTERNATIONAL_TRADE] Trade Route.[NEWLINE][ICON_BULLET]+25% Yields for International [ICON_INTERNATIONAL_TRADE] Trade Routes.[NEWLINE][ICON_BULLET][ICON_INTERNATIONAL_TRADE] Trade Routes to City-States generate +1 [ICON_INFLUENCE] Influence per turn (with the target City-State) per each owned City-State Trade Route (up to +5).'
+SET Text = '[COLOR_POSITIVE_TEXT]Trade Confederacy[ENDCOLOR][NEWLINE][ICON_BULLET]+1 [ICON_HAPPINESS_1] Happiness for every active [ICON_INTERNATIONAL_TRADE] Trade Route.[NEWLINE][ICON_BULLET]+25% Yields for International [ICON_INTERNATIONAL_TRADE] Trade Routes.[NEWLINE][ICON_BULLET][ICON_INTERNATIONAL_TRADE] Trade Routes to City-States generate +1 [ICON_INFLUENCE] Influence per turn (with the target [ICON_CITY_STATE] City-State) per each owned City-State Trade Route (up to +5).'
 WHERE Tag = 'TXT_KEY_POLICY_MERCHANT_CONFEDERACY_HELP';
 
 UPDATE Language_en_US
@@ -569,7 +569,7 @@ SET Text = 'Colonialism'
 WHERE Tag = 'TXT_KEY_POLICY_NAVAL_TRADITION';
 
 UPDATE Language_en_US
-SET Text = '[COLOR_POSITIVE_TEXT]Colonialism[ENDCOLOR][NEWLINE][ICON_BULLET]+2 [ICON_RESEARCH] Science and +1 [ICON_CULTURE] Culture from Barracks, Armories, Military Academies, Forts, and Citadels.[NEWLINE][ICON_BULLET]Each unique [ICON_MONOPOLY] Global Monopoly modifier is increased by an additional 10% if it''s percentage-based, or +3 otherwise.'
+SET Text = '[COLOR_POSITIVE_TEXT]Colonialism[ENDCOLOR][NEWLINE][ICON_BULLET]+2 [ICON_RESEARCH] Science and +1 [ICON_CULTURE] Culture from Barracks, Armories, Military Academies, Forts, and Citadels.[NEWLINE][ICON_BULLET]Each [ICON_MONOPOLY] Global Monopoly Bonus is increased by an additional 5% if it''s percentage-based, or by +5 otherwise.'
 WHERE Tag = 'TXT_KEY_POLICY_NAVAL_TRADITION_HELP';
 
 UPDATE Language_en_US

--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -22677,7 +22677,6 @@ int CvCity::getBaseYieldRateModifier(YieldTypes eIndex, int iAssumedExtraModifie
 		int iTempMod = kOwner.getCityYieldModFromMonopoly(eIndex);
 		if (iTempMod != 0)
 		{
-			iTempMod += kOwner.GetMonopolyModPercent();
 			iModifier += iTempMod;
 			if (toolTipSink)
 			{

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -30733,6 +30733,25 @@ int CvPlayer::GetMonopolyModFlat() const
 void CvPlayer::ChangeMonopolyModPercent(int iChange)
 {
 	m_iMonopolyModPercent += iChange;
+
+	// all the yield monopolies you already have need to be updated
+	for (int iResourceLoop = 0; iResourceLoop < GC.getNumResourceInfos(); iResourceLoop++)
+	{
+		ResourceTypes eResource = (ResourceTypes) iResourceLoop;
+		CvResourceInfo* pkResource = GC.getResourceInfo(eResource);
+		if (pkResource && m_pabHasGlobalMonopoly[eResource])
+		{
+			for (int iI = 0; iI < NUM_YIELD_TYPES; iI++)
+			{
+				eYield = (YieldTypes)iI;
+
+				if (pResource->getCityYieldModFromMonopoly(eYield) != 0)
+				{
+					changeCityYieldModFromMonopoly(eYield, iChange);
+				}
+			}
+		}
+	}
 }
 void CvPlayer::SetMonopolyModPercent(int iChange)
 {
@@ -38042,6 +38061,7 @@ void CvPlayer::SetHasGlobalMonopoly(ResourceTypes eResource, bool bNewValue)
 				int iModValue = pResource->getCityYieldModFromMonopoly(eYield);
 				if (iModValue != 0)
 				{
+					iModValue += GetMonopolyModPercent();
 					if (bNewValue)
 					{
 						changeCityYieldModFromMonopoly(eYield, iModValue);

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -30735,9 +30735,10 @@ void CvPlayer::ChangeMonopolyModPercent(int iChange)
 	m_iMonopolyModPercent += iChange;
 
 	// all the yield monopolies you already have need to be updated
-	for (int iResourceLoop = 0; iResourceLoop < GC.getNumResourceInfos(); iResourceLoop++)
+	const std::vector<ResourceTypes>& vGlobalMonopolies = GetGlobalMonopolies();
+	for (int iResourceLoop = 0; iResourceLoop < vGlobalMonopolies.size(); iResourceLoop++)
 	{
-		ResourceTypes eResource = (ResourceTypes) iResourceLoop;
+		ResourceTypes eResource = vGlobalMonopolies[iResourceLoop];
 		CvResourceInfo* pkResource = GC.getResourceInfo(eResource);
 		if (pkResource && m_pabHasGlobalMonopoly[eResource])
 		{

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -30743,9 +30743,9 @@ void CvPlayer::ChangeMonopolyModPercent(int iChange)
 		{
 			for (int iI = 0; iI < NUM_YIELD_TYPES; iI++)
 			{
-				eYield = (YieldTypes)iI;
+				YieldTypes eYield = (YieldTypes)iI;
 
-				if (pResource->getCityYieldModFromMonopoly(eYield) != 0)
+				if (pkResource->getCityYieldModFromMonopoly(eYield) != 0)
 				{
 					changeCityYieldModFromMonopoly(eYield, iChange);
 				}


### PR DESCRIPTION
The "sensible" way to implement this means it will also affect the Indonesia trait. Therefore this is an out-of-congress balance change and needs approval.
Personally, I think that's probably fine gameplay-wise: the unique restriction is easy to miss and the logic about changing the Imperialism policy also applies to the Indonesia trait.
Note however that Indonesia went up a lot in latest AI test, from 18th place to 5th.

For the Golden Age Yield % modifiers, it seems like these already stacked?
They are calculated on-the-fly as a loop over resources, and the monopoly mod bonus is added per-resource
```
// Resource monopolies (not cached, so give an option to skip this check)
    if (MOD_BALANCE_RESOURCE_MONOPOLIES && bCheckMonopolies)
    {
        for (int iResourceLoop = 0; iResourceLoop < GC.getNumResourceInfos(); iResourceLoop++)
        {
            ResourceTypes eResourceLoop = (ResourceTypes)iResourceLoop;
            if (eResourceLoop != NO_RESOURCE)
            {
                CvResourceInfo* pInfo = GC.getResourceInfo(eResourceLoop);
                if (pInfo && pInfo->isMonopoly())
                {
                    if (HasGlobalMonopoly(eResourceLoop) && pInfo->getMonopolyGALength() > 0)
                    {
                        int iTemp = pInfo->getMonopolyGALength();
                        iTemp += GetMonopolyModPercent();
                        iModifier += iTemp;
                    }
                }
            }
        }
    }
```
 
so either this was bugged and no one noticed, or I missed something?
