### PR TITLE
Fix war-duration tooltips and defeated-leader popups during autoplay.

### DIFF
--- a/(3a) VP - EUI Compatibility Files/LUA/NotificationPanel.lua
+++ b/(3a) VP - EUI Compatibility Files/LUA/NotificationPanel.lua
@@ -1132,7 +1132,7 @@ local g_civListInstanceToolTips = { -- the tooltip function names need to match 
 			end
 
 			local iOurWarWeariness = g_activePlayer:GetWarWearinessPercent(playerID);
-			local iWarDuration = g_activePlayer:GetWarDuration(g_iAIPlayer);
+			local iWarDuration = g_activePlayer:GetWarDuration(playerID);
 			strWarInfo = strWarInfo .. '[NEWLINE]' .. Locale.ConvertTextKey("TXT_KEY_WAR_WEARINESS_US_PERCENT", iOurWarWeariness, iWarDuration);
 
 			tips:insert(strWarInfo);

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -34478,7 +34478,7 @@ void CvPlayer::CheckForMurder(PlayerTypes ePossibleVictimPlayer)
 		if (bMajorVictim)
 		{
 			// Leader pops up and whines
-			if (isMajorCiv() && !CvPreGame::isNetworkMultiplayerGame() && !kPossibleVictimPlayer.isHuman(ISHUMAN_AI_DIPLOMACY)) // Not humans or in MP
+			if (isMajorCiv() && !CvPreGame::isNetworkMultiplayerGame() && !kPossibleVictimPlayer.isHuman(ISHUMAN_AI_DIPLOMACY) && GC.getGame().getAIAutoPlay() == 0) // Not humans, in MP, or during autoplay
 			{
 				kPossibleVictimPlayer.GetDiplomacyAI()->DoKilledByPlayer(GetID());
 			}


### PR DESCRIPTION
(Message generated by GPT-6-Astra; the changes have been long in Vox Deorum. I will send more pull requests once I understand how to do this properly!) 

When hovering over a civilization in the civilization list, the war-weariness tooltip should show how long you have been at war with that civilization. This fixes the tooltip using the wrong opponent when looking up the war duration.

During AI autoplay, defeated leaders should not interrupt the game with a farewell dialogue. This skips those popups so autoplay can continue through a civilization's elimination. Defeated leaders still appear during normal play.

The technical changes are small:

- In `NotificationPanel.lua`, pass the hovered civilization's `playerID` to `GetWarDuration` instead of the undefined `g_iAIPlayer`, matching the adjacent war-weariness query.
- In `CvPlayer::CheckForMurder`, call `DoKilledByPlayer` only when `getAIAutoPlay() == 0`. This guards the dialogue without changing elimination processing or war-victory bonuses.
