### PR TITLE
NewCustomModOptions clean up

### DIFF
--- a/(1) Community Patch/Database Changes/NewCustomModOptions.xml
+++ b/(1) Community Patch/Database Changes/NewCustomModOptions.xml
@@ -269,7 +269,7 @@
 		<!-- Great Generals and Admirals spawned from combat experience appear on top of the unit that triggered the spawn, and not in a distant city -->
 		<!-- If LOCAL_GENERALS_NEAREST_CITY is also enabled, the general or admiral instead spawns in the closest city to the triggering unit -->
 		<Row Class="5" Name="GLOBAL_LOCAL_GENERALS" Value="0"/>
-		<Row Class="5" Name="LOCAL_GENERALS_NEAREST_CITY" Value="1"/>
+		<Row Class="5" Name="LOCAL_GENERALS_NEAREST_CITY" Value="0"/>
 
 		<!-- Removes assembled spaceship parts from conquered capitals -->
 		<Row Class="6" Name="GLOBAL_NO_CONQUERED_SPACESHIPS" Value="0"/>

--- a/(1) Community Patch/Database Changes/NewCustomModOptions.xml
+++ b/(1) Community Patch/Database Changes/NewCustomModOptions.xml
@@ -286,7 +286,7 @@
 		<!-- Units that can found a city take the city's majority religion with them -->
 		<!-- If RELIGIOUS_SETTLERS_WEIGHTED=1, it's instead a weighted random choice, with each religion having a weight equal to its local followers -->
 		<Row Class="5" Name="GLOBAL_RELIGIOUS_SETTLERS" Value="0"/>
-		<Row Class="5" Name="RELIGIOUS_SETTLERS_WEIGHTED" Value="1"/>
+		<Row Class="5" Name="RELIGIOUS_SETTLERS_WEIGHTED" Value="0"/>
 
 		<!-- Submarines under ice are immune to ranged attacks, except from other submarines -->
 		<Row Class="5" Name="GLOBAL_SUBS_UNDER_ICE_IMMUNITY" Value="0"/>


### PR DESCRIPTION
Modmod custom options for LOCAL_GENERALS_NEAREST_CITY and RELIGIOUS_SETTLERS_WEIGHTED were added as default on. 
They both depend on other modmods (GLOBAL_LOCAL_GENERALS and GLOBAL_RELIGIOUS_SETTLERS), so they are inactive. Better to have them default off to avoid confusions.
