### PR TITLE
Tooltip fix: add bullet icon to CS per Wonder and Damage Reduction

### DIFF
--- a/(1) Community Patch/Database Changes/Text/en_US/UI/CoreNewUIText.xml
+++ b/(1) Community Patch/Database Changes/Text/en_US/UI/CoreNewUIText.xml
@@ -737,7 +737,7 @@
 			<Text>Up to {1_YieldBoosts} when [COLOR_POSITIVE_TEXT]Themed[ENDCOLOR]</Text>
 		</Row>
 		<Row Tag="TXT_KEY_PRODUCTION_BUILDING_DEFENSE_FROM_WONDERS">
-			<Text>+{1_Num} [ICON_STRENGTH] City Strength for every National/World Wonder in City</Text>
+			<Text>[ICON_BULLET]+{1_Num} [ICON_STRENGTH] City Strength for every National/World Wonder in City</Text>
 		</Row>
 		<Row Tag="TXT_KEY_PRODUCTION_BUILDING_DEFENSE_MODIFIER">
 			<Text>{2_Sign}{1_Num}% [ICON_STRENGTH] City Strength from Buildings</Text>
@@ -746,7 +746,7 @@
 			<Text>{2_Sign}{1_Num}% [ICON_STRENGTH] City Strength from Buildings in all Cities of your Team</Text>
 		</Row>
 		<Row Tag="TXT_KEY_PRODUCTION_BUILDING_DAMAGE_REDUCTION">
-			<Text>[ICON_STRENGTH] Damage Reduction: {2_Sign}{1_Num}</Text>
+			<Text>[ICON_BULLET][ICON_STRENGTH] Damage Reduction: {2_Sign}{1_Num}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_PRODUCTION_BUILDING_FREE_RESOURCE">
 			<Text>{2_Sign}{1_Num} {3_ResourceIcon} {4_Resource:textkey}</Text>


### PR DESCRIPTION
These guys use the non-bullet code so they need it in the text key
e.g.
<img width="417" height="168" alt="image" src="https://github.com/user-attachments/assets/5fa45713-7fc6-459f-9de4-f234272d0048" />
