### PR TITLE
Allow NO_EVENT_CLASS to fire w/o any other events being enabled

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -2442,15 +2442,7 @@ void CvCity::doTurn()
 		}
 	}
 
-	if (GC.getGame().isOption(GAMEOPTION_GOOD_EVENTS) || GC.getGame().isOption(GAMEOPTION_NEUTRAL_EVENTS) || GC.getGame().isOption(GAMEOPTION_BAD_EVENTS)
-		|| GC.getGame().isOption(GAMEOPTION_TRADE_EVENTS) || GC.getGame().isOption(GAMEOPTION_CIV_SPECIFIC_EVENTS))
-	{
-		DoEvents();
-	}
-	else
-	{
-		DoEvents(/*bEspionageOnly*/ true);
-	}
+	DoEvents();
 
 	setDrafted(false);
 	setMadeAttack(false);
@@ -3332,6 +3324,37 @@ void CvCity::DoEvents(bool bEspionageOnly)
 		if (pkEventInfo->isOneShot() && IsEventFired(eEvent))
 			continue;
 
+		// is the event's class enabled in the options?
+		EventClassTypes eEventClass = (EventClassTypes)pkEventInfo->getEventClass();
+		if (eEventClass != NO_EVENT_CLASS)
+		{
+			if (eEventClass == EVENT_CLASS_GOOD)
+			{
+				if (!GC.getGame().isOption(GAMEOPTION_GOOD_EVENTS))
+					continue;
+			}
+			else if (eEventClass == EVENT_CLASS_BAD)
+			{
+				if (!GC.getGame().isOption(GAMEOPTION_BAD_EVENTS))
+					continue;
+			}
+			else if (eEventClass == EVENT_CLASS_NEUTRAL)
+			{
+				if (!GC.getGame().isOption(GAMEOPTION_NEUTRAL_EVENTS))
+					continue;
+			}
+			else if (eEventClass == EVENT_CLASS_TRADE)
+			{
+				if (!GC.getGame().isOption(GAMEOPTION_TRADE_EVENTS))
+					continue;
+			}
+			else if (eEventClass == EVENT_CLASS_CIV_SPECIFIC)
+			{
+				if (!GC.getGame().isOption(GAMEOPTION_CIV_SPECIFIC_EVENTS))
+					continue;
+			}
+		}
+
 		// Is this event on cooldown?
 		if (GetEventCooldown(eEvent) > 0)
 		{
@@ -3601,36 +3624,6 @@ bool CvCity::IsCityEventValid(CityEventTypes eEvent)
 	if (GAMEEVENTINVOKE_TESTALL(GAMEEVENT_CityEventCanActivate, getOwner(), GetID(), eEvent) == GAMEEVENTRETURN_FALSE)
 	{
 		return false;
-	}
-
-	EventClassTypes eEventClass = (EventClassTypes)pkEventInfo->getEventClass();
-	if (eEventClass != NO_EVENT_CLASS)
-	{
-		if (eEventClass == EVENT_CLASS_GOOD)
-		{
-			if (!GC.getGame().isOption(GAMEOPTION_GOOD_EVENTS))
-				return false;
-		}
-		else if (eEventClass == EVENT_CLASS_BAD)
-		{
-			if (!GC.getGame().isOption(GAMEOPTION_BAD_EVENTS))
-				return false;
-		}
-		else if (eEventClass == EVENT_CLASS_NEUTRAL)
-		{
-			if (!GC.getGame().isOption(GAMEOPTION_NEUTRAL_EVENTS))
-				return false;
-		}
-		else if (eEventClass == EVENT_CLASS_TRADE)
-		{
-			if (!GC.getGame().isOption(GAMEOPTION_TRADE_EVENTS))
-				return false;
-		}
-		else if (eEventClass == EVENT_CLASS_CIV_SPECIFIC)
-		{
-			if (!GC.getGame().isOption(GAMEOPTION_CIV_SPECIFIC_EVENTS))
-				return false;
-		}
 	}
 
 	CvPlayer& kPlayer = GET_PLAYER(m_eOwner);

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -5451,6 +5451,37 @@ void CvPlayer::DoEvents(bool bEspionageOnly)
 		if (pkEventInfo->isOneShot() && IsEventFired(eEvent))
 			continue;
 
+		// is the event's class enabled in the options?
+		EventClassTypes eEventClass = (EventClassTypes)pkEventInfo->getEventClass();
+		if (eEventClass != NO_EVENT_CLASS)
+		{
+			if (eEventClass == EVENT_CLASS_GOOD)
+			{
+				if (!GC.getGame().isOption(GAMEOPTION_GOOD_EVENTS))
+					continue;
+			}
+			else if (eEventClass == EVENT_CLASS_BAD)
+			{
+				if (!GC.getGame().isOption(GAMEOPTION_BAD_EVENTS))
+					continue;
+			}
+			else if (eEventClass == EVENT_CLASS_NEUTRAL)
+			{
+				if (!GC.getGame().isOption(GAMEOPTION_NEUTRAL_EVENTS))
+					continue;
+			}
+			else if (eEventClass == EVENT_CLASS_TRADE)
+			{
+				if (!GC.getGame().isOption(GAMEOPTION_TRADE_EVENTS))
+					continue;
+			}
+			else if (eEventClass == EVENT_CLASS_CIV_SPECIFIC)
+			{
+				if (!GC.getGame().isOption(GAMEOPTION_CIV_SPECIFIC_EVENTS))
+					continue;
+			}
+		}
+
 		// Is this event on cooldown?
 		if (GetEventCooldown(eEvent) > 0)
 		{
@@ -5644,36 +5675,6 @@ bool CvPlayer::IsEventValid(EventTypes eEvent)
 	if (GAMEEVENTINVOKE_TESTALL(GAMEEVENT_EventCanActivate, GetID(), eEvent) == GAMEEVENTRETURN_FALSE)
 	{
 		return false;
-	}
-
-	EventClassTypes eEventClass = (EventClassTypes)pkEventInfo->getEventClass();
-	if (eEventClass != NO_EVENT_CLASS)
-	{
-		if (eEventClass == EVENT_CLASS_GOOD)
-		{
-			if (!GC.getGame().isOption(GAMEOPTION_GOOD_EVENTS))
-				return false;
-		}
-		else if (eEventClass == EVENT_CLASS_BAD)
-		{
-			if (!GC.getGame().isOption(GAMEOPTION_BAD_EVENTS))
-				return false;
-		}
-		else if (eEventClass == EVENT_CLASS_NEUTRAL)
-		{
-			if (!GC.getGame().isOption(GAMEOPTION_NEUTRAL_EVENTS))
-				return false;
-		}
-		else if (eEventClass == EVENT_CLASS_TRADE)
-		{
-			if (!GC.getGame().isOption(GAMEOPTION_TRADE_EVENTS))
-				return false;
-		}
-		else if (eEventClass == EVENT_CLASS_CIV_SPECIFIC)
-		{
-			if (!GC.getGame().isOption(GAMEOPTION_CIV_SPECIFIC_EVENTS))
-				return false;
-		}
 	}
 
 	if(pkEventInfo->getPrereqTech() != -1 && !GET_TEAM(getTeam()).GetTeamTechs()->HasTech((TechTypes)pkEventInfo->getPrereqTech()))
@@ -10555,15 +10556,7 @@ void CvPlayer::doTurnPostDiplomacy()
 		DoGovernmentCooldown();
 	}
 
-	if (GC.getGame().isOption(GAMEOPTION_GOOD_EVENTS) || GC.getGame().isOption(GAMEOPTION_NEUTRAL_EVENTS) || GC.getGame().isOption(GAMEOPTION_BAD_EVENTS)
-		|| GC.getGame().isOption(GAMEOPTION_TRADE_EVENTS) || GC.getGame().isOption(GAMEOPTION_CIV_SPECIFIC_EVENTS))
-	{
-		DoEvents();
-	}
-	else
-	{
-		DoEvents(/*EspionageOnly*/ true);
-	}
+	DoEvents();
 
 	updateYieldPerTurnHistory();
 


### PR DESCRIPTION
For mods where the events are being used to trigger effects, not as part of the "events system" of random occurances 

Currently we use "Civ Specific Events" which requires the advanced option and isn't compatible with the events modmod 

People forget the advanced option and then report to me it isnt working -- ive tried making it clear but this is a surer fixup simple refactor, should have very limited performance hit?