### PR TITLE
Fix setPlotType crash on some mapscripts

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -7417,12 +7417,12 @@ void CvPlot::setPlotType(PlotTypes eNewValue, bool bRecalculate, bool bRebuildGr
 				setArea(-1);
 				setLandmass(-1);
 
-				if (pCurrArea->getNumTiles() == 0)
+				if (pCurrArea && pCurrArea->getNumTiles() == 0)
 				{
 					GC.getMap().deleteArea(pCurrArea->GetID());
 				}
 
-				if (pCurrLandmass->getNumTiles() == 0)
+				if (pCurrLandmass && pCurrLandmass->getNumTiles() == 0)
 				{
 					GC.getMap().deleteLandmass(pCurrLandmass->GetID());
 				}


### PR DESCRIPTION
A change that went live in 5.3.3 ([35ca55c89](https://github.com/LoneGazebo/Community-Patch-DLL/commit/35ca55c89116cc12297cc43d77e5d02c6c3e9f70)) causes `CvPlot::setPlotType` to crash when a plot's area or landmass ID doesn't map to a valid object.

<img width="603" height="124" alt="image" src="https://github.com/user-attachments/assets/690bc701-f2b7-4a75-b37a-d01f652a8738" />

Lua exposes `SetArea`, and calling `SetArea(-1)` before `SetPlotType` with `bRecalculate = true` hits this path.

**Repro**
Any map script calling `plot:SetArea(-1)` then `plot:SetPlotType(PlotTypes.PLOT_OCEAN, true, true)`. Planet Simulator is the one script I have that tripped it in its `AddLakes` function.


[TL;DR](https://www.youtube.com/watch?v=bLHL75H_VEM)