### PR TITLE
Guard debug pathlog allocation, replace deal-ID O(n) scan with counter

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvAStar.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAStar.cpp
@@ -262,8 +262,10 @@ void CvAStar::Reset()
 
 	//will be set multiple times but who cares
 	g_bPathFinderLogging = false;
+#if defined(MOD_CORE_DEBUGGING)
 	g_svPathLog.clear();
 	g_svPathLog.reserve(10000);
+#endif
 }
 
 

--- a/CvGameCoreDLL_Expansion2/CvDealClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvDealClasses.cpp
@@ -4196,6 +4196,7 @@ void CvDeal::RemoveTechTrade(TechTypes eTech)
 /// Constructor
 CvGameDeals::CvGameDeals()
 	: m_uiDealCounter(0)
+	, m_iNextDealID(0)
 {
 	Init();
 }
@@ -4219,6 +4220,7 @@ void CvGameDeals::Init()
 	m_ProposedDeals.clear();
 	m_CurrentDeals.clear();
 	m_HistoricalDeals.clear();
+	m_iNextDealID = 0;
 
 	for (int i = 0; i < MAX_MAJOR_CIVS; i++)
 	{
@@ -5238,19 +5240,7 @@ void CvGameDeals::ActivateDeal(PlayerTypes eFromPlayer, PlayerTypes eToPlayer, C
 	kDeal.m_iFinalTurn = iLatestItemLastTurn;
 	kDeal.m_iStartTurn = GC.getGame().getGameTurn();
 
-	// get first available ID
-	int iHighestDealID = -1;
-	DealList::iterator it;
-	for (it = m_CurrentDeals.begin(); it != m_CurrentDeals.end(); ++it)
-	{
-		iHighestDealID = max(iHighestDealID, it->m_iID);
-	}
-	for (it = m_HistoricalDeals.begin(); it != m_HistoricalDeals.end(); ++it)
-	{
-		iHighestDealID = max(iHighestDealID, it->m_iID);
-	}
-
-	kDeal.m_iID = iHighestDealID + 1;
+	kDeal.m_iID = m_iNextDealID++;
 	m_CurrentDeals.push_back(kDeal);
 
 	LogDealComplete(&kDeal);
@@ -6747,6 +6737,15 @@ FDataStream& operator>>(FDataStream& loadFrom, CvGameDeals& writeTo)
 {
 	CvStreamLoadVisitor serialVisitor(loadFrom);
 	CvGameDeals::Serialize(writeTo, serialVisitor);
+
+	// Recompute monotonic deal-ID counter from loaded data
+	int iMaxID = -1;
+	for (DealList::iterator it = writeTo.m_CurrentDeals.begin(); it != writeTo.m_CurrentDeals.end(); ++it)
+		iMaxID = max(iMaxID, it->m_iID);
+	for (DealList::iterator it = writeTo.m_HistoricalDeals.begin(); it != writeTo.m_HistoricalDeals.end(); ++it)
+		iMaxID = max(iMaxID, it->m_iID);
+	writeTo.m_iNextDealID = iMaxID + 1;
+
 	return loadFrom;
 }
 

--- a/CvGameCoreDLL_Expansion2/CvDealClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvDealClasses.h
@@ -355,6 +355,10 @@ public:
 	DealList m_CurrentDeals;
 	DealList m_HistoricalDeals;
 
+	// Monotonic counter for unique deal IDs in m_CurrentDeals/m_HistoricalDeals.
+	// Avoids O(n) scan of all deals on every activation. Recomputed on load.
+	int m_iNextDealID;
+
 protected:
 	int m_aaiRenewDeal[MAX_MAJOR_CIVS][MAX_MAJOR_CIVS];
 	void LogDealComplete(CvDeal* pDeal);


### PR DESCRIPTION
This PR + https://github.com/LoneGazebo/Community-Patch-DLL/pull/13121 closes https://github.com/LoneGazebo/Community-Patch-DLL/issues/12942

CvAStar: wrap g_svPathLog clear/reserve in #if defined(MOD_CORE_DEBUGGING). The vector and its 10000-element reserve (320 KB) were unconditionally allocated on every pathfind, but only populated when MOD_CORE_DEBUGGING is enabled and a debug unit ID matches. In release builds the vector is never used, so skip the allocation entirely.

CvDealClasses: replace O(n) max-ID scan with monotonic m_iNextDealID counter. ActivateDeal previously scanned all current + historical deals to find the highest ID. With hundreds of historical deals accumulating over a long game this becomes measurable. The counter is initialized to 0 and recomputed from loaded data after deserialization (no save format change).