### PR TITLE
Override city production AI for Citizen Earth Protocol

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvCityAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCityAI.cpp
@@ -81,6 +81,14 @@ void CvCityAI::AI_chooseProduction(bool bInterruptWonders, bool bInterruptBuildi
 	if (isProductionSpaceshipPart())
 		return;
 
+	// the same is true for the Citizen Earth Protocol
+	if (MOD_BALANCE_CULTURE_VICTORY_CHANGES)
+	{
+		ProjectTypes eUtopia = (ProjectTypes)GC.getInfoTypeForString("PROJECT_UTOPIA_PROJECT", true);
+		if (eUtopia != NO_PROJECT && getProductionProject() == eUtopia)
+			return;
+	}
+
 	bool bBuildWonder = false;
 
 	bool bAlreadyBuildingWonder = false;

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -10339,8 +10339,8 @@ void CvPlayer::doTurnPostDiplomacy()
 	// Do turn for all Cities
 	if (getNumCities() > 0)
 	{
-		// AI spaceship production is planned on player level, overriding the normal AI city production selection
-		AI_doSpaceshipProduction();
+		// AI spaceship production and building Citizen Earth Protocol is planned on player level, overriding the normal AI city production selection
+		AI_doSpaceshipAndUtopiaProduction();
 
 		int iLoop = 0;
 		for(CvCity* pLoopCity = firstCity(&iLoop); pLoopCity != NULL; pLoopCity = nextCity(&iLoop))

--- a/CvGameCoreDLL_Expansion2/CvPlayer.h
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.h
@@ -2771,7 +2771,7 @@ public:
 	virtual void AI_doTurnPost() = 0;
 	virtual void AI_doTurnUnitsPre() = 0;
 	virtual void AI_doTurnUnitsPost() = 0;
-	virtual void AI_doSpaceshipProduction() = 0;
+	virtual void AI_doSpaceshipAndUtopiaProduction() = 0;
 	virtual void AI_unitUpdate(bool bHomelandAINeedsUpdate) = 0;
 	virtual void AI_conquerCity(CvCity* pCity, bool bGift, bool bAllowSphereRemoval) = 0;
 	bool HasSameIdeology(PlayerTypes ePlayer) const;

--- a/CvGameCoreDLL_Expansion2/CvPlayerAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayerAI.cpp
@@ -2319,20 +2319,82 @@ const vector<CvCity*> CvPlayerAI::GetBestCitiesForSpaceshipParts()
 	return vpCitiesForSpaceshipParts;
 }
 
+
+//	--------------------------------------------------------------------------------
+/// planner for AI utopia project production: returns the city in which utopia project should be built
+CvCity* CvPlayerAI::GetBestCityForUtopiaProject()
+{
+	ProjectTypes eUtopia = (ProjectTypes)GC.getInfoTypeForString("PROJECT_UTOPIA_PROJECT", true);
+	if (eUtopia == NO_PROJECT)
+		return NULL;
+
+	if (!canCreate(eUtopia))
+		return NULL;
+
+	// find the city in which we can produce it the fastest
+	int iBestCityProductionTurns = INT_MAX;
+	CvCity* pBestCity = NULL;
+
+	int iLoop = 0;
+	for (CvCity* pLoopCity = firstCity(&iLoop); pLoopCity != NULL; pLoopCity = nextCity(&iLoop))
+	{
+		if (pLoopCity->IsPuppet())
+			continue;
+
+		if (pLoopCity->isUnderSiege())
+			continue;
+
+		if (pLoopCity->IsResistance() || pLoopCity->IsRazing() || pLoopCity->isInDangerOfFalling())
+			continue;
+
+		// building a spaceship part?
+		if (pLoopCity->isProductionSpaceshipPart())
+			continue;
+
+		if (!pLoopCity->canCreate(eUtopia))
+			continue;
+
+		// we can consider this city for utopia, check how many turns it would take to build it
+		
+		// temporarily change city focus to production before calculating production turns
+		CityAIFocusTypes eCurrentFocus = pLoopCity->GetCityCitizens()->GetFocusType();
+		pLoopCity->GetCityCitizens()->SetFocusType(CITY_AI_FOCUS_TYPE_PRODUCTION, true);
+		int iProductionTurns = pLoopCity->getProductionTurnsLeft(eUtopia, 0);
+		// change city focus back to what it was before
+		pLoopCity->GetCityCitizens()->SetFocusType(eCurrentFocus, true);
+
+		if (iProductionTurns < iBestCityProductionTurns)
+		{
+			iBestCityProductionTurns = iProductionTurns;
+			pBestCity = pLoopCity;
+		}
+	}
+
+	return pBestCity;
+}
+
 //	--------------------------------------------------------------------------------
 /// if going for spaceship victory, the results from GetBestCitiesForSpaceshipParts are used to overwrite normal AI city production selection
-void CvPlayerAI::AI_doSpaceshipProduction()
+void CvPlayerAI::AI_doSpaceshipAndUtopiaProduction()
 {
 	if (isHuman(ISHUMAN_AI_CITY_PRODUCTION) || isMinorCiv())
 		return;
 
-	if (GetNumSpaceshipPartsBuildableNow(true) == 0)
+	bool bCanBuildUtopia = false;
+	ProjectTypes eUtopia = (ProjectTypes)GC.getInfoTypeForString("PROJECT_UTOPIA_PROJECT", true);
+	if (MOD_BALANCE_CULTURE_VICTORY_CHANGES && eUtopia != NO_PROJECT)
+	{
+		bCanBuildUtopia = canCreate(eUtopia);
+	}
+
+	if (!bCanBuildUtopia && GetNumSpaceshipPartsBuildableNow(true) == 0)
 		return;
 
 	// calculate cities to build spaceship parts in
 	const vector<CvCity*> vBestCitiesForSpaceshipParts = GetBestCitiesForSpaceshipParts();
+	CvCity* pBestCityForUtopia = GetBestCityForUtopiaProject();
 
-	// cancel spaceship part production in cities that are not considered the best cities (have to do this first to make the parts available)
+	// cancel spaceship part and utopia production in cities that are not considered the best cities (have to do this first to make the parts available)
 	CvString strOutBuf;
 	int iLoop = 0;
 	for (CvCity* pLoopCity = firstCity(&iLoop); pLoopCity != NULL; pLoopCity = nextCity(&iLoop))
@@ -2350,13 +2412,22 @@ void CvPlayerAI::AI_doSpaceshipProduction()
 				}
 			}
 		}
