### PR TITLE
Fix rare case where AI would refuse to capture cities

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvTacticalAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTacticalAI.cpp
@@ -7902,8 +7902,8 @@ int ScoreCombatUnitTurnEnd(const CvUnit* pUnit, eUnitAssignmentType eLastAssignm
 	int iMaxHitPoints = pUnit->GetMaxHitPoints();
 	int iCurrHitPoints = iMaxHitPoints - pUnit->getDamage() - iSelfDamage;
 
-	//unseen enemies might be hiding behind the edge, so assume danger there
-	if (testPlot->isEdgePlot())
+	//unseen enemies might be hiding behind the edge, so assume danger there (unless it is a city)
+	if (testPlot->isEdgePlot() && !pTestPlot->isCity())
 	{
 		//siege units (with limited visibility) should not move there unless covered (the -1 is important)
 		if (pUnit->visibilityRange() < 2 && testPlot->getNumAdjacentFriendlies(DomainForUnit(pUnit), -1) < 2)

--- a/CvGameCoreDLL_Expansion2/CvTacticalAI.h
+++ b/CvGameCoreDLL_Expansion2/CvTacticalAI.h
@@ -1244,7 +1244,7 @@ public:
 
 	bool isExhausted() const;
 	const vector<SUnitStats>& getAvailableUnits() const { return availableUnits.read(); }
-	int GetNumAvailableUnits() const { return availableUnits.read().size(); }
+	size_t GetNumAvailableUnits() const { return availableUnits.read().size(); }
 	const vector<SUnitStats>& getFinishedUnits() const { return notQuiteFinishedUnits.read(); }
 	bool lastAssignmentIsAfterRestart(int iUnitID) const;
 	const SUnitStats* getAvailableUnitStats(int iUnitID) const;


### PR DESCRIPTION
Fix case where AI would refuse to capture cities if they were attacking with a single unit which has sight range 1 (like a siege ram).

Fix return type of a function.