### PR TITLE
Fix non-functioning CityEvent column

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -6619,6 +6619,11 @@ void CvCity::DoEventChoice(CityEventChoiceTypes eEventChoice, CityEventTypes eCi
 				if (ePromotion != -1)
 				{
 					changeFreePromotionCount(ePromotion, 1);
+					if (MOD_BALANCE_RETROACTIVE_PROMOTIONS)
+					{
+						// not removed when event ends , as neither are promo gained from the city
+						SetRetroactivePromotion(ePromotion);
+					}
 				}
 			}
 			for (int iI = 0; iI < GC.getNumResourceInfos(); iI++)

--- a/CvGameCoreDLL_Expansion2/CvInfos.cpp
+++ b/CvGameCoreDLL_Expansion2/CvInfos.cpp
@@ -11372,7 +11372,7 @@ CvModEventCityChoiceInfo::CvModEventCityChoiceInfo() :
 	 m_iPillageFortificationsChance(0),
 	 m_iMutuallyExclusiveGroup(0),
 	 m_iBlockBuildingTurns(0),
-	 m_iEventPromotion(0),
+	 m_iEventPromotion(-1),
 	 m_iCityHappiness(0),
 	 m_iReligiousPressureModifier(0),
 	 m_piResourceChange(NULL),
@@ -12267,7 +12267,7 @@ bool CvModEventCityChoiceInfo::CacheResults(Database::Results& kResults, CvDatab
 	m_iCityHappiness = kResults.GetInt("CityHappiness");
 	m_iReligiousPressureModifier = kResults.GetInt("ReligiousPressureModifier");
 
-	szTextVal = kResults.GetText("FreePromotionCity");
+	szTextVal = kResults.GetText("EventPromotion");
 	m_iEventPromotion =  GC.getInfoTypeForString(szTextVal, true);
 
 	szTextVal = kResults.GetText("EventChoiceAudio");


### PR DESCRIPTION
For many, many, (many), years I have been using player level `EventChoice` column `EventPromotion`
The same column exists in the DB for `CityEventChoice` but I had never reason to use it. 

Apparently it has been broken the whole time because the DB string `EventPromotion` does not match the cache function string reference of `FreePromotionCity`

I haven't tested this yet because I've cleverly branched from new master and all my files are mismatched :S 