+		if (eUtopia != NO_PROJECT && pLoopCity->getProductionProject() == eUtopia && pLoopCity != pBestCityForUtopia)
+			pLoopCity->clearOrderQueue();
 	}
 
-	// which of the best cities are not building spaceship parts?
+	// build utopia project in the best city
+	if (pBestCityForUtopia && pBestCityForUtopia->getProductionProject() != eUtopia)
+		pBestCityForUtopia->pushOrder(ORDER_CREATE, eUtopia, -1, false, true, false, false);
+
+	// which of the best cities for spaceship parts are not building spaceship parts?
 	vector<CvCity*> vCitiesForAvailableSpaceshipParts;
 	int iLoop2 = 0;
 	for (CvCity* pLoopCity = firstCity(&iLoop2); pLoopCity != NULL; pLoopCity = nextCity(&iLoop2))
 	{
+		if (pLoopCity == pBestCityForUtopia)
+			continue;
+
 		if (find(vBestCitiesForSpaceshipParts.begin(), vBestCitiesForSpaceshipParts.end(), pLoopCity) != vBestCitiesForSpaceshipParts.end())
 		{
 			// is the city producing a spaceship unit? continue doing so

--- a/CvGameCoreDLL_Expansion2/CvPlayerAI.h
+++ b/CvGameCoreDLL_Expansion2/CvPlayerAI.h
@@ -70,9 +70,10 @@ public:
 	CvPlot* FindBestMerchantTargetPlotForCash(CvUnit* pMerchant);
 	CvPlot* FindBestMerchantTargetPlotForPuppet(CvUnit* pMerchant);
 
-	//spaceship planning
+	//spaceship planning and Citizen Earth Protocol
 	const vector<CvCity*> GetBestCitiesForSpaceshipParts();
-	void AI_doSpaceshipProduction();
+	CvCity* GetBestCityForUtopiaProject();
+	void AI_doSpaceshipAndUtopiaProduction();
 
 	//For Great Diplomats
 	CvPlot* FindBestDiplomatTargetPlot(CvUnit* pUnit);

--- a/CvGameCoreDLL_Expansion2/CvProjectProductionAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvProjectProductionAI.cpp
@@ -168,6 +168,14 @@ int CvProjectProductionAI::CheckProjectBuildSanity(ProjectTypes eProject, int iT
 			return SR_STRATEGY;
 	}
 
+	// For the AI, building the Utopia Project is controlled in AI_doSpaceshipAndUtopiaProduction, overriding normal AI production selection
+	if (MOD_BALANCE_CULTURE_VICTORY_CHANGES)
+	{
+		ProjectTypes eUtopia = (ProjectTypes)GC.getInfoTypeForString("PROJECT_UTOPIA_PROJECT", true);
+		if (eProject == eUtopia && !kPlayer.isHuman(ISHUMAN_AI_CITY_PRODUCTION))
+			return SR_STRATEGY;
+	}
+
 	if(kPlayer.isMinorCiv())
 	{
 		return SR_IMPOSSIBLE;

--- a/CvGameCoreDLL_Expansion2/CvUnitProductionAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnitProductionAI.cpp
@@ -866,7 +866,7 @@ int CvUnitProductionAI::CheckUnitBuildSanity(UnitTypes eUnit, bool bForOperation
 
 		if(pkUnitEntry->GetSpaceshipProject() != NO_PROJECT)
 		{
-			// For the AI, spaceship production is controlled in AI_doSpaceshipProduction, overriding normal AI production selection
+			// For the AI, spaceship production is controlled in AI_doSpaceshipAndUtopiaProduction, overriding normal AI production selection
 			if (!kPlayer.isHuman(ISHUMAN_AI_CITY_PRODUCTION) && !kPlayer.isMinorCiv())
 			{
 				return SR_STRATEGY;


### PR DESCRIPTION
mirroring the approach for spaceship part production, player-level planning is now used for the AI to make sure CEP is built immediately and in the best city once it becomes available