### PR TITLE
Fix int overflow in per-city tech and policy cost scaling

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvPolicyClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPolicyClasses.cpp
@@ -4835,7 +4835,8 @@ int CvPlayerPolicies::GetNextPolicyCost(bool bIgnoreCities, int iCityOffset, int
 		// Unified city cost formula: cost *= (10000 + iTotalTimes100) / 10000
 		// Tech and policy now both use all effective cities in VP, including the first one. CP behavior unchanged (first city included in tech cost calculations, but excluded in policy cost calculations)
 		int iTotalTimes100 = GetPolicyCityModifierTimes100(iCityOffset);
-		iCost = iCost * (10000 + iTotalTimes100) / 10000;
+		long long iScaledCost = ((long long)iCost * (10000 + iTotalTimes100)) / 10000;
+		iCost = (int)std::min<long long>(std::max<long long>(iScaledCost, INT_MIN), INT_MAX);
 	}
 
 	if (pCostBeforePolicyDiscount != NULL)

--- a/CvGameCoreDLL_Expansion2/CvTechClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTechClasses.cpp
@@ -1778,7 +1778,8 @@ int CvPlayerTechs::GetResearchCost(TechTypes eTech, bool bIgnoreCities, int iCit
 		// Unified city cost formula: cost *= (10000 + iTotalTimes100) / 10000
 		// With iScaling=0 (CP), this becomes linear. With iScaling>0 (VP), progressive.
 		int iTotalTimes100 = GetResearchCityModifierTimes100(iCityOffset);
-		iResearchCost = iResearchCost * (10000 + iTotalTimes100) / 10000;
+		long long iScaledCost = ((long long)iResearchCost * (10000 + iTotalTimes100)) / 10000;
+		iResearchCost = (int)std::min<long long>(std::max<long long>(iScaledCost, INT_MIN), INT_MAX);
 	}
 
 	return iResearchCost;


### PR DESCRIPTION
My 10-035b change made the city modifier 100x larger (10000 + modTimes100 instead of 100 + mod) but left the multiply in a 32-bit int, so it wraps negative from ~22 cities and techs/policies complete instantly. eg at 28 cities and 36 policies.

Fix makes the intermediate calc in 64-bit so overflow won't happen unless the numbers is insanely large, and then it'll be clamped back to int range.

Fixes #13280