### PR TITLE
nuke pop loss at least 1 and 2

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvUnitCombat.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnitCombat.cpp
@@ -2631,7 +2631,7 @@ uint CvUnitCombat::ApplyNuclearExplosionDamage(const CvCombatMemberEntry* pkDama
 					iNukedPopulation *= std::max(0, (pkCity->getNukeModifier() + 100));
 					iNukedPopulation /= 100;
 
-					pkCity->changePopulation(-(std::min((pkCity->getPopulation() - 1), iNukedPopulation)));
+					pkCity->changePopulation(-(std::min(std::max(iNukedPopulation, iDamageLevel), (pkCity->getPopulation() - 1))));
 
 					// Add damage to the city
 					pkCity->setDamage(kEntry.GetFinalDamage());


### PR DESCRIPTION
Currently nuclear weapons remove x% of remaining population in a city, rounded down. With strategic defense system this means that population loss from subsequent strikes is sharply dropping, even with high rng damage rolls. To the point the population loss is often below 1 when attacking a 7-5 population city, rounded down to 0, making it literally impossible to destroy a city with 1000 nuclear missiles fired in a single turn. Cause city needs to drop below 5 pop to be destroyed.

To address this problem, this PR makes it so that lvl 2 nuke (nuke missile) always lowers city pop by at least 2, and lvl 1 nuke (atomic bomb, or partially intercepted missile) by at least 1.

An alternative is to always round up pop loss but it'll strengthen earlier strikes by +1.

While it seems a balance change that should go through congress, this in practice is a flavor change for Armageddon LARP, cause noone nukes cities to destruction, it's much more practical to nuke a city 2 times and conquer it normally cause it has 0 hp.