### PR TITLE
Fix areas having non-unique IDs

### DIFF
--- a/(1) Community Patch/Core Files/Overrides/ActionInfoPanel.lua
+++ b/(1) Community Patch/Core Files/Overrides/ActionInfoPanel.lua
@@ -478,7 +478,7 @@ do -- Actions
 			if playerId ~= activePlayerId then
 				local player = Players[playerId]
 
-				if player ~= nil and player:IsHuman() and not player:HasReceivedNetTurnComplete() then
+				if player ~= nil and player:IsHuman() and not player:IsObserver() and not player:HasReceivedNetTurnComplete() then
 					local playerCivKey = txtUnmetPlayer
 
 					if activePlayerTeam:IsHasMet(player:GetTeam()) then

--- a/(1) Community Patch/Core Files/Overrides/EspionageOverview.lua
+++ b/(1) Community Patch/Core Files/Overrides/EspionageOverview.lua
@@ -974,7 +974,10 @@ function RefreshMyCities(selectedAgentIndex, selectedAgentCurrentCityPlayerID, s
 			if (pPlayer ~= nil) then
 				local pCity = pPlayer:GetCityByID(cityInfo.CityID);
 				if(pCity) then
-					if(not Players[Game.GetActivePlayer()]:CanMoveSpyTo(pCity, selectedAgentIndex)) then
+					if (agent ~= nil) then
+						strCityNameToolTip = Locale.Lookup("TXT_KEY_EO_SPY_ALREADY_IN_CITY", cityInfo.Name, agent.Name);
+						strCityCivToolTip = Locale.Lookup("TXT_KEY_EO_SPY_ALREADY_IN_CITY", cityInfo.Name, agent.Name);
+					elseif(not Players[Game.GetActivePlayer()]:CanMoveSpyTo(pCity, selectedAgentIndex)) then
 						strCityNameToolTip = Locale.Lookup("TXT_KEY_EO_NO_ACTIONS_POSSIBLE");
 						strCityCivToolTip = Locale.Lookup("TXT_KEY_EO_NO_ACTIONS_POSSIBLE");
 					end

--- a/(1) Community Patch/Database Changes/Text/en_US/UI/CoreNewUIText.xml
+++ b/(1) Community Patch/Database Changes/Text/en_US/UI/CoreNewUIText.xml
@@ -2654,6 +2654,9 @@
 		<Row Tag="TXT_KEY_ALLY_CBP_SPY">
 			<Text>Allied with the {1_Player}.</Text>
 		</Row>
+		<Row Tag="TXT_KEY_EO_SPY_ALREADY_IN_CITY">
+			<Text>Your spy {2_SpyName} is already present in {1_CityName}.</Text>
+		</Row>
 		<!-- Intrigue list -->
 		<Row Tag="TXT_KEY_INTRIGUE_BRIBE_WAR_US">
 			<Text>{1_PlayerName} bribed {2_PlayerName} to go to war against you.</Text>

--- a/(1) Community Patch/Database Changes/Text/en_US/UI/CoreNewUIText.xml
+++ b/(1) Community Patch/Database Changes/Text/en_US/UI/CoreNewUIText.xml
@@ -2984,14 +2984,26 @@
 		<Row Tag="TXT_KEY_DIPLO_MILITARY_PROMISE_TURNS">
 			<Text>You promised not to declare war on each other for {1_Num} more {1_Num: plural 1?turn; other?turns;}.</Text>
 		</Row>
+		<Row Tag="TXT_KEY_DIPLO_MILITARY_PROMISE_EXPIRING">
+			<Text>You promised not to declare war on each other. (Expires after this turn.)</Text>
+		</Row>
 		<Row Tag="TXT_KEY_DIPLO_EXPANSION_PROMISE_TURNS">
 			<Text>You promised not to settle near them for {1_Num} more {1_Num: plural 1?turn; other?turns;}.</Text>
+		</Row>
+		<Row Tag="TXT_KEY_DIPLO_EXPANSION_PROMISE_EXPIRING">
+			<Text>You promised not to settle near them. (Expires after this turn.)</Text>
 		</Row>
 		<Row Tag="TXT_KEY_DIPLO_BORDER_PROMISE_TURNS">
 			<Text>You promised not to buy land near them for {1_Num} more {1_Num: plural 1?turn; other?turns;}.</Text>
 		</Row>
+		<Row Tag="TXT_KEY_DIPLO_BORDER_PROMISE_EXPIRING">
+			<Text>You promised not to buy land near them. (Expires after this turn.)</Text>
+		</Row>
 		<Row Tag="TXT_KEY_DIPLO_AI_EXPANSION_PROMISE_TURNS">
 			<Text>They promised not to settle near you for {1_Num} more {1_Num: plural 1?turn; other?turns;}.</Text>
+		</Row>
+		<Row Tag="TXT_KEY_DIPLO_AI_EXPANSION_PROMISE_EXPIRING">
+			<Text>They promised not to settle near you. (Expires after this turn.)</Text>
 		</Row>
 		<!-- World Congress -->
 		<Row Tag="TXT_KEY_DIPLO_MAINTAINED_THEIR_HOSTING">

--- a/(2) Vox Populi/Core Files/Overrides/DiploGlobalRelationships.lua
+++ b/(2) Vox Populi/Core Files/Overrides/DiploGlobalRelationships.lua
@@ -389,15 +389,20 @@ function InitMajorCivList()
 				end
 				
 				-- Promises (Vox Populi)
-				local function ShowPromiseTurns(iNumTurns, sDiploText)
-					if iNumTurns <= 0 then return end -- do not display "0 turns"
+				local function ShowPromiseTurns(iNumTurns, sDiploText, sExpiringText)
+					if iNumTurns < 0 then return end -- no promise active
 					local textControls = {};
 					ContextPtr:BuildInstanceForControl("TextEntryLong", textControls, controlTable.PactStack);
-					textControls.Text:LocalizeAndSetText(sDiploText, iNumTurns);
+					if iNumTurns == 0 then
+						-- promise expires after this turn
+						textControls.Text:LocalizeAndSetText(sExpiringText);
+					else
+						textControls.Text:LocalizeAndSetText(sDiploText, iNumTurns);
+					end
 				end
-				ShowPromiseTurns(pOtherPlayer:GetNumTurnsMilitaryPromise(g_iUs),  "TXT_KEY_DIPLO_MILITARY_PROMISE_TURNS");
-				ShowPromiseTurns(pOtherPlayer:GetNumTurnsExpansionPromise(g_iUs), "TXT_KEY_DIPLO_EXPANSION_PROMISE_TURNS");
-				ShowPromiseTurns(pOtherPlayer:GetNumTurnsBorderPromise(g_iUs),    "TXT_KEY_DIPLO_BORDER_PROMISE_TURNS");
+				ShowPromiseTurns(pOtherPlayer:GetNumTurnsMilitaryPromise(g_iUs),  "TXT_KEY_DIPLO_MILITARY_PROMISE_TURNS",  "TXT_KEY_DIPLO_MILITARY_PROMISE_EXPIRING");
+				ShowPromiseTurns(pOtherPlayer:GetNumTurnsExpansionPromise(g_iUs), "TXT_KEY_DIPLO_EXPANSION_PROMISE_TURNS", "TXT_KEY_DIPLO_EXPANSION_PROMISE_EXPIRING");
+				ShowPromiseTurns(pOtherPlayer:GetNumTurnsBorderPromise(g_iUs),    "TXT_KEY_DIPLO_BORDER_PROMISE_TURNS",    "TXT_KEY_DIPLO_BORDER_PROMISE_EXPIRING");
 				-- Promises END
 				
 				--controlTable.NothingLabel:SetHide(bHasEntry);

--- a/(2) Vox Populi/Core Files/Overrides/EspionageOverview.lua
+++ b/(2) Vox Populi/Core Files/Overrides/EspionageOverview.lua
@@ -1195,7 +1195,10 @@ function RefreshTheirCities(selectedAgentIndex, selectedAgentCurrentCityPlayerID
 			if (pPlayer ~= nil) then
 				local pCity = pPlayer:GetCityByID(cityInfo.CityID);
 				if(pCity) then
-					if(not Players[Game.GetActivePlayer()]:CanMoveSpyTo(pCity, selectedAgentIndex)) then
+					if (agent ~= nil) then
+						strCityNameToolTip = Locale.Lookup("TXT_KEY_EO_SPY_ALREADY_IN_CITY", cityInfo.Name, agent.Name);
+						strCityCivToolTip = Locale.Lookup("TXT_KEY_EO_SPY_ALREADY_IN_CITY", cityInfo.Name, agent.Name);
+					elseif(not Players[Game.GetActivePlayer()]:CanMoveSpyTo(pCity, selectedAgentIndex)) then
 						strCityNameToolTip = Locale.Lookup("TXT_KEY_EO_NO_ACTIONS_POSSIBLE");
 						strCityCivToolTip = Locale.Lookup("TXT_KEY_EO_NO_ACTIONS_POSSIBLE");
 					end
@@ -1204,15 +1207,20 @@ function RefreshTheirCities(selectedAgentIndex, selectedAgentCurrentCityPlayerID
 		end
 
 		if (bIsCityState) then
-			local strTraitText = GetCityStateTraitText(cityInfo.PlayerID);
-			local strTraitTT = GetCityStateTraitToolTip(cityInfo.PlayerID);
+			if (selectedAgentIndex ~= nil and agent ~= nil) then
+				strCityNameToolTip = Locale.Lookup("TXT_KEY_EO_SPY_ALREADY_IN_CITY", cityInfo.Name, agent.Name);
+				strCityCivToolTip = Locale.Lookup("TXT_KEY_EO_SPY_ALREADY_IN_CITY", cityInfo.Name, agent.Name);
+			else
+				local strTraitText = GetCityStateTraitText(cityInfo.PlayerID);
+				local strTraitTT = GetCityStateTraitToolTip(cityInfo.PlayerID);
 
-			strCityNameToolTip = Locale.Lookup("TXT_KEY_EO_CITY_NAME_CITY_STATE_TT", cityInfo.Name, strTraitText);
-			strCityNameToolTip = strCityNameToolTip .. "[NEWLINE][NEWLINE]";
-			strCityNameToolTip = strCityNameToolTip .. strTraitTT;
-			strCityCivToolTip = Locale.Lookup("TXT_KEY_EO_CITY_CIV_CITY_STATE_TT", cityInfo.Name, strTraitText);
-			strCityCivToolTip = strCityCivToolTip .. "[NEWLINE][NEWLINE]";
-			strCityCivToolTip = strCityCivToolTip .. strTraitTT;
+				strCityNameToolTip = Locale.Lookup("TXT_KEY_EO_CITY_NAME_CITY_STATE_TT", cityInfo.Name, strTraitText);
+				strCityNameToolTip = strCityNameToolTip .. "[NEWLINE][NEWLINE]";
+				strCityNameToolTip = strCityNameToolTip .. strTraitTT;
+				strCityCivToolTip = Locale.Lookup("TXT_KEY_EO_CITY_CIV_CITY_STATE_TT", cityInfo.Name, strTraitText);
+				strCityCivToolTip = strCityCivToolTip .. "[NEWLINE][NEWLINE]";
+				strCityCivToolTip = strCityCivToolTip .. strTraitTT;
+			end
 
 			local strCityStateTT = Locale.Lookup("TXT_KEY_EO_CITY_STATE_POTENTIAL_TT");
 			strCityStateTT = strCityStateTT .. "[NEWLINE][NEWLINE]";

--- a/CvGameCoreDLL_Expansion2/CvMap.cpp
+++ b/CvGameCoreDLL_Expansion2/CvMap.cpp
@@ -1709,8 +1709,13 @@ CvArea* CvMap::getAreaByIndex(int iIndex)
 CvArea* CvMap::addArea()
 {
 	//do not use TContainer::Add here, it uses the global ID counter which we don't need here
+	//we can't use m_areas.GetCount() for the new area ID here: After deleting an area area IDs might no longer be contiguous, so m_areas.GetCount() might return an existing ID
+	int iNewAreaID = 0;
+	for (int iI = 0; iI < m_areas.GetCount(); iI++)
+		iNewAreaID = max(iNewAreaID, m_areas.GetAt(iI)->GetID()+1);
+
 	CvArea* pNew = new CvArea();
-	pNew->SetID( m_areas.GetCount() );
+	pNew->SetID(iNewAreaID);
 	m_areas.Load(pNew);
 	return pNew;
 }
@@ -1987,12 +1992,17 @@ void CvMap::calculateAreas()
 	{
 		CvPlot* pLoopPlot = plotByIndexUnchecked(iI);
 
-		cp[pLoopPlot->getArea()][pLoopPlot->getX()] = true;
-		rp[pLoopPlot->getArea()][pLoopPlot->getY()] = true;
-	
+		//area ids are not necessarily identical to their index (see CvMap::addArea()), so look up the index
+		int iAreaIndex = m_areas.GetIndexForID(pLoopPlot->getArea());
+		if (iAreaIndex == -1)
+			continue;
+
+		cp[iAreaIndex][pLoopPlot->getX()] = true;
+		rp[iAreaIndex][pLoopPlot->getY()] = true;
+
 		pLoopPlot->area()->UpdateBadPlotsCount(pLoopPlot);
 	}
-	//important assumption: area ids are identical to their index!
+
 	for (int iI = 0; iI < m_areas.GetCount(); iI++)
 	{
 		m_areas.GetAt(iI)->FindBoundaries(cp[iI],rp[iI]);
@@ -2543,8 +2553,13 @@ CvLandmass* CvMap::getLandmassByIndex(int iIndex)
 CvLandmass* CvMap::addLandmass()
 {
 	//do not use TContainer::Add here, it uses the global ID counter which we don't need here
+	//we can't use m_landmasses.GetCount() for the new landmass ID here: After deleting a landmass landmass IDs might no longer be contiguous, so m_landmasses.GetCount() might return an existing ID
+	int iNewLandmassID = 0;
+	for (int iI = 0; iI < m_landmasses.GetCount(); iI++)
+		iNewLandmassID = max(iNewLandmassID, m_landmasses.GetAt(iI)->GetID()+1);
+
 	CvLandmass* pNew = new CvLandmass();
-	pNew->SetID( m_landmasses.GetCount()+1 );
+	pNew->SetID(iNewLandmassID);
 	m_landmasses.Load(pNew);
 	return pNew;
 }
@@ -2648,8 +2663,13 @@ CvContinent* CvMap::getContinentById(int iID)
 CvContinent* CvMap::addContinent()
 {
 	//do not use TContainer::Add here, it uses the global ID counter which we don't need here
+	//here it would also be fine to just use m_continents.GetCount() for the new id, but for consistency with areas and landmasses which can have non-contiguous IDs (see CvMap::addArea() and deleteArea()) we calculate the new id instead
+	int iNewContinentID = 0;
+	for (int iI = 0; iI < m_continents.GetCount(); iI++)
+		iNewContinentID = max(iNewContinentID, m_continents.GetAt(iI)->GetID() + 1);
+
 	CvContinent* pNew = new CvContinent();
-	pNew->SetID(m_continents.GetCount() + 1);
+	pNew->SetID(iNewContinentID);
 	m_continents.Load(pNew);
 	return pNew;
 }
@@ -2715,8 +2735,12 @@ CvRiver* CvMap::GetRiverByIndex(int iIndex)
 CvRiver* CvMap::AddRiver()
 {
 	//do not use TContainer::Add here, it uses the global ID counter which we don't need here
+	//we can't use m_rivers.GetCount() for the new river ID here: After deleting a river river IDs might no longer be contiguous, so m_rivers.GetCount() might return an existing ID
+	int iNewRiverID = 0;
+	for (int iI = 0; iI < m_rivers.GetCount(); iI++)
+		iNewRiverID = max(iNewRiverID, m_rivers.GetAt(iI)->GetID() + 1);
 	CvRiver* pNew = new CvRiver();
-	pNew->SetID(m_rivers.GetCount() + 1);
+	pNew->SetID(iNewRiverID);
 	m_rivers.Load(pNew);
 	return pNew;
 }

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
@@ -15145,39 +15145,39 @@ int CvLuaPlayer::lGetOpinionTable(lua_State* L)
 
 		// Human Promises
 		iValue = pDiplo->GetNumTurnsMilitaryPromise(ePlayer); // This is a mutual promise and the turn counter will always be the same on both sides
-		if (iValue > 0)
+		if (iValue >= 0)
 		{
 			Opinion kOpinion;
 			kOpinion.m_iValue = 0;
-			kOpinion.m_str = GetLocalizedText("TXT_KEY_DIPLO_MILITARY_PROMISE_TURNS", iValue);
+			kOpinion.m_str = (iValue > 0) ? GetLocalizedText("TXT_KEY_DIPLO_MILITARY_PROMISE_TURNS", iValue) : GetLocalizedText("TXT_KEY_DIPLO_MILITARY_PROMISE_EXPIRING");
 			aOpinions.push_back(kOpinion);
 		}
 
 		iValue = pDiplo->GetNumTurnsExpansionPromise(ePlayer);
-		if (iValue > 0)
+		if (iValue >= 0)
 		{
 			Opinion kOpinion;
 			kOpinion.m_iValue = 0;
-			kOpinion.m_str = GetLocalizedText("TXT_KEY_DIPLO_EXPANSION_PROMISE_TURNS", iValue);
+			kOpinion.m_str = (iValue > 0) ? GetLocalizedText("TXT_KEY_DIPLO_EXPANSION_PROMISE_TURNS", iValue) : GetLocalizedText("TXT_KEY_DIPLO_EXPANSION_PROMISE_EXPIRING");
 			aOpinions.push_back(kOpinion);
 		}
 
 		iValue = pDiplo->GetNumTurnsBorderPromise(ePlayer);
-		if (iValue > 0)
+		if (iValue >= 0)
 		{
 			Opinion kOpinion;
 			kOpinion.m_iValue = 0;
-			kOpinion.m_str = GetLocalizedText("TXT_KEY_DIPLO_BORDER_PROMISE_TURNS", iValue);
+			kOpinion.m_str = (iValue > 0) ? GetLocalizedText("TXT_KEY_DIPLO_BORDER_PROMISE_TURNS", iValue) : GetLocalizedText("TXT_KEY_DIPLO_BORDER_PROMISE_EXPIRING");
 			aOpinions.push_back(kOpinion);
 		}
-		
+
 		// AI Promises
 		iValue = GET_PLAYER(ePlayer).GetDiplomacyAI()->GetNumTurnsExpansionPromise(pkPlayer->GetID());
-		if (iValue > 0)
+		if (iValue >= 0)
 		{
 			Opinion kOpinion;
 			kOpinion.m_iValue = 0;
-			kOpinion.m_str = GetLocalizedText("TXT_KEY_DIPLO_AI_EXPANSION_PROMISE_TURNS", iValue);
+			kOpinion.m_str = (iValue > 0) ? GetLocalizedText("TXT_KEY_DIPLO_AI_EXPANSION_PROMISE_TURNS", iValue) : GetLocalizedText("TXT_KEY_DIPLO_AI_EXPANSION_PROMISE_EXPIRING");
 			aOpinions.push_back(kOpinion);
 		}
 


### PR DESCRIPTION
Root cause of #13266, and a more serious issue than expected: An Area ID collision that caused memory leakage and plot and area information not matching