### PR TITLE
Finish Animism implementation

### DIFF
--- a/(2) Vox Populi/Database Changes/Beliefs/EnhancerChanges.sql
+++ b/(2) Vox Populi/Database Changes/Beliefs/EnhancerChanges.sql
@@ -140,3 +140,26 @@ INSERT INTO Belief_FreePromotions
 	(BeliefType, PromotionType)
 VALUES
 	('BELIEF_ANIMISM', 'PROMOTION_ANIMISM');
+
+INSERT INTO Belief_LakePlotYield
+	(BeliefType, YieldType, Yield)
+VALUES
+	('BELIEF_ANIMISM', 'YIELD_FOOD', 1),
+	('BELIEF_ANIMISM', 'YIELD_CULTURE', 1);
+
+INSERT INTO Belief_UnimprovedFeatureYieldChanges
+	(BeliefType, FeatureType, YieldType, Yield)
+SELECT
+	'BELIEF_ANIMISM', f.Type, y.Type, 1
+FROM Features f, Yields y
+WHERE y.Type IN ('YIELD_FOOD', 'YIELD_CULTURE')
+AND f.NaturalWonder = 0;
+
+-- some natural wonders can be improved in modmods
+INSERT INTO Belief_FeatureYieldChanges
+	(BeliefType, FeatureType, YieldType, Yield)
+SELECT
+	'BELIEF_ANIMISM', f.Type, y.Type, 1
+FROM Features f, Yields y
+WHERE y.Type IN ('YIELD_FOOD', 'YIELD_CULTURE')
+AND f.NaturalWonder = 1;


### PR DESCRIPTION
was missing yields

note in VP natural wonders cannot be improved, but in modmods they can. I think it's best to let modmods update this one since they can use a PseudoNaturalWonder column but I'm not 100% how