### PR TITLE
Tooltip changes

### DIFF
--- a/(1) Community Patch/Core Files/Overrides/Includes/InfoTooltipInclude.lua
+++ b/(1) Community Patch/Core Files/Overrides/Includes/InfoTooltipInclude.lua
@@ -862,7 +862,13 @@ function GetHelpTextForUnit(eUnit, bIncludeRequirementsInfo, pCity, bExcludeName
 		end
 
 		if not kUnitInfo.PurchaseOnly then
-			AddTooltipPositive(tCosts, "TXT_KEY_PRODUCTION_COST_PRODUCTION", iProductionCost);
+			-- if production cost scales with era, it wouldn't be shown in pedia tooltip (no active city)
+			local iScalingProd = kUnitInfo.ProductionCostAddedPerEra;
+			if (iScalingProd > 0) and (not pActiveCity) then
+				AddTooltipPositive(tCosts, "TXT_KEY_PRODUCTION_COST_PRODUCTION_ADDED_PER_ERA", iProductionCost, iScalingProd);
+			else
+				AddTooltipPositive(tCosts, "TXT_KEY_PRODUCTION_COST_PRODUCTION", iProductionCost);
+			end
 		end
 		AddTooltipPositive(tCosts, "TXT_KEY_PRODUCTION_COST_GOLD", iGoldCost);
 		AddTooltipPositive(tCosts, "TXT_KEY_PRODUCTION_COST_FAITH", iFaithCost);

--- a/(1) Community Patch/Database Changes/Text/en_US/UI/CoreNewUIText.xml
+++ b/(1) Community Patch/Database Changes/Text/en_US/UI/CoreNewUIText.xml
@@ -403,7 +403,7 @@
 			<Text>Max Hit Points: {1_Num}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_PRODUCTION_UNIT_SIGHT">
-			<Text>[ICON_BULLET] Sight: {1_Num}</Text>
+			<Text>[ICON_VISION] Sight: {1_Num}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_PRODUCTION_UNIT_AIR_DEFENSE">
 			<Text>[ICON_AIRSTRIKE_DEFENSE] Air Strike Defense: {1_Num}</Text>
@@ -737,7 +737,7 @@
 			<Text>Up to {1_YieldBoosts} when [COLOR_POSITIVE_TEXT]Themed[ENDCOLOR]</Text>
 		</Row>
 		<Row Tag="TXT_KEY_PRODUCTION_BUILDING_DEFENSE_FROM_WONDERS">
-			<Text>+{1_Num} [ICON_STRENGTH] City Strength for every National/World Wonder in City</Text>
+			<Text>[ICON_BULLET]+{1_Num} [ICON_STRENGTH] City Strength for every National/World Wonder in City</Text>
 		</Row>
 		<Row Tag="TXT_KEY_PRODUCTION_BUILDING_DEFENSE_MODIFIER">
 			<Text>{2_Sign}{1_Num}% [ICON_STRENGTH] City Strength from Buildings</Text>
@@ -746,7 +746,7 @@
 			<Text>{2_Sign}{1_Num}% [ICON_STRENGTH] City Strength from Buildings in all Cities of your Team</Text>
 		</Row>
 		<Row Tag="TXT_KEY_PRODUCTION_BUILDING_DAMAGE_REDUCTION">
-			<Text>[ICON_STRENGTH] Damage Reduction: {2_Sign}{1_Num}</Text>
+			<Text>[ICON_BULLET][ICON_STRENGTH] Damage Reduction: {2_Sign}{1_Num}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_PRODUCTION_BUILDING_FREE_RESOURCE">
 			<Text>{2_Sign}{1_Num} {3_ResourceIcon} {4_Resource:textkey}</Text>
@@ -1088,7 +1088,7 @@
 			<Text>{2_Sign}{1_Num}% Duration for [ICON_INTERNATIONAL_TRADE] Trade Routes originated from this City</Text>
 		</Row>
 		<Row Tag="TXT_KEY_PRODUCTION_BUILDING_TRADE_UNIT_EXTRA_SIGHT">
-			<Text>{2_Sign}{1_Num} Sight for Trade Units</Text>
+			<Text>{2_Sign}{1_Num} [ICON_VISION] Sight for Trade Units</Text>
 		</Row>
 		<Row Tag="TXT_KEY_PRODUCTION_BUILDING_TRADE_UNIT_SPEED_MULTIPLIER">
 			<Text>{1_Num}x Speed for Trade Units</Text>

--- a/(1) Community Patch/Database Changes/Text/en_US/UI/CoreNewUIText.xml
+++ b/(1) Community Patch/Database Changes/Text/en_US/UI/CoreNewUIText.xml
@@ -299,6 +299,9 @@
 		<Row Tag="TXT_KEY_PRODUCTION_COST_PRODUCTION">
 			<Text>{1_Num} [ICON_PRODUCTION]</Text>
 		</Row>
+		<Row Tag="TXT_KEY_PRODUCTION_COST_PRODUCTION_ADDED_PER_ERA">
+			<Text>{1_Num} [ICON_PRODUCTION] + {2_Num} [ICON_PRODUCTION] per Era</Text>
+		</Row>
 		<Row Tag="TXT_KEY_PRODUCTION_COST_GOLD">
 			<Text>{1_Num} [ICON_GOLD]</Text>
 		</Row>

--- a/(2) Vox Populi/Database Changes/Text/en_US/Corporations/NewCorporationText.xml
+++ b/(2) Vox Populi/Database Changes/Text/en_US/Corporations/NewCorporationText.xml
@@ -53,7 +53,7 @@
 			<Text>+3 [ICON_CULTURE_LOCAL] Border Growth Points for every Global [ICON_FRANCHISE] Franchise. +15% [ICON_PRODUCTION] Production towards Military Units. When you train a Military Unit in this City, gain [ICON_RESEARCH] Science equal to 25% of the Unit's [ICON_PRODUCTION] Production cost.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CORPORATION_TRADE_ROUTE_BONUS_HEXXON_REFINERY">
-			<Text>[ICON_INTERNATIONAL_TRADE] Trade Routes from Cities with a Hexxon Refinery Office to Cities with a Hexxon Refinery Franchise produce +50% additional [ICON_SCIENCE] Science.</Text>
+			<Text>[ICON_INTERNATIONAL_TRADE] Trade Routes from Cities with a Hexxon Refinery Office to Cities with a Hexxon Refinery Franchise produce +50% additional [ICON_RESEARCH] Science.</Text>
 		</Row>
 		<Row Tag="TXT_KEY_CORPORATION_HEXXON_REFINERY_OFFICE_BENEFIT_HELP">
 			<Text>Current Office Bonus: {1_String}</Text>

--- a/(2) Vox Populi/Database Changes/Text/en_US/UnitPromotions/NewPromotionText.xml
+++ b/(2) Vox Populi/Database Changes/Text/en_US/UnitPromotions/NewPromotionText.xml
@@ -13,6 +13,11 @@
 			<Text>+1 [ICON_WAR] Attack.</Text>
 		</Row>
 
+		<!-- Flat Movement Cost -->
+		<Row Tag="TXT_KEY_PROMOTION_FLAT_MOVEMENT_COST_HELP">
+			<Text>All tiles cost 1 [ICON_MOVES] Movement.[NEWLINE][COLOR_NEGATIVE_TEXT]Cannot use Roads and Railroads.[ENDCOLOR]</Text>
+		</Row>
+		
 		<!-- Tank Hunter -->
 		<Row Tag="TXT_KEY_PROMOTION_HELI_AMBUSH_1_HELP">
 			<Text>+50% [ICON_STRENGTH] Combat Strength VS [COLOR_POSITIVE_TEXT]Armored Units[ENDCOLOR].</Text>

--- a/(2) Vox Populi/Database Changes/Text/en_US/UnitPromotions/PromotionTextChanges.sql
+++ b/(2) Vox Populi/Database Changes/Text/en_US/UnitPromotions/PromotionTextChanges.sql
@@ -494,7 +494,7 @@ SET Text = 'Can enter [COLOR_POSITIVE_TEXT]Impassable[ENDCOLOR] tiles, and can e
 WHERE Tag = 'TXT_KEY_PROMOTION_HOVERING_UNIT_HELP';
 
 UPDATE Language_en_US
-SET Text = 'All tiles cost 1 [ICON_MOVES] Movement.[NEWLINE][COLOR_NEGATIVE_TEXT]Cannot use Roads and Railroads.[ENDCOLOR]'
+SET Text = 'Flat Movement Cost'
 WHERE Tag = 'TXT_KEY_PROMOTION_FLAT_MOVEMENT_COST';
 
 UPDATE Language_en_US

--- a/(2) Vox Populi/Database Changes/UnitPromotions/OldPromotions.xml
+++ b/(2) Vox Populi/Database Changes/UnitPromotions/OldPromotions.xml
@@ -912,9 +912,9 @@
 		<Replace>
 			<Type>PROMOTION_FLAT_MOVEMENT_COST</Type>
 			<Description>TXT_KEY_PROMOTION_FLAT_MOVEMENT_COST</Description>
-			<Help>TXT_KEY_PROMOTION_FLAT_MOVEMENT_COST</Help>
+			<Help>TXT_KEY_PROMOTION_FLAT_MOVEMENT_COST_HELP</Help>
 			<PediaType>PEDIA_MOUNTED</PediaType>
-			<PediaEntry>TXT_KEY_PEDIA_PROMOTION_FLAT_MOVEMENT_COST</PediaEntry>
+			<PediaEntry>TXT_KEY_PROMOTION_FLAT_MOVEMENT_COST</PediaEntry>
 		</Replace>
 		<Replace>
 			<Type>PROMOTION_MUST_SET_UP</Type>

--- a/(3a) VP - EUI Compatibility Files/ImprovedTopPanel/TopPanel.lua
+++ b/(3a) VP - EUI Compatibility Files/ImprovedTopPanel/TopPanel.lua
@@ -1514,7 +1514,7 @@ if civ5_mode then
 			local BoredomUnhappiness = g_activePlayer:GetUnhappinessFromBoredom();
 			local ReligiousUnrestUnhappiness = g_activePlayer:GetUnhappinessFromReligiousUnrest();
 			local BuildingsUnhappiness = g_activePlayer:GetUnhappinessFromBuildings();
-			local UrbanizationUnhappiness = g_activePlayer:GetUnhappinessFromCitySpecialists() / 100;
+			local UrbanizationUnhappiness = g_activePlayer:GetUnhappinessFromCitySpecialists();
 			local UrbanizationPuppetUnhappiness = g_activePlayer:GetUnhappinessFromPuppetCitySpecialists();
 
 			tips:insert( "[COLOR:255:150:150:255]" )

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -22412,7 +22412,7 @@ int CvPlayer::GetUnhappinessFromCityJFDSpecial() const
 		iUnhappiness += pLoopCity->getJFDSpecialUnhappinessSources();
 	}
 
