### PR TITLE
Fix permanent pantheon projected improvement yields being double-counted

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
@@ -5043,37 +5043,31 @@ void CvBuilderTaskingAI::UpdateProjectedPlotYields(const CvPlot* pPlot, BuildTyp
 
 		const CvReligion* pReligion = (eMajority != NO_RELIGION) ? GC.getGame().GetGameReligions()->GetReligion(eMajority, pOwningCity->getOwner()) : 0;
 		const CvBeliefEntry* pBelief = (eSecondaryPantheon != NO_BELIEF) ? GC.GetGameBeliefs()->GetEntry(eSecondaryPantheon) : 0;
+		const CvReligion* pPlayerPantheon = NULL;
 
-		const CvReligion* pPantheon = NULL;
-		BeliefTypes ePantheonBelief = NO_BELIEF;
 		// Mod for civs keeping their pantheon belief forever
 		if (MOD_BALANCE_PERMANENT_PANTHEONS)
 		{
-			pPantheon = GC.getGame().GetGameReligions()->GetReligion(RELIGION_PANTHEON, pOwningCity->getOwner());
-			ePantheonBelief = GC.getGame().GetGameReligions()->GetBeliefInPantheon(pOwningCity->getOwner());
+			if (GC.getGame().GetGameReligions()->HasCreatedPantheon(m_pPlayer->GetID()))
+			{
+				const CvReligion* pPantheon = GC.getGame().GetGameReligions()->GetReligion(RELIGION_PANTHEON, pOwningCity->getOwner());
+				BeliefTypes ePantheonBelief = GC.getGame().GetGameReligions()->GetBeliefInPantheon(pOwningCity->getOwner());
+				if (pPantheon != NULL && ePantheonBelief != NO_BELIEF && ePantheonBelief != eSecondaryPantheon)
+				{
+					if (pReligion == NULL || !pReligion->m_Beliefs.IsPantheonBeliefInReligion(ePantheonBelief, eMajority, m_pPlayer->GetID())) // check that the our religion does not have our belief, to prevent double counting
+					{
+						pPlayerPantheon = pPantheon;
+					}
+				}
+			}
 		}
 
 		for (uint ui = 0; ui < NUM_YIELD_TYPES; ui++)
 		{
 			if ((YieldTypes)ui <= YIELD_CULTURE_LOCAL)
 			{
-				m_aiProjectedPlotYields[ui] = pPlot->getYieldWithBuild(eBuild, (YieldTypes)ui, false, eForceCityConnection, m_pPlayer->GetID(), pOwningCity, pReligion, pBelief);
+				m_aiProjectedPlotYields[ui] = pPlot->getYieldWithBuild(eBuild, (YieldTypes)ui, false, eForceCityConnection, m_pPlayer->GetID(), pOwningCity, pReligion, pBelief, pPlayerPantheon);
 				m_aiProjectedPlotYields[ui] = max(m_aiProjectedPlotYields[ui], 0);
-
-				if (MOD_BALANCE_PERMANENT_PANTHEONS)
-				{
-					if (GC.getGame().GetGameReligions()->HasCreatedPantheon(m_pPlayer->GetID()))
-					{
-						if (pPantheon != NULL && ePantheonBelief != NO_BELIEF && ePantheonBelief != eSecondaryPantheon)
-						{
-							if (pReligion == NULL || !pReligion->m_Beliefs.IsPantheonBeliefInReligion(ePantheonBelief, eMajority, m_pPlayer->GetID())) // check that the our religion does not have our belief, to prevent double counting
-							{
-								m_aiProjectedPlotYields[ui] += pPlot->getYieldWithBuild(eBuild, (YieldTypes)ui, false, eForceCityConnection, m_pPlayer->GetID(), pOwningCity, pPantheon, NULL);
-								m_aiProjectedPlotYields[ui] = max(m_aiProjectedPlotYields[ui], 0);
-							}
-						}
-					}
-				}
 
 				/*if (m_bLogging) {
 					CvString strLog;

--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -14232,13 +14232,15 @@ int CvPlot::getYieldWithBuild(BuildTypes eBuild, YieldTypes eYield, bool bWithUp
 		}
 
 		iYield += calculateImprovementYield(eYield, ePlayer, eNewImprovement, eNewRoute, eFeature, eResource, eForceCityConnection, pOwningCity, false) + calculateReligionImprovementYield(eYield, ePlayer, eNewImprovement, eResource, pOwningCity, pMajorityReligion, pSecondaryPantheon);
-		if (MOD_BALANCE_PERMANENT_PANTHEONS && pPlayerPantheon != NULL)
-		{
-			iYield += calculateReligionImprovementYield(eYield, ePlayer, eNewImprovement, eResource, pOwningCity, pPlayerPantheon, NULL);
-		}
 	}
 
 	iYield += calculatePlayerYield(eYield, iYield, ePlayer, eNewImprovement, eFeature, eResource, eForceCityConnection, pOwningCity, pMajorityReligion, pSecondaryPantheon, pPlayerPantheon, false);
+
+	if (MOD_BALANCE_PERMANENT_PANTHEONS && pPlayerPantheon != NULL)
+	{
+		iYield += calculateReligionImprovementYield(eYield, ePlayer, eNewImprovement, eResource, pOwningCity, pPlayerPantheon, NULL);
+		iYield += calculateReligionNatureYield(eYield, ePlayer, eNewImprovement, eFeature, eResource, pOwningCity, pPlayerPantheon, NULL);
+	}
 
 	//no overhead if empty
 	for (size_t i=0; i<m_vExtraYields.size(); i++)

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlot.cpp
@@ -1813,7 +1813,7 @@ int CvLuaPlot::lGetYieldWithBuild(lua_State* L)
 
 		const CvReligion* pReligion = (eMajority != NO_RELIGION) ? GC.getGame().GetGameReligions()->GetReligion(eMajority, pOwningCity->getOwner()) : 0;
 		const CvBeliefEntry* pBelief = (eSecondaryPantheon != NO_BELIEF) ? GC.GetGameBeliefs()->GetEntry(eSecondaryPantheon) : 0;
-		int iResult = pkPlot->getYieldWithBuild(eBuild, eYield, bUpgrade, NUM_ROUTE_TYPES, ePlayer, pOwningCity, pReligion, pBelief);
+		const CvReligion* pPlayerPantheon = NULL;
 
 		// Mod for civs keeping their pantheon belief forever
 		if (MOD_BALANCE_PERMANENT_PANTHEONS)
@@ -1826,12 +1826,13 @@ int CvLuaPlot::lGetYieldWithBuild(lua_State* L)
 				{
 					if (pReligion == NULL || !pReligion->m_Beliefs.IsPantheonBeliefInReligion(ePantheonBelief, eMajority, pOwningCity->getOwner())) // check that the our religion does not have our belief, to prevent double counting
 					{
-						iResult += pkPlot->getYieldWithBuild(eBuild, eYield, bUpgrade, NUM_ROUTE_TYPES, ePlayer, pOwningCity, pPantheon, NULL);
+						pPlayerPantheon = pPantheon;
 					}
 				}
 			}
 		}
 
+		const int iResult = pkPlot->getYieldWithBuild(eBuild, eYield, bUpgrade, NUM_ROUTE_TYPES, ePlayer, pOwningCity, pReligion, pBelief, pPlayerPantheon);
 		lua_pushinteger(L, iResult);
 		return 1;
 	}


### PR DESCRIPTION
With permanent pantheons on, worker tooltips and builder AI projected yields were calling `getYieldWithBuild` twice and adding the results, so the whole projected yield got counted again. Actual tile yields were already fine because they pass the pantheon in through the proper `pPlayerPantheon` argument.

This makes the projection path do the same thing: resolve the pantheon once, pass it into a single `getYieldWithBuild` call, and only layer on the pantheon-specific religion yields. Also lined up pantheon nature yields in that helper with how real yields are calculated.

Bug isolated by @Hokath at [https://forums.civfanatics.com/threads/religion-permanent-pantheons.670446/#post-16852120](https://forums.civfanatics.com/threads/religion-permanent-pantheons.670446/#post-16852120)