### PR TITLE
Feature Additions for upcoming economic victory modmod

### DIFF
--- a/(1) Community Patch/Core Files/Overrides/Includes/InfoTooltipInclude.lua
+++ b/(1) Community Patch/Core Files/Overrides/Includes/InfoTooltipInclude.lua
@@ -3250,7 +3250,11 @@ function GetHelpTextForBuilding(eBuilding, bExcludeName, _, bNoMaintenance, pCit
 		AddTooltipIfTrue(tReqLines, "TXT_KEY_PRODUCTION_BUILDING_NO_RIVER", kBuildingInfo.IsNoRiver);
 		AddTooltipIfTrue(tReqLines, "TXT_KEY_PRODUCTION_BUILDING_NO_COASTAL", kBuildingInfo.IsNoCoast);
 		AddTooltipIfTrue(tReqLines, "TXT_KEY_PRODUCTION_BUILDING_INDUSTRIAL_CONNECTION", kBuildingInfo.RequiresIndustrialCityConnection);
+		AddTooltipIfTrue(tReqLines, "TXT_KEY_PRODUCTION_BUILDING_PUPPET", kBuildingInfo.RequiresPuppet);
 		AddTooltipIfTrue(tReqLines, "TXT_KEY_PRODUCTION_BUILDING_OCCUPIED_ONLY", kBuildingInfo.NoOccupiedUnhappiness and not kBuildingInfo.BuildAnywhere);
+
+		AddTooltipPositive(tReqLines, "TXT_KEY_PRODUCTION_BUILDING_NUM_FRANCHISES", kBuildingInfo.RequiresXFranchises);
+		AddTooltipPositive(tReqLines, "TXT_KEY_PRODUCTION_BUILDING_PERCENT_MONOPOLIES", kBuildingInfo.RequiresXPercentGlobalMonopolies);
 
 		-- Coastal or whatever custom water size
 		if kBuildingInfo.Water then

--- a/(1) Community Patch/Core Files/Overrides/Includes/TechButtonInclude.lua
+++ b/(1) Community Patch/Core Files/Overrides/Includes/TechButtonInclude.lua
@@ -427,7 +427,7 @@ function AddSmallButtonsToTechButton(buttonStack, kTechInfo, iButtonCount, iText
 		end
 	end
 
-	for kProjectInfo in GameInfo.Projects{TechPrereq = kTechInfo.Type} do
+	for kProjectInfo in GameInfo.Projects{TechPrereq = kTechInfo.Type, ShowInTechTree = 1} do
 		if not kProjectInfo.CivilizationType or kProjectInfo.CivilizationType == strCivType then
 			GenerateNextButtonFromInfo(SetupProjectButton, kProjectInfo);
 			if iButtonIndex > iButtonCount then return iButtonCount end
@@ -640,6 +640,11 @@ function AddSmallButtonsToTechButton(buttonStack, kTechInfo, iButtonCount, iText
 		if iButtonIndex > iButtonCount then return iButtonCount end
 	end
 
+	if kTechInfo.ExtraLuxuriesEnabled then
+		GenerateNextButtonCustom(L("TXT_KEY_ALLOWS_EXTRA_LUXURIES"));
+		if iButtonIndex > iButtonCount then return iButtonCount end
+	end
+	
 	-- Yield-related
 	local tSpecialistBoosts = {};
 	local tTerrainBoosts = {};

--- a/(1) Community Patch/Database Changes/City/Buildings/BuildingTableChanges.sql
+++ b/(1) Community Patch/Database Changes/City/Buildings/BuildingTableChanges.sql
@@ -135,6 +135,9 @@ ALTER TABLE Buildings ADD ResourceType text REFERENCES Resources (Type);
 -- Allows for Building to be purchased in puppet city
 ALTER TABLE Buildings ADD PuppetPurchaseOverride boolean DEFAULT 0;
 
+-- The building can only be built in a puppet city
+ALTER TABLE Buildings ADD RequiresPuppet boolean DEFAULT 0;
+
 -- Allows for Building to grant a single WC vote (or any value) - not scaled by CS
 ALTER TABLE Buildings ADD SingleLeagueVotes integer DEFAULT 0;
 

--- a/(1) Community Patch/Database Changes/City/Buildings/BuildingTableChanges.sql
+++ b/(1) Community Patch/Database Changes/City/Buildings/BuildingTableChanges.sql
@@ -237,6 +237,8 @@ ALTER TABLE Buildings ADD TRSpeedBoost integer DEFAULT 0;
 ALTER TABLE Buildings ADD TRVisionBoost integer DEFAULT 0;
 ALTER TABLE Buildings ADD TRTurnModGlobal integer DEFAULT 0; -- modifies the turns a TR takes to complete, an int between 100 and -100, like a percent
 ALTER TABLE Buildings ADD TRTurnModLocal integer DEFAULT 0;
+ALTER TABLE Buildings ADD RequiresXFranchises integer DEFAULT 0;
+ALTER TABLE Buildings ADD RequiresXPercentGlobalMonopolies integer DEFAULT 0;
 
 -- CSD
 ALTER TABLE Buildings ADD DPToVotes integer DEFAULT 0;

--- a/(1) Community Patch/Database Changes/City/Projects/NewProjectTables.xml
+++ b/(1) Community Patch/Database Changes/City/Projects/NewProjectTables.xml
@@ -13,4 +13,11 @@
 		<Column name="YieldType" type="text" reference="Yields(Type)" notnull="true"/>
 		<Column name="Yield" type="integer" notnull="true"/>
 	</Table>
+	
+	<!-- Free copies of these resources from the city -->
+	<Table name="Project_FreeResource">
+		<Column name="ProjectType" type="text" reference="Projects(Type)" notnull="true"/>
+		<Column name="ResourceType" type="text" reference="Resources(Type)" notnull="true"/>
+		<Column name="Number" type="integer" notnull="true"/>
+	</Table>
 </GameData>

--- a/(1) Community Patch/Database Changes/City/Projects/ProjectTableChanges.sql
+++ b/(1) Community Patch/Database Changes/City/Projects/ProjectTableChanges.sql
@@ -46,3 +46,10 @@ ALTER TABLE Projects ADD CityEventToStart text REFERENCES CityEvents (Type);
 
 -- Requires this Policy to be unlocked in order to build
 ALTER TABLE Projects ADD PolicyType text REFERENCES Policies (Type);
+
+-- Requires this Resource locally
+ALTER TABLE Projects ADD LocalResourcePrereq text REFERENCES Resources (Type);
+
+-- Increases copies of luxuries from this city by this integer
+-- If LocalResourcePrereq is set, only affects that one
+ALTER TABLE Projects ADD ExtraLuxuries integer DEFAULT 0;

--- a/(1) Community Patch/Database Changes/City/Projects/ProjectTableChanges.sql
+++ b/(1) Community Patch/Database Changes/City/Projects/ProjectTableChanges.sql
@@ -53,3 +53,5 @@ ALTER TABLE Projects ADD LocalResourcePrereq text REFERENCES Resources (Type);
 -- Increases copies of luxuries from this city by this integer
 -- If LocalResourcePrereq is set, only affects that one
 ALTER TABLE Projects ADD ExtraLuxuries integer DEFAULT 0;
+
+ALTER TABLE Projects ADD ShowInTechTree boolean DEFAULT 1;

--- a/(1) Community Patch/Database Changes/Policies/PolicyTableChanges.sql
+++ b/(1) Community Patch/Database Changes/Policies/PolicyTableChanges.sql
@@ -347,6 +347,10 @@ ALTER TABLE Policies ADD GreatDiplomatRateModifier integer DEFAULT 0;
 
 -- Ignore restriction on founding Cities next to borders
 ALTER TABLE Policies ADD BorderSettle boolean DEFAULT 0;
+
+-- Great Merchants copy city-state resources x times
+ALTER TABLE Policies ADD GreatMerchantExtraLuxuries integer DEFAULT 0;
+
 ----------------------------------------------------------------
 -- Policy Branches
 ----------------------------------------------------------------

--- a/(1) Community Patch/Database Changes/Tech/TechTableChanges.sql
+++ b/(1) Community Patch/Database Changes/Tech/TechTableChanges.sql
@@ -39,3 +39,6 @@ ALTER TABLE Technologies ADD CityAutomatonWorkersChange integer DEFAULT 0;
 -- Extra working range for every city
 -- Note that working range caps at MAX_CITY_RADIUS
 ALTER TABLE Technologies ADD CityWorkingChange integer DEFAULT 0;
+
+-- database hook to display tooltip in tech tree
+ALTER TABLE Technologies ADD ExtraLuxuriesEnabled boolean DEFAULT 0;

--- a/(1) Community Patch/Database Changes/Text/en_US/UI/CoreNewUIText.xml
+++ b/(1) Community Patch/Database Changes/Text/en_US/UI/CoreNewUIText.xml
@@ -143,6 +143,9 @@
 		<Row Tag="TXT_KEY_ABLTY_CITY_INDIRECT_INCREASE">
 			<Text>+1 City Indirect Attack Range</Text>
 		</Row>
+		<Row Tag="TXT_KEY_ALLOWS_EXTRA_LUXURIES">
+			<Text>Unlocks Projects that increase local Luxury copies</Text>
+		</Row>
 
 		<!-- Theming bonus -->
 		<Row Tag="TXT_KEY_CO_TOURISM_THEME_BONUS">

--- a/(1) Community Patch/Database Changes/Text/en_US/UI/CoreNewUIText.xml
+++ b/(1) Community Patch/Database Changes/Text/en_US/UI/CoreNewUIText.xml
@@ -1444,6 +1444,15 @@
 		<Row Tag="TXT_KEY_PRODUCTION_BUILDING_INDUSTRIAL_CONNECTION">
 			<Text>City must have [ICON_INDUSTRIAL_CONNECTED] Industrial City Connection with [ICON_CAPITAL] Capital</Text>
 		</Row>
+		<Row Tag="TXT_KEY_PRODUCTION_BUILDING_PUPPET">
+			<Text>City must be a [ICON_PUPPET] Puppet</Text>
+		</Row>
+		<Row Tag="TXT_KEY_PRODUCTION_BUILDING_NUM_FRANCHISES">
+			<Text>Requires {1_Num} Global [ICON_FRANCHISE] Franchises</Text>
+		</Row>
+		<Row Tag="TXT_KEY_PRODUCTION_BUILDING_PERCENT_MONOPOLIES">
+			<Text>Requires control of {1_Num}% of possible Global [ICON_MONOPOLY] Monopolies</Text>
+		</Row>
 		<Row Tag="TXT_KEY_PRODUCTION_BUILDING_REQUIRED_BUILDINGS_GLOBAL">
 			<Text>Required Buildings in any City: [COLOR_YIELD_FOOD]{1_Buildings}[ENDCOLOR]</Text>
 		</Row>

--- a/(1) Community Patch/Database Changes/Text/en_US/UI/CoreNewUIText.xml
+++ b/(1) Community Patch/Database Changes/Text/en_US/UI/CoreNewUIText.xml
@@ -1325,7 +1325,7 @@
 			<Text>When killing an enemy [ICON_SPY] Spy: {1_InstantYield}</Text>
 		</Row>
 		<Row Tag="TXT_KEY_PRODUCTION_BUILDING_EXTRA_LUXURIES">
-			<Text>+100% Luxury Resources from Improved Tiles owned by this City</Text>
+			<Text>+1 copy of Luxury Resources from Improved Tiles owned by this City</Text>
 		</Row>
 		<Row Tag="TXT_KEY_PRODUCTION_BUILDING_REMOVE_OCCUPIED_UNHAPPINESS">
 			<Text>Removes [ICON_HAPPINESS_3] Unhappiness from [ICON_OCCUPIED] Occupation</Text>

--- a/(1) Community Patch/Database Changes/Units/UnitTableChanges.sql
+++ b/(1) Community Patch/Database Changes/Units/UnitTableChanges.sql
@@ -150,6 +150,9 @@ ALTER TABLE Units ADD StackCombat integer DEFAULT 0;
 -- This Great Person will give the player Spy Points when it is expended. See also the building column of the same name
 ALTER TABLE Units ADD ExtraSpies integer DEFAULT 0;
 
+-- This Great Person will give +x copies of every luxury resource in the City State's borders when expended for a trade mission
+ALTER TABLE Units ADD ExtraLuxuries integer DEFAULT 0;
+
 --------------------------------------------------------
 -- Other Tables
 --------------------------------------------------------

--- a/CvGameCoreDLL_Expansion2/CvBuildingClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuildingClasses.cpp
@@ -46,6 +46,7 @@ CvBuildingEntry::CvBuildingEntry(void):
 	m_iResourceType(NO_RESOURCE),
 	m_iGrantsRandomResourceTerritory(0),
 	m_bPuppetPurchaseOverride(false),
+	m_bRequiresPuppet(false),
 	m_bAllowsPuppetPurchase(false),
 	m_bNoStarvationNonSpecialist(false),
 	m_iMinimumFood(0),
@@ -905,6 +906,7 @@ bool CvBuildingEntry::CacheResults(Database::Results& kResults, CvDatabaseUtilit
 	m_iNeedBuildingThisCity = GC.getInfoTypeForString(szTextVal, true);
 	m_iGrantsRandomResourceTerritory = kResults.GetInt("GrantsRandomResourceTerritory");
 	m_bPuppetPurchaseOverride = kResults.GetBool("PuppetPurchaseOverride");
+	m_bRequiresPuppet = kResults.GetBool("RequiresPuppet");
 	m_bAllowsPuppetPurchase = kResults.GetBool("AllowsPuppetPurchase");
 	m_bNoStarvationNonSpecialist = kResults.GetBool("NoStarvationNonSpecialist");
 	m_iMinimumFood = kResults.GetInt("MinimumFood");
@@ -2101,6 +2103,11 @@ int CvBuildingEntry::GrantsRandomResourceTerritory() const
 bool CvBuildingEntry::IsPuppetPurchaseOverride() const
 {
 	return m_bPuppetPurchaseOverride;
+}
+/// Is this building only buildable in puppets?
+bool CvBuildingEntry::IsRequiresPuppet() const
+{
+	return m_bRequiresPuppet;
 }
 /// Does this building unlock purchasing in any city?
 bool CvBuildingEntry::IsAllowsPuppetPurchase() const

--- a/CvGameCoreDLL_Expansion2/CvBuildingClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuildingClasses.cpp
@@ -385,6 +385,8 @@ CvBuildingEntry::CvBuildingEntry(void):
 	m_viResourceMonopolyOrs(),
 	m_piYieldChangePerMonopoly(NULL),
 	m_piYieldChangeFromPassingTR(NULL),
+	m_iRequiredPercentGlobalMonopolies(0),
+	m_iRequiredFranchises(0),
 	m_piYieldPerFranchise(NULL),
 	m_iGPRateModifierPerXFranchises(0),
 	m_piResourceQuantityPerXFranchises(NULL),
@@ -912,6 +914,8 @@ bool CvBuildingEntry::CacheResults(Database::Results& kResults, CvDatabaseUtilit
 	m_iMinimumFood = kResults.GetInt("MinimumFood");
 	m_iGetCooldown = kResults.GetInt("PurchaseCooldown");
 	m_iNumPoliciesNeeded = kResults.GetInt("NumPoliciesNeeded");
+	m_iRequiredPercentGlobalMonopolies = kResults.GetInt("RequiresXPercentGlobalMonopolies");
+	m_iRequiredFranchises = kResults.GetInt("RequiresXFranchises");
 
 	szTextVal = kResults.GetText("SpecialistType");
 	m_iSpecialistType = GC.getInfoTypeForString(szTextVal, true);
@@ -4493,7 +4497,19 @@ int CvBuildingEntry::GetResourceMonopolyOr(uint ui) const
 	PRECONDITION(ui < m_viResourceMonopolyOrs.size(), "Index out of bounds");
 	return m_viResourceMonopolyOrs[ui];
 }
-//Coroporation Stuff
+/// Requires certain percent of the world's global monopolies to build
+int CvBuildingEntry::GetRequiredPercentGlobalMonopolies() const
+{
+	return m_iRequiredPercentGlobalMonopolies;
+}
+
+/// Corporation Stuff
+/// Requires certain number of franchises to build
+int CvBuildingEntry::GetRequiredFranchises() const
+{
+	return m_iRequiredFranchises;
+}
+/// GP bonus per franchise
 int CvBuildingEntry::GetGPRateModifierPerXFranchises() const
 {
 	return m_iGPRateModifierPerXFranchises;

--- a/CvGameCoreDLL_Expansion2/CvBuildingClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvBuildingClasses.h
@@ -145,6 +145,7 @@ public:
 	int GetNumPoliciesNeeded() const;
 	int GrantsRandomResourceTerritory() const;
 	bool IsPuppetPurchaseOverride() const;
+	bool IsRequiresPuppet() const;
 	bool IsAllowsPuppetPurchase() const;
 	bool IsNoStarvationNonSpecialist() const;
 	int GetMinimumFood() const;
@@ -734,6 +735,7 @@ private:
 	int m_iResourceType;
 	int m_iGrantsRandomResourceTerritory;
 	bool m_bPuppetPurchaseOverride;
+	bool m_bRequiresPuppet;
 	bool m_bAllowsPuppetPurchase;
 	bool m_bNoStarvationNonSpecialist;
 	int m_iMinimumFood;

--- a/CvGameCoreDLL_Expansion2/CvBuildingClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvBuildingClasses.h
@@ -146,6 +146,8 @@ public:
 	int GrantsRandomResourceTerritory() const;
 	bool IsPuppetPurchaseOverride() const;
 	bool IsRequiresPuppet() const;
+	int GetRequiredFranchises() const;
+	int GetRequiredPercentGlobalMonopolies() const;
 	bool IsAllowsPuppetPurchase() const;
 	bool IsNoStarvationNonSpecialist() const;
 	int GetMinimumFood() const;
@@ -736,6 +738,8 @@ private:
 	int m_iGrantsRandomResourceTerritory;
 	bool m_bPuppetPurchaseOverride;
 	bool m_bRequiresPuppet;
+	int m_iRequiredFranchises;
+	int m_iRequiredPercentGlobalMonopolies;
 	bool m_bAllowsPuppetPurchase;
 	bool m_bNoStarvationNonSpecialist;
 	int m_iMinimumFood;

--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -8836,15 +8836,14 @@ bool CvCity::canConstruct(BuildingTypes eBuilding, const std::vector<int>& vPreE
 
 	CvBuildingEntry* pkBuildingInfo = GC.getBuildingInfo(eBuilding);
 
-	//no wonders for minor civs or in puppets (also affects venice unless invest or already invested)
-	if (GET_PLAYER(m_eOwner).isMinorCiv() || (IsPuppet() && !(GET_PLAYER(m_eOwner).GetPlayerTraits()->IsNoAnnexing() && (bContinue || bWillPurchase))))
+	//no wonders or limited copy buildings for minor civs, or in puppets (including venice unless invest or already invested) unless purchase override is set
+	if (GET_PLAYER(m_eOwner).isMinorCiv() || (IsPuppet() && !(GET_PLAYER(m_eOwner).GetPlayerTraits()->IsNoAnnexing() && (bContinue || bWillPurchase)) && !pkBuildingInfo->IsPuppetPurchaseOverride()))
 	{
 		if (isWorldWonderClass(pkBuildingInfo->GetBuildingClassInfo()) || isNationalWonderClass(pkBuildingInfo->GetBuildingClassInfo()))
 		{
 			return false;
 		}
 	}
-
 
 	if (!(GET_PLAYER(getOwner()).canConstruct(eBuilding, vPreExistingBuildings, bContinue, bTestVisible, bIgnoreCost, toolTipSink)))
 	{

--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -8884,6 +8884,10 @@ bool CvCity::canConstruct(BuildingTypes eBuilding, const std::vector<int>& vPreE
 	{
 		return false;
 	}
+	if (!IsBuildingFeatureValid(eBuilding, toolTipSink))
+	{
+		return false;
+	}
 
 	// Religion-enabled national wonder
 	if (pkBuildingInfo->IsUnlockedByBelief() && pkBuildingInfo->IsReformation())
@@ -8914,9 +8918,14 @@ bool CvCity::canConstruct(BuildingTypes eBuilding, const std::vector<int>& vPreE
 	{
 		return false;
 	}
-	if (!IsBuildingFeatureValid(eBuilding, toolTipSink))
+	// Own a certain percentage of the world's global monopolies?
+	if (pkBuildingInfo->GetRequiredPercentGlobalMonopolies() > 0)
 	{
-		return false;
+		int iPercentOwned = GET_PLAYER(getOwner()).GetPercentGlobalMonopolies();
+		if (iPercentOwned < pkBuildingInfo->GetRequiredPercentGlobalMonopolies())
+		{
+			return false;
+		}
 	}
 	// Corporation building?
 	if (pkBuildingInfo->GetBuildingClassInfo().getCorporationType() != NO_CORPORATION)
@@ -8954,6 +8963,30 @@ bool CvCity::canConstruct(BuildingTypes eBuilding, const std::vector<int>& vPreE
 			}
 		}
 	}
+	// this buildings requires a certain number of franchises established
+	if (pkBuildingInfo->GetRequiredFranchises() > 0)
+	{
+		// Must have Corporations tech
+		if (!GET_TEAM(GET_PLAYER(getOwner()).getTeam()).IsCorporationsEnabled())
+		{
+			return false;
+		}
+
+		CvPlayerCorporations* pPlayerCorporation = GET_PLAYER(getOwner()).GetCorporations();
+		if (pPlayerCorporation->HasFoundedCorporation())
+		{
+			int iNumFranchises = pPlayerCorporation->GetNumFranchises();
+			if (iNumFranchises < pkBuildingInfo->GetRequiredFranchises())
+			{
+				return false;
+			}
+		}
+		else
+		{
+			return false;
+		}
+	}
+	
 	// Holy city requirement
 	if (pkBuildingInfo->IsRequiresHolyCity() && !GetCityReligions()->IsHolyCityAnyReligion())
 	{

--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -241,7 +241,7 @@ CvCity::CvCity() :
 	, m_iResistanceTurns()
 	, m_iRazingTurns()
 	, m_iLowestRazingPop()
-	, m_iCountExtraLuxuries()
+	, m_aiExtraResources()
 	, m_iCheapestPlotInfluenceDistance()
 	, m_iEspionageModifier()
 	, m_iSpySecurityModifier()
@@ -1235,7 +1235,6 @@ void CvCity::reset(int iID, PlayerTypes eOwner, int iX, int iY, bool bConstructo
 	m_iResistanceTurns = 0;
 	m_iRazingTurns = 0;
 	m_iLowestRazingPop = 0;
-	m_iCountExtraLuxuries = 0;
 	m_iCheapestPlotInfluenceDistance = 0;
 	m_unitBeingBuiltForOperation.Invalidate();
 	m_hGarrisonOverride = -1;
@@ -1258,6 +1257,7 @@ void CvCity::reset(int iID, PlayerTypes eOwner, int iX, int iY, bool bConstructo
 	m_eOriginalOwner = eOwner;
 	m_ePlayersReligion = NO_PLAYER;
 
+	m_aiExtraResources.resize(GC.getNumResourceInfos());
 
 	m_aiSeaPlotYield.resize(NUM_YIELD_TYPES);
 	m_aiRiverPlotYield.resize(NUM_YIELD_TYPES);
@@ -9173,6 +9173,20 @@ bool CvCity::canCreate(ProjectTypes eProject, bool bContinue, bool bTestVisible,
 	if (!(GET_PLAYER(getOwner()).canCreate(eProject, bContinue, bTestVisible, toolTipSink)))
 	{
 		return false;
+	}
+
+	CvProjectEntry* pkProjectInfo = GC.getProjectInfo(eProject);
+	if (pkProjectInfo)
+	{
+		ResourceTypes eResource = (ResourceTypes)pkProjectInfo->GetLocalResourcePrereq();
+
+		// IsBuildingLocalResourceValid
+		if (eResource != NO_RESOURCE && !IsHasResourceLocal(eResource, bTestVisible))
+		{
+			CvResourceInfo* pResource = GC.getResourceInfo(eResource);
+			GC.getGame().BuildCannotPerformActionHelpText(toolTipSink, "TXT_KEY_NO_ACTION_BUILDING_LOCAL_RESOURCE", pResource->GetTextKey(), pResource->GetIconString());
+			return false;
+		}
 	}
 
 	ICvEngineScriptSystem1* pkScriptSystem = gDLL->GetScriptSystem();
@@ -27040,21 +27054,33 @@ void CvCity::doFoundMessage()
 }
 
 //	--------------------------------------------------------------------------------
-bool CvCity::IsExtraLuxuryResources()
+int CvCity::GetExtraResources(ResourceTypes eResource)
 {
-	return (m_iCountExtraLuxuries > 0);
+	PRECONDITION(eResource < GC.getNumResourceInfos(), "Index out of bounds");
+	PRECONDITION(eResource > -1, "Index out of bounds");
+	return m_aiExtraResources[eResource];
 }
-
 //	--------------------------------------------------------------------------------
-void CvCity::SetExtraLuxuryResources(int iNewValue)
+void CvCity::ChangeExtraResources(ResourceTypes eResource, int iChange)
 {
-	m_iCountExtraLuxuries = iNewValue;
+	PRECONDITION(eResource < GC.getNumResourceInfos(), "Index out of bounds");
+	PRECONDITION(eResource > -1, "Index out of bounds");
+	m_aiExtraResources[eResource] += iChange;
 }
-
 //	--------------------------------------------------------------------------------
 void CvCity::ChangeExtraLuxuryResources(int iChange)
 {
-	m_iCountExtraLuxuries += iChange;
+	for (int iI = 0; iI < GC.getNumResourceInfos(); iI++)
+	{
+		ResourceTypes eLoopResource = (ResourceTypes)iI;
+		if (eLoopResource != NO_RESOURCE)
+		{
+			if (GC.getResourceInfo(eLoopResource)->getResourceUsage() == RESOURCEUSAGE_LUXURY)
+			{
+				m_aiExtraResources[eLoopResource] += iChange;
+			}
+		}
+	}
 }
 
 //	--------------------------------------------------------------------------------
@@ -30320,7 +30346,7 @@ bool CvCity::CreateProject(ProjectTypes eProjectType)
 	CvProjectEntry* pProject = GC.getProjectInfo(eProjectType);
 	if (pProject)
 	{
-		GET_PLAYER(getOwner()).GetTreasury()->ChangeBaseBuildingGoldMaintenance(pProject->GetGoldMaintenance()); // Maintenance cost
+		thisPlayer.GetTreasury()->ChangeBaseBuildingGoldMaintenance(pProject->GetGoldMaintenance()); // Maintenance cost
 		ChangeUnmoddedHappinessFromBuildings(pProject->GetHappiness());
 		ChangeEmpireSizeModifierReduction(pProject->GetEmpireSizeModifierReduction());
 		ChangeDistressFlatReduction(pProject->GetDistressFlatReduction());
@@ -30335,14 +30361,14 @@ bool CvCity::CreateProject(ProjectTypes eProjectType)
 		ChangeReligiousUnrestModifier(pProject->GetReligiousUnrestModifier());
 		ChangeSpySecurityModifier(pProject->GetSpySecurityModifier());
 		changeCitySupplyFlat(pProject->GetCitySupplyFlat());
-		GET_PLAYER(getOwner()).ChangeEmpireSizeModifierPerCityMod(pProject->GetEmpireSizeModifierPerCityMod());
+		thisPlayer.ChangeEmpireSizeModifierPerCityMod(pProject->GetEmpireSizeModifierPerCityMod());
 		
 		for (int iI = 0; iI < GC.getNumUnitCombatClassInfos(); iI++)
 		{
 			int iModifier = pProject->GetUnitCombatProductionModifiersGlobal(iI);
 			if (iModifier != 0)
 			{
-				GET_PLAYER(getOwner()).changeUnitCombatProductionModifiers((UnitCombatTypes)iI, iModifier);
+				thisPlayer.changeUnitCombatProductionModifiers((UnitCombatTypes)iI, iModifier);
 			}
 		}
 		
@@ -30351,10 +30377,85 @@ bool CvCity::CreateProject(ProjectTypes eProjectType)
 			int iModifier = pProject->GetYieldFromConquestAllCities(iI);
 			if (iModifier != 0)
 			{
-				GET_PLAYER(getOwner()).changeYieldFromConquestAllCities((YieldTypes)iI, iModifier);
+				thisPlayer.changeYieldFromConquestAllCities((YieldTypes)iI, iModifier);
+			}
+		}
+
+		int iExtraLux = pProject->GetExtraLuxuries();
+		if (iExtraLux > 0)
+		{
+			// if there is a prereq resource set, only affect that
+			ResourceTypes ePrereqResource = (ResourceTypes)pProject->GetLocalResourcePrereq();
+			
+			CvPlot* pLoopPlot = NULL;
+
+			// TODO: Do we want this to be removed if the city is lost? is it already?
+			if (iExtraLux > 0)
+			{
+				if (ePrereqResource != NO_RESOURCE)
+				{
+					ChangeExtraResources(ePrereqResource, iExtraLux);
+				}
+				else
+				{
+					ChangeExtraLuxuryResources(iExtraLux);
+				}
+			}
+
+			// Add extra luxury counts
+			std::set<int>::iterator it;
+			for (it = m_siPlots.begin(); it != m_siPlots.end(); ++it)
+			{
+				pLoopPlot = GC.getMap().plotByIndex(*it);
+				ASSERT(pLoopPlot);
+
+				ResourceTypes eLoopResource = pLoopPlot->getResourceType(getTeam());
+				if (eLoopResource != NO_RESOURCE && GC.getResourceInfo(eLoopResource)->getResourceUsage() == RESOURCEUSAGE_LUXURY)
+				{
+					if (ePrereqResource != NO_RESOURCE && eLoopResource != ePrereqResource)
+						continue;
+							
+					if (pLoopPlot->IsResourceImprovedForOwner())
+					{
+						if (iExtraLux > 0)
+						{
+							thisPlayer.addResourcesOnPlotToTotal(pLoopPlot, true);
+						}
+						else
+						{
+							thisPlayer.removeResourcesOnPlotFromTotal(pLoopPlot, true);
+						}
+					}
+					else
+					{
+						if (iExtraLux > 0)
+						{
+							thisPlayer.addResourcesOnPlotToUnimproved(pLoopPlot, true);
+						}
+						else
+						{
+							thisPlayer.removeResourcesOnPlotFromUnimproved(pLoopPlot, true);
+						}
+					}
+				}
 			}
 		}
 	}
+
+	for (int iResourceLoop = 0; iResourceLoop < GC.getNumResourceInfos(); iResourceLoop++)
+	{
+		const ResourceTypes eResource = static_cast<ResourceTypes>(iResourceLoop);
+
+		if (pProject->GetFreeResources(eResource) > 0)
+		{
+			CvResourceInfo* pkResourceInfo = GC.getResourceInfo(eResource);
+			if (pkResourceInfo)
+			{
+					GET_PLAYER(getOwner()).changeNumResourceTotal(eResource, pProject->GetFreeResources(eResource), true, true, false);
+			}
+		}
+	}
+	
 	if (GetWLTKDFromProject(eProjectType) > 0)
 	{
 		int iWLTKDTurns = GetWLTKDFromProject(eProjectType);
@@ -32033,7 +32134,7 @@ void CvCity::Serialize(City& city, Visitor& visitor)
 	visitor(city.m_iResistanceTurns);
 	visitor(city.m_iRazingTurns);
 	visitor(city.m_iLowestRazingPop);
-	visitor(city.m_iCountExtraLuxuries);
+	visitor(city.m_aiExtraResources);
 	visitor(city.m_iCheapestPlotInfluenceDistance);
 	visitor(city.m_iEspionageModifier);
 	visitor(city.m_iSpySecurityModifier);

--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -8968,6 +8968,10 @@ bool CvCity::canConstruct(BuildingTypes eBuilding, const std::vector<int>& vPreE
 	if (pkBuildingInfo->IsNoOccupiedUnhappiness() && !IsOccupied() && !pkBuildingInfo->IsBuildAnywhere())
 		return false;
 
+	// Some buildings can only be built in puppet cities
+	if (pkBuildingInfo->IsRequiresPuppet() && !IsPuppet())
+		return false;
+
 	// Does this city have prereq buildings?
 	if (!hasBuildingPrerequisites(eBuilding))
 	{

--- a/CvGameCoreDLL_Expansion2/CvCity.h
+++ b/CvGameCoreDLL_Expansion2/CvCity.h
@@ -1438,8 +1438,8 @@ public:
 
 	void doFoundMessage();
 
-	bool IsExtraLuxuryResources();
-	void SetExtraLuxuryResources(int iNewValue);
+	int GetExtraResources(ResourceTypes eResource);
+	void ChangeExtraResources(ResourceTypes eResource, int iChange);
 	void ChangeExtraLuxuryResources(int iChange);
 
 	CvCityBuildings* GetCityBuildings() const;
@@ -1927,7 +1927,6 @@ protected:
 	int m_iResistanceTurns;
 	int m_iRazingTurns;
 	int m_iLowestRazingPop;
-	int m_iCountExtraLuxuries;
 	int m_iCheapestPlotInfluenceDistance;
 	int m_iEspionageModifier;
 	int m_iSpySecurityModifier;
@@ -1938,6 +1937,7 @@ protected:
 
 	OperationSlot m_unitBeingBuiltForOperation;
 
+	std::vector<int> m_aiExtraResources;
 	bool m_bNeverLost;
 	bool m_bDrafted;
 	bool m_bProductionAutomated;
@@ -2342,7 +2342,7 @@ SYNC_ARCHIVE_VAR(int, m_iDemandResourceCounter)
 SYNC_ARCHIVE_VAR(int, m_iResistanceTurns)
 SYNC_ARCHIVE_VAR(int, m_iRazingTurns)
 SYNC_ARCHIVE_VAR(int, m_iLowestRazingPop)
-SYNC_ARCHIVE_VAR(int, m_iCountExtraLuxuries)
+SYNC_ARCHIVE_VAR(std::vector<int>, m_aiExtraResources)
 SYNC_ARCHIVE_VAR(int, m_iCheapestPlotInfluenceDistance)
 SYNC_ARCHIVE_VAR(int, m_iEspionageModifier)
 SYNC_ARCHIVE_VAR(int, m_iSpySecurityModifier)

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -33240,14 +33240,11 @@ void CvPlayer::setTurnActive(bool bNewValue, bool bDoTurn) // R: bDoTurn default
 						if (eRes == (ResourceTypes)iJ)
 						{
 							CvResourceInfo* pResourceInfo = GC.getResourceInfo(eRes);
-							int iNumExtraLuxury = 0;
-							if (pResourceInfo->getResourceUsage() == RESOURCEUSAGE_LUXURY)
+							int iNumExtraResource = 0;
+							CvCity* pCity = pLoopPlot->getOwningCity();
+							if (pCity && pCity->GetExtraResources(eRes) > 0)
 							{
-								CvCity* pCity = pLoopPlot->getOwningCity();
-								if (pCity && pCity->IsExtraLuxuryResources())
-								{
-									iNumExtraLuxury = 1;
-								}
+								iNumExtraResource = pCity->GetExtraResources(eRes);
 							}
 							int iNumResource = pLoopPlot->getNumResource();
 
@@ -33291,7 +33288,7 @@ void CvPlayer::setTurnActive(bool bNewValue, bool bDoTurn) // R: bDoTurn default
 							}
 							else
 							{
-								iCntUnimproved += iNumResource + iNumExtraLuxury;
+								iCntUnimproved += iNumResource + iNumExtraResource;
 
 							}
 						}

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -429,6 +429,7 @@ CvPlayer::CvPlayer() :
 	, m_iMinorResourceBonusCount()
 	, m_iAbleToAnnexCityStatesCount()
 	, m_iBorderSettle()
+	, m_iGreatMerchantExtraLuxuries()
 	, m_iOnlyTradeSameIdeology()
 	, m_iSupplyFreeUnits()
 	, m_aistrInstantYield()
@@ -1411,6 +1412,7 @@ void CvPlayer::uninit()
 	m_iMinorResourceBonusCount = 0;
 	m_iAbleToAnnexCityStatesCount = 0;
 	m_iBorderSettle = 0;
+	m_iGreatMerchantExtraLuxuries = 0;
 	m_iOnlyTradeSameIdeology = 0;
 	m_iSupplyFreeUnits = 0;
 	m_strJFDCurrencyName = "";
@@ -28362,6 +28364,8 @@ CvString CvPlayer::getInstantGreatPersonProgressText(InstantYieldType iType) con
 /// Do effects when a GP is consumed
 void CvPlayer::DoGreatPersonExpended(UnitTypes eGreatPersonUnit, CvUnit* pGreatPersonUnit)
 {
+	PRECONDITION(pGreatPersonUnit, "DoGreatPersonExpended shouldn't ever be called with a non-existent unit");
+	
 	// Gold gained
 	int iExpendGold = GetGreatPersonExpendGold();
 	if (iExpendGold > 0)
@@ -28392,86 +28396,98 @@ void CvPlayer::DoGreatPersonExpended(UnitTypes eGreatPersonUnit, CvUnit* pGreatP
 		}
 	}
 
-	if (pGreatPersonUnit)
+	const CvUnitEntry& kGreatPersonUnitInfo = pGreatPersonUnit->getUnitInfo();
+	
+	//is this expended on the tile of a foreign city? pre-evaluate for the loop below
+	bool bForeignTerritory = false;
+	CvCity* pForeignCity = NULL;
+	int iExtraLux = kGreatPersonUnitInfo.GetExtraLuxuries();
+	if (pGreatPersonUnit->getUnitClassType() == GC.getInfoTypeForString("UNITCLASS_MERCHANT"))
+		iExtraLux += GetGreatMerchantExtraLuxuries();
+	if (iExtraLux > 0)
 	{
-		//great diplomat grants a paper resource - admiral code is handled in CvUnit::createFreeLuxury()
-		for (int iResourceLoop = 0; iResourceLoop < GC.getNumResourceInfos(); iResourceLoop++)
+		PlayerTypes eOwner = pGreatPersonUnit->plot()->getOwner();
+		if (eOwner != NO_PLAYER && eOwner != GetID())
 		{
-			int Gained = pGreatPersonUnit->getUnitInfo().GetResourceQuantityExpended((ResourceTypes)iResourceLoop);
-			if (Gained != 0)
-			{
-				changeResourceFromGP((ResourceTypes)iResourceLoop, Gained);
-			}
+			bForeignTerritory = true;
+			pForeignCity = pGreatPersonUnit->plot()->getOwningCity();
+		}
+	}
+
+	//great diplomat grants a paper resource - admiral code is handled in CvUnit::createFreeLuxury()
+	//extra luxuries copy resources from minors
+	for (int iResourceLoop = 0; iResourceLoop < GC.getNumResourceInfos(); iResourceLoop++)
+	{
+		ResourceTypes eResource = (ResourceTypes)iResourceLoop;
+		
+		int Gained = kGreatPersonUnitInfo.GetResourceQuantityExpended(eResource);
+		if (Gained != 0)
+		{
+			changeResourceFromGP(eResource, Gained);
 		}
 
-		//general grants supply points
-		int iSupply = pGreatPersonUnit->getUnitInfo().GetSupplyCapBoost() + pGreatPersonUnit->GetMilitaryCapChange();
-		if (iSupply > 0)
+		if (bForeignTerritory && pForeignCity && iExtraLux > 0)
 		{
-			ChangeUnitSupplyFromExpendedGreatPeople(iSupply);
-
-			// force recalculation
-			m_iNumUnitsSuppliedCached = -1;
-			m_iNumUnitsSuppliedCachedWarWeariness = -1;
-
-			if (GetID() == GC.getGame().getActivePlayer())
+			if (pForeignCity->IsHasResourceLocal(eResource, true))  // improved or unimproved
 			{
-				char text[256] = { 0 };
-
-				sprintf_s(text, "[COLOR_WHITE]+%d[ENDCOLOR][ICON_WAR]", iSupply);
-				SHOW_PLOT_POPUP( pGreatPersonUnit->plot(), GetID(), text);
-
-				CvNotifications* pNotification = GetNotifications();
-				if (pNotification)
+				CvResourceInfo* pkResourceInfo = GC.getResourceInfo(eResource);
+				if (pkResourceInfo && pkResourceInfo->getResourceUsage() == RESOURCEUSAGE_LUXURY)
 				{
-					CvString strMessage;
-					CvString strSummary;
-					strMessage = GetLocalizedText("TXT_KEY_UNIT_EXPENDED_SUPPLY", pGreatPersonUnit->getName().c_str(), iSupply);
-					strSummary = GetLocalizedText("TXT_KEY_UNIT_EXPENDED_SUPPLY_S");
-					pNotification->Add(NOTIFICATION_GENERIC, strMessage, strSummary, pGreatPersonUnit->getX(), pGreatPersonUnit->getY(), GetID());
+					changeResourceFromGP(eResource, iExtraLux);
 				}
 			}
 		}
 	}
 
-	//Influence Gained with all CS per expend
-	int iExpendInfluence = GetInfluenceGPExpend() + GetGPExpendInfluence();
-	if(iExpendInfluence > 0)
+	//general grants supply points
+	int iSupply = kGreatPersonUnitInfo.GetSupplyCapBoost() + pGreatPersonUnit->GetMilitaryCapChange();
+	if (iSupply > 0)
 	{
-		for (int iMinorLoop = MAX_MAJOR_CIVS; iMinorLoop < MAX_CIV_PLAYERS; iMinorLoop++)
+		ChangeUnitSupplyFromExpendedGreatPeople(iSupply);
+
+		// force recalculation
+		m_iNumUnitsSuppliedCached = -1;
+		m_iNumUnitsSuppliedCachedWarWeariness = -1;
+
+		if (GetID() == GC.getGame().getActivePlayer())
 		{
-			PlayerTypes eMinorLoop = (PlayerTypes) iMinorLoop;
-			if(eMinorLoop != NO_PLAYER)
+			char text[256] = { 0 };
+
+			sprintf_s(text, "[COLOR_WHITE]+%d[ENDCOLOR][ICON_WAR]", iSupply);
+			SHOW_PLOT_POPUP( pGreatPersonUnit->plot(), GetID(), text);
+
+			CvNotifications* pNotification = GetNotifications();
+			if (pNotification)
 			{
-				CvPlayer* pMinorLoop = &GET_PLAYER(eMinorLoop);
-				if(pMinorLoop->isMinorCiv() && pMinorLoop->isAlive())
-				{
-					if(GET_TEAM(pMinorLoop->getTeam()).isHasMet(getTeam()))
-					{
-						pMinorLoop->GetMinorCivAI()->ChangeFriendshipWithMajor(GetID(), iExpendInfluence, false);
-					}
-				}
+				CvString strMessage;
+				CvString strSummary;
+				strMessage = GetLocalizedText("TXT_KEY_UNIT_EXPENDED_SUPPLY", pGreatPersonUnit->getName().c_str(), iSupply);
+				strSummary = GetLocalizedText("TXT_KEY_UNIT_EXPENDED_SUPPLY_S");
+				pNotification->Add(NOTIFICATION_GENERIC, strMessage, strSummary, pGreatPersonUnit->getX(), pGreatPersonUnit->getY(), GetID());
 			}
 		}
 	}
 
+	// spy points
+	int iExtraSpies = kGreatPersonUnitInfo.GetExtraSpies();
+	if (iExtraSpies > 0)
+	{
+		CreateSpies(iExtraSpies);
+	}
+	
 	// add yields to capital based on the tile the GP was expended on
-	GreatPersonTypes eGreatPerson = GetGreatPersonFromUnitClass(pGreatPersonUnit->getUnitClassType());
-	if (pGreatPersonUnit->getUnitInfo().IsCopyYieldsFromExpendTile())
+	if (kGreatPersonUnitInfo.IsCopyYieldsFromExpendTile())
 	{
 		for (int iI = 0; iI < NUM_YIELD_TYPES; iI++)
 		{
 			YieldTypes eYield = (YieldTypes)iI;
 			changeYieldFromExpendTileCapital(eYield, pGreatPersonUnit->plot()->calculateYield(eYield));
 		}
-		
 	}
 	
-	doInstantYield(INSTANT_YIELD_TYPE_GP_USE, false, eGreatPerson);
-	
-	if (pGreatPersonUnit->getUnitInfo().GetTileXPOnExpend() > 0)
+	// give XP to the nearest eligible unit
+	if (kGreatPersonUnitInfo.GetTileXPOnExpend() > 0)
 	{
-		// give XP to the nearest eligible unit
 		// first check for units on the tile the GP was expended on
 		CvUnit* pNearestCombatUnit = NULL;
 		IDInfo* pPlotUnitNode = pGreatPersonUnit->plot()->headUnitNode();
@@ -28506,10 +28522,34 @@ void CvPlayer::DoGreatPersonExpended(UnitTypes eGreatPersonUnit, CvUnit* pGreatP
 		}
 		if (pNearestCombatUnit)
 		{
-			pNearestCombatUnit->changeExperienceTimes100(pGreatPersonUnit->getUnitInfo().GetTileXPOnExpend() * 100);
+			pNearestCombatUnit->changeExperienceTimes100(kGreatPersonUnitInfo.GetTileXPOnExpend() * 100);
 			pNearestCombatUnit->testPromotionReady();
 		}
 	}
+
+	//Influence Gained with all CS per expend
+	int iExpendInfluence = GetInfluenceGPExpend() + GetGPExpendInfluence();
+	if(iExpendInfluence > 0)
+	{
+		for (int iMinorLoop = MAX_MAJOR_CIVS; iMinorLoop < MAX_CIV_PLAYERS; iMinorLoop++)
+		{
+			PlayerTypes eMinorLoop = (PlayerTypes) iMinorLoop;
+			if(eMinorLoop != NO_PLAYER)
+			{
+				CvPlayer* pMinorLoop = &GET_PLAYER(eMinorLoop);
+				if(pMinorLoop->isMinorCiv() && pMinorLoop->isAlive())
+				{
+					if(GET_TEAM(pMinorLoop->getTeam()).isHasMet(getTeam()))
+					{
+						pMinorLoop->GetMinorCivAI()->ChangeFriendshipWithMajor(GetID(), iExpendInfluence, false);
+					}
+				}
+			}
+		}
+	}
+	
+	GreatPersonTypes eGreatPerson = GetGreatPersonFromUnitClass(pGreatPersonUnit->getUnitClassType());
+	doInstantYield(INSTANT_YIELD_TYPE_GP_USE, false, eGreatPerson);
 
 	if (MOD_EVENTS_GREAT_PEOPLE)
 	{
@@ -30057,6 +30097,16 @@ bool CvPlayer::IsBorderSettle() const
 void CvPlayer::SetBorderSettle(int iValue)
 {
 	m_iBorderSettle += iValue;
+}
+
+int CvPlayer::GetGreatMerchantExtraLuxuries() const
+{
+	return m_iGreatMerchantExtraLuxuries;
+}
+
+void CvPlayer::ChangeGreatMerchantExtraLuxuries(int iChange)
+{
+	m_iGreatMerchantExtraLuxuries += iChange;
 }
 
 // JFD
@@ -42928,6 +42978,7 @@ void CvPlayer::processPolicies(PolicyTypes ePolicy, int iChange)
 	changePuppetYieldAndSupplyModifierChange(pkPolicyInfo->GetPuppetYieldAndSupplyModifierChange() * iChange);
 	changeConquestPerEraBuildingProductionMod(pkPolicyInfo->GetConquestPerEraBuildingProductionMod() * iChange);
 	changeAdmiralLuxuryBonus(pkPolicyInfo->GetAdmiralLuxuryBonus() * iChange);
+	ChangeGreatMerchantExtraLuxuries(pkPolicyInfo->GetGreatMerchantExtraLuxuries() * iChange);
 	changeExtraMoves(pkPolicyInfo->GetExtraMoves() * iChange);
 	ChangeAllFeatureProduction(pkPolicyInfo->GetAllFeatureProduction());
 	ChangeIncreasedQuestInfluence(pkPolicyInfo->GetIncreasedQuestInfluence() * iChange);
@@ -44362,6 +44413,7 @@ void CvPlayer::Serialize(Player& player, Visitor& visitor)
 	visitor(player.m_iMinorResourceBonusCount);
 	visitor(player.m_iAbleToAnnexCityStatesCount);
 	visitor(player.m_iBorderSettle);
+	visitor(player.m_iGreatMerchantExtraLuxuries);
 	visitor(player.m_iOnlyTradeSameIdeology);
 	visitor(player.m_iSupplyFreeUnits);
 	visitor(player.m_abActiveContract);

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -38595,6 +38595,18 @@ void CvPlayer::SetHasGlobalMonopoly(ResourceTypes eResource, bool bNewValue)
 	}
 }
 
+int CvPlayer::GetPercentGlobalMonopolies() const
+{
+	int iGlobalsOnMap = GetNumGlobalMonopolies();
+	
+	if (iGlobalsOnMap == 0)
+		return 0;
+	
+	int iNumMonopolies = GetGlobalMonopolies().size();
+			
+	return 100 * iNumMonopolies / iGlobalsOnMap;
+}
+
 bool CvPlayer::HasStrategicMonopoly(ResourceTypes eResource) const
 {
 	return m_pabHasStrategicMonopoly[eResource];

--- a/CvGameCoreDLL_Expansion2/CvPlayer.h
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.h
@@ -2069,6 +2069,7 @@ public:
 
 	bool HasGlobalMonopoly(ResourceTypes eResource) const;
 	void SetHasGlobalMonopoly(ResourceTypes eResource, bool bNewValue);
+	int GetPercentGlobalMonopolies() const;
 	bool HasStrategicMonopoly(ResourceTypes eResource) const;
 	void SetHasStrategicMonopoly(ResourceTypes eResource, bool bNewValue);
 	void CheckForMonopoly(ResourceTypes eResource);

--- a/CvGameCoreDLL_Expansion2/CvPlayer.h
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.h
@@ -1324,6 +1324,9 @@ public:
 	bool IsBorderSettle() const;
 	void SetBorderSettle(int iValue);
 
+	int GetGreatMerchantExtraLuxuries() const;
+	void ChangeGreatMerchantExtraLuxuries(int iChange);
+
 	bool IsOnlyTradeSameIdeology() const;
 	void ChangeOnlyTradeSameIdeology(int iChange);
 	
@@ -3258,6 +3261,7 @@ protected:
 	int m_iMinorResourceBonusCount;
 	int m_iAbleToAnnexCityStatesCount;
 	int m_iBorderSettle;
+	int m_iGreatMerchantExtraLuxuries;
 	int m_iOnlyTradeSameIdeology;
 	int m_iSupplyFreeUnits; //military units which don't count against the supply limit
 	std::vector<CvString> m_aistrInstantYield; // not serialized
@@ -4064,6 +4068,7 @@ SYNC_ARCHIVE_VAR(int, m_iMinorScienceAlliesCount)
 SYNC_ARCHIVE_VAR(int, m_iMinorResourceBonusCount)
 SYNC_ARCHIVE_VAR(int, m_iAbleToAnnexCityStatesCount)
 SYNC_ARCHIVE_VAR(int, m_iBorderSettle)
+SYNC_ARCHIVE_VAR(int, m_iGreatMerchantExtraLuxuries)
 SYNC_ARCHIVE_VAR(int, m_iOnlyTradeSameIdeology)
 SYNC_ARCHIVE_VAR(int, m_iSupplyFreeUnits)
 SYNC_ARCHIVE_VAR(std::vector<bool>, m_abActiveContract)

--- a/CvGameCoreDLL_Expansion2/CvPlayerAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayerAI.cpp
@@ -1701,8 +1701,12 @@ GreatPeopleDirectiveTypes CvPlayerAI::GetDirectiveEngineer(CvUnit* pGreatEnginee
 GreatPeopleDirectiveTypes CvPlayerAI::GetDirectiveMerchant(CvUnit* pGreatMerchant)
 {
 	// if the merchant is in an army, he's already marching to a destination, so don't evaluate him
-	if(pGreatMerchant->getArmyID() != -1)
+	if (pGreatMerchant->getArmyID() != -1)
 		return NO_GREAT_PEOPLE_DIRECTIVE_TYPE;
+
+	// do we have a special bonus to merchant mission? if so, use it!
+	if (pGreatMerchant->getUnitInfo().GetExtraLuxuries() + GetGreatMerchantExtraLuxuries())
+		return GREAT_PEOPLE_DIRECTIVE_USE_POWER;
 
 	ImprovementTypes eCustomHouse = (ImprovementTypes)GC.getInfoTypeForString("IMPROVEMENT_CUSTOMS_HOUSE");
 	// buff up customs houses up to your flavor

--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -7901,15 +7901,12 @@ int CvPlot::getNumResourceForPlayer(PlayerTypes ePlayer, bool bExtraResources, b
 			{
 				if (bExtraResources)
 				{
-					if (pkResource->getResourceUsage() == RESOURCEUSAGE_LUXURY)
+					CvCity* pCity = getOwningCity();
+					if (pCity)
 					{
-						CvCity* pCity = getOwningCity();
-						if (pCity)
+						if (pCity->GetExtraResources(eResource) > 0)
 						{
-							if (pCity->IsExtraLuxuryResources())
-							{
-								return 1;
-							}
+							return pCity->GetExtraResources(eResource);
 						}
 					}
 					return 0;

--- a/CvGameCoreDLL_Expansion2/CvPolicyClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPolicyClasses.cpp
@@ -199,6 +199,7 @@ CvPolicyEntry::CvPolicyEntry(void):
 	m_bAbleToAnnexCityStates(false),
 	m_bBorderSettle(false),
 	m_bIsOnlyTradeSameIdeology(false),
+	m_iGreatMerchantExtraLuxuries(0),
 	m_bOneShot(false),
 	m_bIncludesOneShotFreeUnits(false),
 	m_iDistressFlatReduction(0),
@@ -691,6 +692,7 @@ bool CvPolicyEntry::CacheResults(Database::Results& kResults, CvDatabaseUtility&
 	m_bEnablesSSPartPurchase = kResults.GetBool("EnablesSSPartPurchase");
 	m_bAbleToAnnexCityStates = kResults.GetBool("AbleToAnnexCityStates");
 	m_bBorderSettle = kResults.GetBool("BorderSettle");
+	m_iGreatMerchantExtraLuxuries = kResults.GetInt("GreatMerchantExtraLuxuries");
 	m_bOneShot = kResults.GetBool("OneShot");
 	m_bIsOnlyTradeSameIdeology = kResults.GetBool("IsOnlyTradeSameIdeology");
 	m_bIncludesOneShotFreeUnits = kResults.GetBool("IncludesOneShotFreeUnits");
@@ -2473,6 +2475,12 @@ bool CvPolicyEntry::IsAbleToAnnexCityStates() const
 bool CvPolicyEntry::IsBorderSettle() const
 {
 	return m_bBorderSettle;
+}
+
+// Does this enable Great Merchants to copy luxuries?
+int CvPolicyEntry::GetGreatMerchantExtraLuxuries() const
+{
+	return m_iGreatMerchantExtraLuxuries;
 }
 
 /// Only trade with same ideologies

--- a/CvGameCoreDLL_Expansion2/CvPolicyClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvPolicyClasses.h
@@ -234,6 +234,7 @@ public:
 	bool IsEnablesSSPartPurchase() const;
 	bool IsAbleToAnnexCityStates() const;
 	bool IsBorderSettle() const;
+	int GetGreatMerchantExtraLuxuries() const;
 	std::string pyGetWeLoveTheKing()
 	{
 		return GetWeLoveTheKing();
@@ -656,6 +657,7 @@ private:
 	bool m_bEnablesSSPartPurchase;
 	bool m_bAbleToAnnexCityStates;
 	bool m_bBorderSettle;
+	int m_iGreatMerchantExtraLuxuries;
 
 	bool m_bIsOnlyTradeSameIdeology;
 	bool m_bOneShot;

--- a/CvGameCoreDLL_Expansion2/CvProjectClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvProjectClasses.cpp
@@ -25,7 +25,8 @@ CvProjectEntry::CvProjectEntry(void):
 	m_piProjectsNeeded(NULL),
 	m_piFlavorValue(NULL),
 	m_piUnitCombatProductionModifiersGlobal(NULL),
-	m_piYieldFromConquestAllCities(NULL)
+	m_piYieldFromConquestAllCities(NULL),
+	m_piFreeResources(NULL)
 {
 }
 //------------------------------------------------------------------------------
@@ -38,6 +39,7 @@ CvProjectEntry::~CvProjectEntry(void)
 	SAFE_DELETE_ARRAY(m_piFlavorValue);
 	SAFE_DELETE_ARRAY(m_piUnitCombatProductionModifiersGlobal);
 	SAFE_DELETE_ARRAY(m_piYieldFromConquestAllCities);
+	SAFE_DELETE_ARRAY(m_piFreeResources);
 }
 //------------------------------------------------------------------------------
 bool CvProjectEntry::CacheResults(Database::Results& kResults, CvDatabaseUtility& kUtility)
@@ -81,6 +83,7 @@ bool CvProjectEntry::CacheResults(Database::Results& kResults, CvDatabaseUtility
 	m_iReligiousUnrestModifier = kResults.GetInt("ReligiousUnrestModifier");
 	m_iSpySecurityModifier = kResults.GetInt("SpySecurityModifier");
 	m_iCitySupplyFlat = kResults.GetInt("CitySupplyFlat");
+	m_iExtraLuxuries = kResults.GetInt("ExtraLuxuries");
 	
 	const char* szFreeBuilding = kResults.GetText("FreeBuildingClassIfFirst");
 	if(szFreeBuilding)
@@ -116,6 +119,9 @@ bool CvProjectEntry::CacheResults(Database::Results& kResults, CvDatabaseUtility
 	const char* szTechPrereq = kResults.GetText("TechPrereq");
 	m_iTechPrereq = GC.getInfoTypeForString(szTechPrereq, true);
 
+	const char* szResourcePrereq = kResults.GetText("LocalResourcePrereq");
+	m_iLocalResourcePrereq = GC.getInfoTypeForString(szResourcePrereq, true);
+	
 	const char* szEveryoneSpecialUnit = kResults.GetText("EveryoneSpecialUnit");
 	m_iEveryoneSpecialUnit = GC.getInfoTypeForString(szEveryoneSpecialUnit, true);
 
@@ -158,6 +164,7 @@ bool CvProjectEntry::CacheResults(Database::Results& kResults, CvDatabaseUtility
 	kUtility.PopulateArrayByValue(m_piProjectsNeeded, "Projects", "Project_Prereqs", "PrereqProjectType", "ProjectType", szProjectType, "AmountNeeded");
 	kUtility.PopulateArrayByValue(m_piUnitCombatProductionModifiersGlobal, "UnitCombatInfos", "Project_UnitCombatProductionModifiersGlobal", "UnitCombatType", "ProjectType", szProjectType, "Modifier");
 	kUtility.SetYields(m_piYieldFromConquestAllCities, "Project_YieldFromConquestAllCities", "ProjectType", szProjectType);
+	kUtility.PopulateArrayByValue(m_piFreeResources, "Resources", "Project_FreeResource", "ResourceType", "ProjectType", szProjectType, "Number");
 
 	return true;
 }
@@ -172,6 +179,12 @@ int CvProjectEntry::GetVictoryPrereq() const
 int CvProjectEntry::GetTechPrereq() const
 {
 	return m_iTechPrereq;
+}
+
+/// Local Resource prerequisite
+int CvProjectEntry::GetLocalResourcePrereq() const
+{
+	return m_iLocalResourcePrereq;
 }
 
 /// Is there a project someone must have completed?
@@ -373,6 +386,11 @@ int CvProjectEntry::GetCitySupplyFlat() const
 {
 	return m_iCitySupplyFlat;
 }
+int CvProjectEntry::GetExtraLuxuries() const
+{
+	return m_iExtraLuxuries;
+}
+
 EventTypes CvProjectEntry::GetEventToStart() const
 {
 	return m_eEventToStart;
@@ -486,6 +504,20 @@ int CvProjectEntry::GetYieldFromConquestAllCities(int i) const
 	if(i > -1 && i < NUM_YIELD_TYPES && m_piYieldFromConquestAllCities)
 	{
 		return m_piYieldFromConquestAllCities[i];
+	}
+
+	return 0;
+}
+
+/// Unit combat production modifiers global
+int CvProjectEntry::GetFreeResources(int i) const
+{
+	PRECONDITION(i < GC.getNumResourceInfos(), "Index out of bounds");
+	PRECONDITION(i > -1, "Index out of bounds");
+
+	if(i > -1 && i < NUM_YIELD_TYPES && m_piFreeResources)
+	{
+		return m_piFreeResources[i];
 	}
 
 	return 0;

--- a/CvGameCoreDLL_Expansion2/CvProjectClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvProjectClasses.h
@@ -29,6 +29,7 @@ public:
 
 	int GetVictoryPrereq() const;
 	int GetTechPrereq() const;
+	int GetLocalResourcePrereq() const;
 	int GetAnyoneProjectPrereq() const;
 	void SetAnyoneProjectPrereq(int i);
 	int GetMaxGlobalInstances() const;
@@ -69,6 +70,8 @@ public:
 	int GetReligiousUnrestModifier() const;
 	int GetSpySecurityModifier() const;
 	int GetCitySupplyFlat() const;
+	int GetExtraLuxuries() const;
+
 	EventTypes GetEventToStart() const;
 	CityEventTypes GetCityEventToStart() const;
 
@@ -84,10 +87,12 @@ public:
 	int GetProjectsNeeded(int i) const;
 	int GetUnitCombatProductionModifiersGlobal(int i) const;
 	int GetYieldFromConquestAllCities(int i) const;
+	int GetFreeResources(int i) const;
 
 protected:
 	int m_iVictoryPrereq;
 	int m_iTechPrereq;
+	int m_iLocalResourcePrereq;
 	int m_iAnyoneProjectPrereq;
 	int m_iMaxGlobalInstances;
 	int m_iMaxTeamInstances;
@@ -127,6 +132,8 @@ protected:
 	int m_iReligiousUnrestModifier;
 	int m_iSpySecurityModifier;
 	int m_iCitySupplyFlat;
+	int m_iExtraLuxuries;
+
 	EventTypes m_eEventToStart;
 	CityEventTypes m_eCityEventToStart;
 
@@ -141,6 +148,7 @@ protected:
 	int* m_piFlavorValue;
 	int* m_piUnitCombatProductionModifiersGlobal;
 	int* m_piYieldFromConquestAllCities;
+	int* m_piFreeResources;
 };
 
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/CvGameCoreDLL_Expansion2/CvProjectProductionAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvProjectProductionAI.cpp
@@ -408,6 +408,47 @@ int CvProjectProductionAI::CheckProjectBuildSanity(ProjectTypes eProject, int iF
 
 	iTempWeight += iHappinessWeight;
 
+	/// Resources check
+	int iTempBonus = 0;
+	for (int iResourceLoop = 0; iResourceLoop < GC.getNumResourceInfos(); iResourceLoop++)
+	{
+		int iLuxuries = 0;
+		const ResourceTypes eResource = static_cast<ResourceTypes>(iResourceLoop);
+
+		// do we need to both calling the class?
+		if (pkProjectInfo->GetFreeResources(eResource) > 0 || pkProjectInfo->GetExtraLuxuries() > 0)
+		{
+			CvResourceInfo* pkResourceInfo = GC.getResourceInfo(eResource);
+			if (pkResourceInfo)
+			{
+				
+				if (pkProjectInfo->GetFreeResources(eResource))
+				{
+					if (kPlayer.getNumResourceAvailable(eResource, false) == 0)
+					{
+						iTempBonus += 100 + (pkProjectInfo->GetFreeResources(eResource) - 1) * 20;
+					}
+					else
+					{
+						iTempBonus += pkProjectInfo->GetFreeResources(eResource) * 20;
+					}
+				}
+				
+				if (pkResourceInfo->getResourceUsage() == RESOURCEUSAGE_LUXURY)
+				{
+					if (pkProjectInfo->GetExtraLuxuries() && (pkProjectInfo->GetLocalResourcePrereq() == NO_RESOURCE || pkProjectInfo->GetLocalResourcePrereq() == eResource))
+					{
+						iLuxuries += m_pCity->GetNumResourceLocal(eResource, true);
+						iLuxuries += m_pCity->GetNumResourceLocal(eResource, false);
+						
+						iTempBonus += pkProjectInfo->GetExtraLuxuries() * iLuxuries * 20;
+					}
+				}
+			}
+		}
+	}
+	iTempWeight += iTempBonus;
+
 	return max(1,iTempWeight);
 }
 /// Log all potential builds

--- a/CvGameCoreDLL_Expansion2/CvUnitClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnitClasses.cpp
@@ -131,6 +131,7 @@ CvUnitEntry::CvUnitEntry(void) :
 	m_bCopyYieldsFromExpendTile(false),
 	m_iTileXPOnExpend(0),
 	m_iExtraSpies(0),
+	m_iExtraLuxuries(0),
 	m_bWLTKD(false),
 	m_bGoldenAge(false),
 	m_bCultureBoost(false),
@@ -382,6 +383,7 @@ bool CvUnitEntry::CacheResults(Database::Results& kResults, CvDatabaseUtility& k
 	m_bCopyYieldsFromExpendTile = kResults.GetBool("CopyYieldsFromExpendTile");
 	m_iTileXPOnExpend = kResults.GetInt("TileXPOnExpend");
 	m_iExtraSpies = kResults.GetInt("ExtraSpies");
+	m_iExtraLuxuries = kResults.GetInt("ExtraLuxuries");
 	m_bWLTKD = kResults.GetBool("WLTKDFromBirth");
 	m_bGoldenAge = kResults.GetBool("GoldenAgeFromBirth");
 	m_bCultureBoost = kResults.GetBool("CultureBoost");
@@ -1354,6 +1356,10 @@ int CvUnitEntry::GetTileXPOnExpend() const
 int CvUnitEntry::GetExtraSpies() const
 {
     return m_iExtraSpies;
+}
+int CvUnitEntry::GetExtraLuxuries() const
+{
+    return m_iExtraLuxuries;
 }
 bool CvUnitEntry::IsWLTKDFromBirth() const
 {

--- a/CvGameCoreDLL_Expansion2/CvUnitClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvUnitClasses.h
@@ -188,6 +188,7 @@ public:
     bool IsCopyYieldsFromExpendTile() const;
     int GetTileXPOnExpend() const;
     int GetExtraSpies() const;
+    int GetExtraLuxuries() const;
     bool IsWLTKDFromBirth() const;
     bool IsGoldenAgeFromBirth() const;
 	bool IsCultureBoost() const;
@@ -351,6 +352,7 @@ private:
 	bool m_bCopyYieldsFromExpendTile;
 	int m_iTileXPOnExpend;
 	int m_iExtraSpies;
+	int m_iExtraLuxuries;
 	bool m_bWLTKD;
 	bool m_bGoldenAge;
 	bool m_bCultureBoost;


### PR DESCRIPTION
Some building preqreqs and related functions:
Requires a Puppet City
Requires X Global Franchises of a Corporation
Requires X% of Global Monopolies on the Map

For Projects:
Local resource prereq
Column that acts like Chartered Company giving +x copies of luxuries
When the two are combined, gives +x copies of just that particular luxury
Also a free resources table like the recently added Policy_FreeResource

For Great People:
A column for Great People units that gives +x free copies of every luxury in the minor civ in whose territory they are expended (intended for Great Merchant but will work on others like Great Diplomat if desired)
A Policy column that does the same thing but just for Great Merchants