-	iUnhappiness += (GetUnhappinessFromCitySpecialists() / 100);
+	iUnhappiness += GetUnhappinessFromCitySpecialists();
 	return iUnhappiness;
 }
 

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -21828,12 +21828,12 @@ void CvUnit::changeExperienceTimes100(int iChangeTimes100, int iMax, bool bFromC
 		}
 		if (eNearestMinor != NO_PLAYER)
 		{
-			int iInfluenceGained = iUnitExperienceTimes100 * GetInfluenceFromCombatXPTimes100() / 100;
-			GET_PLAYER(eNearestMinor).GetMinorCivAI()->ChangeFriendshipWithMajorTimes100(getOwner(), iInfluenceGained);
+			int iInfluenceGainedTimes100 = GetInfluenceFromCombatXPTimes100() * iUnitExperienceTimes100 / 100;
+			GET_PLAYER(eNearestMinor).GetMinorCivAI()->ChangeFriendshipWithMajorTimes100(getOwner(), iInfluenceGainedTimes100);
 			if(getOwner() == GC.getGame().getActivePlayer())
 			{
 				char text[256] = {0};
-				sprintf_s(text, "[COLOR_WHITE]+%d[ENDCOLOR][ICON_INFLUENCE]", iInfluenceGained);
+				sprintf_s(text, "[COLOR_WHITE]+%d[ENDCOLOR][ICON_INFLUENCE]", iInfluenceGainedTimes100 / 100);
 				SHOW_PLOT_POPUP(plot(), getOwner(), text);
 			}
 		}

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaCity.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaCity.cpp
@@ -1638,7 +1638,6 @@ int CvLuaCity::lGetBuildingYieldRateTimes100(lua_State* L)
 	iYieldTimes100 += pkBuildingInfo->GetYieldPerFriendTimes100(eYield) * kPlayer.GetNumCSFriends();
 	iYieldTimes100 += pkBuildingInfo->GetYieldPerAllyTimes100(eYield) * kPlayer.GetNumCSAllies();
 	iYieldTimes100 += pkBuildingInfo->GetYieldChangePerMonopoly(eYield) * kPlayer.GetNumGlobalMonopolies() * 100;
-	iYieldTimes100 += (pkBuildingInfo->GetYieldChangePerBuilding(eYield) * pCity->GetCityBuildings()->GetNumBuildings() * 100).Truncate();
 
 	int iYieldPerReligion = pkBuildingInfo->GetYieldChangePerReligion(eYield);
 	if (iYieldPerReligion != 0)


### PR DESCRIPTION
These guys use the non-bullet code so they need it in the text key
e.g.
<img width="417" height="168" alt="image" src="https://github.com/user-attachments/assets/88a03986-d360-41b4-9e0f-d44a4e38e82d" />

non-standard sight values are shown (nice) but use a bullet, not an eye icon
it's also missing from the (atm unused) sight boost to TR units
<img width="233" height="109" alt="image" src="https://github.com/user-attachments/assets/91e1d334-6dde-4dbf-b31d-02d580844df0" />


