### PR TITLE
Fix citadels not being buildable in foreign territory in CP (#13094)

### DIFF
--- a/(1) Community Patch/Database Changes/Text/en_US/UI/CoreNewUIText.xml
+++ b/(1) Community Patch/Database Changes/Text/en_US/UI/CoreNewUIText.xml
@@ -2267,6 +2267,12 @@
 		<Row Tag="TXT_KEY_BUILD_BLOCKED_OTHER_UNIT_WORKING">
 			<Text>Another unit is already building something here.</Text>
 		</Row>
+		<Row Tag="TXT_KEY_BUILD_BLOCKED_NOT_IN_ENEMY_TERRITORY">
+			<Text>{TXT_KEY_GRAMMAR_UPPER_A_AN &lt;&lt; {@1_ImprovementName}} cannot be constructed in enemy territory.</Text>
+		</Row>
+		<Row Tag="TXT_KEY_BUILD_BLOCKED_TILE_IMPROVEMENT">
+			<Text>The existing improvement on this tile prevents the tile from being claimed.</Text>
+		</Row>
 		<!-- Upgrade action disabled tooltips -->
 		<Row Tag="TXT_KEY_UPGRADE_HELP_DISABLED_EMBARKED">
 			<Text>Embarked units cannot upgrade.</Text>

--- a/(1) Community Patch/Database Changes/WorldMap/Improvements/CoreImprovementChanges.sql
+++ b/(1) Community Patch/Database Changes/WorldMap/Improvements/CoreImprovementChanges.sql
@@ -9,3 +9,5 @@ INSERT INTO Improvement_YieldPerXAdjacentImprovement
 	(ImprovementType, OtherImprovementType, YieldType, Yield, NumRequired)
 VALUES
 	('IMPROVEMENT_MOAI', 'IMPROVEMENT_MOAI', 'YIELD_CULTURE', 1, 1);
+
+UPDATE Improvements SET InEnemyTerritory = 1 WHERE Type = 'IMPROVEMENT_CITADEL';

--- a/(1) Community Patch/Database Changes/WorldMap/Improvements/ImprovementTableChanges.sql
+++ b/(1) Community Patch/Database Changes/WorldMap/Improvements/ImprovementTableChanges.sql
@@ -78,6 +78,9 @@ ALTER TABLE Improvements ADD NoFollowUp boolean DEFAULT 0;
 -- Improvement grants new Ownership if plot is not owned.
 ALTER TABLE Improvements ADD NewOwner boolean DEFAULT 0;
 
+-- Improvement can be built in plots owned by other players. Has to be combined with OutsideBorders or InFriendlyAdjacent
+ALTER TABLE Improvements ADD InEnemyTerritory boolean DEFAULT 0;
+
 -- Improvement grants promotion if plot is owned by the player.
 ALTER TABLE Improvements ADD OwnerOnly boolean DEFAULT 1;
 

--- a/(2) Vox Populi/Database Changes/WorldMap/Improvements/ImprovementChanges.sql
+++ b/(2) Vox Populi/Database Changes/WorldMap/Improvements/ImprovementChanges.sql
@@ -100,6 +100,12 @@ SET
 WHERE Type = 'IMPROVEMENT_FORT';
 
 -- Citadel
+
+-- can no longer be built in foreign territory by default
+UPDATE Improvements
+SET InEnemyTerritory = 0
+WHERE Type = 'IMPROVEMENT_CITADEL';
+
 INSERT INTO Improvement_Yields
 	(ImprovementType, YieldType, Yield)
 VALUES

--- a/CvGameCoreDLL_Expansion2/CvImprovementClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvImprovementClasses.cpp
@@ -125,6 +125,7 @@ CvImprovementEntry::CvImprovementEntry(void):
 	m_bPermanent(false),
 	m_bOutsideBorders(false),
 	m_bInAdjacentFriendly(false),
+	m_bInEnemyTerritory(false),
 	m_bIgnoreOwnership(false),
 	m_bOnlyCityStateTerritory(false),
 	m_bIsEmbassy(false),
@@ -315,6 +316,7 @@ bool CvImprovementEntry::CacheResults(Database::Results& kResults, CvDatabaseUti
 	m_iPillageGold = kResults.GetInt("PillageGold");
 	m_bOutsideBorders = kResults.GetBool("OutsideBorders");
 	m_bInAdjacentFriendly = kResults.GetBool("InAdjacentFriendly");
+	m_bInEnemyTerritory = kResults.GetBool("InEnemyTerritory");
 	m_bIgnoreOwnership = kResults.GetBool("IgnoreOwnership");
 	m_bOnlyCityStateTerritory = kResults.GetBool("OnlyCityStateTerritory");
 	m_bIsEmbassy = kResults.GetBool("IsEmbassy");
@@ -1357,6 +1359,12 @@ bool CvImprovementEntry::IsAllowsWalkWater() const
 bool CvImprovementEntry::IsInAdjacentFriendly() const
 {
 	return m_bInAdjacentFriendly;
+}
+
+/// Can this improvement be built in territory owned by other players?
+bool CvImprovementEntry::IsInEnemyTerritory() const
+{
+	return m_bInEnemyTerritory;
 }
 
 bool CvImprovementEntry::IsCreatedByGreatPerson() const

--- a/CvGameCoreDLL_Expansion2/CvImprovementClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvImprovementClasses.h
@@ -127,6 +127,7 @@ public:
 	bool IsPermanent() const;
 	bool IsOutsideBorders() const;
 	bool IsInAdjacentFriendly() const;
+	bool IsInEnemyTerritory() const;
 	bool IsIgnoreOwnership() const;
 	bool IsOnlyCityStateTerritory() const;
 	bool IsEmbassy() const;
@@ -302,6 +303,7 @@ protected:
 	bool m_bPermanent;
 	bool m_bOutsideBorders;
 	bool m_bInAdjacentFriendly;
+	bool m_bInEnemyTerritory;
 	bool m_bIgnoreOwnership;
 	bool m_bOnlyCityStateTerritory;
 	bool m_bIsEmbassy;

--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -3152,10 +3152,11 @@ bool CvPlot::canBuild(BuildTypes eBuild, PlayerTypes ePlayer, bool bTestVisible,
 				// Gifts for minors can ignore borders requirements
 				if(bTestPlotOwner)
 				{
-					// Outside Borders - Can be built in or outside our lands, but not in other lands
+					// Outside Borders - Can be built in or outside our lands
+					// Can be built in other lands if IsInEnemyTerritory is true
 					if(GC.getImprovementInfo(eImprovement)->IsOutsideBorders())
 					{
-						if (getTeam() != eTeam && getTeam() != NO_TEAM)
+						if (!GC.getImprovementInfo(eImprovement)->IsInEnemyTerritory() && getTeam() != eTeam && getTeam() != NO_TEAM)
 						{
 							if (toolTipSink && !toolTipSink->empty())
 								(*toolTipSink) += "[NEWLINE]";
@@ -3167,7 +3168,6 @@ bool CvPlot::canBuild(BuildTypes eBuild, PlayerTypes ePlayer, bool bTestVisible,
 					// In Adjacent Friendly - Can be built in or adjacent to our lands
 					else if (GC.getImprovementInfo(eImprovement)->IsInAdjacentFriendly())
 					{
-						//citadels only in adjacent _unowned_ territory
 						if (getTeam() == NO_TEAM)
 						{
 							if (!isAdjacentTeam(eTeam, false))
@@ -3182,7 +3182,7 @@ bool CvPlot::canBuild(BuildTypes eBuild, PlayerTypes ePlayer, bool bTestVisible,
 						else if (getTeam() != eTeam)
 						{
 							bool bBlocked = true;
-							if (GC.getImprovementInfo(eImprovement)->GetCultureBombRadius() > 0 && GET_PLAYER(ePlayer).IsCultureBombForeignTerritory())
+							if (GC.getImprovementInfo(eImprovement)->IsInEnemyTerritory() || (GC.getImprovementInfo(eImprovement)->GetCultureBombRadius() > 0 && GET_PLAYER(ePlayer).IsCultureBombForeignTerritory()))
 							{
 								if (!IsStealBlockedByImprovement() && isAdjacentTeam(eTeam, false))
 									bBlocked = false;
@@ -3226,7 +3226,8 @@ bool CvPlot::canBuild(BuildTypes eBuild, PlayerTypes ePlayer, bool bTestVisible,
 						}
 					}
 					else if(getTeam() != eTeam)
-					{//only buildable in own culture
+					{
+						//only buildable in own culture
 						if (toolTipSink && !toolTipSink->empty())
 							(*toolTipSink) += "[NEWLINE]";
 						GC.getGame().BuildCannotPerformActionHelpText(toolTipSink, "TXT_KEY_BUILD_BLOCKED_OUTSIDE_TERRITORY", GC.getImprovementInfo(eImprovement)->GetDescription());

--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -3168,7 +3168,7 @@ bool CvPlot::canBuild(BuildTypes eBuild, PlayerTypes ePlayer, bool bTestVisible,
 					// In Adjacent Friendly - Can be built in or adjacent to our lands
 					else if (GC.getImprovementInfo(eImprovement)->IsInAdjacentFriendly())
 					{
-						if (getTeam() == NO_TEAM)
+						if (getTeam() != eTeam)
 						{
 							if (!isAdjacentTeam(eTeam, false))
 							{
@@ -3178,22 +3178,25 @@ bool CvPlot::canBuild(BuildTypes eBuild, PlayerTypes ePlayer, bool bTestVisible,
 								if (toolTipSink == NULL) return false;
 								bPlotCanBuild = false;
 							}
-						}
-						else if (getTeam() != eTeam)
-						{
-							bool bBlocked = true;
-							if (GC.getImprovementInfo(eImprovement)->IsInEnemyTerritory() || (GC.getImprovementInfo(eImprovement)->GetCultureBombRadius() > 0 && GET_PLAYER(ePlayer).IsCultureBombForeignTerritory()))
+
+							if (getTeam() != NO_TEAM)
 							{
-								if (!IsStealBlockedByImprovement() && isAdjacentTeam(eTeam, false))
-									bBlocked = false;
-							}
-							if (bBlocked)
-							{
-								if (toolTipSink && !toolTipSink->empty())
-									(*toolTipSink) += "[NEWLINE]";
-								GC.getGame().BuildCannotPerformActionHelpText(toolTipSink, "TXT_KEY_BUILD_BLOCKED_NOT_IN_ADJACENT_TERRITORY", GC.getImprovementInfo(eImprovement)->GetDescription());
-								if (toolTipSink == NULL) return false;
-								bPlotCanBuild = false;
+								if (!GC.getImprovementInfo(eImprovement)->IsInEnemyTerritory() && (GC.getImprovementInfo(eImprovement)->GetCultureBombRadius() == 0 || !GET_PLAYER(ePlayer).IsCultureBombForeignTerritory()))
+								{
+									if (toolTipSink && !toolTipSink->empty())
+										(*toolTipSink) += "[NEWLINE]";
+									GC.getGame().BuildCannotPerformActionHelpText(toolTipSink, "TXT_KEY_BUILD_BLOCKED_NOT_IN_ENEMY_TERRITORY", GC.getImprovementInfo(eImprovement)->GetDescription());
+									if (toolTipSink == NULL) return false;
+									bPlotCanBuild = false;
+								}
+								else if (IsStealBlockedByImprovement())
+								{
+									if (toolTipSink && !toolTipSink->empty())
+										(*toolTipSink) += "[NEWLINE]";
+									GC.getGame().BuildCannotPerformActionHelpText(toolTipSink, "TXT_KEY_BUILD_BLOCKED_TILE_IMPROVEMENT");
+									if (toolTipSink == NULL) return false;
+									bPlotCanBuild = false;
+								}
 							}
 						}
 					}


### PR DESCRIPTION
Added new database column InEnemyTerritory to make the VP change that citadels can't be built in enemy territory database-backed. The new table can also be combined with IsOutsideBorders, in case a modmodder is interested in that